### PR TITLE
enable source-map for js

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -90,6 +90,11 @@ module Chemotion
 
     config.browserify_rails.commandline_options = "-t [ babelify --presets [ es2015 react ] --plugins [ transform-object-rest-spread ] ] "# -t aliasify "
 
+    # Environments in which to generate source maps
+    # The default is none
+    config.browserify_rails.source_map_environments << "development"
+
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
Make React debug easier.

The same error warning...
__Before__: warning at line 21179??, and code is not the same as the original code.
![sm_old_console](https://cloud.githubusercontent.com/assets/8849364/17479364/8498153e-5d72-11e6-9c4e-1dbcf42a01e5.png)
![sm_old_code](https://cloud.githubusercontent.com/assets/8849364/17479378/928b6560-5d72-11e6-83c7-6af78205e8ab.png)

__Now__: you can see the problem is at ReportContainer line 37.
![sm_new_console](https://cloud.githubusercontent.com/assets/8849364/17479387/99dc8f7e-5d72-11e6-8956-e74388869d71.png)
![sm_new_code](https://cloud.githubusercontent.com/assets/8849364/17479389/9ba4fad0-5d72-11e6-9fdb-fd96c75b5226.png)
