### PR TITLE
Bugfix wellplate import in research plan

### DIFF
--- a/app/api/chemotion/measurements_api.rb
+++ b/app/api/chemotion/measurements_api.rb
@@ -104,7 +104,7 @@ module Chemotion
         end
 
         post do
-          Usecases::Measurements::BulkCreateFromRawData.new(current_user, params).execute!
+          { measurements: Usecases::Measurements::BulkCreateFromRawData.new(current_user, params).execute! }
         rescue StandardError => e
           error!(e.full_message, 500)
         end

--- a/app/packs/src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsFieldTableMeasurementExportModal.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsFieldTableMeasurementExportModal.js
@@ -184,7 +184,7 @@ class ResearchPlanDetailsFieldTableMeasurementExportModal extends Component {
           <div>
             <ButtonToolbar>
               <Button bsStyle="warning" onClick={this.props.onHide}>
-                Cancel
+                Close
               </Button>
               <Button bsStyle="primary" disabled={!this.readyForSubmit()} onClick={this.handleSubmit.bind(this)}>
                 Link data to sample

--- a/app/packs/src/fetchers/MeasurementsFetcher.js
+++ b/app/packs/src/fetchers/MeasurementsFetcher.js
@@ -43,7 +43,7 @@ export default class MeasurementsFetcher {
         source_id: researchPlanId
       })
     }).then(response => response.json())
-      .then(json => json.bulk_create_from_raw_data)
+      .then(json => json.measurements)
       .catch((errorMessage) => { console.log(errorMessage); });
   }
 

--- a/app/usecases/research_plans/import_wellplate_as_table.rb
+++ b/app/usecases/research_plans/import_wellplate_as_table.rb
@@ -57,11 +57,11 @@ module Usecases
         columns = [
           {
             colId: :wellplate_position, field: :wellplate_position,
-            headerName: 'Position', editable: false, resizable: true
+            headerName: 'Position', editable: true, resizable: true
           },
           {
             colId: :sample, field: :sample,
-            headerName: 'Sample', editable: false, resizable: true
+            headerName: 'Sample', editable: true, resizable: true
           }
         ]
 

--- a/spec/api/chemotion/measurements_api_spec.rb
+++ b/spec/api/chemotion/measurements_api_spec.rb
@@ -71,7 +71,8 @@ describe Chemotion::MeasurementsAPI do
 
     describe 'POST /api/v1/measurements/bulk_create_from_raw_data' do
       let(:collection) { create(:collection, user_id: user.id, is_shared: true, permission_level: 3) }
-      let(:wellplate) { create(:wellplate, :with_random_wells, number_of_readouts: 3) }
+      let(:sample) { create(:sample, creator: user) }
+      let(:wellplate) { create(:wellplate, :with_random_wells, number_of_readouts: 3, sample: sample) }
       let(:raw_data) do
         wellplate.wells.map do |well|
           well.readouts.map.with_index do |readout, readout_index|
@@ -95,9 +96,7 @@ describe Chemotion::MeasurementsAPI do
       before do
         CollectionsResearchPlan.create(research_plan: research_plan, collection: collection)
         CollectionsWellplate.create!(wellplate: wellplate, collection: collection)
-        wellplate.wells.each do |well|
-          CollectionsSample.create!(sample: well.sample, collection: collection)
-        end
+        CollectionsSample.create!(sample: sample, collection: collection)
       end
 
       it 'creates measurements from the given well' do

--- a/spec/factories/wellplates.rb
+++ b/spec/factories/wellplates.rb
@@ -25,17 +25,20 @@ FactoryBot.define do
     trait :with_random_wells do
       transient do
         number_of_readouts { 1 }
+        sample { } # allows to pass in a custom sample to prevent the well factory from creating one sample per well
       end
 
       wells do
         (1..8).map do |pos_y|
           (1..12).map do |pos_x|
-            build(
-              :well, :with_random_readouts,
+            well_attributes = {
               position_x: pos_x,
               position_y: pos_y,
               number_of_readouts: number_of_readouts
-            )
+            }
+            well_attributes[:sample] = sample if sample
+
+            build(:well, :with_random_readouts, well_attributes)
           end
         end.flatten
       end


### PR DESCRIPTION
This PR fixes a little bug in the measurements API, which caused the Javascript to fail as it expected a different structure returned from the server.

Measurements-Workflow
---------------------

## 1) Import wellplate
- The Attachments tab within a wellplate contains a downloadable Excel Template. This templates allows importing a whole wellplate and has preset Columns that allow importing a wellplate into a research plan table.
![Screenshot 2022-09-14 at 10 46 45](https://user-images.githubusercontent.com/3226541/190116544-4ac1c3e6-fc4c-4437-b824-01a182ab30f4.png)
- You can either create a wellplate manually or use the import template.
- Required fields for the measurement export are: 
  - Sample (contains the sample short label)
  - at least one pair of columns that represent a readout: READOUT Value, READOUT Unit (The columns must contain value and unit respectively, either as a separate word or with underscore READOUT_Value, READOUT_Unit)
![Screenshot 2022-09-14 at 10 47 44](https://user-images.githubusercontent.com/3226541/190116612-0f1eeef0-01c6-4046-94c9-86b99e4b2a52.png)

## 2) Add wellplate to a research plan
- Open the wellplates tab of the research plan (might be hidden) and drag your wellplate here.
![Screenshot 2022-09-14 at 10 51 02](https://user-images.githubusercontent.com/3226541/190116813-00c1f098-e4c7-42bd-9afa-c561532391ea.png)
- Save the research plan to enable the Wellplate Import Button

## 3) Import wellplate data into research plan table
- Click the wellplate import button. This will import the wellplate data into a table in the research plan tab
![Screenshot 2022-09-14 at 10 52 32](https://user-images.githubusercontent.com/3226541/190117058-8dbcce93-8677-487c-9ecf-c214b832937c.png)
- Press the "Click to edit" button to enter the edit mode of the research plan body. 
![Screenshot 2022-09-14 at 10 54 19](https://user-images.githubusercontent.com/3226541/190117397-a7cfb759-f05a-4a14-b0d8-aa7a525c132b.png)

## 4) Export measurements
- Below the table you can find an "Export Measurements" button, which shows all exportable measurements. 
![Screenshot 2022-09-14 at 10 55 52](https://user-images.githubusercontent.com/3226541/190117534-f9b1310d-f284-49a1-a75f-993bffaa41a6.png)
- Only measurements that have entries in Sample and at least one pair of Value/Unit columns will be shown here.
- Check boxes for all measurements you want to export. There are some convenience buttons to select all measurements or all measurements of a specific readout.
- Click "Link data to sample" button. The measurements will be exported and linked to their respective samples.

## 5) View measurements for a sample
- Open a sample for which you exported measurements
- click on the Measurements tab (might be hidden)
![Screenshot 2022-09-14 at 11 14 50](https://user-images.githubusercontent.com/3226541/190117667-e36e5ccd-bfa0-417e-a4e0-72c64b8c7d60.png)
- The exported measurements can be shown in either a tabular form as well as a list form
![Screenshot 2022-09-14 at 11 15 00](https://user-images.githubusercontent.com/3226541/190117724-86104105-c9c3-4795-8270-28950fbd6da3.png)
- Deletion of measurements can only be done in the "Show as list" tab.
- WARNING: Deletion of measurements is immediate, the is no undo implemented!