### PR TITLE
Elemental composition values now have 2 decimal places

### DIFF
--- a/app/packs/src/components/ElementalComposition.js
+++ b/app/packs/src/components/ElementalComposition.js
@@ -26,7 +26,7 @@ export default class ElementalComposition extends React.Component {
           </strong>
           &nbsp;
           &nbsp;
-          {value}
+          {Number(value).toFixed(2)}
           &nbsp;
           &nbsp;
         </span>

--- a/app/packs/src/components/ElementalComposition.js
+++ b/app/packs/src/components/ElementalComposition.js
@@ -19,14 +19,6 @@ export default class ElementalComposition extends React.Component {
 
     keys.map(function(key, index) {
       let value = elemental_composition.data[key];
-      // adding significant figures to value if needed - no decimal places, add .00; 1 decimal place, add 0;
-      const regexp = /^\d+$/; // regex for an integer (no decimal places)
-      const regexp1 = /\.\d{0,1}$/; // regex to search for a value with ONLY ONE decimal place
-      if (value.match(regexp)) {
-        value += '.00'
-      } else if (value.match(regexp1)){
-        value += '0'
-      }
       elements.push(
         <span className="data-item" key={key}>
           <strong>

--- a/app/packs/src/components/ElementalComposition.js
+++ b/app/packs/src/components/ElementalComposition.js
@@ -19,6 +19,14 @@ export default class ElementalComposition extends React.Component {
 
     keys.map(function(key, index) {
       let value = elemental_composition.data[key];
+      // adding significant figures to value if needed - no decimal places, add .00; 1 decimal place, add 0;
+      const regexp = /^\d+$/; // regex for an integer (no decimal places)
+      const regexp1 = /\.\d{0,1}$/; // regex to search for a value with ONLY ONE decimal place
+      if (value.match(regexp)) {
+        value += '.00'
+      } else if (value.match(regexp1)){
+        value += '0'
+      }
       elements.push(
         <span className="data-item" key={key}>
           <strong>
@@ -32,7 +40,7 @@ export default class ElementalComposition extends React.Component {
         </span>
       );
     });
-
+    
     return elements;
   }
 

--- a/lib/chemotion/calculations.rb
+++ b/lib/chemotion/calculations.rb
@@ -193,7 +193,7 @@ private
 
   def self.convert_to_percents elements
     elements.each do |key, value|
-      elements[key] = sprintf('%.2f',(value.to_d * 100.0)) # convert to % and format to show 2 d.p.
+      elements[key] = (value.to_d * 100.0).round 2 # convert to %
     end
   end
 

--- a/lib/chemotion/calculations.rb
+++ b/lib/chemotion/calculations.rb
@@ -193,7 +193,7 @@ private
 
   def self.convert_to_percents elements
     elements.each do |key, value|
-      elements[key] = (value.to_d * 100.0).round 2 # convert to %
+      elements[key] = sprintf('%.2f',(value.to_d * 100.0)) # convert to % and format to show 2 d.p.
     end
   end
 


### PR DESCRIPTION
CHANGELOG: Closes #721

Significant zeroes are added to elemental compositional values, to ensure that all values are 2 decimal places.

The initial example (2,2-bipyridine) is now:
![bipyridine](https://user-images.githubusercontent.com/67055123/170698346-665ae902-018b-44a8-aed8-14db9f155f36.png)

Example 2 (C10H18MnO6):
Original
![old1](https://user-images.githubusercontent.com/67055123/170696056-bad0bf1d-9a66-4dad-9834-25aaa3f2a81b.png)
New
![new1](https://user-images.githubusercontent.com/67055123/170696055-c76d98c7-ddde-468d-8419-894320459ebf.png)
