### PR TITLE
Fixed conditionals that involve `material_group` in reaction API

### DIFF
--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -46,7 +46,6 @@ module ReactionHelpers
   end
 
   def update_materials_for_reaction(reaction, material_attributes, current_user)
-    collections = reaction.collections
     materials = {
       starting_material: Array(material_attributes['starting_materials']).map { |m| OSample.new(m) },
       reactant: Array(material_attributes['reactants']).map { |m| OSample.new(m) },
@@ -68,7 +67,7 @@ module ReactionHelpers
               parent_sample = Sample.find(sample.parent_id)
 
               # TODO: extract subsample method
-              subsample = parent_sample.create_subsample(current_user, collections, true)
+              subsample = parent_sample.create_subsample(current_user, reaction.collections, true)
 
               # Use 'reactant' or 'solvent' as short_label
               subsample.short_label = fixed_label if fixed_label
@@ -119,7 +118,7 @@ module ReactionHelpers
               # add new data container
               new_sample.container = update_datamodel(container_info)
 
-              new_sample.collections << collections
+              new_sample.collections << reaction.collections
               new_sample.save!
               new_sample.save_segments(segments: sample.segments, current_user_id: current_user.id)
               included_sample_ids << new_sample.id

--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -56,14 +56,15 @@ module ReactionHelpers
     ActiveRecord::Base.transaction do
       included_sample_ids = []
       materials.each do |material_group, samples|
-        fixed_label = material_group =~ /solvents?|reactants?/ && $&
-        reactions_sample_klass = "Reactions#{material_group.to_s.camelize}Sample"
+        material_group = material_group.to_s
+        fixed_label = material_group if %w[reactant solvent].include?(material_group)
+        reactions_sample_klass = "Reactions#{material_group.camelize}Sample"
         samples.each_with_index do |sample, idx|
           sample.position = idx if sample.position.nil?
-          sample.reference = false if material_group === 'solvent' && sample.reference == true
+          sample.reference = false if material_group == 'solvent' && sample.reference == true
           # create new subsample
           if sample.is_new
-            if sample.parent_id && material_group != 'products'
+            if sample.parent_id && material_group != 'product'
               parent_sample = Sample.find(sample.parent_id)
 
               # TODO: extract subsample method

--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -47,7 +47,6 @@ module ReactionHelpers
 
   def update_materials_for_reaction(reaction, material_attributes, current_user)
     collections = reaction.collections
-    materials = OpenStruct.new(material_attributes)
     materials = {
       starting_material: Array(material_attributes['starting_materials']).map { |m| OSample.new(m) },
       reactant: Array(material_attributes['reactants']).map { |m| OSample.new(m) },

--- a/spec/api/helpers_spec.rb
+++ b/spec/api/helpers_spec.rb
@@ -2,6 +2,117 @@
 
 require 'rails_helper'
 
+describe Chemotion::ReactionAPI do
+  subject do
+    Class.new(Grape::API) do |inst|
+      inst.extend(ReactionHelpers)
+      inst.extend(ContainerHelpers)
+    end
+  end
+
+  describe 'ReactionHelpers' do
+    let(:user) { create(:user) }
+    let(:collection) { Collection.create!(label: 'Collection', user: user) }
+    let(:reaction) { create(:reaction, name: 'Reaction', collections: [collection]) }
+    let(:root_container) { create(:root_container) }
+    let(:sample) { create(:sample, name: 'Sample', container: FactoryBot.create(:container)) }
+    let(:molfile) { File.read(Rails.root + 'spec/fixtures/test_2.mol') }
+    let(:starting_materials) do
+      {
+        'starting_materials' => [
+          {
+            # hits existing_sample branch
+            'id' => sample.id,
+            'name' => 'starting_material',
+            'target_amount_unit' => 'mg',
+            'target_amount_value' => 75.09596,
+            'equivalent' => 1,
+            'reference' => false,
+            'is_new' => false,
+            'molfile' => molfile,
+            'container' => root_container
+          }
+        ]
+      }
+    end
+    let(:reactants) do
+      {
+        'reactants' => [
+          # hits subsample branch
+          'target_amount_unit' => 'mg',
+          'target_amount_value' => 86.09596,
+          'equivalent' => 2,
+          'reference' => false,
+          'is_new' => true,
+          'molfile' => molfile,
+          'container' => root_container,
+          'parent_id' => sample.id # gets named after parent, hence no name specified
+        ]
+      }
+    end
+    let(:products) do
+      {
+        'products' => [
+          {
+            # hits new_sample branch
+            'name' => 'product',
+            'target_amount_unit' => 'mg',
+            'target_amount_value' => 99.08304,
+            'equivalent' => 5.5,
+            'reference' => false,
+            'is_new' => true,
+            'molfile' => molfile,
+            'container' => root_container
+          }
+        ]
+      }
+    end
+    let(:materials) do
+      {
+        'solvents' => [
+          # hits new_sample branch
+          'name' => 'solvent',
+          'target_amount_unit' => 'mg',
+          'target_amount_value' => 76.09596,
+          'equivalent' => 1,
+          'reference' => true,
+          'is_new' => true,
+          'molfile' => molfile,
+          'container' => root_container
+        ]
+      }.merge(starting_materials, reactants, products)
+    end
+
+    it 'update existing sample' do
+      subject.update_materials_for_reaction(reaction, starting_materials, user)
+      expect(Sample.all.size).to eq(1) # RSpec creates `sample` fixture, and ReactionHelpers update it
+      expect(Sample.find_by(name: 'starting_material').target_amount_value).to eq(75.09596)
+    end
+
+    it 'create sample for new materials with parent ID that are not products' do
+      subject.update_materials_for_reaction(reaction, reactants, user)
+      expect(Sample.all.size).to eq(2) # RSpec creates `sample` fixture (parent), ReactionHelpers derive new sample from it
+      expect(Sample.find_by(short_label: 'reactant').target_amount_value).to eq(86.09596)
+    end
+
+    it 'create sample for new materials that are products' do
+      subject.update_materials_for_reaction(reaction, products, user)
+      expect(Sample.all.size).to eq(1) # ReactionHelpers create new sample
+      expect(Sample.find_by(name: 'product').target_amount_value).to eq(99.08304)
+    end
+
+    it 'associate reaction with materials' do
+      subject.update_materials_for_reaction(reaction, materials, user)
+      expect(ReactionsSample.all.size).to eq(4)
+      expect(ReactionsStartingMaterialSample.all.size).to eq(1)
+      expect(ReactionsReactantSample.all.size).to eq(1)
+      expect(ReactionsSolventSample.all.size).to eq(1)
+      expect(ReactionsProductSample.all.size).to eq(1)
+      expect(reaction.reactions_samples).to eq(ReactionsSample.all)
+    end
+  end
+end
+
 describe Chemotion::CollectionAPI do
   subject do
     Class.new(Grape::API) do |inst|

--- a/spec/api/reaction_api_spec.rb
+++ b/spec/api/reaction_api_spec.rb
@@ -289,6 +289,7 @@ describe Chemotion::ReactionAPI do
                 'equivalent' => 1,
                 'is_new' => true,
                 'is_split' => true,
+                'molfile' => File.read(Rails.root + 'spec/fixtures/test_2.mol'),
                 'container' => new_root_container
               ]
             }
@@ -307,7 +308,7 @@ describe Chemotion::ReactionAPI do
           subsample = r.products.last
           expect(subsample.parent).to eq(sample_1)
           expect(subsample.attributes).to include(
-            'name' => sample_1.name, 'target_amount_value' => 76.09596,
+            'target_amount_value' => 76.09596,
             'target_amount_unit' => 'mg'
           )
           subsample_association = r.reactions_product_samples
@@ -347,6 +348,7 @@ describe Chemotion::ReactionAPI do
                 'equivalent' => 1,
                 'is_new' => true,
                 'is_split' => true,
+                'molfile' => File.read(Rails.root + 'spec/fixtures/test_2.mol'),
                 'molecule' => { molfile: molfile_1 },
                 'container' => new_root_container
               ],
@@ -360,7 +362,6 @@ describe Chemotion::ReactionAPI do
                 'equivalent' => 2,
                 'is_new' => true,
                 'is_split' => false,
-                # 'molecule' => { molfile: molfile_1 },
                 'molfile' => molfile_1,
                 'container' => new_root_container
               ]
@@ -381,7 +382,6 @@ describe Chemotion::ReactionAPI do
 
           expect(subsample.parent).to eq(sample_1)
           expect(subsample.attributes).to include(
-            'name' => sample_1.name,
             'target_amount_value' => 76.09596,
             'target_amount_unit' => 'mg'
           )


### PR DESCRIPTION
I came across two conditionals whose right-hand-side operator is specified incorrectly.

Specifically, I mean `material_group === 'solvent'` in 
https://github.com/ComPlat/chemotion_ELN/blob/fad0e8efd9535a01d3f2677f636fe515d4ec2caf/app/api/chemotion/reaction_api.rb#L65

and `material_group != 'products'` in
https://github.com/ComPlat/chemotion_ELN/blob/fad0e8efd9535a01d3f2677f636fe515d4ec2caf/app/api/chemotion/reaction_api.rb#L68

The problem is that `material_group` is not a string, but a hash-key from
https://github.com/ComPlat/chemotion_ELN/blob/fad0e8efd9535a01d3f2677f636fe515d4ec2caf/app/api/chemotion/reaction_api.rb#L51-L57

This means that `material_group === 'solvent'` will never evaluate to `true` ,
and `material_group != 'products'` will never evaluate to `false`.

Regarding `material_group != 'products'`, even if `material_group` would be a string, the expression still couldn't possibly evaluate to `false`, since the hash-key is `product` (singular) not `products` (plural). Therefore, materials that are products are erroneously entering the conditional branch guarded by `material_group != 'products'`.

 I fixed the conditionals in 17f199919d180196462852d8c1cf4a1db91280b6. The fix broke some tests in `spec/api/reaction_api_spec.rb` that relied on the bug, i.e., they relied on the fact that products entered the wrong conditional branch. Those tests are fixed in the same commit.

a598982cb0cf4c8f40106b3f98475b4eacf82667 and 4e4578232eefed0a4370489de2d41900a9ace07f are just some very minor clean-ups.

5f7c9de71e2e2b9be5ab193f012ea6ebed5c5c90 contains tests I wrote before starting any of the other work on this PR.