### PR TITLE
fix scrubbed sample svg from imported collection

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -347,16 +347,19 @@ class Sample < ApplicationRecord
 
     svg_file_name = "#{SecureRandom.hex(64)}.svg"
 
-    if svg =~ /TMPFILE[0-9a-f]{64}.svg/
+    if svg =~ /\ATMPFILE[0-9a-f]{64}.svg\z/
       src = full_svg_path(svg.to_s)
       return unless File.exist?(src)
 
       svg = File.read(src)
       FileUtils.remove(src)
     end
-    if svg.start_with?('<?xml', '<svg')
+    if svg.start_with?(/\s*\<\?xml/, /\s*\<svg/)
       File.write(full_svg_path(svg_file_name), scrub(svg))
       self.sample_svg_file = svg_file_name
+    end
+    unless sample_svg_file =~ /\A[0-9a-f]{128}.svg\z/
+      self.sample_svg_file = nil
     end
   end
 


### PR DESCRIPTION
error due to scrubbed data having blank character in the first bytes

also enforce encoding of openbabel produced svg


