### PR TITLE
Reaction Drag and Drop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -540,6 +540,3 @@ DEPENDENCIES
   webmock
   whenever
   yaml_db
-
-BUNDLED WITH
-   1.13.2

--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -299,7 +299,6 @@ module ReactionUpdator
               )
             #create new sample
             else
-
               attributes = sample.to_h
                 .except(:id, :is_new, :is_split, :reference, :equivalent, :type, :molecule, :collection_id, :short_label)
                 .merge(molecule_attributes: {molfile: sample.molecule.molfile}, created_by: current_user.id)
@@ -327,6 +326,7 @@ module ReactionUpdator
             existing_sample.real_amount_value = sample.real_amount_value
             existing_sample.real_amount_unit = sample.real_amount_unit
             existing_sample.external_label = sample.external_label if sample.external_label
+            existing_sample.name = sample.name if sample.name
 
             if r = existing_sample.residues[0]
               r.assign_attributes sample.residues_attributes[0]

--- a/app/assets/javascripts/components/ReactionDetailsScheme.js
+++ b/app/assets/javascripts/components/ReactionDetailsScheme.js
@@ -23,26 +23,12 @@ export default class ReactionDetailsScheme extends Component {
 
   dropSample(sample, materialGroup, external_label) {
     let {reaction} = this.state;
-    let splitSample ;
+    let splitSample;
 
     if (sample instanceof Molecule || materialGroup == 'products'){
       // Create new Sample with counter
-      splitSample =
-        Sample.buildReactionSample(reaction.collection_id,
-          reaction.temporary_sample_counter, materialGroup, sample)
-
-      if (materialGroup == 'products') {
-        let productsCount = reaction.products.length
-        splitSample.name = reaction.short_label + "-" +
-          String.fromCharCode('A'.charCodeAt(0) + productsCount)
-      }
-
-      if (sample.external_label)
-        splitSample.external_label = sample.external_label
-      if (sample.elemental_compositions)
-        splitSample.elemental_compositions = sample.elemental_compositions
-
-    } else if (sample instanceof Sample){
+      splitSample = Sample.buildNew(sample, reaction.collection_id);
+    } else if (sample instanceof Sample) {
       // Else split Sample
       if(reaction.hasSample(sample.id)) {
         NotificationActions.add({
@@ -54,21 +40,12 @@ export default class ReactionDetailsScheme extends Component {
 
       if (materialGroup == 'reactants' || materialGroup == 'solvents') {
         // Skip counter for reactants or solvents
-        splitSample = sample.buildChildWithoutCounter()
-        splitSample.short_label = materialGroup.slice(0, -1)
+        splitSample = sample.buildChildWithoutCounter();
       } else {
-        splitSample = sample.buildChild()
-      }
-
-      if(materialGroup == 'products') {
-        splitSample.reaction_product = true;
-        splitSample.equivalent = 0;
+        splitSample = sample.buildChild();
       }
     }
 
-    if(external_label && materialGroup === 'solvents' && !splitSample.external_label) {
-      splitSample.external_label = external_label;
-    }
     reaction.addMaterial(splitSample, materialGroup);
 
     this.onReactionChange(reaction, {schemaChanged: true});

--- a/app/assets/javascripts/components/models/Sample.js
+++ b/app/assets/javascripts/components/models/Sample.js
@@ -61,37 +61,79 @@ export default class Sample extends Element {
     ];
   }
 
+  static buildNewShortLabel(delta = 0) {
+    let {currentUser} = UserStore.getState();
+    if(!currentUser) {
+      return 'NEW SAMPLE';
+    } else {
+      return `${currentUser.initials}-${currentUser.samples_count + delta +  1}`;
+    }
+  }
+
+  static buildEmpty(collection_id) {
+    let sample = new Sample({
+      collection_id: collection_id,
+      type: 'sample',
+      external_label: '',
+      target_amount_value: 0,
+      target_amount_unit: 'g',
+      description: '',
+      purity: 1,
+      density: 1,
+      solvent: '',
+      impurities: '',
+      location: '',
+      molfile: '',
+      molecule: { id: '_none_' },
+      analyses: [],
+      residues: [],
+      elemental_compositions: [{
+        composition_type: 'found',
+        data: {}
+      }],
+      imported_readout: '',
+      attached_amount_mg: '' // field for polymers calculations
+    });
+
+    sample.short_label = Sample.buildNewShortLabel();
+    return sample;
+  }
+
+  getChildrenCount() {
+    return parseInt(Sample.children_count[this.id] || this.children_count);
+  }
+
+  buildSplitShortLabel() {
+    let children_count = this.getChildrenCount() + 1;
+    return this.short_label + "-" + children_count;
+  }
+
   buildCopy() {
     let sample = super.buildCopy()
     sample.short_label = sample.short_label + " Copy"
     return sample;
   }
 
+  static buildNew(sample, collection_id) {
+    let newSample = Sample.buildEmpty(collection_id)
+
+    newSample.molecule = sample.molecule == undefined ? sample : sample.molecule
+
+    if (sample instanceof Sample)
+      newSample.split_label = sample.buildSplitShortLabel();
+
+    newSample.molfile = this.molfile || ''
+    newSample.sample_svg_file = this.sample_svg_file
+
+    return newSample;
+  }
+
   buildChild() {
     Sample.counter += 1;
+    let splitSample = this.buildChildWithoutCounter();
+    splitSample.short_label = splitSample.split_label;
+    Sample.children_count[this.id] = this.getChildrenCount() + 1;
 
-    //increase subsample count per sample on client side, as we have no persisted data at this moment
-    let children_count = parseInt(Sample.children_count[this.id] || this.children_count);
-    children_count += 1;
-    Sample.children_count[this.id] = children_count;
-
-    let splitSample = this.clone();
-    splitSample.parent_id = this.id;
-    splitSample.id = Element.buildID();
-
-    if (this.name) splitSample.name = this.name
-    if (this.external_label)
-      splitSample.external_label = this.external_label
-    if (this.elemental_compositions)
-      splitSample.elemental_compositions = this.elemental_compositions
-
-    splitSample.short_label += "-" + children_count;
-    splitSample.created_at = null;
-    splitSample.updated_at = null;
-    splitSample.target_amount_value = 0;
-    splitSample.real_amount_value = null;
-    splitSample.is_split = true;
-    splitSample.is_new = true;
     return splitSample;
   }
 
@@ -101,8 +143,7 @@ export default class Sample extends Element {
     splitSample.id = Element.buildID();
 
     if (this.name) splitSample.name = this.name
-    if (this.external_label)
-      splitSample.external_label = this.external_label
+    if (this.external_label) splitSample.external_label = this.external_label
     if (this.elemental_compositions)
       splitSample.elemental_compositions = this.elemental_compositions
 
@@ -112,11 +153,18 @@ export default class Sample extends Element {
     splitSample.real_amount_value = null;
     splitSample.is_split = true;
     splitSample.is_new = true;
+
+    splitSample.split_label = splitSample.buildSplitShortLabel();
+
     return splitSample;
   }
 
   get isSplit() {
     return this.is_split
+  }
+
+  set isSplit(is_split) {
+    this.is_split = is_split;
   }
 
   serialize() {
@@ -150,96 +198,6 @@ export default class Sample extends Element {
     });
 
     return serialized;
-  }
-
-  static buildEmpty(collection_id) {
-    let sample = new Sample({
-      collection_id: collection_id,
-      type: 'sample',
-      external_label: '',
-      target_amount_value: 0,
-      target_amount_unit: 'g',
-      description: '',
-      purity: 1,
-      density: 1,
-      solvent: '',
-      impurities: '',
-      location: '',
-      molfile: '',
-      molecule: { id: '_none_' },
-      analyses: [],
-      residues: [],
-      elemental_compositions: [{
-        composition_type: 'found',
-        data: {}
-      }],
-      imported_readout: '',
-      attached_amount_mg: '' // field for polymers calculations
-    });
-
-    sample.short_label = Sample.buildNewSampleShortLabelForCurrentUser();
-    return sample;
-  }
-
-  static buildReactionSample(collection_id, delta, materialGroup = null, molecule = { id: '_none_'}) {
-    let target_molecule = molecule.molecule == undefined ? molecule : molecule.molecule
-    let sample = new Sample({
-      collection_id: collection_id,
-      type: 'sample',
-      external_label: '',
-      target_amount_value: 0,
-      target_amount_unit: 'g',
-      description: '',
-      purity: 1,
-      density: 1,
-      solvent: '',
-      impurities: '',
-      location: '',
-      molfile: molecule.molfile || '',
-      molecule:  target_molecule,
-      analyses: [],
-      elemental_compositions: [{
-        composition_type: 'found',
-        data: {}
-      }],
-      residues: [],
-      imported_readout: ''
-    });
-    sample.sample_svg_file = molecule.sample_svg_file;
-
-    if(molecule.residues && molecule.residues.length > 0) {
-      sample.residues = molecule.residues;
-      sample.contains_residues = true;
-
-      if(materialGroup == 'products')
-        sample.loading = 0;
-    }
-
-    // allow zero loading for reaction product
-    sample.reaction_product = (materialGroup == 'products');
-
-    // Skip short_label for reactants and solvents
-    if (materialGroup != "reactants" && materialGroup != "solvents")
-      sample.short_label = Sample.buildNewSampleShortLabelForCurrentUser(delta)
-    else
-      sample.short_label = materialGroup
-
-    return sample;
-  }
-
-  static buildNewSampleShortLabelWithCounter(counter) {
-    let {currentUser} = UserStore.getState();
-
-    return `${currentUser.initials}-${counter}`;
-  }
-
-  static buildNewSampleShortLabelForCurrentUser(delta = 0) {
-    let {currentUser} = UserStore.getState();
-    if(!currentUser) {
-      return 'NEW SAMPLE';
-    } else {
-      return `${currentUser.initials}-${currentUser.samples_count + delta +  1}`;
-    }
   }
 
   get is_top_secret() {
@@ -341,10 +299,9 @@ export default class Sample extends Element {
 
   iupac_name_tag(length) {
     let iupac_name = this.molecule.iupac_name || "";
-    return iupac_name.length > length ?
-      iupac_name.slice(0, length) + "..."
-      :
-      iupac_name
+    return iupac_name.length > length
+           ? iupac_name.slice(0, length) + "..."
+           : iupac_name
   }
 
   get location() {

--- a/app/assets/javascripts/components/stores/ElementStore.js
+++ b/app/assets/javascripts/components/stores/ElementStore.js
@@ -312,11 +312,11 @@ class ElementStore {
   handleAddSampleToMaterialGroup(params) {
     const { materialGroup } = params
     let { reaction } = params
-    const { temporary_sample_counter } = reaction
 
-    let sample = Sample.buildReactionSample(reaction.collection_id,
-                                            temporary_sample_counter,
-                                            materialGroup)
+    let sample = Sample.buildEmpty(reaction.collection_id)
+    sample.molfile = sample.molfile || ''
+    sample.molecule = sample.molecule == undefined ? sample : sample.molecule
+    sample.sample_svg_file = sample.sample_svg_file
 
     this.state.currentMaterialGroup = materialGroup
     reaction.changed = true


### PR DESCRIPTION
- Re-factor Sample and Reaction js model
  + Keep sample logic (copy, split, new) in Sample model
  + Keep reaction logic (drag sample to starting, reactant/solvent, product) in Reaction model
- Rebuild logic while moving between MaterialGroup
- If create new Product through Reaction create button, product name must be manually input
- Resolves #649