### PR TITLE
added pH value options (<, >, =) in condition drop down menu

### DIFF
--- a/app/packs/src/components/staticDropdownOptions/options.js
+++ b/app/packs/src/components/staticDropdownOptions/options.js
@@ -482,4 +482,13 @@ export const conditionsOptions = [{
 }, {
   label: 'visible light',
   value: 'visible light'
+}, {
+  label: 'pH = value',
+  value: 'pH = value'
+}, {
+  label: 'pH < value',
+  value: 'pH &lt; value' /* &lt; renders < in HTML*/
+}, {
+  label: 'pH > value',
+  value: 'pH &gt; value' /* &gt; renders > in HTML*/
 }];


### PR DESCRIPTION
Changelog:

- Closes #472 - options for specifying pH values added to conditions drop down menu - can specify if pH is equal to, greater than, or less than a value that the user can manually change in the conditions text field.

Preview:
- pH value options in conditions menu:
![pH_dropdown_options](https://user-images.githubusercontent.com/67055123/160580627-14ad13c6-77ce-45df-b2d9-c7e9919cc263.png)

- pH value options in conditions text area:
![pH_options_conditons_box](https://user-images.githubusercontent.com/67055123/160580632-742f1d1c-6e57-424b-bab0-986969d17559.png)

- pH values rendered on reaction image:
![pH_options_rendered](https://user-images.githubusercontent.com/67055123/160580634-febc9e95-9efd-4e1d-b193-ab7d22e5a656.png)