### PR TITLE
fix reaction svg size

### DIFF
--- a/app/assets/stylesheets/molecules.css
+++ b/app/assets/stylesheets/molecules.css
@@ -51,5 +51,7 @@
 }
 
 .reaction-details svg {
-  width: 100%
+  max-width: 100%;
+  max-height: 150px;
+  margin-top: 20px;
 }


### PR DESCRIPTION
Regarding to reaction SVG, we need to display it on RTF Report & Web.
For rendering in RTF Report, we need to convert SVG to PNG, which is less flexible.
Therefore, I decide to make SVG size fit to RTF report generation(~12in), and control the size of it by css on the webtsite. 