### PR TITLE
Remake ElementCollectionLabel

### DIFF
--- a/app/assets/javascripts/components/ElementReactionLabels.js
+++ b/app/assets/javascripts/components/ElementReactionLabels.js
@@ -4,18 +4,8 @@ import {Label} from 'react-bootstrap';
 export default class ElementReactionLabels extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      hover: false
-    }
 
-    this.toggleHover = this.toggleHover.bind(this)
     this.handleOnClick = this.handleOnClick.bind(this)
-  }
-
-  toggleHover() {
-    this.setState({
-      hover: !this.state.hover
-    })
   }
 
   handleOnClick(e) {
@@ -36,9 +26,9 @@ export default class ElementReactionLabels extends React.Component {
     let {element} = this.props
 
     // If the Sample has no role in any reaction. Don't display the icon
-    if (!element.reactions_product_samples || element.reactions_product_samples.length == 0 &&
-        element.reactions_starting_material_samples.length == 0)
-      return (<div></div>)
+    if ((!element.reactions_product_samples || element.reactions_product_samples.length == 0) &&
+       (!element.reactions_starting_material_samples || element.reactions_starting_material_samples.length == 0))
+      return (<span></span>)
 
     let reaction = <i className='icon-reaction'/>
     let labelStyle = {
@@ -47,21 +37,10 @@ export default class ElementReactionLabels extends React.Component {
       border: '1px solid grey'
     }
 
-    let {hover} = this.state
-    if (hover == true) {
-     labelStyle.backgroundColor = '#19B5FE'
-    } else {
-      labelStyle.backgroundColor = 'white'
-    }
-
     return (
       <div style={{display: 'inline-block'}} onClick={this.handleOnClick}>
         <span className="collection-label" key={element.id}>
-        <Label style={labelStyle}
-               onMouseEnter={this.toggleHover}
-               onMouseLeave={this.toggleHover}>
-          {reaction}
-        </Label>
+        <Label>{reaction}</Label>
         </span>
       </div>
     )

--- a/app/assets/stylesheets/elements_table.css
+++ b/app/assets/stylesheets/elements_table.css
@@ -19,6 +19,67 @@ th.drag {
   cursor: pointer;
 }
 
+.collection-label span {
+  border: 1px solid grey;
+  background-color: white;
+  color: black;
+}
+
+.collection-label span:hover {
+  background-color: #19B5FE;
+}
+
+.custom-overlay {
+  position: absolute;
+  background-color: #FFF;
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  border: 1px solid #CCC;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  z-index: 1060;
+  -webkit-background-clip: padding-box;
+  background-clip: padding-box;
+  border-radius: 6px;
+  -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, .2);
+  box-shadow: 0 5px 10px rgba(0, 0, 0, .2);
+  top: -12px !important;
+  left: 0;
+  padding: 1px;
+  text-align: left;
+  white-space: normal;
+  width: 250px !important;
+  color: black;
+}
+
+.custom-overlay > .arrow,
+.custom-overlay > .arrow:after {
+  position: absolute;
+  display: block;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+}
+.custom-overlay > .arrow {
+  border-width: 11px;
+  top: 29%;
+  right: -11px;
+  margin-top: -11px;
+  border-right-width: 0;
+  border-left-color: #999;
+  border-left-color: rgba(0, 0, 0, .25);
+}
+
+.custom-overlay > .arrow:after {
+  content: "";
+  border-width: 10px;
+  right: 1px;
+  bottom: -10px;
+  content: " ";
+  border-right-width: 0;
+  border-left-color: #fff;
+}
+
 .fa-user-secret {
   float:right;
   margin-top:2px;

--- a/app/models/concerns/labeled.rb
+++ b/app/models/concerns/labeled.rb
@@ -7,6 +7,19 @@ module Labeled
 
   def collection_labels
     collections = object.collections.where.not(label: 'All')
-    collections.map {|c| {name: c.label, is_shared: c.is_shared,id: c.id}}.uniq
+    collections.map {|c|
+      collection_id =
+        if c.is_synchronized
+          SyncCollectionsUser.where(collection_id: c.id).first.id
+        else
+          c.id
+        end
+
+      {
+        name: c.label, is_shared: c.is_shared, user_id: c.user_id,
+        id: collection_id, shared_by_id: c.shared_by_id,
+        is_synchronized: c.is_synchronized
+      }
+    }.uniq
   end
 end

--- a/app/models/sync_collections_user.rb
+++ b/app/models/sync_collections_user.rb
@@ -7,4 +7,10 @@ class SyncCollectionsUser < ActiveRecord::Base
   has_many :reactions, through: :collection
   has_many :wellplates, through: :collection
   has_many :screens, through: :collection
+
+  before_create :auto_set_synchronized_flag
+
+  def auto_set_synchronized_flag
+    self.collection.update_attribute(:is_synchronized, true) if self.collection.present?
+  end
 end

--- a/db/migrate/20161004121244_add_is_synchronized_to_collections.rb
+++ b/db/migrate/20161004121244_add_is_synchronized_to_collections.rb
@@ -1,0 +1,10 @@
+class AddIsSynchronizedToCollections < ActiveRecord::Migration
+  def change
+    add_column :collections, :is_synchronized, :boolean, null: false, default: false
+    Collection.reset_column_information
+
+    SyncCollectionsUser.find_each do |sc|
+      sc.collection.update_attribute(:is_synchronized, true) if sc.collection.present?
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160920105050) do
+ActiveRecord::Schema.define(version: 20161004121244) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 20160920105050) do
     t.integer  "screen_detail_level",    default: 10
     t.boolean  "is_locked",              default: false
     t.datetime "deleted_at"
+    t.boolean  "is_synchronized",        default: false, null: false
   end
 
   add_index "collections", ["ancestry"], name: "index_collections_on_ancestry", using: :btree

--- a/spec/api/reaction_api_spec.rb
+++ b/spec/api/reaction_api_spec.rb
@@ -27,7 +27,12 @@ describe Chemotion::ReactionAPI do
           id: r2.id,
           name: r2.name,
           type: 'reaction',
-          collection_labels: [{"name" => 'C1', "is_shared" => false, "id" => c1.id}]
+          collection_labels: [{
+            "name" => 'C1', "is_shared" => false,
+            "id" => c1.id, "user_id" => user.id,
+            "shared_by_id" => c1.shared_by_id,
+            "is_synchronized" => c1.is_synchronized
+          }]
         )
       end
     end

--- a/spec/api/sample_api_spec.rb
+++ b/spec/api/sample_api_spec.rb
@@ -205,7 +205,11 @@ describe Chemotion::SampleAPI do
           type: 'sample',
           #collection_labels: [{"name" => 'C1', "is_shared" => false, "id"=>c.id}]
         )
-        expect(first_sample["collection_labels"]).to include({"name" => 'C1', "is_shared" => false, "id"=>c.id})
+        expect(first_sample["collection_labels"]).to include({
+          "name" => 'C1', "is_shared" => false, "id"=>c.id,
+          "user_id" => user.id, "shared_by_id" => c.shared_by_id,
+          "is_synchronized" => c.is_synchronized
+        })
       end
     end
 


### PR DESCRIPTION
- Add new column `is_synchronized` to Collection table, which turn on to synchronized collection. This flag will be automatically update while synchronized collection is created.
- Remake ElementCollectionLabel with a counter for own collections and shared (include synchronized) collections.
- Fix a bug when non-owned collections are displayed inside the label
- Resolves #488 #489