### PR TITLE
Changing ratio of the main list and details sections

### DIFF
--- a/app/packs/src/components/Elements.js
+++ b/app/packs/src/components/Elements.js
@@ -37,9 +37,9 @@ export default class Elements extends Component {
     let page = null;
 
     if (currentElement) {
-      md = 5;
+      md = 4;
       page = (
-        <Col md={7} className="small-col">
+        <Col md={8} className="small-col">
           <ElementDetails currentElement={currentElement} />
         </Col>
       );


### PR DESCRIPTION
Closes: #723 - ratio of list and details sections changed from 5 : 7 to 8 : 4 -

Original ratio:
![7-5 ratio](https://user-images.githubusercontent.com/67055123/170272286-b10344f7-6f32-481d-85b8-127e1f5f3e98.png)

New ratio:
![8-4 ratio](https://user-images.githubusercontent.com/67055123/170272294-d7f2349d-b997-4d27-a6a4-996945c37cf7.png)
