### PR TITLE
Fix #488

### DIFF
--- a/app/packs/src/components/SampleDetails.js
+++ b/app/packs/src/components/SampleDetails.js
@@ -517,7 +517,7 @@ export default class SampleDetails extends React.Component {
   }
 
   sampleInfo(sample) {
-    const style = { height: '200px' };
+    const style = { min-height: '200px' };
     const pubchemLcss = sample.pubchem_tag && sample.pubchem_tag.pubchem_lcss ?
       sample.pubchem_tag.pubchem_lcss.Record.Section[0].Section[0].Section[0].Information : null;
     const pubchemCid = sample.pubchem_tag && sample.pubchem_tag.pubchem_cid ?


### PR DESCRIPTION
Should fix #488. It's not clear to me if this component is used somewhere else, but I assume there is no need at all for an element style. Couldnt the style property on `<row>` be removed all together?