### PR TITLE
Add unique class to reactions tab so spec can explicitly find the tab…

### DIFF
--- a/app/packs/src/apps/mydb/elements/list/ElementsList.js
+++ b/app/packs/src/apps/mydb/elements/list/ElementsList.js
@@ -208,7 +208,7 @@ export default class ElementsList extends React.Component {
 
 
       const navItem = (
-        <NavItem eventKey={i} key={`${value}_navItem`}>
+        <NavItem eventKey={i} key={`${value}_navItem`} className={`elements-list-tab-${value}s`}>
           <OverlayTrigger delayShow={500} placement="top" overlay={ttl}>
             <i className={iconClass} />
           </OverlayTrigger>

--- a/spec/features/copy_reaction_spec.rb
+++ b/spec/features/copy_reaction_spec.rb
@@ -38,7 +38,7 @@ describe 'Copy reaction' do
 
   def copy_reaction(source_collection, target_collection)
     find_by_id("tree-id-#{source_collection}").click
-    find('i.icon-reaction').click
+    find('.elements-list-tab-reactions').click
     find('div.preview-table', text: 'Reaction').click
     click_button('copy-element-btn')
     fill_in('modal-collection-id-select', with: target_collection).send_keys(:enter)


### PR DESCRIPTION
… instead of the reaction icons

The copy_reaction_spec.rb is currently blinking a lot. 
One of the recurrent errors is that the copy_reaction method tries to find the
Reactions tab by looking for an icon. Unfortunately, this icon is also displayed for samples
that are part of a reaction, so there are 3 icons on screen, causing an "Ambiguous match" error.

What is strange though, is that SOMETIMES the spec runs properly... might be an artifact though, by having the sample list not yet loaded, so only the reactions tab matches the filter.

![copy-reaction-from-own-collection-to-different-own-collection-140-1662620784 6477458](https://user-images.githubusercontent.com/3226541/189074436-9311a24e-5f81-45c6-8596-19d1ef0c993e.png)
