### PR TITLE
Save automated reaction product string into external label

### DIFF
--- a/app/assets/javascripts/components/ReactionDetailsScheme.js
+++ b/app/assets/javascripts/components/ReactionDetailsScheme.js
@@ -36,7 +36,7 @@ export default class ReactionDetailsScheme extends Component {
 
       if (materialGroup == 'products') {
         let productsCount = reaction.products.length
-        splitSample.name = reaction.short_label + "-" +
+        splitSample.external_label = reaction.short_label + "-" +
           String.fromCharCode('A'.charCodeAt(0) + productsCount)
       }
     } else if (sample instanceof Sample){


### PR DESCRIPTION
- The automated string for reaction product will not be saved into product's external label
. Resolves #553