### PR TITLE
fixed cannot display the latest image of updated jdx on preview chemspectra

### DIFF
--- a/app/api/entities/container_entity.rb
+++ b/app/api/entities/container_entity.rb
@@ -48,9 +48,12 @@ module Entities
       attachments = attachments.select do |a|
         a.thumb == true && a.attachable_type == 'Container' && container_ids.include?(a.attachable_id)
       end
+      
       image_atts = attachments.select do |a_img|
         a_img&.content_type&.match(Regexp.union(%w[jpg jpeg png tiff]))
       end
+
+      image_atts = image_atts.sort_by{ |a_img| a_img[:id] }.reverse
 
       attachment = image_atts[0] || attachments[0]
 

--- a/app/packs/src/components/stores/SpectraStore.js
+++ b/app/packs/src/components/stores/SpectraStore.js
@@ -57,7 +57,10 @@ class SpectraStore {
   decodeSpectra(fetchedFiles = {}) {
     const { files } = fetchedFiles;
     if (!files) return [];
-    return files.map(f => this.decodeSpectrum(f)).filter(r => r !== null);
+    const returnFiles = files.map(f => this.decodeSpectrum(f)).filter(r => r !== null);
+    return returnFiles.sort(function(a, b) {
+      return b.idx - a.idx;
+    });
   }
 
   handleToggleModal() {


### PR DESCRIPTION
- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured
