### PR TITLE
Fix #735: harmonized mail settings

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,5 @@
+require "uri"
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -55,9 +57,28 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  uri = URI.parse("#{ENV['HOST_URL'] || 'http://localhost'}")
+  scheme = uri.scheme   || 'http'
+  host   = uri.host     || 'localhost'
+  port   = uri.port     || 80
+
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = { :address => "localhost", :port => 1025 }
-  #config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = { host: host, protocol: scheme, port: port }
+  config.action_mailer.smtp_settings = {
+    :address              => ENV["SMTP_ADDRESS"] || "localhost",
+    :port                 => ENV["SMTP_PORT"] || 1025,
+    :user_name            => ENV['SMTP_USERNAME'],
+    :domain               => ENV['SMTP_DOMAIN'],
+    :password             => ENV['SMTP_PASSWORD'],
+    :authentication       => ENV['SMTP_AUTH'] && ENV['SMTP_AUTH'].to_sym,
+    :enable_starttls_auto => ENV['SMTP_TLS'] && ENV['SMTP_TLS'].match(/true/),
+    :openssl_verify_mode  => ENV['SMTP_SSL_MODE']
+  }
+
+  if (ENV["SMTP_ADDRESS"] || '').empty? || ENV["DISABLE_MAIL_DELIVERY"].present?
+    config.action_mailer.perform_deliveries = false
+  end
 
 #  TurboSprockets.configure do |config|
 #    config.precompiler.enabled = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+require "uri"
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -107,9 +109,14 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  uri = URI.parse("#{ENV['HOST_URL'] || 'http://localhost'}")
+  scheme = uri.scheme   || 'https'
+  host   = uri.host     || 'localhost'
+  port   = uri.port     || 443
+
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.default_url_options = { host: ENV['SMTP_HOST']}
+  config.action_mailer.default_url_options = { host: host, protocol: scheme, port: port }
   config.action_mailer.smtp_settings = {
     :address              => ENV["SMTP_ADDRESS"],
     :port                 => ENV["SMTP_PORT"],
@@ -121,4 +128,7 @@ Rails.application.configure do
     :openssl_verify_mode  => ENV['SMTP_SSL_MODE']
   }
 
+  if (ENV["SMTP_ADDRESS"] || '').empty? || ENV["DISABLE_MAIL_DELIVERY"].present?
+    config.action_mailer.perform_deliveries = false
+  end
 end


### PR DESCRIPTION
Harmonized mail settings as described in #735:
- action_mail now builds it's URL based on the environment variable HOST_URL.
- HOST_URL defaults to "http://localhost" in dev environments and to "https://localhost:443" in production environments.
- If no SMTP_ADDRESS is set or if DISABLE_MAIL_DELIVERY is set, mail delivery is disabled completely.

Note: HOST_URL is intended to be used in container environments to point to the public web entrypoint of the Chemotion instance.