### PR TITLE
Apply temperature convert to user text

### DIFF
--- a/app/assets/javascripts/components/ReactionDetails.js
+++ b/app/assets/javascripts/components/ReactionDetails.js
@@ -92,7 +92,11 @@ export default class ReactionDetails extends Component {
     }).filter(s => s)
 
     const solventsArray = solvents.length !== 0 ? solvents : [reaction.solvent]
-    const temperature = reaction.temperature_display
+    let temperature = reaction.temperature_display
+    if (/^\-?\d*\.{0,1}\d{0,2}$/.test(temperature)) {
+      temperature = temperature + " " + reaction.temperature.valueUnit
+    }
+
     ElementActions.fetchReactionSvgByMaterialsSvgPaths(materialsSvgPaths, temperature, solventsArray);
   }
 

--- a/app/assets/javascripts/components/lineChart/LineChart.js
+++ b/app/assets/javascripts/components/lineChart/LineChart.js
@@ -53,10 +53,10 @@ class D3LineChart {
     const margin = this.margin
 
     const xExtent = d3.extent(decimalData, d => d.time)
-    const yExtent = [
-      d3.min(decimalData, d => parseFloat(d.value)),
-      d3.max(decimalData, d => parseFloat(d.value))
-    ]
+    const yMin = d3.min(decimalData, d => parseFloat(d.value))
+    const yMax = d3.max(decimalData, d => parseFloat(d.value))
+    const delta = (yMax - yMin) * 0.1
+    const yExtent = [yMin - delta, yMax + delta]
 
     const xScale = d3.scale.linear().range([0, width]).domain(xExtent)
     const yScale = d3.scale.linear().range([height, 0]).domain(yExtent)

--- a/app/assets/javascripts/components/models/Reaction.js
+++ b/app/assets/javascripts/components/models/Reaction.js
@@ -104,9 +104,9 @@ export default class Reaction extends Element {
     let minTemp = Math.min.apply(Math, arrayData.map(function(o){return o.value}))
 
     if (minTemp == maxTemp)
-      return minTemp + " " + this._temperature.valueUnit
+      return minTemp
     else
-      return minTemp + " ~ " + maxTemp + " " + this._temperature.valueUnit
+      return minTemp + " ~ " + maxTemp
   }
 
   get temperature() {
@@ -133,6 +133,14 @@ export default class Reaction extends Element {
       default:
         convertFunc = this.convertFromCelcius
         break
+    }
+
+    // If userText is number only, treat as normal temperature value
+    if (/^\-?\d*\.{0,1}\d{0,2}$/.test(temperature.userText)) {
+      temperature.userText =
+        convertFunc(newUnit, temperature.userText).toFixed(2)
+
+      return temperature
     }
 
     temperature.data.forEach(function(data, index, theArray) {

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -126,8 +126,8 @@ class Reaction < ActiveRecord::Base
 
     return ""  if (minTemp == nil || maxTemp == nil)
 
-    return minTemp + " " + temperature["valueUnit"] if (minTemp.to_i == maxTemp.to_i)
-    return minTemp + " ~ " + maxTemp + " " + temperature["valueUnit"]
+    return minTemp
+    return minTemp + " ~ " + maxTemp
   end
 
   def update_svg_file!
@@ -141,6 +141,11 @@ class Reaction < ActiveRecord::Base
 
     begin
       temperature_display = self.temperature_display
+      if ((temperature_display =~ /^\-?\d*\.{0,1}\d{0,2}$/).present?)
+        temperature_display = temperature_display + " " +
+                              self.temperature["valueUnit"]
+      end
+
       composer = SVG::ReactionComposer.new(paths, temperature: temperature_display,
                                                   solvents: solvents_in_svg)
       self.reaction_svg_file = composer.compose_reaction_svg_and_save


### PR DESCRIPTION
- If user enter text, keep original. If user enter a number, treat it as temperature:
  + Display unit in SVG
  + Apply unit conversion on entered text
- Increase chart range: 10% of total variability. For example: if the temperature change from 1 to 100. We have: (100 - 1) * 0.1 = 9.9,  the chart range is from 8.9 to 109.9. With this way, the temperature line can fit within the chart
- Resolves #667 #668 #669