### PR TITLE
add new fields for sample color and state at RT

### DIFF
--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -86,7 +86,7 @@ module Chemotion
                 melting_point: { field: 'melting_point', displayName: 'Melting Point' },
                 boiling_point: { field: 'boiling_point', displayName: 'Boiling Point' },
                 color: { field: 'color', displayName: 'Color' },
-                state: { field: 'state', displayName: 'State at RT' }
+                state: { field: 'aggregateState', displayName: 'State at RT' }
               },
               current_user_id: current_user.id)
             sdf_import.find_or_create_mol_by_batch
@@ -308,7 +308,7 @@ module Chemotion
         optional :molecular_mass, type: Float
         optional :sum_formula, type: String
         optional :color, type: String
-        optional :state, type: String
+        optional :aggregateState, type: String
         #use :root_container_params
       end
 
@@ -429,7 +429,7 @@ module Chemotion
         optional :molecular_mass, type: Float
         optional :sum_formula, type: String
         optional :color, type: String
-        optional :state, type: String
+        optional :aggregateState, type: String
       end
       post do
         molecule_id = params[:decoupled] && params[:molfile].blank? ? Molecule.find_or_create_dummy&.id : params[:molecule_id]
@@ -462,7 +462,7 @@ module Chemotion
           molecular_mass: params[:molecular_mass],
           sum_formula: params[:sum_formula],
           color: params[:color],
-          state: params[:state]
+          aggregateState: params[:aggregateState]
         }
 
         boiling_point_lowerbound = params['boiling_point_lowerbound'].blank? ? -Float::INFINITY : params['boiling_point_lowerbound']

--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -85,6 +85,8 @@ module Chemotion
                 density: { field: 'density', displayName: 'Density' },
                 melting_point: { field: 'melting_point', displayName: 'Melting Point' },
                 boiling_point: { field: 'boiling_point', displayName: 'Boiling Point' },
+                color: { field: 'color', displayName: 'Color' },
+                state: { field: 'state', displayName: 'State at RT' }
               },
               current_user_id: current_user.id)
             sdf_import.find_or_create_mol_by_batch
@@ -305,6 +307,8 @@ module Chemotion
         optional :decoupled, type: Boolean, desc: 'Sample is decoupled from structure?', default: false
         optional :molecular_mass, type: Float
         optional :sum_formula, type: String
+        optional :color, type: String
+        optional :state, type: String
         #use :root_container_params
       end
 
@@ -424,6 +428,8 @@ module Chemotion
         optional :decoupled, type: Boolean, desc: 'Sample is decoupled from structure?', default: false
         optional :molecular_mass, type: Float
         optional :sum_formula, type: String
+        optional :color, type: String
+        optional :state, type: String
       end
       post do
         molecule_id = params[:decoupled] && params[:molfile].blank? ? Molecule.find_or_create_dummy&.id : params[:molecule_id]
@@ -454,7 +460,9 @@ module Chemotion
           molecule_name_id: params[:molecule_name_id],
           decoupled: params[:decoupled],
           molecular_mass: params[:molecular_mass],
-          sum_formula: params[:sum_formula]
+          sum_formula: params[:sum_formula],
+          color: params[:color],
+          state: params[:state]
         }
 
         boiling_point_lowerbound = params['boiling_point_lowerbound'].blank? ? -Float::INFINITY : params['boiling_point_lowerbound']

--- a/app/api/entities/sample_attr_entity.rb
+++ b/app/api/entities/sample_attr_entity.rb
@@ -12,7 +12,7 @@ module Entities
     :pubchem_tag, :xref, :code_log,
     :can_update, :can_copy, :can_publish, :molecule_name_hash, #:molecule_computed_props,
     :showed_name, :user_labels, :decoupled,
-    :molecular_mass, :sum_formula
+    :molecular_mass, :sum_formula, :color, :state
 
     def created_at
       object.created_at.strftime("%d.%m.%Y, %H:%M")

--- a/app/api/entities/sample_attr_entity.rb
+++ b/app/api/entities/sample_attr_entity.rb
@@ -12,7 +12,7 @@ module Entities
     :pubchem_tag, :xref, :code_log,
     :can_update, :can_copy, :can_publish, :molecule_name_hash, #:molecule_computed_props,
     :showed_name, :user_labels, :decoupled,
-    :molecular_mass, :sum_formula, :color, :state
+    :molecular_mass, :sum_formula, :color, :aggregateState
 
     def created_at
       object.created_at.strftime("%d.%m.%Y, %H:%M")

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -42,7 +42,7 @@
 #  molecular_mass      :float
 #  sum_formula         :string
 #  solvent             :jsonb
-#  state               :string
+#  aggregateState      :string
 #  color               :string
 #
 # Indexes

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -42,6 +42,8 @@
 #  molecular_mass      :float
 #  sum_formula         :string
 #  solvent             :jsonb
+#  state               :string
+#  color               :string
 #
 # Indexes
 #

--- a/app/packs/src/components/SampleForm.js
+++ b/app/packs/src/components/SampleForm.js
@@ -513,7 +513,7 @@ export default class SampleForm extends React.Component {
           </tr>
 
           <tr>
-            <td colSpan="4">
+            <td colSpan="6">
               <div className="name-form">
                 <div style={{ width: '25%' }}>
                   {this.textInput(sample, 'name', 'Name')}
@@ -521,7 +521,7 @@ export default class SampleForm extends React.Component {
                 <div style={{ width: '25%', paddingLeft: '5px' }}>
                   {this.textInput(sample, 'external_label', 'External label')}
                 </div>
-                <div style={{ width: '25%', paddingLeft: '5px' }}>
+                <div style={{ width: '30%', paddingLeft: '5px' }}>
                   <TextRangeWithAddon
                     field="boiling_point"
                     label="Boiling point"
@@ -532,7 +532,7 @@ export default class SampleForm extends React.Component {
                     tipOnText="Use space-separated value to input a Temperature range"
                   />
                 </div>
-                <div style={{ width: '25%', paddingLeft: '5px' }}>
+                <div style={{ width: '30%', paddingLeft: '5px' }}>
                   <TextRangeWithAddon
                     field="melting_point"
                     label="Melting point"
@@ -542,6 +542,12 @@ export default class SampleForm extends React.Component {
                     onChange={this.handleRangeChanged}
                     tipOnText="Use space-separated value to input a Temperature range"
                   />
+                </div>
+                <div style={{ width: '20%', paddingLeft: '5px' }}>
+                  {this.textInput(sample, 'color', 'Color')}
+                </div>
+                <div style={{ width: '20%', paddingLeft: '5px' }}>
+                  {this.textInput(sample, 'state', 'State at RT')}
                 </div>
                 {/* <div style={{ width: '40%' }}>
                   <label htmlFor="solventInput">Solvent</label>

--- a/app/packs/src/components/SampleForm.js
+++ b/app/packs/src/components/SampleForm.js
@@ -547,7 +547,7 @@ export default class SampleForm extends React.Component {
                   {this.textInput(sample, 'color', 'Color')}
                 </div>
                 <div style={{ width: '20%', paddingLeft: '5px' }}>
-                  {this.textInput(sample, 'state', 'State at RT')}
+                  {this.textInput(sample, 'aggregateState', 'State at RT')}
                 </div>
                 {/* <div style={{ width: '40%' }}>
                   <label htmlFor="solventInput">Solvent</label>

--- a/app/packs/src/components/models/Sample.js
+++ b/app/packs/src/components/models/Sample.js
@@ -191,7 +191,7 @@ export default class Sample extends Element {
       sum_formula: '',
       xref: {},
       color: '',
-      state: ''
+      aggregateState: ''
     });
 
     sample.short_label = Sample.buildNewShortLabel();
@@ -322,7 +322,7 @@ export default class Sample extends Element {
       sum_formula: this.sum_formula,
       segments: this.segments.map(s => s.serialize()),
       color: this.color,
-      state: this.state,
+      aggregateState: this.aggregateState,
     });
 
     return serialized;
@@ -336,12 +336,12 @@ export default class Sample extends Element {
     this._color = color;
   }
 
-  get state() {
-    return this._state;
+  get aggregateState() {
+    return this._aggregateState;
   }
 
-  set state(state) {
-    this._state = state;
+  set aggregateState(aggregateState) {
+    this._aggregateState = aggregateState;
   }
 
   get is_top_secret() {

--- a/app/packs/src/components/models/Sample.js
+++ b/app/packs/src/components/models/Sample.js
@@ -189,7 +189,9 @@ export default class Sample extends Element {
       decoupled: false,
       molecular_mass: 0,
       sum_formula: '',
-      xref: {}
+      xref: {},
+      color: '',
+      state: ''
     });
 
     sample.short_label = Sample.buildNewShortLabel();
@@ -319,9 +321,27 @@ export default class Sample extends Element {
       molecular_mass: this.molecular_mass,
       sum_formula: this.sum_formula,
       segments: this.segments.map(s => s.serialize()),
+      color: this.color,
+      state: this.state,
     });
 
     return serialized;
+  }
+
+  get color() {
+    return this._color;
+  }
+
+  set color(color) {
+    this._color = color;
+  }
+
+  get state() {
+    return this._state;
+  }
+
+  set state(state) {
+    this._state = state;
   }
 
   get is_top_secret() {

--- a/app/serializers/detail_levels/sample.rb
+++ b/app/serializers/detail_levels/sample.rb
@@ -9,8 +9,7 @@ class DetailLevels::Sample
       :sample_svg_file, :density, :boiling_point, :melting_point, :stereo,
       :reaction_description, :container, :pubchem_tag, :xref, :code_log, :metrics,
       :can_update, :can_copy, :can_publish, :molecule_name_hash, # :molecule_computed_props,
-      :showed_name, :decoupled,
-      :molecular_mass, :sum_formula
+      :showed_name, :decoupled, :molecular_mass, :sum_formula, :state, :color
     ]
   end
 

--- a/app/serializers/detail_levels/sample.rb
+++ b/app/serializers/detail_levels/sample.rb
@@ -9,7 +9,7 @@ class DetailLevels::Sample
       :sample_svg_file, :density, :boiling_point, :melting_point, :stereo,
       :reaction_description, :container, :pubchem_tag, :xref, :code_log, :metrics,
       :can_update, :can_copy, :can_publish, :molecule_name_hash, # :molecule_computed_props,
-      :showed_name, :decoupled, :molecular_mass, :sum_formula, :state, :color
+      :showed_name, :decoupled, :molecular_mass, :sum_formula, :aggregateState, :color
     ]
   end
 

--- a/db/migrate/20220530094704_add_sc_fields_to_samples.rb
+++ b/db/migrate/20220530094704_add_sc_fields_to_samples.rb
@@ -1,0 +1,6 @@
+class AddScFieldsToSamples < ActiveRecord::Migration[5.2]
+  def change
+    add_column :samples, :state, :string
+    add_column :samples, :color, :string
+  end
+end

--- a/db/migrate/20220530094704_add_sc_fields_to_samples.rb
+++ b/db/migrate/20220530094704_add_sc_fields_to_samples.rb
@@ -1,6 +1,6 @@
 class AddScFieldsToSamples < ActiveRecord::Migration[5.2]
   def change
-    add_column :samples, :state, :string
+    add_column :samples, :aggregateState, :string
     add_column :samples, :color, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -914,7 +914,7 @@ ActiveRecord::Schema.define(version: 2022_05_30_094704) do
     t.float "molecular_mass"
     t.string "sum_formula"
     t.jsonb "solvent"
-    t.string "state"
+    t.string "aggregateState"
     t.string "color"
     t.index ["deleted_at"], name: "index_samples_on_deleted_at"
     t.index ["identifier"], name: "index_samples_on_identifier"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_09_182512) do
+ActiveRecord::Schema.define(version: 2022_05_30_094704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -914,6 +914,8 @@ ActiveRecord::Schema.define(version: 2022_03_09_182512) do
     t.float "molecular_mass"
     t.string "sum_formula"
     t.jsonb "solvent"
+    t.string "state"
+    t.string "color"
     t.index ["deleted_at"], name: "index_samples_on_deleted_at"
     t.index ["identifier"], name: "index_samples_on_identifier"
     t.index ["molecule_id"], name: "index_samples_on_sample_id"


### PR DESCRIPTION
CHANGELOG: Closes #722

2 new free text fields have been implemented in the sample properties tab - allowing the user to specify both color and state at room temperature:

![color_state_fields](https://user-images.githubusercontent.com/67055123/171360703-104a91af-0541-4348-a508-e7692d0a03cf.png)