### PR TITLE
Update ReactionDetails UI

### DIFF
--- a/app/assets/javascripts/components/ElementsTableSampleEntries.js
+++ b/app/assets/javascripts/components/ElementsTableSampleEntries.js
@@ -140,20 +140,21 @@ export default class ElementsTableSampleEntries extends Component {
         style={{backgroundColor: '#F5F5F5', cursor: 'pointer'}}
         onClick={() => this.handleMoleculeToggle(molecule.iupac_name || molecule.inchistring)}
       >
-        <td colSpan="2">
+        <td colSpan="2" style={{position: 'relative'}}>
           <div style={{float: 'left'}}>
             <SVG src={sample.svgPath} className="molecule" key={sample.svgPath}/>
           </div>
-          <div style={{float: 'right'}}>
+          <div style={{position: 'absolute', float: 'right', right: '3px'}}>
             <OverlayTrigger placement="bottom" overlay={<Tooltip id="toggle_molecule">Toggle Molecule</Tooltip>}>
               <span style={{fontSize: 15, color: '#337ab7', lineHeight: '10px'}}>
                 <i className={`glyphicon ${showIndicator}`}></i>
               </span>
             </OverlayTrigger>
           </div>
-          <div style={{display: 'inherit', paddingLeft: 10}}>
+          <div style={{paddingLeft: 5, wordWrap: 'break-word'}}>
             <h4><SampleName sample={sample}/></h4>
           </div>
+
           {tdExtraContents.map((e)=>{return e;})}
         </td>
           {this.dragColumn(dragItem)}

--- a/app/assets/javascripts/components/List.js
+++ b/app/assets/javascripts/components/List.js
@@ -110,7 +110,7 @@ export default class List extends React.Component {
 
     return (
       <Tabs defaultActiveKey={this.state.currentTab} activeKey={this.state.currentTab}
-            onSelect={(e) => this.handleTabSelect(e)} id="tabList">
+            onSelect={(e) => this.handleTabSelect(e)} id="tabList" style={{display: 'table'}}>
         <Tab eventKey={1} title={samples}>
           <ElementsTable overview={overview} showReport={showReport} type='sample'/>
         </Tab>

--- a/app/assets/javascripts/components/ReactionDetails.js
+++ b/app/assets/javascripts/components/ReactionDetails.js
@@ -176,15 +176,13 @@ export default class ReactionDetails extends Component {
       )
   }
 
-  reactionSVG(reaction, svgContainerStyle) {
+  reactionSVG(reaction) {
     if(!reaction.svgPath) {
       return false;
     } else {
       return (
-        <Col md={9}>
-          <div style={svgContainerStyle}>
-            <SVG key={reaction.svgPath} src={reaction.svgPath} className='reaction-details'/>
-          </div>
+        <Col md={12}>
+          <SVG key={reaction.svgPath} src={reaction.svgPath} className='reaction-details'/>
         </Col>
       )
     }
@@ -193,9 +191,7 @@ export default class ReactionDetails extends Component {
   render() {
     let {reaction} = this.state;
     reaction.temporary_sample_counter = reaction.temporary_sample_counter || 0;
-    const svgContainerStyle = {
-      textAlign: 'center'
-    };
+
     const submitLabel = (reaction && reaction.isNew) ? "Create" : "Save";
     const style = {height: '220px'};
     let extraTabs =[];
@@ -213,28 +209,34 @@ export default class ReactionDetails extends Component {
                   onClick={this.closeDetails.bind(this)}>
             <i className="fa fa-times"></i>
           </Button>
-          <Row>
-            <Col md={3} style={style}>
-              <h3>{reaction.name}</h3>
-              <ElementCollectionLabels element={reaction} key={reaction.id}/><br/>
-              <ElementAnalysesLabels element={reaction} key={reaction.id+"_analyses"}/><br/>
-              <Button
-                style={{cursor: 'pointer'}}
-                disabled={reaction.changed || reaction.isNew}
-                title={(reaction.changed || reaction.isNew) ?
+          <Button bsStyle="success" bsSize="xsmall" className="button-right"
+            style={{cursor: 'pointer', marginTop: '-47px', right: '3%'}}
+            disabled={reaction.changed || reaction.isNew}
+            title={(reaction.changed || reaction.isNew) ?
                    "Report can be generated after reaction is saved."
                    : "Generate report for this reaction"}
-                onClick={() => Utils.downloadFile({
-                  contents: "api/v1/reports/docx?id=" + reaction.id,
-                  name: reaction.name
-                })}
-              >
-                Generate Report
-              </Button>
-            </Col>
-            {this.reactionSVG(reaction, svgContainerStyle)}
+            onClick={() => Utils.downloadFile({
+              contents: "api/v1/reports/docx?id=" + reaction.id,
+              name: reaction.name
+            })} > <i className="fa fa-cogs"></i>
+          </Button>
+          <Row>
+            <div style={{marginLeft: '15px', marginTop: '-10px',
+                         display: 'flex', 'alignItems': 'center'}}>
+              <h3 style={{float: 'left'}}>
+                {reaction.name}
+              </h3>
+              <div style={{float: 'left', paddingLeft: '10px', marginTop: '5px'}}>
+                <ElementCollectionLabels element={reaction}
+                                          key={reaction.id} />
+                <ElementAnalysesLabels element={reaction}
+                                       key={reaction.id+"_analyses"} />
+              </div>
+            </div>
           </Row>
-          <hr/>
+          <Row>
+            {this.reactionSVG(reaction)}
+          </Row>
           <Tabs defaultActiveKey={0} id="reaction-detail-tab">
             <Tab eventKey={0} title={'Scheme'}>
               <ReactionDetailsScheme

--- a/app/assets/javascripts/components/structure_editor/StructureEditorModal.js
+++ b/app/assets/javascripts/components/structure_editor/StructureEditorModal.js
@@ -41,6 +41,19 @@ export default class StructureEditorModal extends React.Component {
     ketcher.setMolecule(molfile);
   }
 
+  setIframeSize() {
+    let ketcherFrame = document.getElementById("ifKetcher");
+    // Different attributes due to Chrome and FF return value
+    let width = Math.max(ketcherFrame.contentWindow.document.body.scrollWidth,
+                         ketcherFrame.contentWindow.document.documentElement.scrollWidth)
+    let height = Math.max(ketcherFrame.contentWindow.document.body.scrollHeight,
+                          ketcherFrame.contentWindow.document.documentElement.scrollHeight)
+    // The Ketcher increasing width when it has more space, so that we need to
+    //   increase to its maximum width
+    ketcherFrame.style.width = width + 136 + 'px'
+    ketcherFrame.style.height = height + 20 + 'px'
+  }
+
   getMolfileFromEditor() {
     var ketcher = this.getKetcher();
 
@@ -103,6 +116,7 @@ export default class StructureEditorModal extends React.Component {
         submitAddons = {
           this.props.submitAddons ? this.props.submitAddons : ""
         }
+        setIframeSize = {this.setIframeSize.bind(this)}
       />
     return (
       <div>
@@ -124,11 +138,11 @@ export default class StructureEditorModal extends React.Component {
 }
 
 const StructureEditor =
-  ({handleCancelBtn, handleSaveBtn, cancelBtnText, submitBtnText, submitAddons}) => {
+  ({handleCancelBtn, handleSaveBtn, cancelBtnText, submitBtnText, submitAddons, setIframeSize}) => {
     return (
       <div>
         <div>
-          <iframe id="ifKetcher" src="/ketcher"></iframe>
+          <iframe id="ifKetcher" src="/ketcher" onLoad={setIframeSize}></iframe>
         </div>
         <div>
           <ButtonToolbar>

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,7 +45,7 @@ div[class^="col-"] {
 }
 
 .panel-fixed {
-  overflow-y: scroll;
+  overflow-y: auto;
   max-height: 100vh;
 
   button.btn-danger {

--- a/app/assets/stylesheets/elements_details.css
+++ b/app/assets/stylesheets/elements_details.css
@@ -5,7 +5,7 @@
 .button-right {
   position: absolute;
   margin-right: 25px;
-  margin-top: -45px;
+  margin-top: -47px;
   float: right;
   right: 0px;
   z-index: 1;

--- a/app/assets/stylesheets/molecules.css
+++ b/app/assets/stylesheets/molecules.css
@@ -52,6 +52,6 @@
 
 .reaction-details svg {
   max-width: 100%;
-  max-height: 150px;
-  margin-top: 20px;
+  max-height: 200px;
+  width: 100%;
 }

--- a/app/assets/stylesheets/structur_editor.css
+++ b/app/assets/stylesheets/structur_editor.css
@@ -7,11 +7,12 @@
 }
 
 .structure-editor .modal-content {
-  width: 1040px;
+  /*width: 1040px;*/
 }
+
 .structure-editor #ifKetcher {
-  width: 1006px;
-  height: 608px;
+  /*width: 1010px;
+  height: 620px;*/
 }
 
 /*@media screen and (max-height: 768px) {

--- a/lib/svg/reaction_composer.rb
+++ b/lib/svg/reaction_composer.rb
@@ -91,7 +91,7 @@ module SVG
           content = inner_file_content(material).to_s
           output = "<g transform='translate(#{shift}, 0) scale(#{scale})'>" + content + yield_svg +"</g>" + divider
           divider = "<g transform='translate(#{shift + material_width}, 0) scale(#{scale})'>" + @divider + "</g>"
-          shift += material_width
+          shift += material_width + 10 # Add a small space between material
           output
         end
       end


### PR DESCRIPTION
- Make old "GenerateReport" button smaller and move to title, next to close button
- Reaction title now will take 1 line space above reaction svg
- Stretch reaction svg to 100% width
- Svg Generating: Add a small space between starting materials
- Use JS to auto update StructureEditorModal. 
- Fix CSS bugs when Sample or Element content is too big, lead to the breaking of ElementsTable
- Fix FF bug in Ketcher and ElementsDetail
- Redmine: #448 #450 #462 #465