### PR TITLE
re-arrange reaction input & time capture button resolve #314 #336

### DIFF
--- a/app/assets/javascripts/components/ReactionDetails.js
+++ b/app/assets/javascripts/components/ReactionDetails.js
@@ -13,11 +13,12 @@ import UIActions from './actions/UIActions';
 import SVG from 'react-inlinesvg';
 import Utils from './utils/Functions';
 
-
 import XTab from "./extra/ReactionDetailsXTab";
 import XTabName from "./extra/ReactionDetailsXTabName";
 
 import StickyDiv from 'react-stickydiv'
+
+import {setReactionByType} from './ReactionDetailsShare'
 
 export default class ReactionDetails extends Component {
   constructor(props) {
@@ -103,6 +104,14 @@ export default class ReactionDetails extends Component {
     } else{
       this.setState({ reaction });
     }
+  }
+
+  handleInputChange(type, event) {
+    const {value} = event.target;
+    const {reaction} = this.state;
+
+    const {newReaction, options} = setReactionByType(reaction, type, value)
+    this.handleReactionChange(newReaction, options);
   }
 
   handleProductClick(product) {
@@ -223,12 +232,13 @@ export default class ReactionDetails extends Component {
               <ReactionDetailsScheme
                 reaction={reaction}
                 onReactionChange={(reaction, options) => this.handleReactionChange(reaction, options)}
+                onInputChange={(type, event) => this.handleInputChange(type, event)}
                 />
             </Tab>
             <Tab eventKey={1} title={'Properties'}>
               <ReactionDetailsProperties
                 reaction={reaction}
-                onReactionChange={(reaction, options) => this.handleReactionChange(reaction, options)}
+                onInputChange={(type, event) => this.handleInputChange(type, event)}
                 />
             </Tab>
             <Tab eventKey={2} title={'Literatures'}>
@@ -259,4 +269,8 @@ export default class ReactionDetails extends Component {
       </StickyDiv>
     );
   }
+}
+
+ReactionDetails.propTypes = {
+  reaction: React.PropTypes.object
 }

--- a/app/assets/javascripts/components/ReactionDetailsAnalyses.js
+++ b/app/assets/javascripts/components/ReactionDetailsAnalyses.js
@@ -12,3 +12,7 @@ export default class ReactionDetailsAnalyses extends Component {
     );
   }
 }
+
+ReactionDetailsAnalyses.propTypes = {
+  sample: React.PropTypes.object
+}

--- a/app/assets/javascripts/components/ReactionDetailsLiteratures.js
+++ b/app/assets/javascripts/components/ReactionDetailsLiteratures.js
@@ -77,3 +77,8 @@ export default class ReactionDetailsLiteratures extends Component {
   }
 
 }
+
+ReactionDetailsLiteratures.propTypes = {
+  reaction: React.PropTypes.object,
+  onReactionChange: React.PropTypes.func
+}

--- a/app/assets/javascripts/components/ReactionDetailsMainProperties.js
+++ b/app/assets/javascripts/components/ReactionDetailsMainProperties.js
@@ -1,128 +1,71 @@
 import React, {Component} from 'react';
 import {Row, Col, FormGroup, FormControl, ControlLabel, ListGroupItem, ListGroup} from 'react-bootstrap'
 import Select from 'react-select'
-import {statusOptions} from './staticDropdownOptions/options'
+import {solventOptions} from './staticDropdownOptions/options'
 
-export default class ReactionDetailsMainProperties extends Component {
-
-  constructor(props) {
-    super(props);
-    const {reaction} = props;
-    this.state = { reaction };
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const {reaction} = this.state;
-    const nextReaction = nextProps.reaction;
-    this.setState({ reaction: nextReaction });
-  }
-
-  handleInputChange(type, event) {
-    const {onReactionChange} = this.props;
-    const {value} = event.target;
-    let {reaction} = this.state;
-
-    switch (type) {
-      case 'name':
-        reaction.name = value;
-        break;
-      case 'observation':
-        reaction.observation = value;
-        break;
-      case 'status':
-        reaction.status = value;
-        break;
-      case 'description':
-        reaction.description = value;
-        break;
-      case 'purification':
-        reaction.purification = value;
-        break;
-      case 'solvents':
-        reaction.solvents = value;
-        break;
-      case 'rfValue':
-        reaction.rf_value = value;
-        break;
-      case 'timestampStart':
-        reaction.timestamp_start = value;
-        break;
-      case 'timestampStop':
-        reaction.timestamp_stop = value;
-        break;
-      case 'tlcDescription':
-        reaction.tlc_description = value;
-        break;
-      case 'temperature':
-        reaction.temperature = value;
-        break;
-      case 'dangerousProducts':
-        reaction.dangerous_products = value;
-        break;
-    }
-
-    onReactionChange(reaction);
-  }
-
-  render() {
-    const {reaction} = this.state;
-    return (
-      <ListGroup>
-        <ListGroupItem header="">
-          <Row>
-            <Col md={6}>
-              <FormGroup>
-                <ControlLabel>Name</ControlLabel>
-                <FormControl
-                  type="text"
-                  value={reaction.name}
-                  placeholder="Name..."
-                  disabled={reaction.isMethodDisabled('name')}
-                  onChange={event => this.handleInputChange('name', event)}/>
-              </FormGroup>
-            </Col>
-            <Col md={3}>
-              <label>Status</label>
-              <Select
-                name='status'
-                multi={false}
-                options={statusOptions}
-                value={reaction.status}
-                disabled={reaction.isMethodDisabled('status')}
-                onChange={event => {
-                  const wrappedEvent = {target: {value: event}};
-                  this.handleInputChange('status', wrappedEvent)
-                }}
-              />
-            </Col>
-            <Col md={3}>
-              <FormGroup>
-                <ControlLabel>Temperature</ControlLabel>
-                <FormControl
-                  type="text"
-                  value={reaction.temperature}
-                  disabled={reaction.isMethodDisabled('temperature')}
-                  placeholder="Temperature..."
-                  onChange={event => this.handleInputChange('temperature', event)}/>
-              </FormGroup>
-            </Col>
-          </Row>
-          <Row>
-            <Col md={12}>
-              <FormGroup>
-                <ControlLabel>Description</ControlLabel>
-                <FormControl
-                  type="textarea"
-                  value={reaction.description}
-                  disabled={reaction.isMethodDisabled('description')}
-                  placeholder="Description..."
-                  rows={6}
-                  onChange={event => this.handleInputChange('description', event)}/>
-              </FormGroup>
-            </Col>
-          </Row>
-        </ListGroupItem>
-      </ListGroup>
-    );
-  }
+const ReactionDetailsMainProperties = ({reaction, onInputChange}) => {
+  return (
+    <ListGroup>
+      <ListGroupItem header="">
+        <Row>
+          <Col md={5}>
+            <FormGroup>
+              <ControlLabel>Name</ControlLabel>
+              <FormControl
+                type="text"
+                value={reaction.name}
+                placeholder="Name..."
+                disabled={reaction.isMethodDisabled('name')}
+                onChange={event => onInputChange('name', event)}/>
+            </FormGroup>
+          </Col>
+          <Col md={4}>
+            <label>Solvent</label>
+            <Select
+              name='solvent'
+              multi={false}
+              options={solventOptions}
+              value={reaction.solvent}
+              disabled={reaction.isMethodDisabled('solvent')}
+              onChange={event => {
+                const wrappedEvent = {target: {value: event}};
+                onInputChange('solvent', wrappedEvent)
+              }}
+            />
+          </Col>
+          <Col md={3}>
+            <FormGroup>
+              <ControlLabel>Temperature</ControlLabel>
+              <FormControl
+                type="text"
+                value={reaction.temperature}
+                disabled={reaction.isMethodDisabled('temperature')}
+                placeholder="Temperature..."
+                onChange={event => onInputChange('temperature', event)}/>
+            </FormGroup>
+          </Col>
+        </Row>
+        <Row>
+          <Col md={12}>
+            <FormGroup>
+              <ControlLabel>Description</ControlLabel>
+              <FormControl
+                componentClass="textarea"
+                value={reaction.description}
+                disabled={reaction.isMethodDisabled('description')}
+                placeholder="Description..."
+                onChange={event => onInputChange('description', event)}/>
+            </FormGroup>
+          </Col>
+        </Row>
+      </ListGroupItem>
+    </ListGroup>
+  )
 }
+
+ReactionDetailsMainProperties.propTypes = {
+  reaction: React.PropTypes.object,
+  onInputChange: React.PropTypes.func
+}
+
+export default ReactionDetailsMainProperties

--- a/app/assets/javascripts/components/ReactionDetailsProperties.js
+++ b/app/assets/javascripts/components/ReactionDetailsProperties.js
@@ -1,8 +1,10 @@
 import React, {Component} from 'react';
-import {Row, Col, FormGroup, ControlLabel, FormControl, ListGroupItem, ListGroup} from 'react-bootstrap'
+import {Row, Col, FormGroup, ControlLabel, FormControl,
+        ListGroupItem, ListGroup, InputGroup, Button} from 'react-bootstrap'
 import Select from 'react-select'
-import {solventOptions, purificationOptions, statusOptions, dangerousProductsOptions}
-  from './staticDropdownOptions/options';
+import {solventOptions, purificationOptions, statusOptions,
+        dangerousProductsOptions} from './staticDropdownOptions/options';
+import ReactionDetailsMainProperties from './ReactionDetailsMainProperties';
 
 export default class ReactionDetailsProperties extends Component {
 
@@ -17,84 +19,34 @@ export default class ReactionDetailsProperties extends Component {
     this.setState({ reaction: nextReaction });
   }
 
-  handleInputChange(type, event) {
-    const {onReactionChange} = this.props;
-    const {value} = event.target;
-    const {reaction} = this.state;
-    let options = {};
-
-    switch (type) {
-      case 'name':
-        reaction.name = value;
-        break;
-      case 'observation':
-        reaction.observation = value;
-        break;
-      case 'status':
-        reaction.status = value;
-        break;
-      case 'description':
-        reaction.description = value;
-        break;
-      case 'purification':
-        reaction.purification = value;
-        break;
-      case 'tlc_solvents':
-        reaction.tlc_solvents = value;
-        break;
-      case 'rfValue':
-        reaction.rf_value = value;
-        break;
-      case 'timestampStart':
-        reaction.timestamp_start = value;
-        break;
-      case 'timestampStop':
-        reaction.timestamp_stop = value;
-        break;
-      case 'tlcDescription':
-        reaction.tlc_description = value;
-        break;
-      case 'temperature':
-        reaction.temperature = value;
-        options = {schemaChanged: true}
-        break;
-      case 'dangerousProducts':
-        reaction.dangerous_products = value;
-        break;
-        case 'solvent':
-          reaction.solvent = value;
-          options = {schemaChanged: true}
-          break;
-    }
-
-    onReactionChange(reaction, options);
-  }
-
   handleMultiselectChange(type, selectedOptions) {
     const values = selectedOptions.map(option => option.value);
     const wrappedEvent = {target: {value: values}};
-    this.handleInputChange(type, wrappedEvent)
+    this.props.onInputChange(type, wrappedEvent)
+  }
+
+  setCurrentTime(type) {
+    const currentTime = new Date().toLocaleString('en-GB').split(', ').join(' ')
+    const {reaction} = this.state
+    if(type === 'start') {
+      reaction.timestamp_start = currentTime
+    } else {
+      reaction.timestamp_stop = currentTime
+    }
+    this.setState({ reaction: reaction });
   }
 
   render() {
     const {reaction} = this.state;
     return (
+      <div>
+      <ReactionDetailsMainProperties
+        reaction={reaction}
+        onInputChange={(type, event) => this.props.onInputChange(type, event)} />
       <ListGroup>
         <ListGroupItem>
-          <h4 className="list-group-item-heading" ></h4>
           <Row>
-            <Col md={6}>
-              <FormGroup>
-                <ControlLabel>Name</ControlLabel>
-                <FormControl
-                  type="text"
-                  value={reaction.name}
-                  placeholder="Name..."
-                  disabled={reaction.isMethodDisabled('name')}
-                  onChange={event => this.handleInputChange('name', event)}/>
-              </FormGroup>
-            </Col>
-            <Col md={6}>
+            <Col md={4}>
               <label>Status</label>
               <Select
                 name='status'
@@ -104,61 +56,44 @@ export default class ReactionDetailsProperties extends Component {
                 disabled={reaction.isMethodDisabled('status')}
                 onChange={event => {
                   const wrappedEvent = {target: {value: event}};
-                  this.handleInputChange('status', wrappedEvent)
+                  this.props.onInputChange('status', wrappedEvent)
                 }}
                 />
-            </Col>
-          </Row>
-          <Row>
-            <Col md={12}>
-              <FormGroup>
-                <ControlLabel>Description</ControlLabel>
-                <FormControl
-                  type="textarea"
-                  value={reaction.description}
-                  disabled={reaction.isMethodDisabled('description')}
-                  placeholder="Description..."
-                  onChange={event => this.handleInputChange('description', event)}/>
-              </FormGroup>
-            </Col>
-          </Row>
-        </ListGroupItem>
-        <ListGroupItem>
-          <Row>
-            <Col md={4}>
-              <label>Solvent</label>
-              <Select
-                name='solvent'
-                multi={false}
-                options={solventOptions}
-                value={reaction.solvent}
-                disabled={reaction.isMethodDisabled('solvent')}
-                onChange={event => {
-                  const wrappedEvent = {target: {value: event}};
-                  this.handleInputChange('solvent', wrappedEvent)
-                }}
-              />
             </Col>
             <Col md={4}>
               <FormGroup>
                 <ControlLabel>Start</ControlLabel>
-                <FormControl
-                  type="text"
-                  value={reaction.timestamp_start}
-                  disabled={reaction.isMethodDisabled('timestamp_start')}
-                  placeholder="Start..."
-                  onChange={event => this.handleInputChange('timestampStart', event)}/>
+                <InputGroup>
+                  <FormControl
+                    type="text"
+                    value={reaction.timestamp_start}
+                    disabled={reaction.isMethodDisabled('timestamp_start')}
+                    placeholder="Start..."
+                    onChange={event => this.props.onInputChange('timestampStart', event)}/>
+                  <InputGroup.Button>
+                    <Button active style={ {padding: '6px'}} onClick={e => this.setCurrentTime('start')} >
+                      <i className="fa fa-clock-o"></i>
+                    </Button>
+                  </InputGroup.Button>
+                </InputGroup>
               </FormGroup>
             </Col>
             <Col md={4}>
               <FormGroup>
                 <ControlLabel>Stop</ControlLabel>
-                <FormControl
-                  type="text"
-                  value={reaction.timestamp_stop}
-                  disabled={reaction.isMethodDisabled('timestamp_stop')}
-                  placeholder="Stop..."
-                  onChange={event => this.handleInputChange('timestampStop', event)}/>
+                <InputGroup>
+                  <FormControl
+                    type="text"
+                    value={reaction.timestamp_stop}
+                    disabled={reaction.isMethodDisabled('timestamp_stop')}
+                    placeholder="Stop..."
+                    onChange={event => this.props.onInputChange('timestampStop', event)}/>
+                  <InputGroup.Button>
+                    <Button active style={ {padding: '6px'}} onClick={e => this.setCurrentTime('stop')} >
+                      <i className="fa fa-clock-o"></i>
+                    </Button>
+                  </InputGroup.Button>
+                </InputGroup>
               </FormGroup>
             </Col>
           </Row>
@@ -167,11 +102,11 @@ export default class ReactionDetailsProperties extends Component {
               <FormGroup>
                 <ControlLabel>Observation</ControlLabel>
                 <FormControl
-                  type="textarea"
+                  componentClass="textarea"
                   value={reaction.observation}
                   disabled={reaction.isMethodDisabled('observation')}
                   placeholder="Observation..."
-                  onChange={event => this.handleInputChange('observation', event)}/>
+                  onChange={event => this.props.onInputChange('observation', event)}/>
               </FormGroup>
             </Col>
           </Row>
@@ -213,10 +148,10 @@ export default class ReactionDetailsProperties extends Component {
                   value={reaction.tlc_solvents}
                   disabled={reaction.isMethodDisabled('tlc_solvents')}
                   placeholder="Solvents as parts..."
-                  onChange={event => this.handleInputChange('tlc_solvents', event)}/>
+                  onChange={event => this.props.onInputChange('tlc_solvents', event)}/>
               </FormGroup>
             </Col>
-            <Col md={3}>
+            <Col md={6}>
               <FormGroup>
                 <ControlLabel>Rf-Value</ControlLabel>
                 <FormControl
@@ -224,18 +159,7 @@ export default class ReactionDetailsProperties extends Component {
                   value={reaction.rf_value}
                   disabled={reaction.isMethodDisabled('rf_value')}
                   placeholder="Rf-Value..."
-                  onChange={event => this.handleInputChange('rfValue', event)}/>
-              </FormGroup>
-            </Col>
-            <Col md={3}>
-              <FormGroup>
-                <ControlLabel>Temperature</ControlLabel>
-                <FormControl
-                  type="text"
-                  value={reaction.temperature}
-                  disabled={reaction.isMethodDisabled('temperature')}
-                  placeholder="Temperature..."
-                  onChange={event => this.handleInputChange('temperature', event)}/>
+                  onChange={event => this.props.onInputChange('rfValue', event)}/>
               </FormGroup>
             </Col>
           </Row>
@@ -244,16 +168,22 @@ export default class ReactionDetailsProperties extends Component {
               <FormGroup>
                 <ControlLabel>TLC-Description</ControlLabel>
                 <FormControl
-                  type="textarea"
+                  componentClass="textarea"
                   value={reaction.tlc_description}
                   disabled={reaction.isMethodDisabled('tlc_description')}
                   placeholder="TLC-Description..."
-                  onChange={event => this.handleInputChange('tlcDescription', event)}/>
+                  onChange={event => this.props.onInputChange('tlcDescription', event)}/>
               </FormGroup>
             </Col>
           </Row>
         </ListGroupItem>
       </ListGroup>
+      </div>
     );
   }
+}
+
+ReactionDetailsProperties.propTypes = {
+  reaction: React.PropTypes.object,
+  onInputChange: React.PropTypes.func
 }

--- a/app/assets/javascripts/components/ReactionDetailsScheme.js
+++ b/app/assets/javascripts/components/ReactionDetailsScheme.js
@@ -334,7 +334,6 @@ export default class ReactionDetailsScheme extends Component {
     });
   }
 
-
   render() {
     const {reaction} = this.state;
     let addSampleButton = (sampleType)=> <Button bsStyle="success" bsSize="xs" onClick={() => this.addSampleToMaterialGroup(reaction, sampleType)}><Glyphicon glyph="plus" /></Button>
@@ -384,9 +383,14 @@ export default class ReactionDetailsScheme extends Component {
         </ListGroup>
         <ReactionDetailsMainProperties
           reaction={reaction}
-          onReactionChange={reaction => this.onReactionChange(reaction)}
-          />
+          onInputChange={(type, event) => this.props.onInputChange(type, event)} />
       </div>
     );
   }
+}
+
+ReactionDetailsScheme.propTypes = {
+  reaction: React.PropTypes.object,
+  onReactionChange: React.PropTypes.func,
+  onInputChange: React.PropTypes.func
 }

--- a/app/assets/javascripts/components/ReactionDetailsShare.js
+++ b/app/assets/javascripts/components/ReactionDetailsShare.js
@@ -1,0 +1,51 @@
+const setReactionByType = (reaction, type, value) => {
+  let options = {};
+
+  switch (type) {
+    case 'name':
+      reaction.name = value;
+      break;
+    case 'observation':
+      reaction.observation = value;
+      break;
+    case 'status':
+      reaction.status = value;
+      break;
+    case 'description':
+      reaction.description = value;
+      break;
+    case 'purification':
+      reaction.purification = value;
+      break;
+    case 'tlc_solvents':
+      reaction.tlc_solvents = value;
+      break;
+    case 'rfValue':
+      reaction.rf_value = value;
+      break;
+    case 'timestampStart':
+      reaction.timestamp_start = value;
+      break;
+    case 'timestampStop':
+      reaction.timestamp_stop = value;
+      break;
+    case 'tlcDescription':
+      reaction.tlc_description = value;
+      break;
+    case 'temperature':
+      reaction.temperature = value;
+      options = {schemaChanged: true}
+      break;
+    case 'dangerousProducts':
+      reaction.dangerous_products = value;
+      break;
+    case 'solvent':
+      reaction.solvent = value;
+      options = {schemaChanged: true}
+      break;
+  }
+
+  return { newReaction: reaction, options: options }
+}
+
+export {setReactionByType}


### PR DESCRIPTION
1. make ```ReactionDetailsMainProperties.js``` as a stateless component. 
2. refactor reaction edit input arrangement.
3. DRY: move a shared function to ```ReactionDetailsShare.js```
4. finish #336 time capture button for start stop input.