### PR TITLE
Fix structure editor height resolve #515

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/ComPlat/ketcher-rails.git
-  revision: b5dad8b98f6bcc9f795218a93d64a9bc028afc3d
+  revision: f84acb3f16f13bc0dcb7f256d25a4af21c784ba4
   specs:
     ketcherails (0.1.3)
       bootstrap-kaminari-views

--- a/app/assets/javascripts/components/structure_editor/StructureEditorModal.js
+++ b/app/assets/javascripts/components/structure_editor/StructureEditorModal.js
@@ -127,10 +127,18 @@ export default class StructureEditorModal extends React.Component {
 
 const StructureEditor =
   ({handleCancelBtn, handleSaveBtn, cancelBtnText, submitBtnText, submitAddons}) => {
+    let height = window.innerHeight;
+    let minHeight = 590;//min table height is 590px, each <tr> is 36px
+    let add_tr_count = ((height*0.75 - minHeight)/36).toFixed();// 75% screen
+    add_tr_count = add_tr_count < 0 ? 0 : add_tr_count
+    let adjustedHeight = add_tr_count*36 + minHeight;
     return (
       <div>
         <div>
-          <iframe id="ifKetcher" src="/ketcher"></iframe>
+          <iframe id="ifKetcher"
+                  style={{height: adjustedHeight }}
+                  src={"/ketcher?height=" + height + "&add_tr_count=" + add_tr_count }>
+          </iframe>
         </div>
         <div>
           <ButtonToolbar>

--- a/app/assets/stylesheets/structur_editor.css
+++ b/app/assets/stylesheets/structur_editor.css
@@ -11,7 +11,6 @@
 
 iframe#ifKetcher {
   width: 100%;
-  height: 590px;
   overflow-x: hidden;
   overflow-y: hidden;
 }


### PR DESCRIPTION
The solution was to calculate the editor height that will suit the following:
- must be 590px (basic menu table size) + N*36px. N is integer so that we avoid situation when we hide a part of the bottom menu line.
- it must be close to 75% of screen height

Then it is sent as a parameter to Ketcher and it adds table lines and adjusts 'rowspan' attribute of working area.

Refer to Ketcherails changeset:

https://github.com/ComPlat/ketcher-rails/commit/a39798ebbd78c7d8c2eaead085f9f1524d23b128