### PR TITLE
fix generate report action resolve #239

### DIFF
--- a/app/api/chemotion/report_api.rb
+++ b/app/api/chemotion/report_api.rb
@@ -56,7 +56,7 @@ module Chemotion
             r.add_table(reaction.reactants.count + 1, 6) do |t|
               t.add_line 'Name', 'Molecule', 'mg', 'ml', 'mmol', 'Equiv'
               samples = reaction.reactions_reactant_samples.includes(:sample).each do |item|
-                t.add_line item.sample.name.to_s, item.sample.molecule.sum_formular, item.sample.amount_mg.round(5).to_s, item.sample.amount_ml.to_s, item.sample.amount_mmol.round(5).to_s, item.equivalent.round(2).to_s
+                t.add_line item.sample.name.to_s, item.sample.molecule.sum_formular, item.sample.amount_mg.round(5).to_s, item.sample.amount_ml.to_s, item.sample.amount_mmol.round(5).to_s, item.equivalent.try(:round, 2).try(:to_s)
               end
             end
           end

--- a/app/models/reactions_product_sample.rb
+++ b/app/models/reactions_product_sample.rb
@@ -6,6 +6,6 @@ class ReactionsProductSample < ActiveRecord::Base
   include Reactable
 
   def formatted_yield
-    (self.equivalent * 100).round(2).to_s + ' %'
+    self.equivalent ? (self.equivalent * 100).to_s + " %" : " %"
   end
 end

--- a/spec/models/reactions_product_sample.rb
+++ b/spec/models/reactions_product_sample.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe ReactionsProductSample, type: :model do
+  let(:sample) { ReactionsProductSample.new }
+  let(:eq_val) { 5.0 }
+
+  describe 'formatted_yield' do
+    context 'without an equivalent value' do
+      it 'yields " %" only' do
+        expect(sample.formatted_yield).to eq " %"
+      end
+    end
+
+    context 'with an equivalent value' do
+      before do
+        sample.update_attribute :equivalent, eq_val
+      end
+
+      it 'yields "#{eq_val * 100} %"' do
+        expect(sample.formatted_yield).to eq "#{eq_val * 100} %"
+      end
+    end
+  end
+end


### PR DESCRIPTION
prevent errors when `sample.equivalent` is `NULL`
