### PR TITLE
fix generate report bug on firefox (checked on chromium) resolve #180

### DIFF
--- a/app/assets/javascripts/components/utils/Functions.js
+++ b/app/assets/javascripts/components/utils/Functions.js
@@ -15,7 +15,6 @@ const Functions = {
     const link = document.createElement('a');
     link.download = name;
     link.href = contents;
-    //link.click();
     let event = new MouseEvent('click', {
       'view': window,
       'bubbles': true,


### PR DESCRIPTION
checked on chromium: name of the reaction was truncated at whitespace
