### PR TITLE
links to open rxns and samples in research plans

### DIFF
--- a/app/packs/src/components/research_plan/ResearchPlanDetailsFieldReaction.js
+++ b/app/packs/src/components/research_plan/ResearchPlanDetailsFieldReaction.js
@@ -73,11 +73,7 @@ class ResearchPlanDetailsFieldReaction extends Component {
     if (!hasAuth(reaction.id)) {
       return noAuth(reaction);
     }
-    const { edit } = this.props;
-    const title = reaction.title();
-    let link;
-    if (edit) { link = <p>{title}</p> }
-    else { link = <p>{reaction.name}</p> }
+    const link = <p>{reaction.title()}</p>;
     
     return (
       <div className="research-plan-field-reaction">

--- a/app/packs/src/components/research_plan/ResearchPlanDetailsFieldReaction.js
+++ b/app/packs/src/components/research_plan/ResearchPlanDetailsFieldReaction.js
@@ -76,25 +76,19 @@ class ResearchPlanDetailsFieldReaction extends Component {
     const { edit } = this.props;
     const title = reaction.title();
     let link;
-    if (edit) {
-      link = (
-        <p className="float-left">
-          Reaction:
-          <a role="link" tabIndex={0} onClick={() => this.showReaction()} style={{ cursor: 'pointer' }}>
-            {title}
-          </a>
-        </p>
-      );
-    }
+    if (edit) { link = <p>{title}</p> }
+    else { link = <p>{reaction.name}</p> }
+    
     return (
       <div className="research-plan-field-reaction">
-        {link}
         <div className="image-container">
           <img src={reaction.svgPath} alt={title} />
-          <p>{reaction.name}</p>
+          <a role="link" tabIndex={0} onClick={() => this.showReaction()} style={{ cursor: 'pointer' }}>
+          {link}
+          </a>
         </div>
       </div>
-    );
+      );
   }
 
   renderEdit() {

--- a/app/packs/src/components/research_plan/ResearchPlanDetailsFieldSample.js
+++ b/app/packs/src/components/research_plan/ResearchPlanDetailsFieldSample.js
@@ -80,21 +80,33 @@ class ResearchPlanDetailsFieldSample extends Component {
     if (edit) {
       link = (
         <p>
-          Sample:
-          <a role="link" tabIndex={0} onClick={() => this.showSample()} style={{ cursor: 'pointer' }}>
-            {title}
-          </a>
+          Sample: {title}
         </p>
       );
+    }
+    let image;
+    if (sample.svgPath) {
+      image = (
+      <div className="image-container">
+        <a role="link" tabIndex={0} onClick={() => this.showSample()} style={{ cursor: 'pointer' }}>
+          <img src={sample.svgPath} alt={title} />
+        </a>
+        <SampleName sample={sample} />
+      </div>)
+    }
+    // render name of sample if no image exists
+    else {
+      image = (
+      <div className="image-container">
+        <a role="link" tabIndex={0} onClick={() => this.showSample()} style={{ cursor: 'pointer' }}>
+          {title}
+        </a>     
+      </div>)
     }
     return (
       <div className="research-plan-field-image">
         {link}
-        <div className="image-container">
-        <a role="link" tabIndex={0} onClick={() => this.showSample()} style={{ cursor: 'pointer' }}>
-            <img src={sample.svgPath} alt={title} /> </a>
-          <SampleName sample={sample} />
-        </div>
+        {image}
       </div>
     );
   }

--- a/app/packs/src/components/research_plan/ResearchPlanDetailsFieldSample.js
+++ b/app/packs/src/components/research_plan/ResearchPlanDetailsFieldSample.js
@@ -91,7 +91,8 @@ class ResearchPlanDetailsFieldSample extends Component {
       <div className="research-plan-field-image">
         {link}
         <div className="image-container">
-          <img src={sample.svgPath} alt={title} />
+        <a role="link" tabIndex={0} onClick={() => this.showSample()} style={{ cursor: 'pointer' }}>
+            <img src={sample.svgPath} alt={title} /> </a>
           <SampleName sample={sample} />
         </div>
       </div>


### PR DESCRIPTION
CHANGELOG:
- Added links to reactions within research plan. (Closes #666)
- Added links to samples, and modified rendering to account for (decoupled) samples with no image. (Closes #727)
- clicking sample images now opens the sample page in Chemotion
- (Decoupled) samples with no image render ONLY the sample name

Video 1:

https://user-images.githubusercontent.com/67055123/163406494-ea481983-e107-4b24-ae22-6c699f272b8e.mp4

Video 2: Decoupled sample with no image

https://user-images.githubusercontent.com/67055123/169822122-3899b316-1db3-47c2-9640-bbd59149c533.mp4

