### PR TITLE
Split Sample

### DIFF
--- a/app/assets/javascripts/components/models/Sample.js
+++ b/app/assets/javascripts/components/models/Sample.js
@@ -72,7 +72,11 @@ export default class Sample extends Element {
     let splitSample = this;
     splitSample.parent_id = this.id;
     splitSample.id = Element.buildID();
-    splitSample.name = null;
+
+    if (this.name) splitSample.name = this.name + "-split"
+    if (this.external_label)
+      splitSample.external_label = this.external_label + "-split"
+
     splitSample.short_label += "-" + children_count;
     splitSample.created_at = null;
     splitSample.updated_at = null;
@@ -87,7 +91,11 @@ export default class Sample extends Element {
     let splitSample = this;
     splitSample.parent_id = this.id;
     splitSample.id = Element.buildID();
-    splitSample.name = null;
+
+    if (this.name) splitSample.name = this.name + "-split"
+    if (this.external_label)
+      splitSample.external_label = this.external_label + "-split"
+
     splitSample.created_at = null;
     splitSample.updated_at = null;
     splitSample.target_amount_value = 0;

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -149,7 +149,16 @@ class Sample < ActiveRecord::Base
 
   def create_subsample user, collection_id
     subsample = self.dup
-    subsample.short_label = nil # we need to reset it
+
+    if self.name.to_s != ''
+      subsample.name = self.name + "-split"
+    end
+    if self.external_label.to_s != ''
+      subsample.external_label = self.external_label + "-split"
+    end
+    children_count = self.children.count
+    subsample.short_label = self.short_label + "-" + (children_count + 1).to_s
+
     subsample.parent = self
     subsample.created_by = user.id
     subsample.residues_attributes = self.residues.to_a.map do |r|

--- a/spec/api/sample_api_spec.rb
+++ b/spec/api/sample_api_spec.rb
@@ -354,8 +354,8 @@ describe Chemotion::SampleAPI do
     describe "subsamples" do
       context "with valid parameters" do
         let!(:c)      { create(:collection, user_id: user.id) }
-        let!(:s1) { create(:sample, name: 's1') }
-        let!(:s2) { create(:sample, name: 's2') }
+        let!(:s1) { create(:sample, name: 's1', external_label: 'ext1') }
+        let!(:s2) { create(:sample, name: 's2', external_label: 'ext2') }
 
         before do
           CollectionsSample.create!(sample_id: s1.id, collection_id: c.id)
@@ -377,15 +377,25 @@ describe Chemotion::SampleAPI do
         describe 'POST /api/v1/samples/subsamples' do
           it 'should be able to split Samples into Subsamples' do
             post '/api/v1/samples/subsamples', params
-            subsamples = Sample.where(name: ['s1','s2']).where.not(id: [s1.id,s2.id])
+            subsamples = Sample.where(name: ['s1-split','s2-split']).where.not(id: [s1.id,s2.id])
             s3 = subsamples[0]
             s4 = subsamples[1]
-            s3.attributes.except("id", "created_at", "updated_at", "ancestry", "created_by", "short_label").each do |k, v|
+            except_attr = ["id", "created_at", "updated_at", "ancestry", "created_by",
+              "short_label", "name", "external_label"]
+            s3.attributes.except(*except_attr).each do |k, v|
               expect(s1[k]).to eq(v)
             end
-            s4.attributes.except("id", "created_at", "updated_at", "ancestry", "created_by", "short_label").each do |k, v|
+            expect(s3.name).to eq(s1.name + "-split")
+            expect(s3.external_label).to eq(s1.external_label + "-split")
+            expect(s3.short_label).to eq(s1.short_label + "-" + s1.children.count.to_s)
+
+            s4.attributes.except(*except_attr).each do |k, v|
               expect(s2[k]).to eq(v)
             end
+            expect(s4.name).to eq(s2.name + "-split")
+            expect(s4.external_label).to eq(s2.external_label + "-split")
+            expect(s4.short_label).to eq(s2.short_label + "-" + s2.children.count.to_s)
+
             expect(s1.id).to_not eq(s3.id)
             expect(s2.id).to_not eq(s4.id)
             expect(s3.parent).to eq(s1)


### PR DESCRIPTION
- Split sample (using splitButton and split during creating Reaction) will inherit some properties from parent
  - Name: {parent_name}-split (if parent_Name not empty)
  - External_label: {parent_external_label}-split (if parent_external_label not empty)
  - Short_label is updated (exclude reactants and solvents)

- Resolves #544