### PR TITLE
Moving element using keyboard

### DIFF
--- a/app/assets/javascripts/components/App.js
+++ b/app/assets/javascripts/components/App.js
@@ -17,6 +17,7 @@ import initRoutes from './routes';
 import Notifications from './Notifications';
 
 import UserActions from './actions/UserActions';
+import KeyboardActions from './actions/KeyboardActions';
 
 class App extends Component {
   constructor(props) {
@@ -25,20 +26,32 @@ class App extends Component {
       showCollectionManagement: false
     };
     this.handleUiStoreChange = this.handleUiStoreChange.bind(this)
+    this.documentKeyDown = this.documentKeyDown.bind(this)
   }
 
   componentDidMount() {
     UIStore.listen(this.handleUiStoreChange);
     UserActions.fetchProfile();
+
+    $(document).on('keydown', this.documentKeyDown);
   }
 
   componentWillUnmount() {
     UIStore.unlisten(this.handleUiStoreChange);
+
+    $(document).off('keydown', this.documentKeyDown);
   }
 
   handleUiStoreChange(state) {
     if(this.state.showCollectionManagement != state.showCollectionManagement) {
       this.setState({showCollectionManagement: state.showCollectionManagement});
+    }
+  }
+
+  documentKeyDown(event) {
+    // Only trigger arrow and Enter keys
+    if ([13, 38, 39, 40].includes(event.keyCode)) {
+      KeyboardActions.documentKeyDown(event.keyCode)
     }
   }
 

--- a/app/assets/javascripts/components/ElementsTableEntries.js
+++ b/app/assets/javascripts/components/ElementsTableEntries.js
@@ -5,14 +5,71 @@ import ElementCollectionLabels from './ElementCollectionLabels';
 import ElementAnalysesLabels from './ElementAnalysesLabels';
 import {Tooltip, OverlayTrigger} from 'react-bootstrap';
 import ArrayUtils from './utils/ArrayUtils';
+
 import UIStore from './stores/UIStore';
 import ElementStore from './stores/ElementStore';
+import KeyboardStore from './stores/KeyboardStore';
+
 import SVG from 'react-inlinesvg';
 import DragDropItemTypes from './DragDropItemTypes';
 import classnames from 'classnames';
 import XTdCont from "./extra/ElementsTableEntriesXTdCont";
 
 export default class ElementsTableEntries extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      keyboardElementIndex: null
+    }
+
+    this.entriesOnKeyDown = this.entriesOnKeyDown.bind(this)
+  }
+
+  componentDidMount() {
+    KeyboardStore.listen(this.entriesOnKeyDown)
+  }
+
+  componentWillUnmount() {
+    KeyboardStore.unlisten(this.entriesOnKeyDown)
+  }
+
+  entriesOnKeyDown(state) {
+    let context = state.context
+    const {elements} = this.props;
+
+    if (elements[0] == null || context != elements[0].type)
+      return false
+
+    let documentKeyDownCode = state.documentKeyDownCode
+    let {keyboardElementIndex} = this.state
+
+    switch(documentKeyDownCode) {
+      case 13: // Enter
+      case 39: // Right
+        if (keyboardElementIndex != null && elements[keyboardElementIndex] != null) {
+          this.showDetails(elements[keyboardElementIndex])
+        }
+        break
+
+      case 38: // Up
+        if (keyboardElementIndex > 0) {
+          keyboardElementIndex--
+        } else {
+          keyboardElementIndex = 0
+        }
+        break
+      case 40: // Down
+        if (keyboardElementIndex == null) {
+          keyboardElementIndex = 0
+        } else if (keyboardElementIndex < elements.length - 1){
+          keyboardElementIndex++
+        }
+
+        break
+    }
+    this.setState({keyboardElementIndex})
+  }
+
   isElementChecked(element) {
     let {checkedIds, uncheckedIds, checkedAll} = this.props.ui;
     return (checkedAll && ArrayUtils.isValNotInArray(uncheckedIds || [], element.id))
@@ -161,18 +218,22 @@ export default class ElementsTableEntries extends Component {
 
   render() {
     const {elements} = this.props;
+    let {keyboardElementIndex} = this.state
+
     return (
       <tbody>
       {elements.map((element, index) => {
         const sampleMoleculeName = (element.type == 'sample') ? element.molecule.iupac_name: '';
         let style = {};
-        if (this.isElementSelected(element)) {
+        if (this.isElementSelected(element) ||
+           (keyboardElementIndex != null && keyboardElementIndex == index)) {
           style = {
           color: '#000',
           background: '#ddd',
           border: '4px solid #337ab7'
           }
         }
+
         return (
           <tr key={index} style={style}>
             <td>

--- a/app/assets/javascripts/components/ElementsTableSampleEntries.js
+++ b/app/assets/javascripts/components/ElementsTableSampleEntries.js
@@ -8,8 +8,11 @@ import ElementReactionLabels from './ElementReactionLabels'
 import ArrayUtils from './utils/ArrayUtils'
 import {Tooltip, OverlayTrigger} from 'react-bootstrap'
 import ElementContainer from './ElementContainer'
+
 import UIStore from './stores/UIStore';
 import ElementStore from './stores/ElementStore';
+import KeyboardStore from './stores/KeyboardStore';
+
 import DragDropItemTypes from './DragDropItemTypes';
 import SampleName from './common/SampleName'
 import XMolHeadCont from "./extra/ElementsTableSampleEntriesXMolHeadCont";
@@ -20,8 +23,71 @@ export default class ElementsTableSampleEntries extends Component {
   constructor(props) {
     super()
     this.state = {
-      moleculeGroupsShown: []
+      moleculeGroupsShown: [],
+      keyboardIndex: null,
+      keyboardSeletectedElementId: null
     }
+
+    this.sampleOnKeyDown = this.sampleOnKeyDown.bind(this)
+  }
+
+  componentDidMount() {
+    KeyboardStore.listen(this.sampleOnKeyDown)
+  }
+
+  componentWillReceiveProps(nextProps) {
+    let flattenSamplesId = []
+    let flatIndex = 0
+    nextProps.elements.forEach(function(groupSample, index) {
+      for (let i = 0; i < groupSample.length; i++) {
+        flattenSamplesId[flatIndex + i] = groupSample[i].id
+      }
+
+      flatIndex = flatIndex + groupSample.length
+    }, [])
+    this.flattenSamplesId = flattenSamplesId
+  }
+
+  componentWillUnmount() {
+    KeyboardStore.unlisten(this.sampleOnKeyDown)
+  }
+
+  sampleOnKeyDown(state) {
+    let context = state.context
+    if (context != "sample") return false
+
+    let documentKeyDownCode = state.documentKeyDownCode
+    let {keyboardIndex, keyboardSeletectedElementId} = this.state
+
+    switch(documentKeyDownCode) {
+      case 13: // Enter
+      case 39: // Right
+        if (keyboardIndex != null && keyboardSeletectedElementId != null) {
+          this.showDetails(keyboardSeletectedElementId)
+        }
+        break
+      case 38: // Up
+        if (keyboardIndex > 0) {
+          keyboardIndex--
+        } else {
+          keyboardIndex = 0
+        }
+        break
+      case 40: // Down
+        if (keyboardIndex == null) {
+          keyboardIndex = 0
+        } else if (keyboardIndex < (this.flattenSamplesId.length - 1)){
+          keyboardIndex++
+        }
+
+        break
+    }
+
+    keyboardSeletectedElementId = this.flattenSamplesId[keyboardIndex]
+    this.setState({
+      keyboardIndex: keyboardIndex,
+      keyboardSeletectedElementId: keyboardSeletectedElementId
+    })
   }
 
   render() {
@@ -96,18 +162,23 @@ export default class ElementsTableSampleEntries extends Component {
   }
 
   renderSamples(samples, show) {
+    let {keyboardSeletectedElementId} = this.state
+
     if(show) {
       return samples.map((sample, index) => {
         let style = {}
-        if (this.isElementSelected(sample)) {
+
+        if (this.isElementSelected(sample) || keyboardSeletectedElementId == sample.id) {
           style = {color: '#fff', background: '#337ab7'}
         }
+
         return (
           <tr key={index} style={style}>
             <td width="30px">
               <ElementCheckbox element={sample} key={sample.id} checked={this.isElementChecked(sample)}/>
             </td>
-            <td style={{cursor: 'pointer'}} onClick={() => this.showDetails(sample)}>
+            <td style={{cursor: 'pointer'}}
+                onClick={() => this.showDetails(sample.id)}>
               {sample.title() + " "}
               <div style={{float: 'right'}}>
                 <ElementReactionLabels element={sample} key={sample.id + "_reactions"}/>
@@ -163,9 +234,9 @@ export default class ElementsTableSampleEntries extends Component {
     return type && currentElement && targets[type].includes(currentElement.type)
   }
 
-  showDetails(element) {
+  showDetails(id) {
     const {currentCollection} = UIStore.getState()
-    Aviator.navigate(`/collection/${currentCollection.id}/${element.type}/${element.id}`);
+    Aviator.navigate(`/collection/${currentCollection.id}/sample/${id}`);
   }
 
   topSecretIcon(element) {

--- a/app/assets/javascripts/components/List.js
+++ b/app/assets/javascripts/components/List.js
@@ -4,6 +4,7 @@ import {Tabs, Tab} from 'react-bootstrap';
 import ElementStore from './stores/ElementStore';
 import UIStore from './stores/UIStore';
 import UIActions from './actions/UIActions';
+import KeyboardActions from './actions/KeyboardActions';
 
 export default class List extends React.Component {
   constructor(props) {
@@ -85,6 +86,7 @@ export default class List extends React.Component {
     let page = uiState[type].page;
 
     UIActions.setPagination({type: type, page: page})
+    KeyboardActions.contextChange(type)
   }
 
   render() {
@@ -108,7 +110,7 @@ export default class List extends React.Component {
 
     return (
       <Tabs defaultActiveKey={this.state.currentTab} activeKey={this.state.currentTab}
-                  onSelect={(e) => this.handleTabSelect(e)} id="tabList">
+            onSelect={(e) => this.handleTabSelect(e)} id="tabList">
         <Tab eventKey={1} title={samples}>
           <ElementsTable overview={overview} showReport={showReport} type='sample'/>
         </Tab>

--- a/app/assets/javascripts/components/actions/KeyboardActions.js
+++ b/app/assets/javascripts/components/actions/KeyboardActions.js
@@ -1,0 +1,13 @@
+import alt from '../alt'
+
+class KeyboardActions {
+  documentKeyDown(keyCode) {
+    return keyCode
+  }
+
+  contextChange(context) {
+    return context
+  }
+}
+
+export default alt.createActions(KeyboardActions)

--- a/app/assets/javascripts/components/search/AutoCompleteInput.js
+++ b/app/assets/javascripts/components/search/AutoCompleteInput.js
@@ -4,6 +4,9 @@ import {FormGroup,InputGroup,FormControl, Overlay, ListGroup, ListGroupItem}
   from 'react-bootstrap';
 import debounce from 'es6-promise-debounce';
 
+import KeyboardActions from '../actions/KeyboardActions';
+import KeyboardStore from '../stores/KeyboardStore';
+
 export default class AutoCompleteInput extends React.Component {
 
   constructor(props) {
@@ -18,6 +21,7 @@ export default class AutoCompleteInput extends React.Component {
       inputWidth: 0,
       inputDisabled: false,
       timeoutReference: null,
+      keyboardContext: ''
     }
     this.timeout = 6e2 // 600ms timeout for input typing
     this.doneTyping = this.doneTyping.bind(this)
@@ -157,6 +161,19 @@ export default class AutoCompleteInput extends React.Component {
     }
   }
 
+  handleFocus() {
+    let keyboardState = KeyboardStore.getState()
+    this.setState({
+      keyboardContext: keyboardState.context
+    })
+
+    KeyboardActions.contextChange("search")
+  }
+
+  handleBlur() {
+    KeyboardActions.contextChange(this.state.keyboardContext)
+  }
+
   handleKeyDown(event) {
     let {value, valueBeforeFocus, showSuggestions, error, suggestions} =
       this.state
@@ -204,7 +221,7 @@ export default class AutoCompleteInput extends React.Component {
     }
 
     clearTimeout(timeoutReference)
-    onSelectionChange(selection)    
+    onSelectionChange(selection)
   }
 
   abortAutoSelection() {
@@ -301,6 +318,8 @@ export default class AutoCompleteInput extends React.Component {
               value={value || ''}
               autoComplete='off'
               ref='input'
+              onFocus={() => this.handleFocus()}
+              onBlur={() => this.handleBlur()}
               onChange={event => this.handleValueChange(event, this.doneTyping)}
               onKeyDown={event => this.handleKeyDown(event)}
             />

--- a/app/assets/javascripts/components/stores/KeyboardStore.js
+++ b/app/assets/javascripts/components/stores/KeyboardStore.js
@@ -1,0 +1,26 @@
+import alt from '../alt';
+import KeyboardActions from '../actions/KeyboardActions';
+
+class KeyboardStore {
+  constructor() {
+    this.state = {
+      context: "sample",
+      documentKeyDownCode: null
+    };
+
+    this.bindListeners({
+      handleDocumentKeyDown: KeyboardActions.documentKeyDown,
+      handleContextChange: KeyboardActions.contextChange
+    })
+  }
+
+  handleDocumentKeyDown(keyCode) {
+    this.state.documentKeyDownCode = keyCode
+  }
+
+  handleContextChange(context) {
+    this.state.context = context
+  }
+}
+
+export default alt.createStore(KeyboardStore, 'KeyboardStore');


### PR DESCRIPTION
- From this commit we can move element (samples, reactions, wellplates, screens) using the arrow key. Press "Enter" or "right arrow" to open element.
- "Keydown" will be manipulate through added KeyboardStore