### PR TITLE
show rxn image only if samples are present in rxn

### DIFF
--- a/app/packs/src/components/ReactionDetails.js
+++ b/app/packs/src/components/ReactionDetails.js
@@ -250,12 +250,13 @@ export default class ReactionDetails extends Component {
       return false;
     } else {
       const svgProps = reaction.svgPath.substr(reaction.svgPath.length - 4) === '.svg' ? { svgPath: reaction.svgPath } : { svg: reaction.reaction_svg_file }
-      return (
+      if(reaction.hasMaterials()) {
+        return (
         <SvgFileZoomPan
           duration={300}
           resize={true}
           {...svgProps}
-        />)
+        />)}
     }
   }
 


### PR DESCRIPTION
CHANGELOG: Closes #691

Image of reaction is only shown if there are materials present (Starting materials, Reagents, Products, & Solvents) in the reaction scheme.

Please see the video for a demo.

https://user-images.githubusercontent.com/67055123/168553170-56829a04-ea6f-4f26-a263-522bef3e358c.mp4

