### PR TITLE
fix scheme picture resolve #261

### DIFF
--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -79,11 +79,11 @@ class Reaction < ActiveRecord::Base
     paths = {}
     %i(starting_materials reactants products).each do |prop|
       d = self.send(prop).includes(:molecule)
-      paths[prop]= d.pluck(:sample_svg_file,:'molecules.inchikey').map do |item|
+      paths[prop]= d.pluck(:sample_svg_file,:'molecules.molecule_svg_file').map do |item|
         if item[0].present?
           '/images/samples/' + item[0]
         else
-          "/images/molecules/#{item[1]}.svg"
+          "/images/molecules/#{item[1]}"
         end
       end
     end


### PR DESCRIPTION
In previous code, we gave `molecule.inchikey` to generate SVG file name, but it should be `molecule.molecule_svg_file` .

Therefore, the old reaction images are pointed to single-arrow image, which is wrong.
