### PR TITLE
Add method to handle when changing metric unit

### DIFF
--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -290,6 +290,7 @@ module Chemotion
         optional :molarity_value, type: Float, desc: "Sample molarity value"
         optional :molarity_unit, type: String, desc: "Sample real amount_unit"
         optional :description, type: String, desc: "Sample description"
+        optional :metrics, type: String, desc: "Sample metric units"
         optional :purity, type: Float, desc: "Sample purity"
         optional :solvent, type: Array[Hash], desc: "Sample solvent"
         optional :location, type: String, desc: "Sample location"

--- a/app/packs/src/components/SampleForm.js
+++ b/app/packs/src/components/SampleForm.js
@@ -32,6 +32,7 @@ export default class SampleForm extends React.Component {
     this.showStructureEditor = this.showStructureEditor.bind(this);
     this.handleRangeChanged = this.handleRangeChanged.bind(this);
     this.handleSolventChanged = this.handleSolventChanged.bind(this);
+    this.handleMetricsChange = this.handleMetricsChange.bind(this);
   }
 
   // eslint-disable-next-line camelcase
@@ -364,14 +365,32 @@ export default class SampleForm extends React.Component {
     );
   }
 
+  handleMetricsChange(e) {
+    this.props.sample.setUnitMetrics(e.metricUnit, e.metricPrefix);
+  }
+
   numInput(
     sample, field, unit, prefixes, precision, label, ref = '',
     disabled = false, title = '', block = false, notApplicable = false
   ) {
     if (sample.contains_residues && unit === 'l') return false;
     const value = !isNaN(sample[field]) ? sample[field] : null;
-
-    const mpx = unit === 'l' ? prefixes[1] : unit === 'mol' ? prefixes[2] : prefixes[0];
+    const metricPrefixes = ['m', 'n', 'u'];
+    let metric = unit === 'l' ? prefixes[1] : unit === 'mol' ? prefixes[2] : prefixes[0];
+    if(sample){
+      switch(field) {
+        case 'amount_g':
+          metric = (sample.metrics && sample.metrics.length > 2 && metricPrefixes.indexOf(sample.metrics[0]) > -1) ? sample.metrics[0] : 'm';
+          break;
+        case 'amount_mol':
+          metric = (sample.metrics && sample.metrics.length > 2 && metricPrefixes.indexOf(sample.metrics[2]) > -1) ? sample.metrics[2] : 'm';
+          break;
+          case 'amount_l':
+            metric = (sample.metrics && sample.metrics.length > 3 && metricPrefixes.indexOf(sample.metrics[3]) > -1) ? sample.metrics[3] : 'm';
+            break;
+      }
+    }
+    
     return (
       <td key={field + sample.id.toString()}>
         <NumeralInputWithUnitsCompo
@@ -379,7 +398,7 @@ export default class SampleForm extends React.Component {
           unit={unit}
           label={label}
           ref={ref}
-          metricPrefix={mpx}
+          metricPrefix={metric}
           metricPrefixes={prefixes}
           precision={precision}
           title={title}
@@ -387,6 +406,7 @@ export default class SampleForm extends React.Component {
           block={block}
           bsStyle={unit && sample.amount_unit === unit ? 'success' : 'default'}
           onChange={e => this.handleFieldChanged(field, e)}
+          onMetricsChange={e => this.handleMetricsChange(e)}
           id={`numInput_${field}`}
         />
       </td>
@@ -431,7 +451,7 @@ export default class SampleForm extends React.Component {
       //     4, 'Amount', 'massMgInput', isDisabled, ''));
       // } else {
       content.push(this.numInput(
-        sample, 'amount_g', 'g', ['m', 'n'],
+        sample, 'amount_g', 'g', ['m', 'n', 'u' ],
         4, 'Amount', 'massMgInput', isDisabled, ''
       ));
 


### PR DESCRIPTION
Save metrics attribute when update samples
Read metrics data when render input field



- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
