### PR TITLE
two step import of sd file

### DIFF
--- a/app/assets/javascripts/components/Navigation.js
+++ b/app/assets/javascripts/components/Navigation.js
@@ -5,6 +5,7 @@ import Search from './search/Search';
 import ManagingActions from './managing_actions/ManagingActions';
 import ContextActions from './contextActions/ContextActions';
 import UserStore from './stores/UserStore';
+import UIStore from './stores/UIStore'
 import UserActions from './actions/UserActions';
 import NavNewSession from '../libHome/NavNewSession'
 import NavHead from '../libHome/NavHead'
@@ -25,20 +26,29 @@ export default class Navigation extends React.Component {
       }
     }
     this.onChange = this.onChange.bind(this)
+    this.onUIChange = this.onUIChange.bind(this)
   }
 
   componentDidMount() {
+    UIStore.listen(this.onUIChange)
     UserStore.listen(this.onChange);
     UserActions.fetchCurrentUser();
   }
 
   componentWillUnmount() {
+    UIStore.unlisten(this.onUIChange)
     UserStore.unlisten(this.onChange);
   }
 
   onChange(state) {
     this.setState({
       currentUser: state.currentUser
+    });
+  }
+
+  onUIChange(state) {
+    this.setState({
+      modalProps: state.modalParams
     });
   }
 
@@ -50,18 +60,6 @@ export default class Navigation extends React.Component {
     this.setState({
       modalProps: modalProps
     });
-  }
-
-  handleModalHide() {
-    const modalProps = {
-      show: false,
-      title: "",
-      component: "",
-      action: null
-    };
-    this.updateModalProps(modalProps);
-    // https://github.com/react-bootstrap/react-bootstrap/issues/1137
-    document.body.className = document.body.className.replace('modal-open', '');
   }
 
   render() {
@@ -76,12 +74,7 @@ export default class Navigation extends React.Component {
             <Search />
             <ManagingActions updateModalProps={this.updateModalProps.bind(this)} />
             <ContextActions updateModalProps={this.updateModalProps.bind(this)} />
-            <NavigationModal show={modalProps.show}
-                              title={modalProps.title}
-                              Component={modalProps.component}
-                              action={modalProps.action}
-                              onHide={() => this.handleModalHide()}
-                              listSharedCollections={modalProps.listSharedCollections} />
+            <NavigationModal {...modalProps} />
           </Nav>
           <UserAuth/>
         </Navbar>

--- a/app/assets/javascripts/components/NavigationModal.js
+++ b/app/assets/javascripts/components/NavigationModal.js
@@ -1,17 +1,17 @@
 import React from 'react';
 import {Modal} from 'react-bootstrap';
+import UIActions from './actions/UIActions'
 
-const NavigationModal = ({show, title, Component, action, onHide, listSharedCollections}) => {
+const NavigationModal = ({show, title, component, customModal, ...props}) => {
+  const Component = component
   return(
     show
-      ? <Modal animation={false} show={show} onHide={() => onHide()}>
+      ? <Modal  dialogClassName={customModal} animation={false} show={show} onHide={() => UIActions.hideModal()}>
           <Modal.Header closeButton>
             <Modal.Title>{title}</Modal.Title>
           </Modal.Header>
           <Modal.Body>
-            <Component onHide={() => onHide()}
-                        action={action}
-                        listSharedCollections={listSharedCollections} />
+            <Component onHide={() => UIActions.hideModal()} {...props} />
           </Modal.Body>
         </Modal>
       : <div></div>

--- a/app/assets/javascripts/components/actions/ElementActions.js
+++ b/app/assets/javascripts/components/actions/ElementActions.js
@@ -162,6 +162,15 @@ class ElementActions {
         console.log(errorMessage);
       });};
   }
+  
+  importSamplesFromFileConfirm(params) {
+    return (dispatch) => { SamplesFetcher.importSamplesFromFileConfirm(params)
+      .then((result) => {
+        dispatch(result);
+      }).catch((errorMessage) => {
+        console.log(errorMessage);
+      });};
+  }
 
   // -- Molecules --
 

--- a/app/assets/javascripts/components/actions/UIActions.js
+++ b/app/assets/javascripts/components/actions/UIActions.js
@@ -81,6 +81,13 @@ class UIActions {
   changeNumberOfResultsShown(value) {
     return  value;
   }
+
+  updateModalProps(params){
+    return params
+  }
+  hideModal(){
+    return null
+  }
 }
 
 export default alt.createActions(UIActions);

--- a/app/assets/javascripts/components/contextActions/ModalImportConfirm.js
+++ b/app/assets/javascripts/components/contextActions/ModalImportConfirm.js
@@ -1,0 +1,110 @@
+import React from 'react'
+import {Button, ButtonToolbar, FormGroup,FormControl,Checkbox} from 'react-bootstrap'
+import UIStore from '../stores/UIStore'
+import {Table, Column, Cell} from 'fixed-data-table'
+import SVG from 'react-inlinesvg'
+import ElementActions from '../actions/ElementActions'
+
+
+const MyCell = ({col,data,rowIndex, ...props})=>{
+  return <Cell width={300}>{data[rowIndex][col]}</Cell>
+
+}
+const ImCell = ({col,data,rowIndex, ...props})=>{
+  return <Cell width={300}><SVG src={"/images/molecules/"+data[rowIndex][col]} className="molecule-fixed-data" /></Cell>
+
+}
+const SelectCell = ({col,data,rowIndex, inputChange, ...props})=>{
+  let ik = data[rowIndex][col]
+  return ik&&ik!=="" ? <Cell width={40}>
+    <FormGroup>
+      <Checkbox
+        onChange={(event) => inputChange( event,rowIndex)}
+        defaultChecked
+        />
+    </FormGroup>
+  </Cell>
+  : null
+
+}
+
+export default class ModalImportConfirm extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      inchikeys:this.props.data.map(e=>e.inchikey)
+    };
+  }
+
+  handleClick() {
+    const {onHide, action} = this.props;
+    const {file} = this.state;
+    let ui_state = UIStore.getState();
+    let params = {
+      raw_data: this.props.raw_data,
+      currentCollectionId: ui_state.currentCollection.id,
+      inchikeys: this.state.inchikeys,
+    }
+    ElementActions.importSamplesFromFileConfirm(params)
+    onHide();
+
+  }
+
+  inputChange(event, rowIndex){
+    let iks = this.state.inchikeys
+    let ik = this.props.data[rowIndex].inchikey
+    iks[rowIndex] = event.target.checked ? ik : null
+    this.setState({inchikeys: iks})
+  }
+
+  isDisabled() {
+    false
+  }
+
+  render() {
+    //let rows = this.state.molecules
+    let rows = [];
+    this.props.data.map((e,i)=>rows.push({index: i,inchikey:e.inchikey,svg:e.svg,name:e.name}));
+
+    const {onHide} = this.props;
+    return (
+      <div style={{width:'80%',height:'80%', margin:'auto'}}>
+        <Table
+            rowHeight={100}
+            rowsCount={rows.length}
+            width={710}
+            height={600}
+            headerHeight={50}>
+            <Column
+              header="#"
+              cell={<MyCell col="index" data={rows}/>}
+              width={50}
+              center
+            />
+            <Column
+              header="name"
+              cell={<MyCell col="name" data={rows} />}
+              width={300}
+            />
+            <Column
+              header="structure"
+              cell={<ImCell col="svg" data={rows} />}
+              width={300}
+            />
+            <Column
+              header="Select"
+              cell={<SelectCell col="inchikey" data={rows} inputChange={(e,r)=>this.inputChange(e,r)} />}
+              width={60}
+            />
+
+          </Table>
+        &nbsp;
+
+        <ButtonToolbar>
+          <Button bsStyle="primary" onClick={() => onHide()}>Cancel</Button>
+          <Button bsStyle="warning" onClick={() => this.handleClick()} disabled={this.isDisabled()}>Import</Button>
+        </ButtonToolbar>
+      </div>
+    )
+  }
+}

--- a/app/assets/javascripts/components/fetchers/SamplesFetcher.js
+++ b/app/assets/javascripts/components/fetchers/SamplesFetcher.js
@@ -238,4 +238,29 @@ export default class SamplesFetcher {
 
     return promise;
   }
+
+  static importSamplesFromFileConfirm(params) {
+
+    let promise = fetch('/api/v1/samples/confirm_import/', {
+      credentials: 'same-origin',
+      method: 'post',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        currentCollectionId: params.currentCollectionId,
+        raw_data: params.raw_data,
+        inchikeys: params.inchikeys,
+      })
+    }).then((response) => {
+      return response.json()
+    }).then((json) => {
+      return json;
+    }).catch((errorMessage) => {
+      console.log(errorMessage);
+    });
+
+    return promise;
+  }
 }

--- a/app/assets/javascripts/components/stores/ElementStore.js
+++ b/app/assets/javascripts/components/stores/ElementStore.js
@@ -3,11 +3,13 @@ import ElementActions from '../actions/ElementActions';
 import UIActions from '../actions/UIActions';
 import UserActions from '../actions/UserActions';
 import UIStore from './UIStore';
+import UIStoreActions from '../actions/UIActions'
 import ClipboardStore from './ClipboardStore';
 import Sample from '../models/Sample';
 import Reaction from '../models/Reaction';
 import Wellplate from '../models/Wellplate';
 import Screen from '../models/Screen';
+import ModalImportConfirm from '../contextActions/ModalImportConfirm'
 
 import {extraThing} from '../utils/Functions';
 import Xlisteners from '../extra/ElementStoreXlisteners';
@@ -81,6 +83,8 @@ class ElementStore {
       handleAddSampleToMaterialGroup: ElementActions.addSampleToMaterialGroup,
       handleShowReactionMaterial: ElementActions.showReactionMaterial,
       handleImportSamplesFromFile: ElementActions.importSamplesFromFile,
+      handleImportSamplesFromFileConfirm: ElementActions.importSamplesFromFileConfirm,
+
       handleSetCurrentElement: ElementActions.setCurrentElement,
       handleDeselectCurrentElement: ElementActions.deselectCurrentElement,
       handleChangeSorting: ElementActions.changeSorting,
@@ -320,8 +324,29 @@ class ElementStore {
     this.state.currentElement = sample;
   }
 
-  handleImportSamplesFromFile() {
+  handleImportSamplesFromFile(data) {
+    if (data.sdf){
+      UIActions.updateModalProps.defer({
+        show: true,
+        component: ModalImportConfirm,
+        title: "Sample Import Confirmation",
+        action: null,
+        listSharedCollections: false,
+        customModal: "custom-modal",
+        data: data.data,
+        raw_data: data.raw_data,
+      })
+    } else {
+      this.handleRefreshElements('sample');
+    }
+
     this.handleRefreshElements('sample');
+  }
+
+  handleImportSamplesFromFileConfirm(data) {
+    if (data.sdf){
+      this.handleRefreshElements('sample');
+    }
   }
 
   // -- Wellplates --

--- a/app/assets/javascripts/components/stores/UIStore.js
+++ b/app/assets/javascripts/components/stores/UIStore.js
@@ -42,7 +42,9 @@ class UIStore {
       currentTab: 1,
       currentSearchSelection: null,
       showCollectionManagement: false,
-      isSync: false
+      isSync: false,
+      showModal: false,
+      modalParams: {},
     };
 
     this.bindListeners({
@@ -66,7 +68,9 @@ class UIStore {
       handleShowElements: UIActions.showElements,
       handleToggleCollectionManagement: UIActions.toggleCollectionManagement,
       handleUncheckWholeSelection: UIActions.uncheckWholeSelection,
-      handleChangeNumberOfResultsShown: UIActions.changeNumberOfResultsShown
+      handleChangeNumberOfResultsShown: UIActions.changeNumberOfResultsShown,
+      handleShowModalChange: UIActions.updateModalProps,
+      handleHideModal: UIActions.hideModal,
     });
   }
 
@@ -227,6 +231,20 @@ class UIStore {
 
   handleChangeNumberOfResultsShown(value) {
     this.state.number_of_results = value;
+  }
+  handleShowModalChange(params){
+    this.state.showModal = params.show ? true : false
+    this.state.modalParams = params
+  }
+
+  handleHideModal(){
+    this.state.showModal = false
+    this.state.modalParams = {
+      show: false,
+      title: "",
+      component: "",
+      action: null
+    }
   }
 }
 

--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -37,6 +37,17 @@ div[class^="col-"] {
 .navbar {
   border-radius: 0;
 }
+.custom-modal {
+  width: 100%;
+}
+
+.modal-container {
+  position: relative;
+}
+.modal-container .modal, .modal-container .modal-backdrop {
+  position: absolute;
+}
+
 
 #app {
   -webkit-user-select: none;

--- a/app/assets/stylesheets/fixed-data-table.min.css
+++ b/app/assets/stylesheets/fixed-data-table.min.css
@@ -1,0 +1,1 @@
+../../../node_modules/fixed-data-table/dist/fixed-data-table.min.css

--- a/app/assets/stylesheets/molecules.css
+++ b/app/assets/stylesheets/molecules.css
@@ -33,6 +33,12 @@
   height: 200px;
 }
 
+.molecule-fixed-data svg {
+  max-width: 100%;
+  height: 100px;
+}
+
+
 .molecule-mid rect {
   opacity: 0;
 }

--- a/lib/import/import_sdf.rb
+++ b/lib/import/import_sdf.rb
@@ -1,20 +1,20 @@
 
 class Import::ImportSdf
 
-  attr_reader  :collection_id, :current_user_id
+  attr_reader  :collection_id, :current_user_id, :processed_mol, :file_path,
+   :inchi_array, :raw_data
 
-  SIZE_LIMIT = 10 #MB
+  SIZE_LIMIT = 40 #MB
 
   def initialize(args)
-    @data = args[:data]||[]
+    @raw_data = args[:raw_data]||[]
     @message = {error: [], info:[]}
     @collection_id = args[:collection_id]
     @current_user_id = args[:current_user_id]
     @file_path = args[:file_path]
-
+    @inchi_array = args[:inchikeys]
     read_data
-
-    @count = @data.size
+    @count = @raw_data.size
     if @count == 0
       @message[:error] << 'No Molecule found!'
     else
@@ -23,15 +23,16 @@ class Import::ImportSdf
   end
 
   def read_data
-    if @file_path
-      size = File.size(@file_path)
+    if file_path
+      size = File.size(file_path)
       if size.to_f < SIZE_LIMIT*10**6
-        @data = File.readlines(@file_path,"$$$$\n")
+        @raw_data = File.readlines(file_path,"$$$$\n")
       else
         @message[:error] << "File too large (over #{SIZE_LIMIT}MB). "
       end
     end
-    @data
+    @raw_data.pop if @raw_data[-1].blank?
+    raw_data
   end
 
   def message
@@ -45,13 +46,16 @@ class Import::ImportSdf
   def find_or_create_mol_by_batch(batch_size=50)
     n = batch_size - 1
     inchikeys=[]
-    data = @data
+    @processed_mol=[]
+    data = raw_data.dup
     while !data.empty?
       batch = data.slice!(0..n)
-      molecules = Molecule.find_or_create_by_molfiles batch
-      inchikeys  += molecules.pluck(:inchikey)
+      molecules = find_or_create_by_molfiles batch , false, false
+      inchikeys  += molecules.map{|m| m && m[:inchikey] || nil }
+      @processed_mol += molecules
     end
-    count = inchikeys.size
+
+    count = inchikeys.compact.size
     if count > 0
       @message[:info] << "#{count} Molecule#{count > 1 && "s" || ""} processed. "
     else
@@ -61,12 +65,15 @@ class Import::ImportSdf
 
   def create_samples
     ids = []
-    read_data if @data.empty?
+    read_data if raw_data.empty?
+
     ActiveRecord::Base.transaction do
-      @data.each do |molfile|
+      raw_data.each do |molfile|
         babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(Molecule.skip_residues(molfile))
         inchikey = babel_info[:inchikey]
         unless inchikey.blank? || !(molecule = Molecule.where(inchikey: inchikey).first)
+          next unless i=inchi_array.index(inchikey)
+          @inchi_array[i]=nil
           sample = Sample.new(created_by: current_user_id)
           sample.molfile = molfile
           sample.molecule = molecule
@@ -84,6 +91,69 @@ class Import::ImportSdf
     @message[:info] << "Created #{s} sample#{s <= 1 && "" || "s"}. " if samples
     @message[:info] << "Import successful! " if ids.size == @count
     samples
+  end
+
+  def find_or_create_by_molfiles molfiles, is_partial = false, is_compact = true
+
+    bi = Chemotion::OpenBabelService.molecule_info_from_molfiles(molfiles)
+    inchikeys = bi.map do |babel_info|
+      inchikey = babel_info[:inchikey]
+      !inchikey.blank? && inchikey || nil
+    end
+
+    compact_iks = inchikeys.compact
+    mol_to_get = []
+
+    iks = inchikeys.dup
+    unless compact_iks.empty?
+      existing_ik = Molecule.where('inchikey IN (?)',compact_iks).pluck(:inchikey)
+      mol_to_get = compact_iks - existing_ik
+    end
+    unless mol_to_get.empty?
+      pi = Chemotion::PubchemService.molecule_info_from_inchikeys(mol_to_get)
+      pi.each do |pubchem_info|
+        ik = pubchem_info[:inchikey]
+        Molecule.find_or_create_by(inchikey: ik,
+          is_partial: is_partial) do |molecule|
+          i =  iks.index(ik)
+          iks[i] = nil
+          babel_info = bi[i]
+          molecule.molfile = molfiles[i]
+          molecule.assign_molecule_data babel_info, pubchem_info
+        end
+      end
+    end
+
+    iks = inchikeys.dup
+    unless compact_iks.empty?
+      existing_ik = Molecule.where('inchikey IN (?)',compact_iks).pluck(:inchikey)
+      mol_to_get = compact_iks - existing_ik
+    end
+    unless mol_to_get.empty?
+      mol_to_get.each do |ik|
+        Molecule.find_or_create_by(inchikey: ik,
+          is_partial: is_partial) do |molecule|
+          i =  iks.index(ik)
+          iks[i] = nil
+          babel_info = bi[i]
+          molecule.molfile = molfiles[i]
+          molecule.assign_molecule_data babel_info
+        end
+      end
+    end
+
+    molecules = Molecule.where('inchikey IN (?)',compact_iks).pluck(:inchikey,:molecule_svg_file,:iupac_name)
+    iks = inchikeys.dup
+    mol_array = Array.new(iks.size){ {name: nil,inchikey: nil ,svg: nil} }
+    molecules.each do |mol|
+
+      i = iks.index(mol[0])
+      if i
+        iks[i] = nil
+        mol_array[i]={name: mol[2],inchikey: mol[0],svg: mol[1]}
+      end
+    end
+    mol_array
   end
 
 end

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "es6-promise-debounce": "^1.0.1",
     "eslint": "2.10.2",
     "eslint-plugin-react": "5.1.1",
+    "fixed-data-table": "0.6.3",
     "immutable": "~3.8.1",
     "jsdom": "^9.8.0",
     "lodash": "^4.15.0",


### PR DESCRIPTION
- processed uploaded sdf and create molecule
- return ordered list of processed data
- client checklist to select which sample to create
(fixed-data-table)
- create samples after user confirmation/sample selection
 api action and fetcher (ElementStore)

- navigation modal props through UIstore,
to control Modal thru Alt action
also allow custom modal style

- moved create by batch to import_sdf to min call to DB

- fix missing authorized sample import on user collection