### PR TITLE
Drag and Drop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -540,6 +540,3 @@ DEPENDENCIES
   webmock
   whenever
   yaml_db
-
-BUNDLED WITH
-   1.13.2

--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -327,6 +327,8 @@ module ReactionUpdator
             existing_sample.real_amount_value = sample.real_amount_value
             existing_sample.real_amount_unit = sample.real_amount_unit
             existing_sample.external_label = sample.external_label if sample.external_label
+            existing_sample.short_label = sample.short_label if sample.short_label
+            existing_sample.name = sample.name if sample.name
 
             if r = existing_sample.residues[0]
               r.assign_attributes sample.residues_attributes[0]

--- a/app/assets/javascripts/components/ReactionDetailsScheme.js
+++ b/app/assets/javascripts/components/ReactionDetailsScheme.js
@@ -27,22 +27,8 @@ export default class ReactionDetailsScheme extends Component {
 
     if (sample instanceof Molecule || materialGroup == 'products'){
       // Create new Sample with counter
-      splitSample =
-        Sample.buildReactionSample(reaction.collection_id,
-          reaction.temporary_sample_counter, materialGroup, sample)
-
-      if (materialGroup == 'products') {
-        let productsCount = reaction.products.length
-        splitSample.name = reaction.short_label + "-" +
-          String.fromCharCode('A'.charCodeAt(0) + productsCount)
-      }
-
-      if (sample.external_label)
-        splitSample.external_label = sample.external_label
-      if (sample.elemental_compositions)
-        splitSample.elemental_compositions = sample.elemental_compositions
-
-    } else if (sample instanceof Sample){
+      splitSample = Sample.buildNew(sample, reaction.collection_id);
+    } else if (sample instanceof Sample) {
       // Else split Sample
       if(reaction.hasSample(sample.id)) {
         NotificationActions.add({
@@ -54,21 +40,12 @@ export default class ReactionDetailsScheme extends Component {
 
       if (materialGroup == 'reactants' || materialGroup == 'solvents') {
         // Skip counter for reactants or solvents
-        splitSample = sample.buildChildWithoutCounter()
-        splitSample.short_label = materialGroup.slice(0, -1)
+        splitSample = sample.buildChildWithoutCounter();
       } else {
-        splitSample = sample.buildChild()
-      }
-
-      if(materialGroup == 'products') {
-        splitSample.reaction_product = true;
-        splitSample.equivalent = 0;
+        splitSample = sample.buildChild();
       }
     }
 
-    if(external_label && materialGroup === 'solvents' && !splitSample.external_label) {
-      splitSample.external_label = external_label;
-    }
     reaction.addMaterial(splitSample, materialGroup);
 
     this.onReactionChange(reaction, {schemaChanged: true});

--- a/app/assets/javascripts/components/stores/ElementStore.js
+++ b/app/assets/javascripts/components/stores/ElementStore.js
@@ -312,11 +312,11 @@ class ElementStore {
   handleAddSampleToMaterialGroup(params) {
     const { materialGroup } = params
     let { reaction } = params
-    const { temporary_sample_counter } = reaction
 
-    let sample = Sample.buildReactionSample(reaction.collection_id,
-                                            temporary_sample_counter,
-                                            materialGroup)
+    let sample = Sample.buildEmpty(reaction.collection_id)
+    sample.molfile = sample.molfile || ''
+    sample.molecule = sample.molecule == undefined ? sample : sample.molecule
+    sample.sample_svg_file = sample.sample_svg_file
 
     this.state.currentMaterialGroup = materialGroup
     reaction.changed = true


### PR DESCRIPTION
- Re-factor Sample and Reaction js model
- When moving un-saved sample between groups:
  + FROM products: blank name, short-label changes
  + TO products: auto-naming, short-label for new sample
  + TO starting_materials: split short-label, keep name
  + TO reactans/solvents: change short-label, keep name
- Moving saved sample:
  + Can't split short-label, so that use new short-label
  + reactant/solvents short-label changes
- Resolves #649