### PR TITLE
Display only exportable measurement candidates and fix display issues…

### DIFF
--- a/app/assets/stylesheets/measurement_export_modal.scss
+++ b/app/assets/stylesheets/measurement_export_modal.scss
@@ -2,4 +2,9 @@
   .measurementSelector {
     margin: 0px !important;
   }
+
+  .measurementExportModal__body {
+    max-height: 600px;
+    overflow-y: scroll;
+  }
 }

--- a/app/packs/src/components/research_plan/ResearchPlanDetailsFieldTableMeasurementExportModal.js
+++ b/app/packs/src/components/research_plan/ResearchPlanDetailsFieldTableMeasurementExportModal.js
@@ -34,12 +34,23 @@ class MeasurementCandidate extends Component {
     );
   }
 
+  _canExport() {
+    return this.props.sample_identifier &&
+      this.props.description &&
+      this.props.value &&
+      this.props.unit;
+  }
+
   render() {
+    if (!this._canExport()) {
+      return null;
+    }
+
     return (
       <tr>
         <td>{this._selector()}</td>
         <td>{this.props.sample_identifier}</td>
-        <td>{this.props.description} {this.props.value}{this.props.unit}</td>
+        <td>{this.props.description} {this.props.value} {this.props.unit}</td>
         <td>{this._status()}</td>
       </tr>
     );
@@ -128,7 +139,7 @@ export default class ResearchPlanDetailsFieldTableMeasurementExportModal extends
             Export measurements to samples
           </Modal.Title>
         </Modal.Header>
-        <Modal.Body >
+        <Modal.Body className='measurementExportModal__body'>
           <table className="table">
             <thead>
               <tr>


### PR DESCRIPTION
… on large export tables



- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
