### PR TITLE
Move onclick event to button element

### DIFF
--- a/app/packs/src/components/CitationPanel.js
+++ b/app/packs/src/components/CitationPanel.js
@@ -51,7 +51,7 @@ const buildRow = (title, fnDelete, sortedIds, rows, fnUpdate) => {
               </Button>
             </OverlayTrigger>
             {changeTypeBtn(litype, id, fnUpdate)}
-            <Button bsStyle="danger"><i className="fa fa-trash-o" aria-hidden="true" onClick={() => fnDelete(citation)} /></Button>
+            <Button bsStyle="danger"  onClick={() => fnDelete(citation)} ><i className="fa fa-trash-o" aria-hidden="true"/></Button>
           </ButtonGroup>
         </div>
       </div>


### PR DESCRIPTION

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
