### PR TITLE
add filter to make eps images without irregular word size

### DIFF
--- a/lib/svg/reaction_composer.rb
+++ b/lib/svg/reaction_composer.rb
@@ -40,7 +40,7 @@ module SVG
     def compose_reaction_svg
       set_global_view_box_height
       section_it
-      template_it.strip + @sections.values.flatten.map(&:strip).join.gsub("R#", "") + "</svg></svg>"
+      template_it.strip + sections_string_filtered + "</svg></svg>"
     end
 
     private
@@ -261,6 +261,14 @@ module SVG
         key_base = "#{filenames.to_a.flatten.join}#{solvents.join('_')}#{temperature}"
         hash_of_filenames = Digest::SHA256.hexdigest(key_base)
         hash_of_filenames + '.svg'
+      end
+
+      def sections_string
+        @sections.values.flatten.map(&:strip).join
+      end
+
+      def sections_string_filtered
+        sections_string.gsub("R#", "").gsub("font=\'30px \"Arial\"\'", "")
       end
   end
 end


### PR DESCRIPTION
prevent something like this.
![image](https://cloud.githubusercontent.com/assets/8849364/19855631/e6fa8ff0-9f75-11e6-988e-c294c9b828b1.png)
