### PR TITLE
Split Sample - Reactant without IUPAC

### DIFF
--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -265,32 +265,28 @@ module ReactionUpdator
               parent_sample = Sample.find(sample.parent_id)
 
               #TODO extract subsample method
-              subsample = parent_sample.dup
-              subsample.parent = parent_sample
+              first_collection_id = collections.first.id
+              subsample = parent_sample.create_subsample current_user, first_collection_id
 
               if (material_group == :reactant || material_group == :solvent)
-                # Use 'reactants' or 'solvents' as short_label
+                # Use 'reactant' or 'solvent' as short_label
                 subsample.short_label = sample.short_label
               else
                 #we don't want to inherit short_label from parent
                 subsample.short_label = nil
               end
 
-              subsample.created_by = current_user.id
-              subsample.name = sample.name
               subsample.target_amount_value = sample.target_amount_value
               subsample.target_amount_unit = sample.target_amount_unit
               subsample.real_amount_value = sample.real_amount_value
               subsample.real_amount_unit = sample.real_amount_unit
-              subsample.external_label = sample.external_label if sample.external_label
 
               if ra = (sample.residues_attributes || sample.residues)
-                subsample.residues_attributes = ra.uniq || ra.each do |i|
-                                                             i.delete :id
-                                                           end
+                subsample.residues_attributes =
+                  ra.uniq || ra.each do |i| i.delete :id end
               end
 
-              subsample.collections << collections
+              subsample.collections << collections.where.not(id: first_collection_id)
 
               subsample.save!
               subsample.reload

--- a/app/assets/javascripts/components/Material.js
+++ b/app/assets/javascripts/components/Material.js
@@ -3,6 +3,7 @@ import {Radio,FormControl, Button, InputGroup, OverlayTrigger, Tooltip} from 're
 import {DragSource} from 'react-dnd';
 import DragDropItemTypes from './DragDropItemTypes';
 import NumeralInputWithUnitsCompo from './NumeralInputWithUnitsCompo';
+import SampleName from './common/SampleName'
 import UiStore from './stores/UIStore';
 
 const source = {
@@ -431,41 +432,61 @@ class Material extends Component {
 
   materialNameWithIupac(material) {
     // Skip shortLabel for reactants and solvents
-    let skipShortLabel = this.props.materialGroup == 'reactants' ||
+    let skipIupacName = this.props.materialGroup == 'reactants' ||
                          this.props.materialGroup == 'solvents'
     let materialName = ""
     let moleculeIupacName = ""
+    let iupacStyle = {
+      display: "block", whiteSpace: "nowrap", overflow: "hidden",
+      textOverflow: "ellipsis", maxWidth: "100%"
+    }
+
     var idCheck = /^\d+$/
 
-    if (skipShortLabel) {
+    if (skipIupacName) {
+      let materialDisplayName = material.molecule_iupac_name
+      if (materialDisplayName == null || materialDisplayName == "") {
+        materialDisplayName = (
+          <span>
+            <SampleName sample={material}/>
+          </span>
+        )
+      }
+
       if (idCheck.test(material.id)) {
         materialName =
           <a onClick={() => this.handleMaterialClick(material)}
              style={{cursor: 'pointer'}}>
-            {material.molecule_iupac_name}
+            {materialDisplayName}
           </a>
       } else {
-        materialName =
-          <span>{material.molecule_iupac_name}</span>
+        materialName = <span>{materialDisplayName}</span>
       }
     } else {
       moleculeIupacName = material.molecule_iupac_name
-      materialName =
+      let materialDisplayName = material.title() == ""
+                                ? <SampleName sample={material}/>
+                                : material.title()
+      materialName = (
         <a onClick={() => this.handleMaterialClick(material)} style={{cursor: 'pointer'}}>
-          {material.title()}
+          {materialDisplayName}
         </a>
-      if (material.isNew)
-        materialName = material.title()
+      )
+
+      if (material.isNew) materialName = materialDisplayName
+    }
+    let br = <br />
+    if (moleculeIupacName == "") {
+      iupacStyle = {display: "none"}
+      br = ""
     }
 
     return (
       <OverlayTrigger placement="bottom" overlay={this.iupacNameTooltip(material.molecule.iupac_name)}>
         <div style={{display: "inline-block", maxWidth: "100%"}}>
           {materialName}
-          <br/>
-          <span style={{display: "block", whiteSpace: "nowrap",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis", maxWidth: "100%"}}>
+          {br}
+          <span style={iupacStyle}>
             {moleculeIupacName}
           </span>
         </div>

--- a/app/assets/javascripts/components/ReactionDetails.js
+++ b/app/assets/javascripts/components/ReactionDetails.js
@@ -295,7 +295,7 @@ export default class ReactionDetails extends Component {
                 onInputChange={(type, event) => this.handleInputChange(type, event)}
                 />
             </Tab>
-            <Tab eventKey={2} title={'Literatures'}>
+            <Tab eventKey={2} title={'References'}>
               <ReactionDetailsLiteratures
                 reaction={reaction}
                 onReactionChange={reaction => this.handleReactionChange(reaction)}

--- a/app/assets/javascripts/components/ReactionDetailsScheme.js
+++ b/app/assets/javascripts/components/ReactionDetailsScheme.js
@@ -36,6 +36,12 @@ export default class ReactionDetailsScheme extends Component {
         splitSample.name = reaction.short_label + "-" +
           String.fromCharCode('A'.charCodeAt(0) + productsCount)
       }
+
+      if (sample.external_label)
+        splitSample.external_label = sample.external_label
+      if (sample.elemental_compositions)
+        splitSample.elemental_compositions = sample.elemental_compositions
+
     } else if (sample instanceof Sample){
       // Else split Sample
       if(reaction.hasSample(sample.id)) {
@@ -49,7 +55,7 @@ export default class ReactionDetailsScheme extends Component {
       if (materialGroup == 'reactants' || materialGroup == 'solvents') {
         // Skip counter for reactants or solvents
         splitSample = sample.buildChildWithoutCounter()
-        splitSample.short_label = materialGroup
+        splitSample.short_label = materialGroup.slice(0, -1)
       } else {
         splitSample = sample.buildChild()
       }

--- a/app/assets/javascripts/components/models/Sample.js
+++ b/app/assets/javascripts/components/models/Sample.js
@@ -11,14 +11,19 @@ export default class Sample extends Element {
   }
 
   static copyFromSampleAndCollectionId(sample, collection_id, structure_only = false) {
-    let newSample = sample.buildCopy();
+    let newSample = sample.buildCopy()
 
     if(structure_only)
       newSample.filterSampleData()
 
-    newSample.collection_id = collection_id;
+    newSample.collection_id = collection_id
+    if (sample.name) newSample.name = sample.name
+    if (sample.external_label)
+      newSample.external_label = sample.external_label
+    if (sample.elemental_compositions)
+      newSample.elemental_compositions = sample.elemental_compositions
 
-    return newSample;
+    return newSample
   }
 
   filterSampleData() {
@@ -56,8 +61,8 @@ export default class Sample extends Element {
   }
 
   buildCopy() {
-    let sample = super.buildCopy();
-    sample.short_label = sample.short_label + " Copy";
+    let sample = super.buildCopy()
+    sample.short_label = sample.short_label + " Copy"
     return sample;
   }
 
@@ -73,9 +78,11 @@ export default class Sample extends Element {
     splitSample.parent_id = this.id;
     splitSample.id = Element.buildID();
 
-    if (this.name) splitSample.name = this.name + "-split"
+    if (this.name) splitSample.name = this.name
     if (this.external_label)
-      splitSample.external_label = this.external_label + "-split"
+      splitSample.external_label = this.external_label
+    if (this.elemental_compositions)
+      splitSample.elemental_compositions = this.elemental_compositions
 
     splitSample.short_label += "-" + children_count;
     splitSample.created_at = null;
@@ -92,9 +99,11 @@ export default class Sample extends Element {
     splitSample.parent_id = this.id;
     splitSample.id = Element.buildID();
 
-    if (this.name) splitSample.name = this.name + "-split"
+    if (this.name) splitSample.name = this.name
     if (this.external_label)
-      splitSample.external_label = this.external_label + "-split"
+      splitSample.external_label = this.external_label
+    if (this.elemental_compositions)
+      splitSample.elemental_compositions = this.elemental_compositions
 
     splitSample.created_at = null;
     splitSample.updated_at = null;

--- a/spec/api/reaction_api_spec.rb
+++ b/spec/api/reaction_api_spec.rb
@@ -283,34 +283,33 @@ describe Chemotion::ReactionAPI do
             "name" => "new name",
             "materials" => {
               "starting_materials" => [
-                  {
-                                "id" => sample_1.id,
-                       "target_amount_unit" => "mg",
-                      "target_amount_value" => 76.09596,
-                        "equivalent" => 1,
-                         "reference" => false,
-                            "is_new" => false
-                  },
-                  {
-                                "id" => sample_2.id,
-                       "amount_unit" => "mg",
-                      "amount_value" => 99.08404,
-                        "equivalent" => 5.5,
-                         "reference" => false,
-                            "is_new" => false
-                  }
+                {
+                  "id" => sample_1.id,
+                  "target_amount_unit" => "mg",
+                  "target_amount_value" => 76.09596,
+                  "equivalent" => 1,
+                  "reference" => false,
+                  "is_new" => false
+                },
+                {
+                  "id" => sample_2.id,
+                  "amount_unit" => "mg",
+                  "amount_value" => 99.08404,
+                  "equivalent" => 5.5,
+                  "reference" => false,
+                  "is_new" => false
+                }
               ],
               "products" => [
-                         "id" => "d4ca4ec0-6d8e-11e5-b2f1-c9913eb3e335",
-                       "name" => "New Subsample 1",
+                "id" => "d4ca4ec0-6d8e-11e5-b2f1-c9913eb3e335",
+                "name" => "New Subsample 1",
                 "target_amount_unit" => "mg",
-               "target_amount_value" => 76.09596,
-                  "parent_id" => sample_1.id,
-                  "reference" => true,
-                 "equivalent" => 1,
-                     "is_new" => true,
-                   "is_split" => true,
-
+                "target_amount_value" => 76.09596,
+                "parent_id" => sample_1.id,
+                "reference" => true,
+                "equivalent" => 1,
+                "is_new" => true,
+                "is_split" => true,
               ]
             }
           }
@@ -329,9 +328,9 @@ describe Chemotion::ReactionAPI do
           expect(subsample.parent).to eq(sample_1)
           expect(subsample.attributes).to include(
             {
-                      "name" => "New Subsample 1",
+              "name" => sample_1.name,
               "target_amount_value" => 76.09596,
-               "target_amount_unit" => "mg",
+              "target_amount_unit" => "mg",
             }
           )
 
@@ -398,9 +397,9 @@ describe Chemotion::ReactionAPI do
           expect(subsample.parent).to eq(sample_1)
           expect(subsample.attributes).to include(
             {
-                      "name" => "New Subsample 1",
+              "name" => sample_1.name,
               "target_amount_value" => 76.09596,
-               "target_amount_unit" => "mg"
+              "target_amount_unit" => "mg"
             }
           )
 
@@ -418,10 +417,10 @@ describe Chemotion::ReactionAPI do
 
           expect(reactant.attributes).to include(
             {
-                      "name" => "Copied Sample",
+              "name" => "Copied Sample",
               "target_amount_value" => 86.09596,
-               "target_amount_unit" => "mg",
-                   "solvent" => "solvent1"
+              "target_amount_unit" => "mg",
+              "solvent" => "solvent1"
             }
           )
 

--- a/spec/api/sample_api_spec.rb
+++ b/spec/api/sample_api_spec.rb
@@ -381,23 +381,25 @@ describe Chemotion::SampleAPI do
         describe 'POST /api/v1/samples/subsamples' do
           it 'should be able to split Samples into Subsamples' do
             post '/api/v1/samples/subsamples', params
-            subsamples = Sample.where(name: ['s1-split','s2-split']).where.not(id: [s1.id,s2.id])
+            subsamples = Sample.where(name: ['s1','s2']).where.not(id: [s1.id,s2.id])
             s3 = subsamples[0]
             s4 = subsamples[1]
-            except_attr = ["id", "created_at", "updated_at", "ancestry", "created_by",
-              "short_label", "name", "external_label"]
+            except_attr = [
+              "id", "created_at", "updated_at", "ancestry", "created_by",
+              "short_label", "name", "external_label"
+            ]
             s3.attributes.except(*except_attr).each do |k, v|
               expect(s1[k]).to eq(v)
             end
-            expect(s3.name).to eq(s1.name + "-split")
-            expect(s3.external_label).to eq(s1.external_label + "-split")
+            expect(s3.name).to eq(s1.name)
+            expect(s3.external_label).to eq(s1.external_label)
             expect(s3.short_label).to eq(s1.short_label + "-" + s1.children.count.to_s)
 
             s4.attributes.except(*except_attr).each do |k, v|
               expect(s2[k]).to eq(v)
             end
-            expect(s4.name).to eq(s2.name + "-split")
-            expect(s4.external_label).to eq(s2.external_label + "-split")
+            expect(s4.name).to eq(s2.name)
+            expect(s4.external_label).to eq(s2.external_label)
             expect(s4.short_label).to eq(s2.short_label + "-" + s2.children.count.to_s)
 
             expect(s1.id).to_not eq(s3.id)


### PR DESCRIPTION
- Split sample, copy sample: copy name, external_label and elemental_compositions
- Change "reactants"/"solvents" short_label to "reactant"/"solvent" (singular)
- Bug fixed: if a reactant/solvent have no IUPAC name, display a sum_fomular and "reactant/solvent"
- Resolves #619 #625