### PR TITLE
Prevent sample-model from unnecessarily updating reaction-SVG

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -225,7 +225,7 @@ class Sample < ApplicationRecord
   attr_writer :skip_reaction_svg_update
 
   def skip_reaction_svg_update?
-    @skip_reaction_svg_update
+    @skip_reaction_svg_update.present?
   end
 
   def molecule_sum_formular

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -164,7 +164,8 @@ class Sample < ApplicationRecord
   before_create :set_boiling_melting_points
   after_save :update_counter
   after_create :create_root_container
-  after_save :update_data_for_reactions
+  after_save :update_equivalent_for_reactions
+  after_save :update_svg_for_reactions, unless: :skip_reaction_svg_update?
 
   has_many :collections_samples, inverse_of: :sample, dependent: :destroy
   has_many :collections, through: :collections_samples
@@ -220,6 +221,12 @@ class Sample < ApplicationRecord
 
   delegate :computed_props, to: :molecule, prefix: true
   delegate :inchikey, to: :molecule, prefix: true, allow_nil: true
+
+  attr_writer :skip_reaction_svg_update
+
+  def skip_reaction_svg_update?
+    @skip_reaction_svg_update
+  end
 
   def molecule_sum_formular
     (decoupled? ? sum_formula : molecule&.sum_formular) || ''
@@ -506,11 +513,6 @@ private
     end
 
     el_composition.set_loading self
-  end
-
-  def update_data_for_reactions
-    update_equivalent_for_reactions
-    update_svg_for_reactions
   end
 
   def update_equivalent_for_reactions

--- a/app/usecases/reactions/update_materials.rb
+++ b/app/usecases/reactions/update_materials.rb
@@ -160,6 +160,7 @@ module Usecases
 
         existing_sample.container = update_datamodel(sample.container) if sample.container
 
+        existing_sample.skip_reaction_svg_update = true
         existing_sample.save!
         existing_sample
       end

--- a/spec/usecases/reactions/update_materials_spec.rb
+++ b/spec/usecases/reactions/update_materials_spec.rb
@@ -13,7 +13,6 @@ describe Usecases::Reactions::UpdateMaterials do
   let(:starting_materials) do
     {
       'starting_materials' => [
-        # hits existing_sample branch
         'id' => sample1.id,
         'name' => 'starting_material',
         'target_amount_unit' => 'mg',
@@ -29,7 +28,6 @@ describe Usecases::Reactions::UpdateMaterials do
   let(:reactants) do
     {
       'reactants' => [
-        # hits subsample branch
         'target_amount_unit' => 'mg',
         'target_amount_value' => 86.09596,
         'equivalent' => 2,
@@ -44,7 +42,6 @@ describe Usecases::Reactions::UpdateMaterials do
   let(:products) do
     {
       'products' => [
-        # hits new_sample branch
         'name' => 'product',
         'target_amount_unit' => 'mg',
         'target_amount_value' => 99.08304,
@@ -59,7 +56,6 @@ describe Usecases::Reactions::UpdateMaterials do
   let(:mixed_materials) do
     {
       'solvents' => [
-        # hits new_sample branch
         'name' => 'solvent',
         'target_amount_unit' => 'mg',
         'target_amount_value' => 76.09596,
@@ -92,8 +88,8 @@ describe Usecases::Reactions::UpdateMaterials do
       expect(reaction.reactions_samples).to eq(ReactionsSample.all)
     end
 
-    context 'when sample exists', :existing_sample do
-      let(:samples) { starting_materials }
+    context 'when sample exists' do
+      let(:samples) { starting_materials } # hits .update_existing_sample
 
       it 'does not update reaction-SVG from sample model', :svg_update do
         # Capturing SVG::ReactionComposer:new is the most straightforward way I could think of to test updates to the reaction-SVG.
@@ -108,7 +104,7 @@ describe Usecases::Reactions::UpdateMaterials do
     end
 
     context 'when sample is new and not a product' do
-      let(:samples) { reactants }
+      let(:samples) { reactants } # hits .create_sub_sample
 
       it 'creates sub-sample for sample with parent' do
         expect(Sample.count).to eq(2) # RSpec creates `sample` fixture (parent), UpdateMaterials derive new sample from it
@@ -117,7 +113,7 @@ describe Usecases::Reactions::UpdateMaterials do
     end
 
     context 'when sample is a new product' do
-      let(:samples) { products }
+      let(:samples) { products } # hits .create_new_sample
 
       it 'creates new sample' do
         expect(Sample.count).to eq(1) # UpdateMaterials create new sample

--- a/spec/usecases/reactions/update_materials_spec.rb
+++ b/spec/usecases/reactions/update_materials_spec.rb
@@ -4,16 +4,17 @@ require 'rails_helper'
 
 describe Usecases::Reactions::UpdateMaterials do
   let(:user) { create(:user) }
-  let(:collection) { Collection.create!(label: 'Collection', user: user) }
+  let(:collection) { create(:collection, label: 'Collection', user: user) }
   let(:reaction) { create(:reaction, name: 'Reaction', collections: [collection]) }
   let(:root_container) { create(:root_container) }
-  let(:sample) { create(:sample, name: 'Sample', container: FactoryBot.create(:container)) }
+  let(:sample1) { create(:sample, name: 'Sample1', container: create(:container)) }
+  let(:sample2) { create(:sample, name: 'Sample2', container: create(:container)) }
   let(:molfile) { File.read(Rails.root + 'spec/fixtures/test_2.mol') }
   let(:starting_materials) do
     {
       'starting_materials' => [
         # hits existing_sample branch
-        'id' => sample.id,
+        'id' => sample1.id,
         'name' => 'starting_material',
         'target_amount_unit' => 'mg',
         'target_amount_value' => 75.09596,
@@ -36,7 +37,7 @@ describe Usecases::Reactions::UpdateMaterials do
         'is_new' => true,
         'molfile' => molfile,
         'container' => root_container,
-        'parent_id' => sample.id # gets named after parent, hence no name specified
+        'parent_id' => sample2.id # gets named after parent, hence no name specified
       ]
     }
   end
@@ -55,7 +56,7 @@ describe Usecases::Reactions::UpdateMaterials do
       ]
     }
   end
-  let(:materials) do
+  let(:mixed_materials) do
     {
       'solvents' => [
         # hits new_sample branch
@@ -72,50 +73,56 @@ describe Usecases::Reactions::UpdateMaterials do
   end
 
   describe '#execute!' do
-    context 'when sample exists' do
-      before do
-        ReactionsStartingMaterialSample.create!(
-          reaction: reaction, sample: sample, reference: true, equivalent: 1
-        )
-      end
+    let(:samples) { mixed_materials }
 
-      it 'does not update reaction-SVG from sample model' do
-        # Capturing SVG::ReactionComposer:new is the most straightforward way I could think of to test updates to the reaction-SVG.
-        # Since the updates to the reaction-SVG are a side-effect they are difficult to test.
-        allow(SVG::ReactionComposer).to receive(:new)
-        described_class.new(reaction, starting_materials, user).execute!
-        expect(SVG::ReactionComposer).to have_received(:new).once # only one final update to reaction-SVG once reaction is saved
-      end
-
-      it 'updates the sample' do
-        described_class.new(reaction, starting_materials, user).execute!
-        expect(Sample.count).to eq(1) # RSpec creates `sample` fixture, and UpdateMaterials update it
-        expect(Sample.find_by(name: 'starting_material').target_amount_value).to eq(75.09596)
-      end
-    end
-
-    context 'when sample is new' do
-      it 'creates sub-sample for sample with parent that are not products' do
-        described_class.new(reaction, reactants, user).execute!
-        expect(Sample.count).to eq(2) # RSpec creates `sample` fixture (parent), UpdateMaterials derive new sample from it
-        expect(Sample.find_by(short_label: 'reactant').target_amount_value).to eq(86.09596)
-      end
-
-      it 'creates new sample for samples that are products' do
-        described_class.new(reaction, products, user).execute!
-        expect(Sample.count).to eq(1) # UpdateMaterials create new sample
-        expect(Sample.find_by(name: 'product').target_amount_value).to eq(99.08304)
-      end
+    before do |example|
+      ReactionsStartingMaterialSample.create!(
+        reaction: reaction, sample: sample1, reference: true, equivalent: 1
+      )
+      allow(SVG::ReactionComposer).to receive(:new) if example.metadata[:svg_update]
+      described_class.new(reaction, samples, user).execute!
     end
 
     it 'associates reaction with materials' do
-      described_class.new(reaction, materials, user).execute!
       expect(ReactionsSample.count).to eq(4)
       expect(ReactionsStartingMaterialSample.count).to eq(1)
       expect(ReactionsReactantSample.count).to eq(1)
       expect(ReactionsSolventSample.count).to eq(1)
       expect(ReactionsProductSample.count).to eq(1)
       expect(reaction.reactions_samples).to eq(ReactionsSample.all)
+    end
+
+    context 'when sample exists', :existing_sample do
+      let(:samples) { starting_materials }
+
+      it 'does not update reaction-SVG from sample model', :svg_update do
+        # Capturing SVG::ReactionComposer:new is the most straightforward way I could think of to test updates to the reaction-SVG.
+        # Since the updates to the reaction-SVG are a side-effect they are difficult to test.
+        expect(SVG::ReactionComposer).to have_received(:new).once # only one final update to reaction-SVG once reaction is saved
+      end
+
+      it 'updates the sample' do
+        expect(Sample.count).to eq(1) # RSpec creates `sample` fixture, and UpdateMaterials update it
+        expect(Sample.find_by(name: 'starting_material').target_amount_value).to eq(75.09596)
+      end
+    end
+
+    context 'when sample is new and not a product' do
+      let(:samples) { reactants }
+
+      it 'creates sub-sample for sample with parent' do
+        expect(Sample.count).to eq(2) # RSpec creates `sample` fixture (parent), UpdateMaterials derive new sample from it
+        expect(Sample.find_by(short_label: 'reactant').target_amount_value).to eq(86.09596)
+      end
+    end
+
+    context 'when sample is a new product' do
+      let(:samples) { products }
+
+      it 'creates new sample' do
+        expect(Sample.count).to eq(1) # UpdateMaterials create new sample
+        expect(Sample.find_by(name: 'product').target_amount_value).to eq(99.08304)
+      end
     end
   end
 end

--- a/spec/usecases/reactions/update_materials_spec.rb
+++ b/spec/usecases/reactions/update_materials_spec.rb
@@ -82,8 +82,9 @@ describe Usecases::Reactions::UpdateMaterials do
       it 'does not update reaction-SVG from sample model' do
         # Capturing SVG::ReactionComposer:new is the most straightforward way I could think of to test updates to the reaction-SVG.
         # Since the updates to the reaction-SVG are a side-effect they are difficult to test.
-        expect(SVG::ReactionComposer).to receive(:new).once # only one final update to reaction-SVG once reaction is saved
+        allow(SVG::ReactionComposer).to receive(:new)
         described_class.new(reaction, starting_materials, user).execute!
+        expect(SVG::ReactionComposer).to have_received(:new).once # only one final update to reaction-SVG once reaction is saved
       end
 
       it 'updates the sample' do


### PR DESCRIPTION
Calling `save` on a sample triggers an `after_save` callback in the sample-model that updates the reaction-SVGs that are associated with that sample.

https://github.com/ComPlat/chemotion_ELN/blob/dd3e2c4852ed953b4a89a36dcc1593094e64397a/app/models/sample.rb#L167
https://github.com/ComPlat/chemotion_ELN/blob/dd3e2c4852ed953b4a89a36dcc1593094e64397a/app/models/sample.rb#L511

When a sample is saved in the context of the reaction-API it is not necessary for the sample-model to update the reaction-SVG, since the reaction-model itself updates the reaction-svg.

https://github.com/ComPlat/chemotion_ELN/blob/dd3e2c4852ed953b4a89a36dcc1593094e64397a/app/usecases/reactions/update_materials.rb#L82
https://github.com/ComPlat/chemotion_ELN/blob/dd3e2c4852ed953b4a89a36dcc1593094e64397a/app/models/reaction.rb#L144

The performance of the reaction-API suffers from this, since calling the reaction-API's `post` and `put` endpoints causes the sample-model to carry out unnecessary updates of the reaction-SVG. To improve performance, I prevent the sample-model from updating the reaction-SVG when `sample.save` is called from the reaction-API.

I submit this optimization in preparation of a feature that requires creating multiple reactions in quick succession.
All tests pass locally.