### PR TITLE
Refactor search UI

### DIFF
--- a/app/api/chemotion/collection_api.rb
+++ b/app/api/chemotion/collection_api.rb
@@ -156,7 +156,7 @@ module Chemotion
         put do
 
           ui_state = params[:ui_state]
-          current_collection_id = ui_state[:currentCollectionId]
+          current_collection_id = ui_state[:currentCollection].id
           collection_id = params[:collection_id]
           unless Collection.find(collection_id).is_shared
             sample_ids = Sample.for_user(current_user.id).for_ui_state_with_collection(
@@ -229,7 +229,7 @@ module Chemotion
         post do
           ui_state = params[:ui_state]
           collection_id = params[:collection_id]
-          current_collection_id = ui_state[:currentCollectionId]
+          current_collection_id = ui_state[:currentCollection].id
 
           Sample.for_user(current_user.id).for_ui_state_with_collection(
             ui_state[:sample],
@@ -270,7 +270,7 @@ module Chemotion
         end
         delete do
           ui_state = params[:ui_state]
-          current_collection_id = ui_state[:currentCollectionId]
+          current_collection_id = ui_state[:currentCollection].id
 
           sample_ids = Sample.for_ui_state_with_collection(
             ui_state[:sample],

--- a/app/api/chemotion/search_api.rb
+++ b/app/api/chemotion/search_api.rb
@@ -112,17 +112,13 @@ module Chemotion
         when 'substring'
           AllElementSearch.new(arg, current_user.id).search_by_substring
         when 'structure'
-          is_part = arg.include? ' R# '
+          molfile = Fingerprint.standardized_molfile arg
           fp_vector =
-            Chemotion::OpenBabelService.fingerprint_from_molfile(arg, is_part)
+            Chemotion::OpenBabelService.fingerprint_from_molfile(molfile)
 
           # TODO implement this: http://pubs.acs.org/doi/abs/10.1021/ci600358f
-
           Sample.for_user(current_user.id)
-                .joins(:molecule)
-                .merge(
-                  Molecule.by_tanimoto_coefficient(fp_vector)
-                )
+                .by_fingerprint(fp_vector, params[:page], params[:page_size])
         end
 
         scope = scope.by_collection_id(collection_id.to_i)

--- a/app/api/chemotion/suggestion_api.rb
+++ b/app/api/chemotion/suggestion_api.rb
@@ -1,6 +1,12 @@
 module Chemotion
   class SuggestionAPI < Grape::API
+    include Grape::Kaminari
+
     helpers do
+      def page_size
+        7
+      end
+
       def search_possibilities_to_suggestions(search_possibilities)
         suggestions = []
         search_possibilities.each do |k,v|
@@ -17,7 +23,7 @@ module Chemotion
 
         search_by_field = Proc.new do |klass, field, qry|
           scope = d_for.call klass
-          scope.send("by_#{field}", qry).pluck(field).uniq
+          scope.send("by_#{field}", qry).page(1).per(page_size).pluck(field).uniq
         end
 
         qry = params[:query]

--- a/app/assets/javascripts/components/Analysis.js
+++ b/app/assets/javascripts/components/Analysis.js
@@ -101,14 +101,14 @@ export default class Analysis extends Component {
           <FormControl
             type="textarea"
             label="Content"
-            value={analysis.content}
+            value={analysis.content || ''}
             disabled={readOnly}
             onChange={event => this.handleInputChange('content', event)}
             />
           <FormControl
             type="textarea"
             label="Description"
-            value={analysis.description}
+            value={analysis.description || ''}
             disabled={readOnly}
             onChange={event => this.handleInputChange('description', event)}
             />

--- a/app/assets/javascripts/components/Dataset.js
+++ b/app/assets/javascripts/components/Dataset.js
@@ -164,7 +164,7 @@ export default class Dataset extends Component {
               <ControlLabel>Name</ControlLabel>
               <FormControl
                 type="text"
-                value={dataset.name}
+                value={dataset.name || ''}
                 disabled={readOnly}
                 onChange={event => this.handleInputChange('name', event)}
                 />
@@ -176,7 +176,7 @@ export default class Dataset extends Component {
             <ControlLabel>Instrument</ControlLabel>
               <FormControl
                 type="text"
-                value={dataset.instrument}
+                value={dataset.instrument || ''}
                 disabled={readOnly}
                 onChange={event => this.handleInputChange('instrument', event)}
               />
@@ -187,7 +187,7 @@ export default class Dataset extends Component {
               <ControlLabel>Description</ControlLabel>
               <FormControl
                 type="textarea"
-                value={dataset.description}
+                value={dataset.description || ''}
                 disabled={readOnly}
                 onChange={event => this.handleInputChange('description', event)}
                 style={{minHeight: 100}}

--- a/app/assets/javascripts/components/ElementalCompositionCustom.js
+++ b/app/assets/javascripts/components/ElementalCompositionCustom.js
@@ -83,8 +83,8 @@ export default class ElementalCompositionCustom extends React.Component {
       <td className="loading" align="right" width="13%">
         <FormControl type="text"
            key={"mc-loading" + (el_composition.id || 0).toString()}
-           defaultValue={el_composition.loading}
-           value={el_composition.loading && el_composition.loading.toFixed(2)}
+           defaultValue={el_composition.loading || ''}
+           value={el_composition.loading && el_composition.loading.toFixed(2) || ''}
            disabled
            readOnly
         />

--- a/app/assets/javascripts/components/ElementsSvgCheckbox.js
+++ b/app/assets/javascripts/components/ElementsSvgCheckbox.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {FormGroup,Checkbox} from 'react-bootstrap';
+import {FormGroup,Checkbox, Label} from 'react-bootstrap';
 import UIActions from './actions/UIActions';
 
 export default class ElementsSvgCheckbox extends Component {
@@ -26,12 +26,11 @@ export default class ElementsSvgCheckbox extends Component {
   render() {
     return(
       <FormGroup>
-        <Checkbox inline
-          className="element-svg-checkbox"
+        <Checkbox //className="element-svg-checkbox"
           onChange={() => this.toggleCheckbox()}
           checked={this.state.checked ? this.state.checked : false}
         >
-          Display schemes
+          <Label style={{fontSize: '100%'}}>Display schemes</Label>
         </Checkbox>
       </FormGroup>
     )

--- a/app/assets/javascripts/components/ElementsTable.js
+++ b/app/assets/javascripts/components/ElementsTable.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Pagination, Table, FormGroup, FormControl, ControlLabel} from 'react-bootstrap';
+import { Pagination, Table, Form, Col,
+         FormGroup, FormControl, ControlLabel} from 'react-bootstrap';
 
 import UIStore from './stores/UIStore';
 import UIActions from './actions/UIActions';
@@ -149,14 +150,19 @@ export default class ElementsTable extends React.Component {
   numberOfResultsInput() {
     let {ui} = this.state
     return (
-      <FormGroup >
-        <ControlLabel>Show </ControlLabel>
-        <FormControl
-          className="number-shown-select"
-          onChange={event => this.handleNumberOfResultsChange(event)}
-          type="text"
-          value={ui.number_of_results ? ui.number_of_results : 0} />
-      </FormGroup>
+      <Form horizontal style={{float: 'right'}}>
+        <FormGroup>
+          <Col sm={4} style={{textAlign: 'center', float: 'right'}}>
+            <FormControl type="text" style={{textAlign: 'center', float: 'right'}}
+                         onChange={event => this.handleNumberOfResultsChange(event)}
+                         value={ui.number_of_results ? ui.number_of_results : 0} />
+          </Col>
+          <Col componentClass={ControlLabel} sm={2}
+               style={{textAlign: 'center', float: 'right'}}>
+            Show
+          </Col>
+        </FormGroup>
+      </Form>
 
     );
   }
@@ -215,11 +221,18 @@ export default class ElementsTable extends React.Component {
     return (
       <div>
         {this.renderEntries()}
-        {this.pagination()}
-        <div style={{float: 'right', paddingTop: 4}}>
-          {this.numberOfResultsInput()}
-          {this.previewCheckbox()}
-        </div>
+
+        <table style={{width: '100%'}}><tbody>
+        <tr>
+          <td>{this.pagination()}</td>
+          <td>
+            <div>
+              {this.numberOfResultsInput()}
+              {this.previewCheckbox()}
+            </div>
+          </td>
+        </tr>
+        </tbody></table>
       </div>
     );
   }

--- a/app/assets/javascripts/components/ElementsTableEntries.js
+++ b/app/assets/javascripts/components/ElementsTableEntries.js
@@ -35,7 +35,7 @@ export default class ElementsTableEntries extends Component {
 
   showDetails(element) {
     const uiState = UIStore.getState();
-    Aviator.navigate(`/collection/${uiState.currentCollectionId}/${element.type}/${element.id}`);
+    Aviator.navigate(`/collection/${uiState.currentCollection.id}/${element.type}/${element.id}`);
   }
 
   dragHandle(element) {

--- a/app/assets/javascripts/components/ElementsTableSampleEntries.js
+++ b/app/assets/javascripts/components/ElementsTableSampleEntries.js
@@ -162,8 +162,8 @@ export default class ElementsTableSampleEntries extends Component {
   }
 
   showDetails(element) {
-    const {currentCollectionId} = UIStore.getState()
-    Aviator.navigate(`/collection/${currentCollectionId}/${element.type}/${element.id}`);
+    const {currentCollection} = UIStore.getState()
+    Aviator.navigate(`/collection/${currentCollection.id}/${element.type}/${element.id}`);
   }
 
   topSecretIcon(element) {

--- a/app/assets/javascripts/components/LiteraturesForm.js
+++ b/app/assets/javascripts/components/LiteraturesForm.js
@@ -37,7 +37,7 @@ export default class LiteraturesForm extends Component {
       type="text"
       onChange={event => this.handleInputChange('title', event)}
       placeholder={'Title...'}
-      value={this.state.literature.title}
+      value={this.state.literature.title || ''}
     />
   }
 
@@ -46,7 +46,7 @@ export default class LiteraturesForm extends Component {
       type="text"
       onChange={event => this.handleInputChange('url', event)}
       placeholder={'URL...'}
-      value={this.state.literature.url}
+      value={this.state.literature.url || ''}
     />
   }
 

--- a/app/assets/javascripts/components/MaterialCalculations.js
+++ b/app/assets/javascripts/components/MaterialCalculations.js
@@ -34,7 +34,7 @@ export default class MaterialCalculations extends Component {
         <td style={inputsStyle}>
           <NumeralInputWithUnitsCompo
             key={material.id}
-            value={material.amount_ml}
+            value={material.amount_ml || ''}
             unit='l'
             metricPrefix='milli'
             metricPrefixes = {['milli','none','micro']}

--- a/app/assets/javascripts/components/NumeralInput.js
+++ b/app/assets/javascripts/components/NumeralInput.js
@@ -67,7 +67,7 @@ export default class NumeralInput extends Component {
       <FormGroup>
         <ControlLabel>{label}</ControlLabel>
         <InputGroup>
-          <FormControl type='text'  value={numeralValue} bsSize={bsSize}
+          <FormControl type='text'  value={numeralValue || ''} bsSize={bsSize}
             bsStyle={bsStyle}
             disabled={disabled}
             onChange={ event => this._handleInputValueChange(event)}/>

--- a/app/assets/javascripts/components/NumeralInputWithUnitsCompo.js
+++ b/app/assets/javascripts/components/NumeralInputWithUnitsCompo.js
@@ -111,7 +111,7 @@ export default class NumeralInputWithUnitsCompo extends Component {
           <InputGroup>
             <FormControl type='text'
               disabled={disabled} bsSize={bsSize} bsStyle={bsStyle}
-              value={val()}
+              value={val() || ''}
               onChange={(event) => this._handleInputValueChange(event)}
               onFocus={(event) => this._handleInputValueFocus(event)}
               onBlur={(event)=>this._handleInputValueBlur(event)}
@@ -126,7 +126,7 @@ export default class NumeralInputWithUnitsCompo extends Component {
           {labelWrap}
           <FormControl type='text'
             disabled={disabled} bsSize={bsSize} bsStyle={bsStyle}
-            value={val()}
+            value={val() || ''}
             onChange={(event) => this._handleInputValueChange(event)}
             onFocus={(event) => this._handleInputValueFocus(event)}
             onBlur={(event)=>this._handleInputValueBlur(event)}

--- a/app/assets/javascripts/components/PolymerSection.js
+++ b/app/assets/javascripts/components/PolymerSection.js
@@ -112,7 +112,7 @@ export default class PolymerSection extends React.Component {
       <FormGroup>
         <ControlLabel>Formula</ControlLabel>
         <FormControl type="text"
-          value={residue.custom_info.formula}
+          value={residue.custom_info.formula || ''}
           name="formula"
           key={'polymer_formula_input' + sample.id.toString()}
           onChange={(e) => this.handleCustomInfoChanged(e, residue, sample)}
@@ -233,7 +233,7 @@ export default class PolymerSection extends React.Component {
       <FormGroup>
         <ControlLabel>Cross-linkage</ControlLabel>
         <FormControl type="text"
-          value={residue.custom_info.cross_linkage}
+          value={residue.custom_info.cross_linkage || ''}
           name="cross_linkage"
           key={'cross_linkage' + sample.id.toString()}
           onChange={(e) => this.handleCustomInfoChanged(e, residue, sample)}

--- a/app/assets/javascripts/components/ReactionDetails.js
+++ b/app/assets/javascripts/components/ReactionDetails.js
@@ -52,7 +52,7 @@ export default class ReactionDetails extends Component {
     let uiState = UIStore.getState();
     UIActions.deselectAllElements();
     ElementActions.deselectCurrentReaction();
-    Aviator.navigate(`/collection/${uiState.currentCollectionId}`);
+    Aviator.navigate(`/collection/${uiState.currentCollection.id}`);
   }
 
   updateReactionSvg() {

--- a/app/assets/javascripts/components/ReactionDetailsMainProperties.js
+++ b/app/assets/javascripts/components/ReactionDetailsMainProperties.js
@@ -13,7 +13,7 @@ const ReactionDetailsMainProperties = ({reaction, onInputChange}) => {
               <ControlLabel>Name</ControlLabel>
               <FormControl
                 type="text"
-                value={reaction.name}
+                value={reaction.name || ''}
                 placeholder="Name..."
                 disabled={reaction.isMethodDisabled('name')}
                 onChange={event => onInputChange('name', event)}/>
@@ -25,7 +25,7 @@ const ReactionDetailsMainProperties = ({reaction, onInputChange}) => {
               name='solvent'
               multi={false}
               options={solventOptions}
-              value={reaction.solvent}
+              value={reaction.solvent || ''}
               disabled={reaction.isMethodDisabled('solvent')}
               onChange={event => {
                 const wrappedEvent = {target: {value: event}};
@@ -38,7 +38,7 @@ const ReactionDetailsMainProperties = ({reaction, onInputChange}) => {
               <ControlLabel>Temperature</ControlLabel>
               <FormControl
                 type="text"
-                value={reaction.temperature}
+                value={reaction.temperature || ''}
                 disabled={reaction.isMethodDisabled('temperature')}
                 placeholder="Temperature..."
                 onChange={event => onInputChange('temperature', event)}/>
@@ -51,7 +51,7 @@ const ReactionDetailsMainProperties = ({reaction, onInputChange}) => {
               <ControlLabel>Description</ControlLabel>
               <FormControl
                 componentClass="textarea"
-                value={reaction.description}
+                value={reaction.description || ''}
                 disabled={reaction.isMethodDisabled('description')}
                 placeholder="Description..."
                 onChange={event => onInputChange('description', event)}/>

--- a/app/assets/javascripts/components/ReactionDetailsProperties.js
+++ b/app/assets/javascripts/components/ReactionDetailsProperties.js
@@ -66,7 +66,7 @@ export default class ReactionDetailsProperties extends Component {
                 <InputGroup>
                   <FormControl
                     type="text"
-                    value={reaction.timestamp_start}
+                    value={reaction.timestamp_start || ''}
                     disabled={reaction.isMethodDisabled('timestamp_start')}
                     placeholder="Start..."
                     onChange={event => this.props.onInputChange('timestampStart', event)}/>
@@ -84,7 +84,7 @@ export default class ReactionDetailsProperties extends Component {
                 <InputGroup>
                   <FormControl
                     type="text"
-                    value={reaction.timestamp_stop}
+                    value={reaction.timestamp_stop || ''}
                     disabled={reaction.isMethodDisabled('timestamp_stop')}
                     placeholder="Stop..."
                     onChange={event => this.props.onInputChange('timestampStop', event)}/>
@@ -103,7 +103,7 @@ export default class ReactionDetailsProperties extends Component {
                 <ControlLabel>Observation</ControlLabel>
                 <FormControl
                   componentClass="textarea"
-                  value={reaction.observation}
+                  value={reaction.observation || ''}
                   disabled={reaction.isMethodDisabled('observation')}
                   placeholder="Observation..."
                   onChange={event => this.props.onInputChange('observation', event)}/>
@@ -145,7 +145,7 @@ export default class ReactionDetailsProperties extends Component {
                 <ControlLabel>Solvents (parts)</ControlLabel>
                 <FormControl
                   type="text"
-                  value={reaction.tlc_solvents}
+                  value={reaction.tlc_solvents || ''}
                   disabled={reaction.isMethodDisabled('tlc_solvents')}
                   placeholder="Solvents as parts..."
                   onChange={event => this.props.onInputChange('tlc_solvents', event)}/>
@@ -156,7 +156,7 @@ export default class ReactionDetailsProperties extends Component {
                 <ControlLabel>Rf-Value</ControlLabel>
                 <FormControl
                   type="text"
-                  value={reaction.rf_value}
+                  value={reaction.rf_value || ''}
                   disabled={reaction.isMethodDisabled('rf_value')}
                   placeholder="Rf-Value..."
                   onChange={event => this.props.onInputChange('rfValue', event)}/>
@@ -169,7 +169,7 @@ export default class ReactionDetailsProperties extends Component {
                 <ControlLabel>TLC-Description</ControlLabel>
                 <FormControl
                   componentClass="textarea"
-                  value={reaction.tlc_description}
+                  value={reaction.tlc_description || ''}
                   disabled={reaction.isMethodDisabled('tlc_description')}
                   placeholder="TLC-Description..."
                   onChange={event => this.props.onInputChange('tlcDescription', event)}/>

--- a/app/assets/javascripts/components/SampleDetails.js
+++ b/app/assets/javascripts/components/SampleDetails.js
@@ -161,7 +161,7 @@ export default class SampleDetails extends React.Component {
       ElementActions.deselectCurrentElement();
 
       let uiState = UIStore.getState();
-      Aviator.navigate(`/collection/${uiState.currentCollectionId}`);
+      Aviator.navigate(`/collection/${uiState.currentCollection.id}`);
     }
   }
 
@@ -235,7 +235,7 @@ export default class SampleDetails extends React.Component {
           <InputGroup.Addon>InChI</InputGroup.Addon>
           <FormControl type="text"
              key={sample.id}
-             defaultValue={sample.molecule_inchistring}
+             defaultValue={sample.molecule_inchistring || ''}
              disabled
              readOnly
           />
@@ -264,7 +264,7 @@ export default class SampleDetails extends React.Component {
         <InputGroup>
           <InputGroup.Addon>Canonical Smiles</InputGroup.Addon>
           <FormControl type="text"
-             defaultValue={sample.molecule_cano_smiles}
+             defaultValue={sample.molecule_cano_smiles || ''}
              disabled
              readOnly
           />

--- a/app/assets/javascripts/components/SampleForm.js
+++ b/app/assets/javascripts/components/SampleForm.js
@@ -92,7 +92,7 @@ export default class SampleForm extends React.Component {
         <ControlLabel>Molecule</ControlLabel>
         <InputGroup>
           <FormControl type="text" ref="moleculeInput"
-            value={sample.molecule && (sample.molecule.iupac_name || sample.molecule.sum_formular)}
+            value={sample.molecule && (sample.molecule.iupac_name || sample.molecule.sum_formular || '')}
             disabled={sample.isMethodDisabled('molecule_iupac_name')}
             readOnly={sample.isMethodDisabled('molecule_iupac_name')}
             onChange={(e) => this.handleFieldChanged(sample, 'molecule_iupac_name', e.target.value)}
@@ -218,7 +218,7 @@ export default class SampleForm extends React.Component {
         <ControlLabel>Description</ControlLabel>
         <FormControl type="textarea"  ref="descriptionInput"
              placeholder={sample.description}
-             value={sample.description}
+             value={sample.description || ''}
              onChange={(e) => this.handleFieldChanged(sample, 'description', e.target.value)}
              rows={2}
              disabled={sample.isMethodDisabled('description')}

--- a/app/assets/javascripts/components/ScreenDetails.js
+++ b/app/assets/javascripts/components/ScreenDetails.js
@@ -109,7 +109,7 @@ export default class ScreenDetails extends Component {
                       <ControlLabel>Name</ControlLabel>
                       <FormControl
                         type="text"
-                        value={name}
+                        value={name || ''}
                         onChange={event => this.handleInputChange('name', event)}
                         disabled={screen.isMethodDisabled('name')}
                       />
@@ -120,7 +120,7 @@ export default class ScreenDetails extends Component {
                       <ControlLabel>Collaborator</ControlLabel>
                       <FormControl
                         type="text"
-                        value={collaborator}
+                        value={collaborator || ''}
                         onChange={event => this.handleInputChange('collaborator', event)}
                         disabled={screen.isMethodDisabled('collaborator')}
                       />
@@ -133,7 +133,7 @@ export default class ScreenDetails extends Component {
                       <ControlLabel>Requirements</ControlLabel>
                       <FormControl
                         type="text"
-                        value={requirements}
+                        value={requirements || ''}
                         onChange={event => this.handleInputChange('requirements', event)}
                         disabled={screen.isMethodDisabled('requirements')}
                       />
@@ -144,7 +144,7 @@ export default class ScreenDetails extends Component {
                       <ControlLabel>Conditions</ControlLabel>
                       <FormControl
                         type="text"
-                        value={conditions}
+                        value={conditions || ''}
                         onChange={event => this.handleInputChange('conditions', event)}
                         disabled={screen.isMethodDisabled('conditions')}
                       />
@@ -157,7 +157,7 @@ export default class ScreenDetails extends Component {
                       <ControlLabel>Result</ControlLabel>
                       <FormControl
                         type="text"
-                        value={result}
+                        value={result || ''}
                         onChange={event => this.handleInputChange('result', event)}
                         disabled={screen.isMethodDisabled('result')}
                       />
@@ -170,7 +170,7 @@ export default class ScreenDetails extends Component {
                       <ControlLabel>Description</ControlLabel>
                       <FormControl
                         type="textarea"
-                        value={description}
+                        value={description || ''}
                         onChange={event => this.handleInputChange('description', event)}
                         disabled={screen.isMethodDisabled('description')}
                       />

--- a/app/assets/javascripts/components/ScreenWellplates.js
+++ b/app/assets/javascripts/components/ScreenWellplates.js
@@ -33,7 +33,7 @@ const collect = (connect, monitor) => ({
 class ScreenWellplates extends Component {
   handleWellplateClick(wellplate) {
     const uiState = UiStore.getState();
-    Aviator.navigate(`/collection/${uiState.currentCollectionId}/wellplate/${wellplate.id}`);
+    Aviator.navigate(`/collection/${uiState.currentCollection.id}/wellplate/${wellplate.id}`);
   }
 
   render() {

--- a/app/assets/javascripts/components/WellOverlay.js
+++ b/app/assets/javascripts/components/WellOverlay.js
@@ -6,7 +6,7 @@ import UiStore from './stores/UIStore';
 export default class WellOverlay extends Component {
   handleSampleClick(sample) {
     const uiState = UiStore.getState();
-    Aviator.navigate(`/collection/${uiState.currentCollectionId}/sample/${sample.id}`);
+    Aviator.navigate(`/collection/${uiState.currentCollection.id}/sample/${sample.id}`);
   }
 
   sampleName() {
@@ -106,7 +106,7 @@ export default class WellOverlay extends Component {
                   <ControlLabel>Readout</ControlLabel>
                   <FormControl type="textarea"
                     disabled={true}
-                    value={well.readout}
+                    value={well.readout || ''}
                     style={{height: 100}}
                   />
                 </FormGroup>
@@ -114,7 +114,7 @@ export default class WellOverlay extends Component {
                   <ControlLabel>Imported Readout</ControlLabel>
                   <FormControl type="textarea"
                     disabled={true}
-                    value={this.sampleImportedReadout()}
+                    value={this.sampleImportedReadout() || ''}
                     style={{height: 100}}
                   />
                 </FormGroup>

--- a/app/assets/javascripts/components/WellplateDetails.js
+++ b/app/assets/javascripts/components/WellplateDetails.js
@@ -39,7 +39,7 @@ export default class WellplateDetails extends Component {
   closeDetails() {
     let uiState = UIStore.getState();
     UIActions.deselectAllElements();
-    Aviator.navigate(`/collection/${uiState.currentCollectionId}`);
+    Aviator.navigate(`/collection/${uiState.currentCollection.id}`);
   }
 
   handleSubmit() {
@@ -107,7 +107,8 @@ export default class WellplateDetails extends Component {
             <ElementCollectionLabels element={wellplate}/>
             <ListGroup fill>
               <ListGroupItem>
-                <Tabs activeKey={activeTab} onSelect={event => this.handleTabChange(event)}>
+                <Tabs activeKey={activeTab} onSelect={event => this.handleTabChange(event)}
+                      id="wellplateDetailsTab">
                   <Tab eventKey={0} title={'Designer'}>
                     <Well>
                       <Wellplate

--- a/app/assets/javascripts/components/WellplateList.js
+++ b/app/assets/javascripts/components/WellplateList.js
@@ -66,7 +66,7 @@ export default class WellplateList extends Component {
                 <FormControl
                   type="textarea"
                   style={style}
-                  value={readout}
+                  value={readout || ''}
                   onChange={event => this.handleReadoutOfWellChange(event, well)}
                   groupClassName="no-margin"
                 />
@@ -75,7 +75,7 @@ export default class WellplateList extends Component {
                 <FormControl
                   type="textarea"
                   style={style}
-                  value={importedReadout}
+                  value={importedReadout || ''}
                   disabled
                   groupClassName="no-margin"
                 />

--- a/app/assets/javascripts/components/WellplateProperties.js
+++ b/app/assets/javascripts/components/WellplateProperties.js
@@ -18,7 +18,7 @@ export default class WellplateProperties extends Component {
             <FormGroup>
               <ControlLabel>Name</ControlLabel>
               <FormControl type="text"
-                value={name}
+                value={name || ''}
                 onChange={event => this.handleInputChange('name', event)}
                 disabled={name == '***'}
               />
@@ -28,7 +28,7 @@ export default class WellplateProperties extends Component {
             <FormGroup>
               <ControlLabel>Size</ControlLabel>
               <FormControl type="text"
-                value={size}
+                value={size || ''}
                 onChange={event => this.handleInputChange('size', event)}
                 disabled
               />
@@ -40,7 +40,7 @@ export default class WellplateProperties extends Component {
             <FormGroup>
               <ControlLabel>Description</ControlLabel>
               <FormControl type="textarea"
-                value={description}
+                value={description || ''}
                 onChange={event => this.handleInputChange('description', event)}
                 disabled={description == '***'}
               />

--- a/app/assets/javascripts/components/actions/CollectionActions.js
+++ b/app/assets/javascripts/components/actions/CollectionActions.js
@@ -87,24 +87,24 @@ class CollectionActions {
   }
 
   downloadReportCollectionSamples(){
-    const {currentCollectionId} = UIStore.getState();
-    Utils.downloadFile({contents: "api/v1/reports/export_samples_from_collection_samples?id=" + currentCollectionId});
+    const {currentCollection} = UIStore.getState();
+    Utils.downloadFile({contents: "api/v1/reports/export_samples_from_collection_samples?id=" + currentCollection.id});
   }
 
   downloadReportCollectionReactions(){
-    const {currentCollectionId} = UIStore.getState();
-    Utils.downloadFile({contents: "api/v1/reports/export_samples_from_collection_reactions?id=" + currentCollectionId});
+    const {currentCollection} = UIStore.getState();
+    Utils.downloadFile({contents: "api/v1/reports/export_samples_from_collection_reactions?id=" + currentCollection.id});
   }
 
   downloadReportCollectionWellplates(){
-    const {currentCollectionId} = UIStore.getState();
-    Utils.downloadFile({contents: "api/v1/reports/export_samples_from_collection_wellplates?id=" + currentCollectionId});
+    const {currentCollection} = UIStore.getState();
+    Utils.downloadFile({contents: "api/v1/reports/export_samples_from_collection_wellplates?id=" + currentCollection.id});
   }
 
   downloadReport(tab){
-    const {currentCollectionId} = UIStore.getState();
+    const {currentCollection} = UIStore.getState();
 
-    Utils.downloadFile({contents: "api/v1/reports/excel?id=" + currentCollectionId +"&tab="+tab});
+    Utils.downloadFile({contents: "api/v1/reports/excel?id=" + currentCollection.id +"&tab="+tab});
   }
 
   downloadReportWellplate(wellplateId){

--- a/app/assets/javascripts/components/collection_management/MyCollections.js
+++ b/app/assets/javascripts/components/collection_management/MyCollections.js
@@ -70,7 +70,7 @@ export default class MyCollections extends React.Component {
       return (
         <FormControl className="collection-label" type="text"
           id={'i_' + node.id}
-          value={node.label}
+          value={node.label || ''}
           onChange={this.handleLabelChange.bind(this, node)}
         />
       )

--- a/app/assets/javascripts/components/collection_management/MySharedCollections.js
+++ b/app/assets/javascripts/components/collection_management/MySharedCollections.js
@@ -85,13 +85,13 @@ export default class MySharedCollections extends React.Component {
     } else if (node.is_locked) {
       return (
          <FormControl className="collection-label" type="text" id={node.id} disabled
-        value={node.label}/>
+        value={node.label || ''}/>
       )
 
     } else {
       return (
         <FormControl className="collection-label" type="text" id={node.id}
-        value={node.label} onChange={this.handleLabelChange.bind(this, node)}/>
+        value={node.label || ''} onChange={this.handleLabelChange.bind(this, node)}/>
       )
     }
   }

--- a/app/assets/javascripts/components/contextActions/CreateButton.js
+++ b/app/assets/javascripts/components/contextActions/CreateButton.js
@@ -125,7 +125,7 @@ export default class CreateButton extends React.Component {
             <ControlLabel>Number of wellplates</ControlLabel>
             <FormControl type="text"
               ref="wellplateInput"
-              defaultValue={modalProps.wellplateCount}/>
+              defaultValue={modalProps.wellplateCount || ''}/>
           </FormGroup>
 
           <ButtonToolbar>

--- a/app/assets/javascripts/components/fetchers/SamplesFetcher.js
+++ b/app/assets/javascripts/components/fetchers/SamplesFetcher.js
@@ -181,7 +181,7 @@ export default class SamplesFetcher {
             included_ids: params.sample.checkedIds,
             excluded_ids: params.sample.uncheckedIds
           },
-          currentCollectionId: params.currentCollectionId
+          currentCollectionId: params.currentCollection.id
         }
       })
     }).then((response) => {
@@ -199,7 +199,7 @@ export default class SamplesFetcher {
 
     var data = new FormData();
     data.append("file", params.file);
-    data.append("currentCollectionId", params.currentCollectionId);
+    data.append("currentCollectionId", params.currentCollection.Id);
 
     let promise = fetch('/api/v1/samples/import/', {
       credentials: 'same-origin',

--- a/app/assets/javascripts/components/managing_actions/ManagingModalImport.js
+++ b/app/assets/javascripts/components/managing_actions/ManagingModalImport.js
@@ -19,7 +19,7 @@ export default class ManagingModalImport extends React.Component {
     let ui_state = UIStore.getState();
     let params = {
       file: file,
-      currentCollectionId: ui_state.currentCollectionId
+      currentCollectionId: ui_state.currentCollection.id
     }
     action(params);
     onHide();

--- a/app/assets/javascripts/components/managing_actions/ManagingModalSharing.js
+++ b/app/assets/javascripts/components/managing_actions/ManagingModalSharing.js
@@ -140,7 +140,7 @@ export default class ManagingModalSharing extends React.Component {
     if (this.props.collAction == "Create") {
       let userIds = this.refs.userSelect.state.values.map(o => o.value);
       let uiState = UIStore.getState();
-      let currentCollectionId = uiState.currentCollectionId;
+      let currentCollectionId = uiState.currentCollection.Id;
       let filterParams =
         this.isSelectionEmpty(uiState) ?
           this.filterParamsWholeCollection(uiState) :
@@ -219,7 +219,7 @@ export default class ManagingModalSharing extends React.Component {
           <ControlLabel>Role</ControlLabel>
           <FormControl componentClass="select"
             placeholder="Pick a sharing role (optional)"
-            value={this.state.role}
+            value={this.state.role || ''}
             onChange={(e) => this.handleShortcutChange(e)}>
             <option value='Pick a sharing role'>Pick a sharing role (optional)</option>
             <option value='user'>User</option>
@@ -233,7 +233,7 @@ export default class ManagingModalSharing extends React.Component {
           <ControlLabel>Permission level</ControlLabel>
           <FormControl componentClass="select"
             onChange={(e) => this.handlePLChange(e)}
-            value={this.state.permissionLevel}>
+            value={this.state.permissionLevel || ''}>
             <option value='0'>Read</option>
             <option value='1'>Write</option>
             <option value='2'>Share</option>
@@ -246,7 +246,7 @@ export default class ManagingModalSharing extends React.Component {
           <ControlLabel>Sample detail level</ControlLabel>
           <FormControl componentClass="select"
             onChange={(e) => this.handleDLChange(e,'sample')}
-            value={this.state.sampleDetailLevel}>
+            value={this.state.sampleDetailLevel || ''}>
             <option value='0'>Molecular mass of the compound, external label</option>
             <option value='1'>Molecule, structure</option>
             <option value='2'>Analysis Result + Description</option>
@@ -258,7 +258,7 @@ export default class ManagingModalSharing extends React.Component {
           <ControlLabel>Reaction detail level</ControlLabel>
           <FormControl componentClass="select"
             onChange={(e) => this.handleDLChange(e,'reaction')}
-            value={this.state.reactionDetailLevel}>
+            value={this.state.reactionDetailLevel || ''}>
             <option value='0'>Observation, description, calculation</option>
             <option value='10'>Everything</option>
           </FormControl>
@@ -267,7 +267,7 @@ export default class ManagingModalSharing extends React.Component {
           <ControlLabel>Wellplate detail level</ControlLabel>
           <FormControl componentClass="select"
             onChange={(e) => this.handleDLChange(e,'wellplate')}
-            value={this.state.wellplateDetailLevel}>
+            value={this.state.wellplateDetailLevel || ''}>
             <option value='0'>Wells (Positions)</option>
             <option value='1'>Readout</option>
             <option value='10'>Everything</option>
@@ -277,7 +277,7 @@ export default class ManagingModalSharing extends React.Component {
           <ControlLabel>Screen detail level</ControlLabel>
           <FormControl componentClass="select"
             onChange={(e) => this.handleDLChange(e,'screen')}
-            value={this.state.screenDetailLevel}>
+            value={this.state.screenDetailLevel || ''}>
             <option value='0'>Name, description, condition, requirements</option>
             <option value='10'>Everything</option>
           </FormControl>

--- a/app/assets/javascripts/components/search/Search.js
+++ b/app/assets/javascripts/components/search/Search.js
@@ -1,7 +1,7 @@
 import alt from 'alt';
 import React from 'react';
 import AutoCompleteInput from './AutoCompleteInput';
-import {Glyphicon, ButtonGroup, Button, DropdownButton, MenuItem}
+import {Glyphicon, ButtonGroup, Button, DropdownButton, MenuItem, FormGroup, Radio}
   from 'react-bootstrap';
 import Select from 'react-select'
 
@@ -44,13 +44,14 @@ export default class Search extends React.Component {
   }
 
   structureSearch(elementType, molfile, userId, collectionId) {
+    let uiState = UIStore.getState()
     let selection = {
       elementType: elementType,
-      molfile: molfile
+      molfile: molfile,
+      page_size: uiState.number_of_results
     }
     UIActions.setSearchSelection(selection)
 
-    let uiState = UIStore.getState()
     ElementActions.fetchBasedOnSearchSelectionAndCollection(selection,
       collectionId, 1, 'structure')
   }
@@ -95,20 +96,25 @@ export default class Search extends React.Component {
     if (molfile) {
       this.setState({queryMolfile: molfile});
     }
+    // Check if blank molfile
+    let molfileLines = molfile.match(/[^\r\n]+/g);
+    // If the first character ~ num of atoms is 0, we will not search
+    if (molfileLines[1].trim()[0] != 0) {
+      let userState = UserStore.getState()
+      let uiState = UIStore.getState()
 
-    let userState = UserStore.getState()
-    let uiState = UIStore.getState()
+      this.structureSearch(this.state.elementType, molfile,
+                           userState.currentUser.id,
+                           uiState.currentCollection.id)
 
-    this.structureSearch(this.state.elementType, molfile,
-      userState.currentUser.id, uiState.currentCollection.id)
+      let autoComplete = this.refs.autoComplete
+      autoComplete.setState({
+        value : 'Structure Filter',
+        inputDisabled : true
+      })
+    }
 
     this.hideStructureEditor()
-
-    let autoComplete = this.refs.autoComplete
-    autoComplete.setState({
-      value : 'Structure Filter',
-      inputDisabled : true
-    })
   }
 
   handleStructureEditorCancel() {
@@ -140,6 +146,14 @@ export default class Search extends React.Component {
         </Button>
       </ButtonGroup>
 
+    // let rightDropDown =
+    //   <DropdownButton id="btn-search-dropdown" title="Choose"
+    //                   onSelect={this.handleSelect}>
+    //     <MenuItem eventKey="1">Similar Search</MenuItem>
+    //     <MenuItem eventKey="2">Substructure Search</MenuItem>
+    //     <MenuItem eventKey="3">Exact Search</MenuItem>
+    //   </DropdownButton>
+
     let inputAttributes = {
       placeholder: 'IUPAC, InChI, SMILES, ...',
       style: {
@@ -170,6 +184,7 @@ export default class Search extends React.Component {
             onCancel={this.handleStructureEditorCancel.bind(this)}
             molfile={this.state.queryMolfile}
             rightBtnText="Search"
+            //rightDropDown={rightDropDown}
           />
         </div>
         <div className="search-autocomplete">

--- a/app/assets/javascripts/components/stores/UIStore.js
+++ b/app/assets/javascripts/components/stores/UIStore.js
@@ -39,7 +39,6 @@ class UIStore {
       showPreviews: true,
       number_of_results: 15,
       currentCollection: null,
-      currentCollectionId: null,
       currentTab: 1,
       currentSearchSelection: null,
       showCollectionManagement: false
@@ -162,9 +161,7 @@ class UIStore {
       || (state.currentSearchSelection != null);
 
     if(hasChanged) {
-      // FIXME why both?
       this.state.currentCollection = collection;
-      this.state.currentCollectionId = collection.id;
       this.state.number_of_results = 15;
       if (!collection.noFetch){
         // FIXME state.pagination is undefined
@@ -192,9 +189,7 @@ class UIStore {
   }
 
   handleSelectCollectionWithoutUpdating(collection) {
-    // FIXME why both?
     this.state.currentCollection = collection;
-    this.state.currentCollectionId = collection.id;
   }
 
   handleClearSearchSelection() {

--- a/app/assets/javascripts/components/structure_editor/StructureEditorModal.js
+++ b/app/assets/javascripts/components/structure_editor/StructureEditorModal.js
@@ -100,6 +100,9 @@ export default class StructureEditorModal extends React.Component {
         rightBtnText = {
           this.props.rightBtnText ? this.props.rightBtnText : "Save"
         }
+        rightDropDown = {
+          this.props.rightDropDown ? this.props.rightDropDown : ""
+        }
       />
     return (
       <div>
@@ -121,7 +124,7 @@ export default class StructureEditorModal extends React.Component {
 }
 
 const StructureEditor =
-  ({handleLeftBtn, handleRightBtn, leftBtnText, rightBtnText}) => {
+  ({handleLeftBtn, handleRightBtn, leftBtnText, rightBtnText, rightDropDown}) => {
     return (
       <div>
         <div>
@@ -134,6 +137,7 @@ const StructureEditor =
           <Button bsStyle="primary" onClick={handleRightBtn}>
             {rightBtnText}
           </Button>
+          {rightDropDown}
         </ButtonToolbar>
       </div>
     )

--- a/app/assets/stylesheets/elements_table.css
+++ b/app/assets/stylesheets/elements_table.css
@@ -28,13 +28,12 @@ th.drag {
   overflow: hidden;
 }
 
-.number-shown-select {
+/*.number-shown-select {
   float: right !important;
   text-align: right;
   width: 55% !important;
+}*/
 
-}
-
-.element-svg-checkbox {
+/*.element-svg-checkbox {
   margin: 0px 0 0;
-}
+}*/

--- a/app/assets/stylesheets/structur_editor.css
+++ b/app/assets/stylesheets/structur_editor.css
@@ -1,13 +1,20 @@
-.structure-editor .modal-content {
-  width: 900px;
-}
-.structure-editor #ifKetcher {
-  width: 882px;
-  height: 580px;
+.modal-dialog {
+  position: absolute !important;
+  left: 50%;
+  top: 50%;
+  transform: translate(-90%, -60%) !important;
 }
 
-@media screen and (max-height: 768px) {
+.structure-editor .modal-content {
+  width: 1040px;
+}
+.structure-editor #ifKetcher {
+  width: 1010px;
+  height: 588px;
+}
+
+/*@media screen and (max-height: 768px) {
   .structure-editor #ifKetcher {
     height: 520px;
   }
-}
+}*/

--- a/app/models/fingerprint.rb
+++ b/app/models/fingerprint.rb
@@ -1,0 +1,130 @@
+class Fingerprint < ActiveRecord::Base
+  acts_as_paranoid
+  include Collectable
+
+  has_many :samples
+
+  NUMBER_OF_FINGERPRINT_COL = 16
+
+  def self.count_bits_set(fp_vector)
+    query_num_set_bits = 0
+
+    fp_vector.each do |fp|
+      num_bit_on = ("%064b" % fp).count("1")
+      query_num_set_bits = query_num_set_bits + num_bit_on
+    end
+
+    return query_num_set_bits
+  end
+
+  scope :by_tanimoto_coefficient, -> (fp_vector,
+                                      page,
+                                      page_size,
+                                      threshold) {
+    query = sanitize_sql_for_conditions(
+      ["id, num_set_bits,
+        fp0 & ? n0, fp1 & ? n1, fp2 & ? n2, fp3 & ? n3, fp4 & ? n4, fp5 & ? n5,
+        fp6 & ? n6, fp7 & ? n7, fp8 & ? n8, fp9 & ? n9, fp10 & ? n10,
+        fp11 & ? n11, fp12 & ? n12, fp13 & ? n13, fp14 & ? n14, fp15 & ? n15",
+        "%064b" % fp_vector[0],
+        "%064b" % fp_vector[1],
+        "%064b" % fp_vector[2],
+        "%064b" % fp_vector[3],
+        "%064b" % fp_vector[4],
+        "%064b" % fp_vector[5],
+        "%064b" % fp_vector[6],
+        "%064b" % fp_vector[7],
+        "%064b" % fp_vector[8],
+        "%064b" % fp_vector[9],
+        "%064b" % fp_vector[10],
+        "%064b" % fp_vector[11],
+        "%064b" % fp_vector[12],
+        "%064b" % fp_vector[13],
+        "%064b" % fp_vector[14],
+        "%064b" % fp_vector[15]
+      ])
+
+    new_fp = Fingerprint.unscoped.select(query)
+
+    query_num_set_bits = self.count_bits_set(fp_vector)
+
+    new_fp = new_fp.where('num_set_bits >= ?', (threshold * query_num_set_bits).floor)
+                   .where('num_set_bits <= ?', (query_num_set_bits / threshold).floor)
+
+    NUMBER_OF_FINGERPRINT_COL.times { |i|
+      new_fp = new_fp.where("fp#{i}  & ? = ?",
+                            "%064b" % fp_vector[i],
+                            "%064b" % fp_vector[i])
+    }
+
+    common_set_bits = unscoped.from("(#{new_fp.to_sql}) AS new_fp").select("*,
+        LENGTH(TRANSLATE(
+          CONCAT(new_fp.n0::text, new_fp.n1::text, new_fp.n2::text,
+                 new_fp.n3::text, new_fp.n4::text, new_fp.n5::text,
+                 new_fp.n6::text, new_fp.n7::text, new_fp.n8::text,
+                 new_fp.n9::text, new_fp.n10::text, new_fp.n11::text,
+                 new_fp.n12::text, new_fp.n13::text,
+                 new_fp.n14::text, new_fp.n15::text),
+          '0',
+          '')) as common_set_bit")
+    query = sanitize_sql_for_conditions(["id,
+      (common_set_bit::float8 / (? + num_set_bits - common_set_bit)::float8) AS tanimoto",
+      query_num_set_bits])
+    tanimoto = unscoped.from("(#{common_set_bits.to_sql}) AS common_bits ORDER BY tanimoto DESC")
+                       .select(query).page(page).per(page_size)
+
+    return tanimoto.map(&:id)
+  }
+
+  def self.find_or_create_by_molfile molfile
+    fp_vector = Chemotion::OpenBabelService.fingerprint_from_molfile molfile
+
+    old_fp = Fingerprint.where("fp0  & ? = ?", "%064b" % fp_vector[0], "%064b" % fp_vector[0])
+    (1..15).each do |i|
+      old_fp = old_fp.where("fp#{i}  & ? = ?",
+                            "%064b" % fp_vector[i],
+                            "%064b" % fp_vector[i])
+    end
+    
+    if old_fp.count == 0
+      fp = Fingerprint.create()
+
+      fp.fp0  = "%064b" % fp_vector[0]
+      fp.fp1  = "%064b" % fp_vector[1]
+      fp.fp2  = "%064b" % fp_vector[2]
+      fp.fp3  = "%064b" % fp_vector[3]
+      fp.fp4  = "%064b" % fp_vector[4]
+      fp.fp5  = "%064b" % fp_vector[5]
+      fp.fp6  = "%064b" % fp_vector[6]
+      fp.fp7  = "%064b" % fp_vector[7]
+      fp.fp8  = "%064b" % fp_vector[8]
+      fp.fp9  = "%064b" % fp_vector[9]
+      fp.fp10 = "%064b" % fp_vector[10]
+      fp.fp11 = "%064b" % fp_vector[11]
+      fp.fp12 = "%064b" % fp_vector[12]
+      fp.fp13 = "%064b" % fp_vector[13]
+      fp.fp14 = "%064b" % fp_vector[14]
+      fp.fp15 = "%064b" % fp_vector[15]
+
+      fp.num_set_bits = fp.count_bits_set(fp_vector)
+      fp.save!
+    end
+
+    return fp.id
+  end
+
+  def self.standardized_molfile molfile
+    molfile.gsub! /(> <PolymersList>[\W\w.\n]+[\d]+)/m, ''
+
+    if molfile.include? ' R# '
+      lines = molfile.split "\n"
+      lines[4..-1].each do |line|
+        break if line.match /(M.+END+)/
+        line.gsub! ' R# ', ' R1  ' # replace residues with Hydrogens
+      end
+      molfile = lines.join "\n"
+    end
+
+    return molfile
+  end
+end

--- a/app/models/molecule.rb
+++ b/app/models/molecule.rb
@@ -4,11 +4,10 @@ class Molecule < ActiveRecord::Base
 
   has_many :samples
   has_many :collections, through: :samples
+
   before_save :sanitize_molfile
 
   validates_uniqueness_of :inchikey, scope: :is_partial
-
-  NUMBER_OF_FINGERPRINT_COL = 16
 
   # scope for suggestions
   scope :by_iupac_name, -> (query) {
@@ -37,102 +36,11 @@ class Molecule < ActiveRecord::Base
     where(id: molecule_ids)
   }
 
-  def self.count_bits_set(fp_vector)
-    query_num_set_bits = 0
-
-    fp_vector.each do |fp|
-      num_bit_on = ("%064b" % fp).count("1")
-      query_num_set_bits = query_num_set_bits + num_bit_on
-    end
-
-    return query_num_set_bits
-  end
-
-  def self.selected
-    unscoped.where("deleted_at IS NOT NULL")
-  end
-
-  scope :by_tanimoto_coefficient, -> (fp_vector,
-                                      threshold = 0.5) {
-    query_num_set_bits = self.count_bits_set(fp_vector)
-
-    query = sanitize_sql_for_conditions(
-      ["id, num_set_bits,
-        fp0 & ? n0, fp1 & ? n1, fp2 & ? n2, fp3 & ? n3, fp4 & ? n4, fp5 & ? n5,
-        fp6 & ? n6, fp7 & ? n7, fp8 & ? n8, fp9 & ? n9, fp10 & ? n10,
-        fp11 & ? n11, fp12 & ? n12, fp13 & ? n13, fp14 & ? n14, fp15 & ? n15",
-        "%064b" % fp_vector[0],
-        "%064b" % fp_vector[1],
-        "%064b" % fp_vector[2],
-        "%064b" % fp_vector[3],
-        "%064b" % fp_vector[4],
-        "%064b" % fp_vector[5],
-        "%064b" % fp_vector[6],
-        "%064b" % fp_vector[7],
-        "%064b" % fp_vector[8],
-        "%064b" % fp_vector[9],
-        "%064b" % fp_vector[10],
-        "%064b" % fp_vector[11],
-        "%064b" % fp_vector[12],
-        "%064b" % fp_vector[13],
-        "%064b" % fp_vector[14],
-        "%064b" % fp_vector[15]
-      ])
-
-    new_fp = Molecule.unscoped.select(query)
-
-    NUMBER_OF_FINGERPRINT_COL.times { |i|
-      new_fp = new_fp.where("fp#{i}  & ? = ?",
-                            "%064b" % fp_vector[i],
-                            "%064b" % fp_vector[i])
-    }
-
-    common_set_bits = unscoped.from("(#{new_fp.to_sql}) AS new_fp").select("*,
-        LENGTH(TRANSLATE(
-          CONCAT(new_fp.n0::text, new_fp.n1::text, new_fp.n2::text,
-                 new_fp.n3::text, new_fp.n4::text, new_fp.n5::text,
-                 new_fp.n6::text, new_fp.n7::text, new_fp.n8::text,
-                 new_fp.n9::text, new_fp.n10::text, new_fp.n11::text,
-                 new_fp.n12::text, new_fp.n13::text,
-                 new_fp.n14::text, new_fp.n15::text),
-          '0',
-          '')) as common_set_bit")
-    query = sanitize_sql_for_conditions(["id,
-      (common_set_bit::float8 / (? + num_set_bits - common_set_bit)::float8) AS tanimoto",
-      query_num_set_bits])
-    tanimoto = unscoped.from("(#{common_set_bits.to_sql}) AS common_bits").select(query).sort_by(&:tanimoto)
-
-    molecule_ids = tanimoto.map(&:id)
-
-    where(id: molecule_ids)
-  }
-
-  # Return only molecule with Tanimoto coefficient (T) higher than threshold
-  # Default with molecule with T >= 0.6
-  scope :by_finger_print, -> (fp_vector, threshold = 0.6) {
-    query_num_bit_on = self.count_bits_set(fp_vector)
-
-    scope = where('num_set_bits >= ?', (threshold * query_num_bit_on).floor)
-            .where('num_set_bits <= ?', (query_num_bit_on / threshold).floor)
-    NUMBER_OF_FINGERPRINT_COL.times { |i|
-      scope = scope.where("fp#{i}  & ? = ?",
-                          "%064b" % fp_vector[i],
-                          "%064b" % fp_vector[i])
-    }
-
-    return scope
-  }
-
   def self.find_or_create_by_molfile molfile, is_partial = false
 
-    new_molfile = if is_partial
-                    self.skip_residues(molfile)
-                  else
-                    molfile
-                  end
+    molfile = self.skip_residues(molfile)
 
-    babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(new_molfile, is_partial)
-    babel_info[:fp] = Chemotion::OpenBabelService.fingerprint_from_molfile(molfile, is_partial)
+    babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile)
 
     inchikey = babel_info[:inchikey]
     unless inchikey.blank?
@@ -144,7 +52,7 @@ class Molecule < ActiveRecord::Base
         pubchem_info =
           Chemotion::PubchemService.molecule_info_from_inchikey(inchikey)
 
-        molecule.molfile = new_molfile
+        molecule.molfile = molfile
         molecule.assign_molecule_data babel_info, pubchem_info
 
       end
@@ -179,26 +87,6 @@ class Molecule < ActiveRecord::Base
 
     self.cano_smiles = babel_info[:cano_smiles]
 
-    fp_vector = babel_info[:fp]
-
-    self.fp0  = "%064b" % fp_vector[0]
-    self.fp1  = "%064b" % fp_vector[1]
-    self.fp2  = "%064b" % fp_vector[2]
-    self.fp3  = "%064b" % fp_vector[3]
-    self.fp4  = "%064b" % fp_vector[4]
-    self.fp5  = "%064b" % fp_vector[5]
-    self.fp6  = "%064b" % fp_vector[6]
-    self.fp7  = "%064b" % fp_vector[7]
-    self.fp8  = "%064b" % fp_vector[8]
-    self.fp9  = "%064b" % fp_vector[9]
-    self.fp10 = "%064b" % fp_vector[10]
-    self.fp11 = "%064b" % fp_vector[11]
-    self.fp12 = "%064b" % fp_vector[12]
-    self.fp13 = "%064b" % fp_vector[13]
-    self.fp14 = "%064b" % fp_vector[14]
-    self.fp15 = "%064b" % fp_vector[15]
-
-    self.num_set_bits = self.class.count_bits_set(fp_vector)
   end
 
   def attach_svg svg_data

--- a/db/migrate/20160725120549_create_fingerprints.rb
+++ b/db/migrate/20160725120549_create_fingerprints.rb
@@ -1,0 +1,30 @@
+class CreateFingerprints < ActiveRecord::Migration
+  def change
+    create_table :fingerprints do |t|
+      t.bit      :fp0,           limit: 64
+      t.bit      :fp1,           limit: 64
+      t.bit      :fp2,           limit: 64
+      t.bit      :fp3,           limit: 64
+      t.bit      :fp4,           limit: 64
+      t.bit      :fp5,           limit: 64
+      t.bit      :fp6,           limit: 64
+      t.bit      :fp7,           limit: 64
+      t.bit      :fp8,           limit: 64
+      t.bit      :fp9,           limit: 64
+      t.bit      :fp10,          limit: 64
+      t.bit      :fp11,          limit: 64
+      t.bit      :fp12,          limit: 64
+      t.bit      :fp13,          limit: 64
+      t.bit      :fp14,          limit: 64
+      t.bit      :fp15,          limit: 64
+      t.integer  :num_set_bits,  limit: 1
+
+      t.timestamps null: false
+      t.time :deleted_at
+    end
+
+    Sample.reset_column_information
+    add_column :samples, :fingerprint_id, :integer
+
+  end
+end

--- a/db/migrate/20160725135743_update_fingerprint.rb
+++ b/db/migrate/20160725135743_update_fingerprint.rb
@@ -1,0 +1,51 @@
+class UpdateFingerprint < ActiveRecord::Migration
+  def change
+    Sample.reset_column_information
+    # Extract all molecule
+    Sample.all.each do |sample|
+      molfile = Fingerprint.standardized_molfile sample.molfile
+      fp_vector = Chemotion::OpenBabelService.fingerprint_from_molfile(molfile)
+
+      old_fp = Fingerprint.where("fp0 = ?", "%064b" % fp_vector[0])
+      (1..15).each do |i|
+        old_fp = old_fp.where("fp#{i} = ?", "%064b" % fp_vector[i])
+      end
+
+      if old_fp.count == 0
+        fp = Fingerprint.create()
+      else
+        fp = old_fp.first
+      end
+
+      fp.fp0  = "%064b" % fp_vector[0]
+      fp.fp1  = "%064b" % fp_vector[1]
+      fp.fp2  = "%064b" % fp_vector[2]
+      fp.fp3  = "%064b" % fp_vector[3]
+      fp.fp4  = "%064b" % fp_vector[4]
+      fp.fp5  = "%064b" % fp_vector[5]
+      fp.fp6  = "%064b" % fp_vector[6]
+      fp.fp7  = "%064b" % fp_vector[7]
+      fp.fp8  = "%064b" % fp_vector[8]
+      fp.fp9  = "%064b" % fp_vector[9]
+      fp.fp10 = "%064b" % fp_vector[10]
+      fp.fp11 = "%064b" % fp_vector[11]
+      fp.fp12 = "%064b" % fp_vector[12]
+      fp.fp13 = "%064b" % fp_vector[13]
+      fp.fp14 = "%064b" % fp_vector[14]
+      fp.fp15 = "%064b" % fp_vector[15]
+
+      query_num_set_bits = 0
+
+      fp_vector.each do |fp|
+        num_bit_on = ("%064b" % fp).count("1")
+        query_num_set_bits = query_num_set_bits + num_bit_on
+      end
+
+      fp.num_set_bits = query_num_set_bits
+      fp.save!
+
+      sample.fingerprint_id = fp.id
+      sample.save!
+    end
+  end
+end

--- a/db/migrate/20160725142712_remove_fingerprint_from_molecule.rb
+++ b/db/migrate/20160725142712_remove_fingerprint_from_molecule.rb
@@ -1,0 +1,22 @@
+class RemoveFingerprintFromMolecule < ActiveRecord::Migration
+  def change
+    Molecule.reset_column_information
+    remove_column :molecules, :fp0, "bit(64)"
+    remove_column :molecules, :fp1, "bit(64)"
+    remove_column :molecules, :fp2, "bit(64)"
+    remove_column :molecules, :fp3, "bit(64)"
+    remove_column :molecules, :fp4, "bit(64)"
+    remove_column :molecules, :fp5, "bit(64)"
+    remove_column :molecules, :fp6, "bit(64)"
+    remove_column :molecules, :fp7, "bit(64)"
+    remove_column :molecules, :fp8, "bit(64)"
+    remove_column :molecules, :fp9, "bit(64)"
+    remove_column :molecules, :fp10, "bit(64)"
+    remove_column :molecules, :fp11, "bit(64)"
+    remove_column :molecules, :fp12, "bit(64)"
+    remove_column :molecules, :fp13, "bit(64)"
+    remove_column :molecules, :fp14, "bit(64)"
+    remove_column :molecules, :fp15, "bit(64)"
+    remove_column :molecules, :num_set_bits, :integer
+  end
+end

--- a/lib/chemotion/open_babel_service.rb
+++ b/lib/chemotion/open_babel_service.rb
@@ -33,7 +33,7 @@ M  END
 
   end
 
-  def self.molecule_info_from_molfile molfile, is_partial = false
+  def self.molecule_info_from_molfile molfile
     c = OpenBabel::OBConversion.new
     c.set_in_format 'mol'
 
@@ -64,7 +64,7 @@ M  END
       formula: m.get_formula,
       svg: svg_from_molfile(molfile),
       cano_smiles: ca_smiles,
-      fp: fingerprint_from_molfile(molfile, is_partial)
+      fp: fingerprint_from_molfile(molfile)
     }
 
   end
@@ -100,7 +100,7 @@ M  END
   end
 
   # Return an array of 32
-  def self.fingerprint_from_molfile molfile, is_partial = false
+  def self.fingerprint_from_molfile molfile
     c = OpenBabel::OBConversion.new
     m = OpenBabel::OBMol.new
 
@@ -128,13 +128,7 @@ M  END
     fp_16[12] = fp[7]  << 32 | fp[6]
     fp_16[13] = fp[5]  << 32 | fp[4]
     fp_16[14] = fp[3]  << 32 | fp[2]
-    # Since OpenBabel does not use last 3 bits. We will use it to store Polymer
-    # If molfile contains R# (polymer) then set the last 3 bits
-    if is_partial
-      fp_16[15] = (fp[1]  << 32 | fp[0]) | 7
-    else
-      fp_16[15] = fp[1]  << 32 | fp[0]
-    end
+    fp_16[15] = fp[1]  << 32 | fp[0]
 
     return fp_16
 

--- a/spec/models/fingerprint_spec.rb
+++ b/spec/models/fingerprint_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Fingerprint, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
- Fix a bug when creating new Reaction without any Samples
- Remake PreviewCheckbox + numberOfResultsInput on the right bottom
- Remove redundant currentCollectionId from UIStore
- Suppress warning while creating new Reaction
- Suppress warning related to Tabs `id` field
- Update all FormControl component to be controlled
- Re-size Ketcher Editor
- Move Ketcher Modal to center of the screen
- Limit substring search to 7 for each category (iupac, inchi, canonical smiles, name ... )
- Fetch when user stop typing (no input after 700ms - this value can be changed)
- Move the suggestion scroll when using arrow key to navigate suggestion
- Migrate old fingerprint column to new table Fingerprint
- Associate fingerprint with Sample, since we use the original molfile