### PR TITLE
Enhancement of research plan and screen

### DIFF
--- a/app/api/chemotion/screen_api.rb
+++ b/app/api/chemotion/screen_api.rb
@@ -148,19 +148,19 @@ module Chemotion
         recent_ols_term_update('chmo', kinds) if kinds&.length&.positive?
 
         collection = current_user.collections.where(id: params[:collection_id]).take
-        CollectionsScreen.create(screen: screen, collection: collection) if collection.present?
+        screen.collections << collection if collection.present?
 
         is_shared_collection = false
         unless collection.present?
           sync_collection = current_user.all_sync_in_collections_users.where(id: params[:collection_id]).take
           if sync_collection.present?
             is_shared_collection = true
-            CollectionsScreen.create(screen: screen, collection: Collection.find(sync_collection['collection_id']))
-            CollectionsScreen.create(screen: screen, collection: Collection.get_all_collection_for_user(sync_collection['shared_by_id']))
+            screen.collections << Collection.find(sync_collection['collection_id'])
+            screen.collections << Collection.get_all_collection_for_user(sync_collection['shared_by_id'])
           end
         end
 
-        CollectionsScreen.create(screen: screen, collection: Collection.get_all_collection_for_user(current_user.id)) unless is_shared_collection
+        screen.collections << Collection.get_all_collection_for_user(current_user.id) unless is_shared_collection
 
         params[:wellplate_ids].each do |id|
           ScreensWellplate.find_or_create_by(wellplate_id: id, screen_id: screen.id)

--- a/app/assets/stylesheets/research-plan.scss
+++ b/app/assets/stylesheets/research-plan.scss
@@ -133,6 +133,7 @@
     width: 100%;
     border: 3px dashed lightgray;
     display: flex;
+    cursor:pointer;
     .zone {
         margin: auto;
         color: grey;
@@ -146,9 +147,9 @@
     display: flex;
     cursor: not-allowed;
     background-color: #e8e8e8;
+    pointer-events: none;
     .zone {
         margin: auto;
         color: grey;
-        pointer-events: none;
     }
 }

--- a/app/packs/src/components/ContainerDataset.js
+++ b/app/packs/src/components/ContainerDataset.js
@@ -137,7 +137,7 @@ export default class ContainerDataset extends Component {
 
   listGroupItem(attachment) {
     const { disabled } = this.props;
-    const preview = (attachment.preview ? (<tr><td rowSpan="2" width="128"><img src={attachment.preview} alt="" /></td></tr>) : (
+    const preview = (attachment.preview ? (<tr><td rowSpan="2" width="128"><img style={{ width: '85%', display: 'block' }} src={attachment.preview} alt="" /></td></tr>) : (
       <tr><td rowSpan="2" width="128"><img style={{ width: '128px', display: 'block' }} alt="" /></td></tr>
     ));
     if (attachment.is_deleted) {

--- a/app/packs/src/components/models/Attachment.js
+++ b/app/packs/src/components/models/Attachment.js
@@ -1,17 +1,16 @@
 import Element from './Element';
+import { filePreview } from '../../helper/index';
 
 export default class Attachment extends Element {
-
   static fromFile(file) {
-    return new Attachment(
-      {
-        file: file,
-        name: file.name,
-        filename: file.name,
-        identifier: file.id,
-        is_deleted: false,
-      }
-    )
+    return new Attachment({
+      file,
+      name: file.name,
+      filename: file.name,
+      identifier: file.id,
+      is_deleted: false,
+      preview: filePreview(file),
+    });
   }
 
   get preview() {
@@ -30,7 +29,6 @@ export default class Attachment extends Element {
       thumb: this.thumb,
       content_type: this.content_type,
       is_deleted: this.is_deleted,
-    })
+    });
   }
-
 }

--- a/app/packs/src/helper/index.js
+++ b/app/packs/src/helper/index.js
@@ -1,0 +1,3 @@
+export const filePreview = (file) => {
+  return file.type.split('/')[0] === 'image' ? file.preview : '/images/wild_card/not_available.svg';
+};

--- a/app/serializers/research_plan_serializer.rb
+++ b/app/serializers/research_plan_serializer.rb
@@ -3,6 +3,7 @@ class ResearchPlanSerializer < ActiveModel::Serializer
   attributes *(DetailLevels::ResearchPlan.new.base_attributes + ['research_plan_metadata'])
 
   has_one :container, :serializer => ContainerSerializer
+  has_one :tag
   has_many :wellplates, :serializer => WellplateSerializer
   has_many :segments
 


### PR DESCRIPTION
Collection labels and preview issue has been resolved in research plan. All the changes are as follows,

- Collection label is added in research plan so that user can see the collections where the research plan belongs to
- Collection label is added in screen so that user can see the collections where the screen belongs to
- Preview issue in the attachment section of research plan is fixed
- Preview of uploaded file in analyses section is fixed
- Research plan dropzone is refactored

Research Plan:

![image](https://user-images.githubusercontent.com/8912580/176264279-153cdfc0-49be-4021-82fe-db5ecdaec9c7.png)

Screen:

![image](https://user-images.githubusercontent.com/8912580/176264666-81300647-e571-4c4b-ba52-15bf3b4bd128.png)

Preview in attachment section of  research plan:

![image](https://user-images.githubusercontent.com/8912580/176265716-0fe5b012-f6d9-4cf8-9e70-ba23ba9db840.png)

Preview in analyses section:

![image](https://user-images.githubusercontent.com/8912580/176266683-f213b181-6747-43eb-a90b-13145f3bdd2a.png)

CHANGELOG :  Closes https://github.com/ComPlat/chemotion_ELN/issues/672 and https://github.com/ComPlat/chemotion_ELN/issues/751
