### PR TITLE
Add an icon link to reaction in Sample table

### DIFF
--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -82,7 +82,7 @@ module Chemotion
           begin
             Collection.belongs_to_or_shared_by(current_user.id,current_user.group_ids)
             .find(params[:collection_id]).samples
-            .includes(:molecule, :residues, :elemental_compositions)
+            .includes(:molecule, :residues, :elemental_compositions, :reactions_product_samples, :reactions_starting_material_samples)
           rescue ActiveRecord::RecordNotFound
             Sample.none
           end

--- a/app/assets/javascripts/components/ElementCollectionLabels.js
+++ b/app/assets/javascripts/components/ElementCollectionLabels.js
@@ -5,8 +5,22 @@ export default class ElementCollectionLabels extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      element: props.element
+      element: props.element,
+      hover: false
     }
+
+    this.toggleHover = this.toggleHover.bind(this)
+    this.handleOnClick = this.handleOnClick.bind(this)
+  }
+
+  toggleHover() {
+    this.setState({hover: !this.state.hover})
+  }
+
+  handleOnClick(label) {
+    let url = "/collection/" + label.id + "/" + this.state.element.type +
+              "/" + this.state.element.id
+    Aviator.navigate(url)    
   }
 
   render() {
@@ -21,7 +35,10 @@ export default class ElementCollectionLabels extends React.Component {
     return labels.map((label, index) => {
       return (
         <span className="collection-label" key={index}>
-          <Button bsStyle='default' bsSize='xs' onClick={()=>Aviator.navigate(`/collection/${label.id}/${this.state.element.type}/${this.state.element.id}`)} >{label.name}</Button>
+          <Button bsStyle='default' bsSize='xs'
+                  onClick={() => this.handleOnClick(label)} >
+            {label.name}
+          </Button>
           &nbsp;
         </span>
       )
@@ -30,14 +47,34 @@ export default class ElementCollectionLabels extends React.Component {
 
   labelWithPopover(title, labels) {
     let {element} = this.state;
-    let collection = <i className='fa fa-list'/> // <Glyphicon glyph= 'list'/>
-    let label_popover = <Popover title={title} id={'labelpop'+element.id}>{this.formatLabels(labels)}</Popover>
-    let shared =  title.match(/Shared/) ? <i className="fa fa-share-alt"/> : "" ;
+    let collection = <i className='fa fa-list'/>
+    let label_popover = <Popover title={title} id={'labelpop'+element.id}>
+                          {this.formatLabels(labels)}
+                        </Popover>
+    let shared =  title.match(/Shared/) ? <i className="fa fa-share-alt"/> : ""
+    let labelStyle = {
+      backgroundColor:'white',
+      color:'black',
+      border: '1px solid grey'
+    }
+
+    let {hover} = this.state
+    if (hover == true) {
+     labelStyle.backgroundColor = '#19B5FE'
+    } else {
+      labelStyle.backgroundColor = 'white'
+    }
+
     return (
       labels.length > 0 ?
-        <OverlayTrigger trigger="click" rootClose placement="left" overlay={label_popover}>
+        <OverlayTrigger trigger="click" rootClose placement="left"
+                        overlay={label_popover}>
           <span className="collection-label" key={element.id}>
-            <Label  style={{backgroundColor:'white',color:'black', border: '1px solid grey'}}>{collection} {labels.length} {shared} </Label>
+            <Label style={labelStyle}
+                   onMouseEnter={this.toggleHover}
+                   onMouseLeave={this.toggleHover}>
+              {collection} {labels.length} {shared}
+            </Label>
           </span>
         </OverlayTrigger> : undefined
     );
@@ -55,8 +92,12 @@ export default class ElementCollectionLabels extends React.Component {
         }
       });
 
-      let unsharedTitle = labels.length > 1 ? 'Collections' : 'Collection';
-      let sharedTitle = shared_labels.length > 1 ? 'Shared Collections' : 'Shared Collection';
+      let unsharedTitle = labels.length > 1
+                          ? 'Collections'
+                          : 'Collection';
+      let sharedTitle = shared_labels.length > 1
+                        ? 'Shared Collections'
+                        : 'Shared Collection';
 
       return (
         <div style={{display: 'inline-block'}}>

--- a/app/assets/javascripts/components/ElementReactionLabels.js
+++ b/app/assets/javascripts/components/ElementReactionLabels.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import {Label} from 'react-bootstrap';
+
+export default class ElementReactionLabels extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hover: false
+    }
+
+    this.toggleHover = this.toggleHover.bind(this)
+    this.handleOnClick = this.handleOnClick.bind(this)
+  }
+
+  toggleHover() {
+    this.setState({
+      hover: !this.state.hover
+    })
+  }
+
+  handleOnClick(e) {
+    let {element} = this.props
+    // console.log(element.reactions_product_samples)
+    let reaction_id = element.hasOwnProperty("reactions_product_samples")
+                      ? element.reactions_product_samples[0].reaction_id
+                      : element.reactions_starting_material_samples[0].reaction_id
+
+    let url = "/collection/" + element.collection_labels[0].id +
+               "/reaction/" + reaction_id
+    Aviator.navigate(url)
+
+    e.stopPropagation()
+  }
+
+  render() {
+    let {element} = this.props
+
+    // If the Sample has no role in any reaction. Don't display the icon
+    if (element.reactions_product_samples.length == 0 &&
+        element.reactions_starting_material_samples.length == 0)
+      return (<div></div>)
+
+    let reaction = <i className='icon-reaction'/>
+    let labelStyle = {
+      backgroundColor:'white',
+      color:'black',
+      border: '1px solid grey'
+    }
+
+    let {hover} = this.state
+    if (hover == true) {
+     labelStyle.backgroundColor = '#19B5FE'
+    } else {
+      labelStyle.backgroundColor = 'white'
+    }
+
+    return (
+      <div style={{display: 'inline-block'}} onClick={this.handleOnClick}>
+        <span className="collection-label" key={element.id}>
+        <Label style={labelStyle}
+               onMouseEnter={this.toggleHover}
+               onMouseLeave={this.toggleHover}>
+          {reaction}
+        </Label>
+        </span>
+      </div>
+    )
+  }
+}

--- a/app/assets/javascripts/components/ElementsTableSampleEntries.js
+++ b/app/assets/javascripts/components/ElementsTableSampleEntries.js
@@ -4,6 +4,7 @@ import ElementCheckbox from './ElementCheckbox'
 import SVG from 'react-inlinesvg'
 import ElementCollectionLabels from './ElementCollectionLabels'
 import ElementAnalysesLabels from './ElementAnalysesLabels'
+import ElementReactionLabels from './ElementReactionLabels'
 import ArrayUtils from './utils/ArrayUtils'
 import {Tooltip, OverlayTrigger} from 'react-bootstrap'
 import ElementContainer from './ElementContainer'
@@ -109,6 +110,7 @@ export default class ElementsTableSampleEntries extends Component {
             <td style={{cursor: 'pointer'}} onClick={() => this.showDetails(sample)}>
               {sample.title() + " "}
               <div style={{float: 'right'}}>
+                <ElementReactionLabels element={sample} key={sample.id + "_reactions"}/>
                 <ElementCollectionLabels element={sample} key={sample.id}/>
                 <ElementAnalysesLabels element={sample} key={sample.id+"_analyses"}/>
                 {this.topSecretIcon(sample)}

--- a/app/serializers/sample_serializer.rb
+++ b/app/serializers/sample_serializer.rb
@@ -4,6 +4,8 @@ class SampleSerializer < ActiveModel::Serializer
   attributes *DetailLevels::Sample.new.base_attributes
 
   has_one :molecule
+  has_one :reactions_product_samples
+  has_one :reactions_starting_material_samples
 
   has_many :residues
   has_many :elemental_compositions


### PR DESCRIPTION
+ The new icon can only be rendered in sample that participate to reaction (as product or starting material)
+ Add hover effect to the new 'link-to-reaction' icon and the collection icon
+ ReactionDetails will be open when click on this new icon