### PR TITLE
Remove Reactant/Solvents counter

### DIFF
--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -266,7 +266,15 @@ module ReactionUpdator
               #TODO extract subsample method
               subsample = parent_sample.dup
               subsample.parent = parent_sample
-              subsample.short_label = nil #we don't want to inherit short_label from parent
+
+              if (material_group == :reactant || material_group == :solvent)
+                # Use 'reactants' or 'solvents' as short_label
+                subsample.short_label = sample.short_label
+              else
+                #we don't want to inherit short_label from parent
+                subsample.short_label = nil
+              end
+
               subsample.created_by = current_user.id
               subsample.name = sample.name
               subsample.target_amount_value = sample.target_amount_value

--- a/app/assets/javascripts/components/Material.js
+++ b/app/assets/javascripts/components/Material.js
@@ -23,19 +23,6 @@ class Material extends Component {
     Aviator.navigate(`${currentURI}/sample/${sample.id}`);
   }
 
-  materialName() {
-    const {material} = this.props;
-    if(!material.isNew) {
-      return (
-        <a onClick={() => this.handleMaterialClick(material)} style={{cursor: 'pointer'}}>
-          {material.title()}
-        </a>
-      );
-    } else {
-      return material.title();
-    }
-  }
-
   notApplicableInput(inputsStyle) {
     return (
       <td style={inputsStyle}>
@@ -411,12 +398,43 @@ class Material extends Component {
   }
 
   materialNameWithIupac(material) {
+    // Skip shortLabel for reactants and solvents
+    let skipShortLabel = this.props.materialGroup == 'reactants' ||
+                         this.props.materialGroup == 'solvents'
+    let materialName = ""
+    let moleculeIupacName = ""
+    var idCheck = /^\d+$/
+
+    if (skipShortLabel) {
+      if (idCheck.test(material.id)) {
+        materialName =
+          <a onClick={() => this.handleMaterialClick(material)}
+             style={{cursor: 'pointer'}}>
+            {material.molecule_iupac_name}
+          </a>
+      } else {
+        materialName =
+          <span>{material.molecule_iupac_name}</span>
+      }
+    } else {
+      moleculeIupacName = material.molecule_iupac_name
+      materialName =
+        <a onClick={() => this.handleMaterialClick(material)} style={{cursor: 'pointer'}}>
+          {material.title()}
+        </a>
+      if (material.isNew)
+        materialName = material.title()
+    }
+
     return (
       <OverlayTrigger placement="bottom" overlay={this.iupacNameTooltip(material.molecule.iupac_name)}>
         <div style={{display: "inline-block", maxWidth: "100%"}}>
-          {this.materialName()} <br/>
-          <span style={{display: "block", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", maxWidth: "100%"}}>
-            {material.molecule_iupac_name}
+          {materialName}
+          <br/>
+          <span style={{display: "block", whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis", maxWidth: "100%"}}>
+            {moleculeIupacName}
           </span>
         </div>
       </OverlayTrigger>

--- a/app/assets/javascripts/components/ReactionDetailsScheme.js
+++ b/app/assets/javascripts/components/ReactionDetailsScheme.js
@@ -29,8 +29,12 @@ export default class ReactionDetailsScheme extends Component {
     let splitSample ;
 
     if (sample instanceof Molecule || materialGroup == 'products'){
-      splitSample = Sample.buildReactionSample(reaction.collection_id, reaction.temporary_sample_counter , materialGroup, sample );
+      // Create new Sample with counter
+      splitSample =
+        Sample.buildReactionSample(reaction.collection_id,
+          reaction.temporary_sample_counter, materialGroup, sample);
     } else if (sample instanceof Sample){
+      // Else split Sample
       if(reaction.hasSample(sample.id)) {
         NotificationActions.add({
           message: 'The sample is already present in current reaction.',
@@ -38,8 +42,17 @@ export default class ReactionDetailsScheme extends Component {
         });
         return false;
       }
-      splitSample = sample.buildChild();
-      if(materialGroup == 'products') {splitSample.reaction_product = true }
+
+      if (materialGroup == 'reactants' || materialGroup == 'solvents') {
+        splitSample = sample.buildChildWithoutCounter()
+        splitSample.short_label = materialGroup
+      } else {
+        splitSample = sample.buildChild()
+      }
+
+      if(materialGroup == 'products') {
+        splitSample.reaction_product = true
+      }
     }
     reaction.addMaterial(splitSample, materialGroup);
 

--- a/app/assets/javascripts/components/models/Reaction.js
+++ b/app/assets/javascripts/components/models/Reaction.js
@@ -164,7 +164,9 @@ export default class Reaction extends Element {
     }
 
     materials.push(material);
-    this.temporary_sample_counter += 1;
+    // Skip short_label for reactants and solvents
+    if (materialGroup != "reactants" && materialGroup != "solvents")
+      this.temporary_sample_counter += 1;
   }
 
   deleteMaterial(material, materialGroup) {

--- a/app/assets/javascripts/components/models/Sample.js
+++ b/app/assets/javascripts/components/models/Sample.js
@@ -83,6 +83,20 @@ export default class Sample extends Element {
     return splitSample;
   }
 
+  buildChildWithoutCounter() {
+    let splitSample = this;
+    splitSample.parent_id = this.id;
+    splitSample.id = Element.buildID();
+    splitSample.name = null;
+    splitSample.created_at = null;
+    splitSample.updated_at = null;
+    splitSample.target_amount_value = 0;
+    splitSample.real_amount_value = null;
+    splitSample.is_split = true;
+    splitSample.is_new = true;
+    return splitSample;
+  }
+
   get isSplit() {
     return this.is_split
   }
@@ -178,7 +192,11 @@ export default class Sample extends Element {
     // allow zero loading for reaction product
     sample.reaction_product = (materialGroup == 'products');
 
-    sample.short_label = Sample.buildNewSampleShortLabelForCurrentUser(delta);
+    // Skip short_label for reactants and solvents
+    if (materialGroup != "reactants" && materialGroup != "solvents")
+      sample.short_label = Sample.buildNewSampleShortLabelForCurrentUser(delta)
+    else
+      sample.short_label = materialGroup
 
     return sample;
   }

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -164,6 +164,8 @@ class Sample < ActiveRecord::Base
   end
 
   def auto_set_short_label
+    return if (self.short_label == 'reactants' || self.short_label == 'solvents')
+
     self.short_label = nil if self.short_label == 'NEW SAMPLE'
 
     if parent
@@ -402,6 +404,7 @@ private
   end
 
   def update_counter
+    return if (self.short_label == 'reactants' || self.short_label == 'solvents')
     self.creator.increment_counter 'samples' unless self.parent
   end
 end


### PR DESCRIPTION
- Reactant and Solvents sample will not increase the counter any more.
- Reactant and Solvents short_label will now be 'reactants' or 'solvents'
- In ReactionDetails, only reactant/solvents IUPAC name with the link to its details.
- Resolve #506