### PR TITLE
Fix the bug while searching the polymer

### DIFF
--- a/app/api/chemotion/search_api.rb
+++ b/app/api/chemotion/search_api.rb
@@ -112,8 +112,9 @@ module Chemotion
         when 'substring'
           AllElementSearch.new(arg, current_user.id).search_by_substring
         when 'structure'
+          is_part = arg.include? ' R# '
           fp_vector =
-            Chemotion::OpenBabelService.fingerprint_from_molfile(arg)
+            Chemotion::OpenBabelService.fingerprint_from_molfile(arg, is_part)
 
           # TODO implement this: http://pubs.acs.org/doi/abs/10.1021/ci600358f
 

--- a/app/assets/javascripts/components/SampleForm.js
+++ b/app/assets/javascripts/components/SampleForm.js
@@ -123,7 +123,7 @@ export default class SampleForm extends React.Component {
       <FormGroup>
         <ControlLabel>{label}</ControlLabel>
         <FormControl type="text"
-          value={sample[field]}
+          value={sample[field] || ''}
           onChange={(e) => {this.handleFieldChanged(sample, field, e.target.value)}}
           disabled={disabled || sample.isMethodDisabled(field)}
           readOnly={disabled || sample.isMethodDisabled(field)}

--- a/db/migrate/20160721141337_update_molecule_fingerprint.rb
+++ b/db/migrate/20160721141337_update_molecule_fingerprint.rb
@@ -1,0 +1,34 @@
+class UpdateMoleculeFingerprint < ActiveRecord::Migration
+  def change
+    Molecule.all.each do |molecule|
+      next if molecule.samples.count == 0
+
+      fp_vector =
+        Chemotion::OpenBabelService.fingerprint_from_molfile(molecule.samples.first.molfile, molecule.is_partial)
+
+      molecule.fp0  = "%064b" % fp_vector[0]
+      molecule.fp1  = "%064b" % fp_vector[1]
+      molecule.fp2  = "%064b" % fp_vector[2]
+      molecule.fp3  = "%064b" % fp_vector[3]
+      molecule.fp4  = "%064b" % fp_vector[4]
+      molecule.fp5  = "%064b" % fp_vector[5]
+      molecule.fp6  = "%064b" % fp_vector[6]
+      molecule.fp7  = "%064b" % fp_vector[7]
+      molecule.fp8  = "%064b" % fp_vector[8]
+      molecule.fp9  = "%064b" % fp_vector[9]
+      molecule.fp10 = "%064b" % fp_vector[10]
+      molecule.fp11 = "%064b" % fp_vector[11]
+      molecule.fp12 = "%064b" % fp_vector[12]
+      molecule.fp13 = "%064b" % fp_vector[13]
+      molecule.fp14 = "%064b" % fp_vector[14]
+
+      if molecule.is_partial
+        molecule.fp15 = "%064b" % (fp_vector[15] | 7)
+      else
+        molecule.fp15 = "%064b" % fp_vector[15]
+      end
+
+      molecule.save!
+    end
+  end
+end

--- a/lib/chemotion/open_babel_service.rb
+++ b/lib/chemotion/open_babel_service.rb
@@ -33,7 +33,7 @@ M  END
 
   end
 
-  def self.molecule_info_from_molfile molfile
+  def self.molecule_info_from_molfile molfile, is_partial = false
     c = OpenBabel::OBConversion.new
     c.set_in_format 'mol'
 
@@ -64,7 +64,7 @@ M  END
       formula: m.get_formula,
       svg: svg_from_molfile(molfile),
       cano_smiles: ca_smiles,
-      fp: fingerprint_from_molfile(molfile)
+      fp: fingerprint_from_molfile(molfile, is_partial)
     }
 
   end
@@ -100,7 +100,7 @@ M  END
   end
 
   # Return an array of 32
-  def self.fingerprint_from_molfile molfile
+  def self.fingerprint_from_molfile molfile, is_partial = false
     c = OpenBabel::OBConversion.new
     m = OpenBabel::OBMol.new
 
@@ -128,7 +128,13 @@ M  END
     fp_16[12] = fp[7]  << 32 | fp[6]
     fp_16[13] = fp[5]  << 32 | fp[4]
     fp_16[14] = fp[3]  << 32 | fp[2]
-    fp_16[15] = fp[1]  << 32 | fp[0]
+    # Since OpenBabel does not use last 3 bits. We will use it to store Polymer
+    # If molfile contains R# (polymer) then set the last 3 bits
+    if is_partial
+      fp_16[15] = (fp[1]  << 32 | fp[0]) | 7
+    else
+      fp_16[15] = fp[1]  << 32 | fp[0]
+    end
 
     return fp_16
 


### PR DESCRIPTION
- Fix the warning when 'input' controller has null value
- Change the fingerprint generation to use original molfile from samples table
- Since OpenBabel doen't use the last 3 bits, we will enable those bits for polymer search. We have 3 bits, so we can have total 8 "special groups"
- Resolved for #353