### PR TITLE
add migration for using gem shrine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,4 @@ vendor/cache/*
 .docker-sync/
 
 public/sprite.png
+shrine/*

--- a/Gemfile
+++ b/Gemfile
@@ -113,6 +113,8 @@ gem 'webpacker', git: 'https://github.com/rails/webpacker', branch: 'master'
 gem 'whenever', require: false
 
 gem 'yaml_db'
+gem "shrine", "~> 3.0"
+gem "image_processing", "~> 1.8"
 
 group :development do
   gem 'better_errors' # allows to debug exception on backend from browser

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,6 +276,7 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.1.10)
+    content_disposition (1.0.0)
     countries (3.0.0)
       i18n_data (~> 0.8.0)
       sixarm_ruby_unaccent (~> 1.1)
@@ -310,6 +311,8 @@ GEM
     dotenv-rails (2.7.2)
       dotenv (= 2.7.2)
       railties (>= 3.2, < 6.1)
+    down (5.2.2)
+      addressable (~> 2.5)
     ed25519 (1.2.4)
     equalizer (0.0.11)
     erubi (1.10.0)
@@ -394,6 +397,9 @@ GEM
       concurrent-ruby (~> 1.0)
     i18n_data (0.8.0)
     ice_nine (0.11.2)
+    image_processing (1.12.1)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jaro_winkler (1.5.3)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
@@ -449,6 +455,7 @@ GEM
     mimemagic (0.3.10)
       nokogiri (~> 1)
       rake
+    mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.6.1)
     minitest (5.15.0)
@@ -646,6 +653,8 @@ GEM
     ruby-mailchecker (3.2.29)
     ruby-ole (1.2.12.2)
     ruby-progressbar (1.10.1)
+    ruby-vips (2.1.3)
+      ffi (~> 1.12)
     ruby2_keywords (0.0.2)
     rubyXL (3.3.26)
       nokogiri (>= 1.4.4)
@@ -688,6 +697,9 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    shrine (3.4.0)
+      content_disposition (~> 1.0)
+      down (~> 5.1)
     sixarm_ruby_unaccent (1.2.0)
     slackistrano (3.8.4)
       capistrano (>= 3.8.1)
@@ -834,6 +846,7 @@ DEPENDENCIES
   hashie-forbidden_attributes
   httparty
   inchi-gem (= 1.06.1)!
+  image_processing (~> 1.8)
   jbuilder (~> 2.0)
   jquery-rails
   jwt
@@ -887,9 +900,6 @@ DEPENDENCIES
   scenic
   schmooze
   semacode!
-  sentry-rails
-  sentry-ruby
-  simplecov
   slackistrano
   spring
   stackprof

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -21,6 +21,7 @@
 #  attachable_type :string
 #  aasm_state      :string
 #  filesize        :bigint
+#  attachment_data :jsonb
 #
 # Indexes
 #
@@ -33,20 +34,21 @@ class Attachment < ApplicationRecord
   include AttachmentJcampAasm
   include AttachmentJcampProcess
   include AttachmentConverter
+  include AttachmentUploader::Attachment(:attachment)
 
   attr_accessor :file_data, :file_path, :thumb_path, :thumb_data, :duplicated, :transferred
 
   before_create :generate_key
-  before_create :store_tmp_file_and_thumbnail, if: :new_upload
+  # before_create :store_tmp_file_and_thumbnail, if: :new_upload
   before_create :add_checksum, if: :new_upload
   before_create :add_content_type
   before_save :update_filesize
 
-  before_save  :move_from_store, if: :store_changed, on: :update
+  # before_save  :move_from_store, if: :store_changed, on: :update
 
   #reload to get identifier:uuid
   after_create :reload, on: :create
-  after_create :store_file_and_thumbnail_for_dup, if: :duplicated
+  # after_create :store_file_and_thumbnail_for_dup, if: :duplicated
 
   after_destroy :delete_file_and_thumbnail
 
@@ -82,15 +84,15 @@ class Attachment < ApplicationRecord
   end
 
   def read_file
-    store.read_file
+    self.attachment_attacher.file.read if self.attachment_attacher.file.present?
   end
 
   def read_thumbnail
-    store.read_thumb if self.thumb
+    self.attachment(:thumbnail).read if self.attachment(:thumbnail).present?
   end
 
   def abs_path
-    store.path
+    self.attachment_attacher.url if self.attachment_attacher.file.present?
   end
 
   def abs_prev_path
@@ -106,7 +108,7 @@ class Attachment < ApplicationRecord
   end
 
   def add_checksum
-    store.add_checksum
+    self.checksum = Digest::MD5.hexdigest(read_file) if self.attachment_attacher.file.present?
   end
 
   def reset_checksum
@@ -115,7 +117,7 @@ class Attachment < ApplicationRecord
   end
 
   def regenerate_thumbnail
-    return unless filesize <= 50 * 1024 * 1024
+    return unless self.filesize <= 50 * 1024 * 1024
 
     store.regenerate_thumbnail
     update_column('thumb', thumb) if thumb_changed?
@@ -190,6 +192,16 @@ class Attachment < ApplicationRecord
                         end
   end
 
+  def reload
+    super
+  
+    set_key
+  end
+
+  def set_key
+    self.key = self.identifier
+  end
+
   private
 
   def generate_key
@@ -240,7 +252,7 @@ class Attachment < ApplicationRecord
   end
 
   def delete_file_and_thumbnail
-    store.destroy
+    self.attachment_attacher.destroy
   end
 
   def move_from_store(from_store = self.storage_was)

--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -133,13 +133,19 @@ module AttachmentJcampProcess
       attachable_type: 'Container',
       created_by: created_by,
       created_for: created_for,
-      content_type: content_type
+      content_type: content_type,
+      key: SecureRandom.uuid
     )
+
+    att.attachment_attacher.attach(File.open(meta_tmp.path, binmode: true))
+    att.attachment_attacher.create_derivatives
     att.save!
     att.set_edited if ext != 'png' && to_edit
     att.set_image if ext == 'png'
     att.set_json if ext == 'json'
     att.set_csv if ext == 'csv'
+
+    att.update!(attachable_id: attachable_id, attachable_type: 'Container')
     att.update!(storage: Rails.configuration.storage.primary_store)
     att
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -59,7 +59,7 @@ class Report < ApplicationRecord
       report_template = ReportTemplate.includes(:attachment).find(report_templates_id)
       template = report_template.report_type
       tpl_path = if report_template.attachment
-                   report_template.attachment.store.path
+                   "uploads/#{report_template.attachment.attachment_url}"
                  else
                    report_template.report_type
                  end

--- a/app/packs/src/fetchers/AttachmentFetcher.js
+++ b/app/packs/src/fetchers/AttachmentFetcher.js
@@ -177,7 +177,7 @@ export default class AttachmentFetcher {
   }
 
   static uploadFiles(files) {
-    const data = new FormData()
+    const data = new FormData();
     files.forEach((file) => {
       data.append(file.id || file.name, file);
     });
@@ -187,19 +187,15 @@ export default class AttachmentFetcher {
       method: 'post',
       body: data
     }).then((response) => {
-      if (response.ok == false) {
-        let msg = 'Files uploading failed: ';
-        if (response.status == 413) {
-          msg += 'File size limit exceeded.'
-        } else {
-          msg += response.statusText;
-        }
+      return response.json();
+    }).then((json) => {
+      for (let i = 0; i < json.error_messages.length; i++) {
         NotificationActions.add({
-          message: msg,
+          message: json.error_messages[i],
           level: 'error'
         });
       }
-    })
+    });
   }
 
   static uploadCompleted(filename, key, checksum) {
@@ -222,12 +218,19 @@ export default class AttachmentFetcher {
             msg += response.statusText;
           }
 
+        NotificationActions.add({
+          message: msg,
+          level: 'error'
+        });
+      } else {
+        for (let i = 0; i < response.error_messages.length; i++) {
           NotificationActions.add({
-            message: msg,
+            message: response.error_messages[i],
             level: 'error'
           });
         }
-      })
+      }
+    })
   };
 
   static uploadChunk(chunk, counter, key, progress, filename) {
@@ -303,7 +306,7 @@ export default class AttachmentFetcher {
         'Content-Type': 'application/json'
       }
     }).then((response) => {
-      return response.json()
+      return response.json();
     }).then((json) => {
       return new Attachment(json.attachment);
     }).catch((errorMessage) => {
@@ -322,7 +325,7 @@ export default class AttachmentFetcher {
         'Content-Type': 'application/json'
       }
     }).then((response) => {
-      return response.json()
+      return response.json();
     }).then((json) => {
       return new Attachment(json.attachment);
     }).catch((errorMessage) => {

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -1,0 +1,68 @@
+class AttachmentUploader < Shrine
+  MAX_SIZE = Rails.configuration.storage.maximum_size * 1024 * 1024 # 10 MB
+
+  plugin :derivatives
+  plugin :remove_attachment
+  plugin :validation_helpers
+  plugin :pretty_location
+  Attacher.validate do
+    validate_max_size MAX_SIZE, message: "File #{record.filename} cannot be uploaded. File size must be less than #{Rails.configuration.storage.maximum_size} MB"
+  end
+
+  def is_integer?
+    !!(self =~ /\A[-+]?[0-9]+\z/)
+  end
+
+  def generate_location(io, context = {})
+    sub_directories = Dir["#{storage.directory}/*"].select { |f| File.directory? f }.sort_by { |s| s.scan(/\d+/).last.to_i }
+    if sub_directories.count <= 1
+      bucket = 1 
+    else
+      bucket = sub_directories.count - 1
+    end
+    directory_path = File.join(storage.directory, bucket.to_s)
+    file_count = 0
+    file_count = Dir.entries(directory_path).select { |f| File.file? File.join(directory_path, f) }.count { |file| !file.split('.').include? 'thumb' } if File.directory?(directory_path)
+    bucket = bucket + 1 if file_count > 10_000
+    if context[:record]
+      file_name = if io.path.include? "thumb.jpg"
+                    "#{context[:record][:key]}.thumb.jpg"
+                  else
+                    "#{context[:record][:key]}#{File.extname(context[:record][:filename])}"
+                  end
+      "#{storage.directory}/#{bucket}/#{file_name}"
+    else
+      super
+    end
+  end
+
+  # plugins and uploading logic
+  Attacher.derivatives do |original|
+    begin
+      file_extension = File.extname(file.id)&.downcase
+      file_extension = '.jpg' if file_extension == '.jpeg'
+      file_basename = File.basename(file.metadata['filename'], '.*')
+      tmp = Tempfile.new([file_basename, file_extension], encoding: 'ascii-8bit')
+      tmp.write file.read
+      tmp.rewind
+      thumbnail = begin
+                    Thumbnailer.create(tmp.path)
+                  rescue
+                    nil
+                  end
+      result = {}
+      if thumbnail.present?
+        dir = File.dirname(thumbnail)
+        thumb_path = "#{dir}/#{file_basename}.thumb.jpg"
+        FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
+        FileUtils.move(thumbnail, thumb_path)
+        result[:thumbnail]  = File.open(thumb_path, 'rb')
+        record[:thumb] = true
+      end
+      result
+    ensure
+      tmp.close
+      tmp.unlink
+    end
+  end
+end

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -1,0 +1,12 @@
+require "shrine"
+require "shrine/storage/file_system"
+
+Shrine.storages = {
+  cache: Shrine::Storage::FileSystem.new("uploads", prefix: "shrine/cache"), # temporary
+  store: Shrine::Storage::FileSystem.new("uploads", prefix: "shrine"),       # permanent
+}
+
+Shrine.plugin :activerecord           # loads Active Record integration
+Shrine.plugin :derivatives
+Shrine.plugin :cached_attachment_data # enables retaining cached file across form redisplays
+Shrine.plugin :restore_cached_data    # extracts metadata for assigned cached files

--- a/config/initializers/storage.rb
+++ b/config/initializers/storage.rb
@@ -5,4 +5,5 @@ Rails.application.configure do
   config.storage.stores = storage_config[:stores]
   config.storage.primary_store = storage_config[:primary_store]
   config.storage.secondary_store = storage_config[:secondary_store]
+  config.storage.maximum_size = storage_config[:maximum_size]
 end

--- a/config/storage.yml.example
+++ b/config/storage.yml.example
@@ -1,4 +1,5 @@
 development:
+  :maximum_size: 100
   :primary_store: 'local'
   :secondary_store: ''
   :stores:
@@ -27,6 +28,7 @@ development:
 
 
 test:
+  :maximum_size: 100
   :primary_store: 'local'
   :secondary_store: ''
   :stores:
@@ -38,6 +40,7 @@ test:
       :thumbnail_folder: 'tmp/test/uploads/local'
 
 production:
+  :maximum_size: 100
   :primary_store: 'local'
   :secondary_store: ''
   :stores:

--- a/db/migrate/20210216132619_create_report_templates.rb
+++ b/db/migrate/20210216132619_create_report_templates.rb
@@ -11,10 +11,5 @@ class CreateReportTemplates < ActiveRecord::Migration[4.2]
     add_reference :reports, :report_templates, index: true 
     change_column_null :report_templates, :name, false 
     change_column_null :report_templates, :report_type, false
-
-    ReportTemplate.reset_column_information
-    Attachment.reset_column_information
-    seed_path = Rails.root.join('db', 'seeds', 'shared', 'report_templates.seed.rb')
-    load(seed_path) if File.exist?(seed_path)
   end
 end

--- a/db/migrate/20210825082859_add_attachment_data_to_attachments.rb
+++ b/db/migrate/20210825082859_add_attachment_data_to_attachments.rb
@@ -1,0 +1,5 @@
+class AddAttachmentDataToAttachments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :attachments, :attachment_data, :jsonb
+  end
+end

--- a/db/migrate/20210921114428_update_attachments_with_shrine.rb
+++ b/db/migrate/20210921114428_update_attachments_with_shrine.rb
@@ -1,0 +1,15 @@
+class UpdateAttachmentsWithShrine < ActiveRecord::Migration[5.2]
+  def change
+    Attachment.where(attachment_data: [nil]).find_each do |item|
+      file_path = item.store.path
+      next unless File.exist? file_path
+      item.attachment_attacher.attach(File.open(file_path, binmode: true))
+      if item.valid?
+        item.attachment_attacher.create_derivatives
+        item.save!
+      else
+        File.write('failed_attachement_migrate.log', "#{item.id}: File_path: #{file_path}  Message: #{item.errors.to_h[:attachment]}\n", mode: 'a')
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2022_07_07_164502) do
     t.string "attachable_type"
     t.string "aasm_state"
     t.bigint "filesize"
+    t.jsonb "attachment_data"
     t.index ["attachable_type", "attachable_id"], name: "index_attachments_on_attachable_type_and_attachable_id"
     t.index ["identifier"], name: "index_attachments_on_identifier", unique: true
   end

--- a/db/seeds/shared/report_templates.seed.rb
+++ b/db/seeds/shared/report_templates.seed.rb
@@ -12,7 +12,7 @@ TEMPLATE_LIST = [
 
 def create_template(file_name, template_name, template_type)
   if(file_name)
-    attachment = Attachment.create!(
+    attachment = Attachment.create(
       filename: file_name,
       key: 'file',
       file_path: "#{DIR}/#{file_name}",
@@ -20,13 +20,12 @@ def create_template(file_name, template_name, template_type)
       created_for: USER_ID,
       content_type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
     )
-
+    
+    attachment.attachment_attacher.attach(File.open("#{DIR}/#{file_name}", binmode: true))
+    attachment.save!
     ReportTemplate.create!(
       name: "#{template_name}", report_type: "#{template_type}", attachment: attachment
     )
-  
-    primary_store = Rails.configuration.storage.primary_store
-    attachment.update!(storage: primary_store)
   else
     ReportTemplate.create!(
       name: "#{template_name}", report_type: "#{template_type}"

--- a/lib/export/export_collections.rb
+++ b/lib/export/export_collections.rb
@@ -60,9 +60,9 @@ module Export
           description += "#{schema_json_checksum} schema.json\n"
           # write all attachemnts into an attachments directory
           @attachments.each do |attachment|
-            attachment_path = File.join('attachments', attachment.identifier)
+            attachment_path = File.join('attachments', "#{attachment.identifier}#{File.extname(attachment.filename)}")
             zip.put_next_entry attachment_path
-            zip.write attachment.read_file if attachment.store.file_exist?
+            zip.write attachment.attachment_attacher.file.read if attachment.attachment_attacher.file.present?
             description += "#{attachment.checksum} #{attachment_path}\n"
           end
 

--- a/lib/import/import_collections.rb
+++ b/lib/import/import_collections.rb
@@ -29,14 +29,30 @@ module Import
           when 'export.json'
             @data = JSON.parse(data)
           when %r{attachments/([0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12})}
-            attachment = Attachment.create!(
-              file_data: data,
+            file_name = entry.name.sub('attachments/', '')
+            attachment = Attachment.new(
               transferred: true,
               created_by: @current_user_id,
               created_for: @current_user_id,
-              filename: Regexp.last_match(1)
+              filename: Regexp.last_match(1),
+              key: SecureRandom.uuid,
+              filename: file_name
             )
-            attachments << attachment
+            
+            begin
+              tmp = Tempfile.new(file_name)
+              tmp.write(data)
+              tmp.rewind
+              attachment.attachment_attacher.attach(tmp)
+              if attachment.valid?
+                attachment.attachment_attacher.create_derivatives
+                attachment.save!
+                attachments << attachment
+              end
+            ensure
+              tmp.close
+              tmp.unlink   # deletes the temp file
+            end
           when %r{^images/(samples|reactions|molecules|research_plans)/(\w{1,128}\.\w{1,4})}
             tmp_file = Tempfile.new
             tmp_file.write(data)
@@ -426,8 +442,8 @@ module Import
         attachable_uuid = fields.fetch('attachable_id')
         attachable = @instances.fetch(attachable_type).fetch(attachable_uuid)
 
-        attachment = Attachment.where(id: @attachments, filename: fields.fetch('identifier')).first
-
+        file_name =  "#{fields.fetch('identifier')}#{File.extname(fields.fetch('filename'))}"
+        attachment = Attachment.where(id: @attachments, filename: file_name).first
         attachment.update!(
           attachable: attachable,
           transferred: true,
@@ -443,7 +459,7 @@ module Import
 
         # add attachment to the @instances map
         update_instances!(uuid, attachment)
-        attachment.regenerate_thumbnail
+        # attachment.regenerate_thumbnail
       end
     end
 

--- a/lib/reporter/worker.rb
+++ b/lib/reporter/worker.rb
@@ -54,7 +54,11 @@ module Reporter
           content_type: @typ
         )
 
-        TransferFileFromTmpJob.set(queue: "transfer_report_from_tmp_#{att.id}").perform_later([att.id]) unless att.nil?
+        att.attachment_attacher.attach(File.open(tmp.path, binmode: true))
+        if att.valid?
+          att.attachment_attacher.create_derivatives
+          att.save!
+        end
 
         @report.update_attributes(
           generated_at: Time.zone.now

--- a/spec/api/attachment_api_spec.rb
+++ b/spec/api/attachment_api_spec.rb
@@ -74,10 +74,6 @@ describe Chemotion::AttachmentAPI do
       it 'creates attachments for each file' do
         expect(attachments.count).to eq 2
       end
-
-      it 'stores file localy' do
-        expect(File.exist?(attachments.last.store.path)).to be true
-      end
     end
 
     describe 'upload img thru POST attachments/upload_dataset_attachments' do
@@ -93,12 +89,8 @@ describe Chemotion::AttachmentAPI do
         expect(img_attachments.count).to eq 2
       end
 
-      it 'stores file localy' do
-        expect(File.exist?(img_attachments.last.store.path)).to be true
-      end
-
-      it 'creates thumbnail localy' do
-        expect(File.exist?(img_attachments.last.store.thumb_path)).to be true
+      it 'creates thumbnail' do
+        expect(img_attachments.last.attachment_url(:thumbnail).present?).to be true
       end
 
       describe 'Return Base64 encoded thumbnail' do
@@ -219,15 +211,6 @@ describe Chemotion::SampleAPI do
           expect(
             s1.analyses.first.children.first.attachments.first
           ).to eq(attachment)
-        end
-
-        it 'has stored the file in the primary storage' do
-          expect(
-            s1.analyses.first.children.first.attachments.first.storage
-          ).to eq(Rails.configuration.storage.primary_store)
-          expect(
-            s1.analyses.first.children.first.attachments.first.store.file_exist?
-          ).to be true
         end
       end
     end

--- a/spec/factories/attachment.rb
+++ b/spec/factories/attachment.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :attachment do
     #  container_id nil
+    key { SecureRandom.uuid }
     filename { 'upload.txt' }
     #  identifier nil
     #  checksum nil

--- a/spec/lib/storage/storage_spec.rb
+++ b/spec/lib/storage/storage_spec.rb
@@ -33,11 +33,6 @@ RSpec.describe Storage do
       attachment.storage = 'tmp'
     end
 
-    it 'raises error when attachment has no key for path' do
-      expect(new_store).to be_a(Tmp)
-      expect { new_store.path }.to raise_error(StandardError,
-                                               'cannot build path without attachment key')
-    end
     context 'with a non valid attachment.key' do
       before { attachment.key = SecureRandom.uuid }
 

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Report, type: :report do
       filename: rp1.file_name + '.' + ext,
       attachable_id: rp1.id,
       attachable_type: 'Report',
-      content_type: docx_mime_type
+      content_type: docx_mime_type,
+      attachment: File.open("#{Rails.root}/spec/fixtures/upload.jpg", binmode: true)
     )
   end
 
@@ -66,15 +67,12 @@ RSpec.describe Report, type: :report do
   end
 
   describe 'delete archive file after Report is destroyed' do
-    let(:f_path) { att1.store.path }
-    let(:t_path) { att1.store.thumb_path }
-
-    before do
+    it 'delete the archive file' do
+      att1.attachment_attacher.create_derivatives
+      f_path = att1.attachment_url
+      t_path = att1.attachment_url(:thumbnail)
       rp1.really_destroy!
       att1.destroy!
-    end
-
-    it 'delete the archive file' do
       expect(File.exist?(f_path)).to be false
       expect(File.exist?(t_path)).to be false
     end


### PR DESCRIPTION
using gem shrine for uploading attachment

change ci build

uploading to custom directory

use attacher when export import collections

update unit test

Generate checksum by reading block by block
Replace read_file with file_path
Change filesize datatype from int to bigint
Only generate thumbnails if file < 50MB
Count complete step as a step when uploading
Move delay job to recurring cron job



- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
