### PR TITLE
fix warning setState & empty-list when back from collection-managements

### DIFF
--- a/app/assets/javascripts/components/App.js
+++ b/app/assets/javascripts/components/App.js
@@ -24,15 +24,16 @@ class App extends Component {
     this.state= {
       showCollectionManagement: false
     };
+    this.handleUiStoreChange = this.handleUiStoreChange.bind(this)
   }
 
   componentDidMount() {
-    UIStore.listen(state => this.handleUiStoreChange(state));
+    UIStore.listen(this.handleUiStoreChange);
     UserActions.fetchProfile();
   }
 
   componentWillUnmount() {
-    UIStore.unlisten(state => this.handleUiStoreChange(state));
+    UIStore.unlisten(this.handleUiStoreChange);
   }
 
   handleUiStoreChange(state) {

--- a/app/assets/javascripts/components/CollectionSubtree.js
+++ b/app/assets/javascripts/components/CollectionSubtree.js
@@ -17,6 +17,7 @@ export default class CollectionSubtree extends React.Component {
       root: props.root,
       visible: false
     }
+    this.onChange = this.onChange.bind(this)
   }
 
   isVisible(node, uiState) {
@@ -28,7 +29,7 @@ export default class CollectionSubtree extends React.Component {
   }
 
   componentDidMount() {
-    UIStore.listen(this.onChange.bind(this));
+    UIStore.listen(this.onChange);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -39,7 +40,7 @@ export default class CollectionSubtree extends React.Component {
   }
 
   componentWillUnmount() {
-    UIStore.unlisten(this.onChange.bind(this));
+    UIStore.unlisten(this.onChange);
   }
 
   onChange(state) {

--- a/app/assets/javascripts/components/CollectionTree.js
+++ b/app/assets/javascripts/components/CollectionTree.js
@@ -12,10 +12,11 @@ export default class CollectionTree extends React.Component {
   constructor(props) {
     super(props);
     this.state = CollectionStore.getState();
+    this.onChange = this.onChange.bind(this)
   }
 
   componentDidMount() {
-    CollectionStore.listen(this.onChange.bind(this));
+    CollectionStore.listen(this.onChange);
     CollectionActions.fetchLockedCollectionRoots();
     CollectionActions.fetchUnsharedCollectionRoots();
     CollectionActions.fetchSharedCollectionRoots();
@@ -23,7 +24,7 @@ export default class CollectionTree extends React.Component {
   }
 
   componentWillUnmount() {
-    CollectionStore.unlisten(this.onChange.bind(this));
+    CollectionStore.unlisten(this.onChange);
   }
 
   onChange(state) {

--- a/app/assets/javascripts/components/Elements.js
+++ b/app/assets/javascripts/components/Elements.js
@@ -13,14 +13,15 @@ class Elements extends Component {
     this.state = {
       currentElement: null
     };
+    this.handleOnChange = this.handleOnChange.bind(this)
   }
 
   componentDidMount() {
-    ElementStore.listen(state => this.handleOnChange(state));
+    ElementStore.listen(this.handleOnChange);
   }
 
   componentWillUnmount() {
-    ElementStore.unlisten(state => this.handleOnChange(state));
+    ElementStore.unlisten(this.handleOnChange);
   }
 
   handleOnChange(state) {

--- a/app/assets/javascripts/components/ElementsTable.js
+++ b/app/assets/javascripts/components/ElementsTable.js
@@ -21,28 +21,32 @@ export default class ElementsTable extends React.Component {
       currentElement: null,
       ui: {}
     }
+    this.onChange = this.onChange.bind(this)
+    this.onChangeUI = this.onChangeUI.bind(this)
   }
 
   componentDidMount() {
     UIStore.getState();
-    ElementStore.listen(this.onChange.bind(this));
-    UIStore.listen(this.onChangeUI.bind(this));
+    ElementStore.listen(this.onChange);
+    UIStore.listen(this.onChangeUI);
     this.initializePagination();
+    this.initState();
   }
 
   componentWillUnmount() {
-    ElementStore.unlisten(this.onChange.bind(this));
-    UIStore.unlisten(this.onChangeUI.bind(this));
+    ElementStore.unlisten(this.onChange);
+    UIStore.unlisten(this.onChangeUI);
   }
 
   initializePagination() {
-
     const {page, pages, perPage, totalElements} = this.state;
-
     this.setState({
       page, pages, perPage, totalElements
     });
+  }
 
+  initState(){
+    this.onChange(ElementStore.getState());
   }
 
   onChangeUI(state) {

--- a/app/assets/javascripts/components/List.js
+++ b/app/assets/javascripts/components/List.js
@@ -15,6 +15,10 @@ export default class List extends React.Component {
       totalScreenElements: 0,
       currentTab: 1
     }
+
+    this.onChange = this.onChange.bind(this)
+    this.onChangeUI = this.onChangeUI.bind(this)
+    this.initState = this.initState.bind(this)
   }
 
   _checkedElements(type) {
@@ -28,13 +32,18 @@ export default class List extends React.Component {
   }
 
   componentDidMount() {
-    ElementStore.listen(this.onChange.bind(this));
-    UIStore.listen(this.onChangeUI.bind(this));
+    ElementStore.listen(this.onChange);
+    UIStore.listen(this.onChangeUI);
+    this.initState();
   }
 
   componentWillUnmount() {
-    ElementStore.unlisten(this.onChange.bind(this));
-    UIStore.unlisten(this.onChangeUI.bind(this));
+    ElementStore.unlisten(this.onChange);
+    UIStore.unlisten(this.onChangeUI);
+  }
+
+  initState(){
+    this.onChange(ElementStore.getState())
   }
 
   onChange(state) {

--- a/app/assets/javascripts/components/SampleDetails.js
+++ b/app/assets/javascripts/components/SampleDetails.js
@@ -48,14 +48,15 @@ export default class SampleDetails extends React.Component {
     }
 
     this.clipboard = new Clipboard('.clipboardBtn');
+    this.onChange = this.onChange.bind(this)
   }
 
   componentDidMount() {
-    ElementStore.listen(this.onChange.bind(this));
+    ElementStore.listen(this.onChange);
   }
 
   componentWillUnmount() {
-    ElementStore.unlisten(this.onChange.bind(this));
+    ElementStore.unlisten(this.onChange);
     this.clipboard.destroy();
   }
 

--- a/app/assets/javascripts/components/UserAuth.js
+++ b/app/assets/javascripts/components/UserAuth.js
@@ -12,15 +12,16 @@ export default class UserAuth extends Component {
     this.state = {
       currentUser: props.currentUser || {name: 'unknown'}
     }
+    this.onChange = this.onChange.bind(this)
   }
 
   componentDidMount() {
-    UserStore.listen(this.onChange.bind(this));
+    UserStore.listen(this.onChange);
     UserActions.fetchCurrentUser();
   }
 
   componentWillUnmount() {
-    UserStore.unlisten(this.onChange.bind(this));
+    UserStore.unlisten(this.onChange);
   }
 
   onChange(state) {

--- a/app/assets/javascripts/components/collection_management/MyCollections.js
+++ b/app/assets/javascripts/components/collection_management/MyCollections.js
@@ -21,15 +21,17 @@ export default class MyCollections extends React.Component {
         children: [{}]
       }
     }
+
+    this.onStoreChange = this.onStoreChange.bind(this);
   }
 
   componentDidMount() {
-    CollectionStore.listen(this.onStoreChange.bind(this));
+    CollectionStore.listen(this.onStoreChange);
     CollectionActions.fetchUnsharedCollectionRoots();
   }
 
   componentWillUnmount() {
-    CollectionStore.unlisten(this.onStoreChange.bind(this))
+    CollectionStore.unlisten(this.onStoreChange)
   }
 
   onStoreChange(state) {

--- a/app/assets/javascripts/components/collection_management/MySharedCollections.js
+++ b/app/assets/javascripts/components/collection_management/MySharedCollections.js
@@ -25,15 +25,17 @@ export default class MySharedCollections extends React.Component {
         action: null
       }
     }
+
+    this.onStoreChange = this.onStoreChange.bind(this);
   }
 
   componentDidMount() {
-    CollectionStore.listen(this.onStoreChange.bind(this));
+    CollectionStore.listen(this.onStoreChange);
     CollectionActions.fetchSharedCollectionRoots();
   }
 
   componentWillUnmount(){
-    CollectionStore.unlisten(this.onStoreChange.bind(this));
+    CollectionStore.unlisten(this.onStoreChange);
   }
 
   onStoreChange(state) {


### PR DESCRIPTION
solve:
1. ```setState``` warning
2. When coming back from collection-managements, __List__ will no longer be empty.