### PR TITLE
Fix error when trying to expose timestamps on an empty object

### DIFF
--- a/app/api/entities/application_entity.rb
+++ b/app/api/entities/application_entity.rb
@@ -9,7 +9,7 @@ module Entities
     end
 
     format_with(:eln_timestamp) do |datetime|
-      I18n.l(datetime, format: :eln_timestamp)
+      datetime.present? ? I18n.l(datetime, format: :eln_timestamp) : nil
     end
 
     def self.expose_timestamps(timestamp_fields: %i[created_at updated_at], **additional_args)

--- a/app/api/entities/scifinder_n_credential_entity.rb
+++ b/app/api/entities/scifinder_n_credential_entity.rb
@@ -8,9 +8,6 @@ module Entities
       :refresh_token
     )
 
-    with_options(format_with: :eln_default) do
-      expose :created_at
-      expose :updated_at
-    end
+    expose_timestamps
   end
 end


### PR DESCRIPTION

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
