### PR TITLE
Move/Assign/Remove associated elements

### DIFF
--- a/app/api/chemotion/collection_api.rb
+++ b/app/api/chemotion/collection_api.rb
@@ -160,65 +160,40 @@ module Chemotion
           current_collection_id = ui_state[:currentCollection].id
           collection_id = params[:collection_id]
           unless Collection.find(collection_id).is_shared
+            # Move Sample
             sample_ids = Sample.for_user(current_user.id).for_ui_state_with_collection(
               ui_state[:sample],
               CollectionsSample,
               current_collection_id
-            )
+            ).compact
+            CollectionsSample.move_to_collection(sample_ids,
+              current_collection_id, collection_id)
 
-            CollectionsSample.where(
-              sample_id: sample_ids,
-              collection_id: current_collection_id
-            ).delete_all
-
-            sample_ids.map { |id|
-              CollectionsSample.find_or_create_by(sample_id: id, collection_id: collection_id)
-            }
-
+            # Move Reaction
             reaction_ids = Reaction.for_user(current_user.id).for_ui_state_with_collection(
               ui_state[:reaction],
               CollectionsReaction,
               current_collection_id
-            )
+            ).compact
+            CollectionsReaction.move_to_collection(reaction_ids,
+              current_collection_id, collection_id)
 
-            CollectionsReaction.where(
-              reaction_id: reaction_ids,
-              collection_id: current_collection_id
-            ).delete_all
-
-            reaction_ids.map { |id|
-              CollectionsReaction.find_or_create_by(reaction_id: id, collection_id: collection_id)
-            }
-
+            # Move Wellplate
             wellplate_ids = Wellplate.for_user(current_user.id).for_ui_state_with_collection(
               ui_state[:wellplate],
               CollectionsWellplate,
               current_collection_id
-            )
-
-            CollectionsWellplate.where(
-              wellplate_id: wellplate_ids,
-              collection_id: current_collection_id
-            ).delete_all
-
-            wellplate_ids.map { |id|
-              CollectionsWellplate.find_or_create_by(wellplate_id: id, collection_id: collection_id)
-            }
-
+            ).compact
+            CollectionsWellplate.move_to_collection(wellplate_ids,
+              current_collection_id, collection_id)
+            # Move Screen
             screen_ids = Screen.for_user(current_user.id).for_ui_state_with_collection(
               ui_state[:screen],
               CollectionsScreen,
               current_collection_id
-            )
-
-            CollectionsScreen.where(
-              screen_id: screen_ids,
-              collection_id: current_collection_id
-            ).delete_all
-
-            screen_ids.map { |id|
-              CollectionsScreen.find_or_create_by(screen_id: id, collection_id: collection_id)
-            }
+            ).compact
+            CollectionsScreen.move_to_collection(screen_ids,
+              current_collection_id, collection_id)
           end
         end
 
@@ -231,38 +206,37 @@ module Chemotion
           ui_state = params[:ui_state]
           collection_id = params[:collection_id]
           current_collection_id = ui_state[:currentCollection].id
-
-          Sample.for_user(current_user.id).for_ui_state_with_collection(
+          # Assign Sample
+          sample_ids = Sample.for_user(current_user.id).for_ui_state_with_collection(
             ui_state[:sample],
             CollectionsSample,
             current_collection_id
-          ).each do |id|
-            CollectionsSample.find_or_create_by(sample_id: id, collection_id: collection_id)
-          end
+          )
+          CollectionsSample.create_in_collection(sample_ids, collection_id)
 
-          Reaction.for_user(current_user.id).for_ui_state_with_collection(
+          # Assign Reaction
+          reaction_ids = Reaction.for_user(current_user.id).for_ui_state_with_collection(
             ui_state[:reaction],
             CollectionsReaction,
             current_collection_id
-          ).each do |id|
-            CollectionsReaction.find_or_create_by(reaction_id: id, collection_id: collection_id)
-          end
+          )
+          CollectionsReaction.create_in_collection(reaction_ids, collection_id)
 
-          Wellplate.for_user(current_user.id).for_ui_state_with_collection(
+          # Assign Wellplate
+          wellplate_ids = Wellplate.for_user(current_user.id).for_ui_state_with_collection(
             ui_state[:wellplate],
             CollectionsWellplate,
             current_collection_id
-          ).each do |id|
-            CollectionsWellplate.find_or_create_by(wellplate_id: id, collection_id: collection_id)
-          end
+          )
+          CollectionsWellplate.create_in_collection(wellplate_ids, collection_id)
 
-          Screen.for_user(current_user.id).for_ui_state_with_collection(
+          # Assign Screen
+          screen_ids = Screen.for_user(current_user.id).for_ui_state_with_collection(
             ui_state[:screen],
             CollectionsScreen,
             current_collection_id
-          ).each do |id|
-            CollectionsScreen.find_or_create_by(screen_id: id, collection_id: collection_id)
-          end
+          )
+          CollectionsScreen.create_in_collection(screen_ids, collection_id)
         end
 
         desc "Remove from a collection a set of elements by UI state"
@@ -273,49 +247,37 @@ module Chemotion
           ui_state = params[:ui_state]
           current_collection_id = ui_state[:currentCollection].id
 
+          # Remove Sample
           sample_ids = Sample.for_ui_state_with_collection(
             ui_state[:sample],
             CollectionsSample,
             current_collection_id
           )
+          CollectionsSample.remove_in_collection(sample_ids, current_collection_id)
 
-          CollectionsSample.where(
-            sample_id: sample_ids,
-            collection_id: current_collection_id
-          ).delete_all
-
+          # Remove Reaction
           reaction_ids = Reaction.for_ui_state_with_collection(
             ui_state[:reaction],
             CollectionsReaction,
             current_collection_id
           )
+          CollectionsReaction.remove_in_collection(reaction_ids, current_collection_id)
 
-          CollectionsReaction.where(
-            reaction_id: reaction_ids,
-            collection_id: current_collection_id
-          ).delete_all
-
+          # Remove Wellplate
           wellplate_ids = Wellplate.for_ui_state_with_collection(
             ui_state[:wellplate],
             CollectionsWellplate,
             current_collection_id
           )
+          CollectionsWellplate.remove_in_collection(wellplate_ids, current_collection_id)
 
-          CollectionsWellplate.where(
-            wellplate_id: wellplate_ids,
-            collection_id: current_collection_id
-          ).delete_all
-
+          # Remove Screen
           screen_ids = Screen.for_ui_state_with_collection(
             ui_state[:screen],
             CollectionsScreen,
             current_collection_id
           )
-
-          CollectionsScreen.where(
-            screen_id: screen_ids,
-            collection_id: current_collection_id
-          ).delete_all
+          CollectionsScreen.remove_in_collection(screen_ids, current_collection_id)
         end
 
       end

--- a/app/models/collections_reaction.rb
+++ b/app/models/collections_reaction.rb
@@ -4,6 +4,52 @@ class CollectionsReaction < ActiveRecord::Base
   belongs_to :reaction
   validate :collection_reaction_id_uniqueness
 
+  def self.move_to_collection(reaction_ids, old_col_id, new_col_id)
+    # Get associated: starting_materials, reactants, and product samples
+    sample_ids = Reaction.get_associated_samples(reaction_ids)
+
+    # Delete reactions in old collection
+    self.delete_in_collection(reaction_ids, old_col_id)
+
+    # Move associated samples in current collection
+    CollectionsSample.move_to_collection(sample_ids, old_col_id, new_col_id)
+
+    # Create new reations in target collection
+    self.static_create_in_collection(reaction_ids, new_col_id)
+  end
+
+  # Static delete without checking associated
+  def self.delete_in_collection(reaction_ids, collection_id)
+    self.where(
+      reaction_id: reaction_ids,
+      collection_id: collection_id
+    ).delete_all
+  end
+
+  # Remove from collection and process associated elements
+  def self.remove_in_collection(reaction_ids, collection_id)
+    self.delete_in_collection(reaction_ids, collection_id)
+
+    sample_ids = Reaction.get_associated_samples(reaction_ids)
+    CollectionsSample.remove_in_collection(sample_ids, collection_id)
+  end
+
+  # Static create without checking associated
+  def self.static_create_in_collection(reaction_ids, collection_id)
+    reaction_ids.map { |id|
+      self.find_or_create_by(reaction_id: id, collection_id: collection_id)
+    }
+  end
+
+  def self.create_in_collection(reaction_ids, collection_id)
+    # Get associated: starting_materials, reactants, and product samples
+    sample_ids = Reaction.get_associated_samples(reaction_ids)
+    # Create associated samples in collection
+    CollectionsSample.create_in_collection(sample_ids, collection_id)
+    # Create new reaction in collection
+    self.static_create_in_collection(reaction_ids, collection_id)
+  end
+
   def collection_reaction_id_uniqueness
     unless CollectionsReaction.where(collection_id: collection_id, reaction_id: reaction_id).empty?
       errors.add(:collection_reaction_id_uniqueness, 'Violates uniqueness of reaction_id and collection_id')

--- a/app/models/collections_sample.rb
+++ b/app/models/collections_sample.rb
@@ -3,4 +3,28 @@ class CollectionsSample < ActiveRecord::Base
   belongs_to :collection
   belongs_to :sample
   validates :collection, :sample, presence: true
+
+  def self.move_to_collection(sample_ids, old_col_id, new_col_id)
+    # Delete in collection
+    self.delete_in_collection(sample_ids, old_col_id)
+    # Create new in target collection
+    self.create_in_collection(sample_ids, new_col_id)
+  end
+
+  def self.delete_in_collection(sample_ids, collection_id)
+    self.where(
+      sample_id: sample_ids,
+      collection_id: collection_id
+    ).delete_all
+  end
+
+  def self.remove_in_collection(sample_ids, collection_id)
+    self.delete_in_collection(sample_ids, collection_id)
+  end
+
+  def self.create_in_collection(sample_ids, collection_id)
+    sample_ids.map { |id|
+      self.find_or_create_by(sample_id: id, collection_id: collection_id)
+    }
+  end
 end

--- a/app/models/collections_screen.rb
+++ b/app/models/collections_screen.rb
@@ -5,6 +5,50 @@ class CollectionsScreen < ActiveRecord::Base
 
   validate :collection_screen_id_uniqueness
 
+  def self.move_to_collection(screen_ids, old_col_id, new_col_id)
+    # Get associated wellplates
+    wellplate_ids = ScreensWellplate.get_wellplates(screen_ids)
+
+    # Delete screens in old collection
+    self.delete_in_collection(screen_ids, old_col_id)
+
+    # Move associated wellplates in current collection
+    CollectionsWellplate.move_to_collection(wellplate_ids, old_col_id, new_col_id)
+
+    # Create new screens in target collection
+    self.static_create_in_collection(screen_ids, new_col_id)
+  end
+
+  # Static delete without checking associated
+  def self.delete_in_collection(screen_ids, collection_id)
+    self.where(
+      screen_id: screen_ids,
+      collection_id: collection_id
+    ).delete_all
+  end
+
+  # Remove from collection and process associated elements
+  def self.remove_in_collection(screen_ids, collection_id)
+    self.delete_in_collection(screen_ids, collection_id)
+  end
+
+  # Static create without checking associated
+  def self.static_create_in_collection(screen_ids, collection_id)
+    screen_ids.map { |id|
+      self.find_or_create_by(screen_id: id, collection_id: collection_id)
+    }
+  end
+
+  def self.create_in_collection(screen_ids, collection_id)
+    # Get associated wellplates
+    wellplate_ids = ScreensWellplate.get_wellplates(screen_ids)
+
+    # Create associated wellplates in collection
+    CollectionsWellplate.create_in_collection(wellplate_ids, collection_id)
+    # Create new screens in collection
+    self.static_create_in_collection(screen_ids, collection_id)
+  end
+
   def collection_screen_id_uniqueness
     unless CollectionsScreen.where(collection_id: collection_id, screen_id: screen_id).empty?
       errors.add(:collection_screen_id_uniqueness, 'Violates uniqueness of screen_id and collection_id')

--- a/app/models/collections_wellplate.rb
+++ b/app/models/collections_wellplate.rb
@@ -4,6 +4,53 @@ class CollectionsWellplate < ActiveRecord::Base
   belongs_to :wellplate
   validate :collection_wellplate_id_uniqueness
 
+  def self.move_to_collection(wellplate_ids, old_col_id, new_col_id)
+    # Get associated samples
+    sample_ids = Well.get_samples_in_wellplates(wellplate_ids)
+
+    # Delete wellplates in old collection
+    self.delete_in_collection(wellplate_ids, old_col_id)
+
+    # Move associated samples in current collection
+    CollectionsSample.move_to_collection(sample_ids, old_col_id, new_col_id)
+
+    # Create new wellplates in target collection
+    self.static_create_in_collection(wellplate_ids, new_col_id)
+  end
+
+  # Static delete without checking associated
+  def self.delete_in_collection(wellplate_ids, collection_id)
+    self.where(
+      wellplate_id: wellplate_ids,
+      collection_id: collection_id
+    ).delete_all
+  end
+
+  # Remove from collection and process associated elements
+  def self.remove_in_collection(wellplate_ids, collection_id)
+    self.delete_in_collection(wellplate_ids, collection_id)
+
+    sample_ids = Well.get_samples_in_wellplates(wellplate_ids)
+    CollectionsSample.remove_in_collection(sample_ids, collection_id)
+  end
+
+  # Static create without checking associated
+  def self.static_create_in_collection(wellplate_ids, collection_id)
+    wellplate_ids.map { |id|
+      self.find_or_create_by(wellplate_id: id, collection_id: collection_id)
+    }
+  end
+
+  def self.create_in_collection(wellplate_ids, collection_id)
+    # Get associated samples
+    sample_ids = Well.get_samples_in_wellplates(wellplate_ids)
+
+    # Create associated samples in collection
+    CollectionsSample.create_in_collection(sample_ids, collection_id)
+    # Create new wellplate in collection
+    self.static_create_in_collection(wellplate_ids, collection_id)
+  end
+
   def collection_wellplate_id_uniqueness
     unless CollectionsWellplate.where(collection_id: collection_id, wellplate_id: wellplate_id).empty?
       errors.add(:collection_wellplate_id_uniqueness, 'Violates uniqueness of wellplate_id and collection_id')

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -84,6 +84,13 @@ class Reaction < ActiveRecord::Base
   before_save :cleanup_array_fields
   before_save :auto_format_temperature!
 
+  def self.get_associated_samples(reaction_ids)
+    ( ReactionsProductSample.get_samples(reaction_ids) +
+      ReactionsStartingMaterialSample.get_samples(reaction_ids) +
+      ReactionsReactantSample.get_samples(reaction_ids)
+    ).compact
+  end
+
   def samples
     starting_materials + reactants + products + solvents
   end

--- a/app/models/reactions_product_sample.rb
+++ b/app/models/reactions_product_sample.rb
@@ -5,6 +5,10 @@ class ReactionsProductSample < ActiveRecord::Base
 
   include Reactable
 
+  def self.get_samples reaction_ids
+    self.where(reaction_id: reaction_ids).pluck(:sample_id).compact.uniq
+  end
+
   def formatted_yield
     self.equivalent ? (self.equivalent * 100).to_s + " %" : " %"
   end

--- a/app/models/reactions_reactant_sample.rb
+++ b/app/models/reactions_reactant_sample.rb
@@ -4,4 +4,8 @@ class ReactionsReactantSample < ActiveRecord::Base
   belongs_to :sample
 
   include Reactable
+
+  def self.get_samples reaction_ids
+    self.where(reaction_id: reaction_ids).pluck(:sample_id).compact.uniq
+  end
 end

--- a/app/models/reactions_starting_material_sample.rb
+++ b/app/models/reactions_starting_material_sample.rb
@@ -2,4 +2,8 @@ class ReactionsStartingMaterialSample < ActiveRecord::Base
   acts_as_paranoid
   belongs_to :reaction
   belongs_to :sample
+
+  def self.get_samples reaction_ids
+    self.where(reaction_id: reaction_ids).pluck(:sample_id).compact.uniq
+  end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -139,6 +139,14 @@ class Sample < ActiveRecord::Base
   after_save :update_data_for_reactions
   after_create :update_counter
 
+  def self.associated_by_user_id_and_reaction_ids(user_id, reaction_ids)
+    (for_user(user_id).by_reaction_material_ids(reaction_ids) + for_user(user_id).by_reaction_reactant_ids(reaction_ids) + for_user(user_id).by_reaction_product_ids(reaction_ids)).uniq
+  end
+
+  def self.associated_by_user_id_and_wellplate_ids(user_id, wellplate_ids)
+    for_user(user_id).by_wellplate_ids(wellplate_ids)
+  end
+
   def create_subsample user, collection_id
     subsample = self.dup
     subsample.short_label = nil # we need to reset it
@@ -165,14 +173,6 @@ class Sample < ActiveRecord::Base
     elsif
       self.short_label ||= 'NEW'
     end
-  end
-
-  def self.associated_by_user_id_and_reaction_ids(user_id, reaction_ids)
-    (for_user(user_id).by_reaction_material_ids(reaction_ids) + for_user(user_id).by_reaction_reactant_ids(reaction_ids) + for_user(user_id).by_reaction_product_ids(reaction_ids)).uniq
-  end
-
-  def self.associated_by_user_id_and_wellplate_ids(user_id, wellplate_ids)
-    for_user(user_id).by_wellplate_ids(wellplate_ids)
   end
 
   def reactions

--- a/app/models/screen.rb
+++ b/app/models/screen.rb
@@ -21,7 +21,7 @@ class Screen < ActiveRecord::Base
   has_many :collections_screens, dependent: :destroy
   has_many :collections, through: :collections_screens
   has_many :sync_collections_users, through: :collections
-  
+
   has_many :screens_wellplates, dependent: :destroy
   has_many :wellplates, through: :screens_wellplates
 end

--- a/app/models/screens_wellplate.rb
+++ b/app/models/screens_wellplate.rb
@@ -2,4 +2,9 @@ class ScreensWellplate < ActiveRecord::Base
   acts_as_paranoid
   belongs_to :screen
   belongs_to :wellplate
+
+  def self.get_wellplates screen_ids
+    self.where(screen_id: screen_ids).pluck(:wellplate_id).compact.uniq
+  end
+
 end

--- a/app/models/well.rb
+++ b/app/models/well.rb
@@ -2,4 +2,8 @@ class Well < ActiveRecord::Base
   acts_as_paranoid
   belongs_to :wellplate
   belongs_to :sample
+
+  def self.get_samples_in_wellplates(wellplate_ids)
+    self.where(wellplate_id: wellplate_ids).pluck(:sample_id).compact.uniq
+  end
 end


### PR DESCRIPTION
- When move, assign, or remove reaction/wellplate/screen, associated will also be processed
- Moving  a screen will also move its wellplates, and samples
-  Removing a screen only remove the screen, not the wellplates