### PR TITLE
Fix reaction samples naming

### DIFF
--- a/app/assets/javascripts/components/ReactionDetails.js
+++ b/app/assets/javascripts/components/ReactionDetails.js
@@ -284,7 +284,6 @@ export default class ReactionDetails extends Component {
   render() {
     let {reaction, fullScreen} = this.state;
     let fScrnClass = fullScreen ? "full-screen" : ""
-    reaction.temporary_sample_counter = reaction.temporary_sample_counter || 0;
 
     const submitLabel = (reaction && reaction.isNew) ? "Create" : "Save";
     let extraTabs =[];

--- a/app/assets/javascripts/components/models/Reaction.js
+++ b/app/assets/javascripts/components/models/Reaction.js
@@ -298,7 +298,6 @@ export default class Reaction extends Element {
         material.start_parent = material.parent_id
         material.parent_id = null
       }
-      if (oldGroup == null) this.temporary_sample_counter += 1;
     } else if (newGroup == "reactants" || newGroup == "solvents") {
       // Temporary set true, to fit with server side logical
       material.isSplit = true;
@@ -310,8 +309,6 @@ export default class Reaction extends Element {
       if (material.start_parent && material.parent_id == null) {
         material.parent_id = material.start_parent
       }
-
-      if (oldGroup == null) this.temporary_sample_counter += 1;
     }
 
     this.shortLabelPolicy(material, oldGroup, newGroup);
@@ -333,14 +330,14 @@ export default class Reaction extends Element {
         let savedStartingMaterial = oldGroup == "starting_materials" && !material.isNew
         if (!savedStartingMaterial) {
           material.short_label =
-            Sample.buildNewShortLabel(this.temporary_sample_counter);
+            Sample.buildNewShortLabel();
         }
       } else if (newGroup == "starting_materials") {
         if (material.split_label) {
           material.short_label = material.split_label;
         } else {
           material.short_label =
-            Sample.buildNewShortLabel(this.temporary_sample_counter);
+            Sample.buildNewShortLabel();
         }
       }
     } else {
@@ -348,7 +345,7 @@ export default class Reaction extends Element {
         if (material.split_label) material.short_label = material.split_label;
       } else if (newGroup == "products") {
         material.short_label =
-          Sample.buildNewShortLabel(this.temporary_sample_counter);
+          Sample.buildNewShortLabel();
       } else {
         material.short_label = newGroup.slice(0, -1); // "reactant" or "solvent"
       }

--- a/app/assets/javascripts/components/models/Sample.js
+++ b/app/assets/javascripts/components/models/Sample.js
@@ -63,12 +63,12 @@ export default class Sample extends Element {
     ];
   }
 
-  static buildNewShortLabel(delta = 0) {
+  static buildNewShortLabel() {
     let {currentUser} = UserStore.getState();
     if(!currentUser) {
       return 'NEW SAMPLE';
     } else {
-      return `${currentUser.initials}-${currentUser.samples_count + delta +  1}`;
+      return `${currentUser.initials}-${currentUser.samples_count + 1}`;
     }
   }
 

--- a/app/assets/javascripts/components/stores/ElementStore.js
+++ b/app/assets/javascripts/components/stores/ElementStore.js
@@ -232,7 +232,6 @@ class ElementStore {
     let reaction = this.state.currentReaction;
 
     reaction.addMaterial(sample, materialGroup);
-    reaction.temporary_sample_counter += 1;
 
     this.handleRefreshElements('sample');
 


### PR DESCRIPTION
The problem before was that we did not refresh counter so had to use variable `temporary_samples_counter` in reaction. Now when we create a sample we refresh current user so don't need to use this counter.

**Question:** do I have to change old sample `short_label`-s ?