### PR TITLE
Report Ruby unit test coverage on CI

### DIFF
--- a/.github/workflows/testacceptance.yml
+++ b/.github/workflows/testacceptance.yml
@@ -9,7 +9,6 @@ env:
 
 jobs:
   docker_container:
-    if: "!contains(github.event.commits[0].message, 'skip all') && !contains(github.event.commits[0].message, 'skip acceptance')"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/testacceptance.yml
+++ b/.github/workflows/testacceptance.yml
@@ -2,6 +2,10 @@ name: Acceptance Tests
 
 on: [workflow_dispatch, push, pull_request]
 
+defaults:
+  run:
+    shell: bash
+
 env:
   NODE_OPTIONS: '--max_old_space_size=4096'
 
@@ -38,7 +42,11 @@ jobs:
           POSTGRES_HOST: postgres
           POSTGRES_PORT: 5433
         run: |
-            sudo git clone --branch $(echo $GITHUB_REF | cut -d'/' -f 3) --depth 1 https://github.com/$(echo $GITHUB_REPOSITORY).git
+            branch=${GITHUB_REF##*/}
+            if [[ $GITHUB_EVENT_NAME == pull_request ]]; then
+              branch=$GITHUB_HEAD_REF  # GITHUB_HEAD_REF is only set for PR events
+            fi
+            sudo git clone --branch $branch --depth 1 https://github.com/$(echo $GITHUB_REPOSITORY).git    # replace with actions/checkout/@v3?
 
             sudo bash ./chemotion_ELN/.github/workflows/config.sh
 

--- a/.github/workflows/testacceptance.yml
+++ b/.github/workflows/testacceptance.yml
@@ -1,8 +1,6 @@
 name: Acceptance Tests
 
-on:
-  workflow_dispatch:
-  push:
+on: [workflow_dispatch, push, pull_request]
 
 env:
   NODE_OPTIONS: '--max_old_space_size=4096'

--- a/.github/workflows/testjs.yml
+++ b/.github/workflows/testjs.yml
@@ -1,8 +1,7 @@
 name: JavaScript Unit Tests
 
-on:
-  workflow_dispatch:
-  push:
+on: [workflow_dispatch, push, pull_request]
+
 
 jobs:
   docker_container:

--- a/.github/workflows/testjs.yml
+++ b/.github/workflows/testjs.yml
@@ -2,6 +2,9 @@ name: JavaScript Unit Tests
 
 on: [workflow_dispatch, push, pull_request]
 
+defaults:
+  run:
+    shell: bash
 
 jobs:
   docker_container:
@@ -35,9 +38,12 @@ jobs:
         env:
           POSTGRES_HOST: postgres
           POSTGRES_PORT: 5432
-
         run: |
-            sudo git clone --branch $(echo $GITHUB_REF | cut -d'/' -f 3) --depth 1 https://github.com/$(echo $GITHUB_REPOSITORY).git
+            branch=${GITHUB_REF##*/}
+            if [[ $GITHUB_EVENT_NAME == pull_request ]]; then
+              branch=$GITHUB_HEAD_REF  # GITHUB_HEAD_REF is only set for PR events
+            fi
+            sudo git clone --branch $branch --depth 1 https://github.com/$(echo $GITHUB_REPOSITORY).git    # replace with actions/checkout/@v3?
 
             sudo bash ./chemotion_ELN/.github/workflows/config.sh
 

--- a/.github/workflows/testjs.yml
+++ b/.github/workflows/testjs.yml
@@ -3,17 +3,16 @@ name: JavaScript Unit Tests
 on:
   workflow_dispatch:
   push:
-    
+
 jobs:
   docker_container:
-    if: "!contains(github.event.commits[0].message, 'skip all') && !contains(github.event.commits[0].message, 'skip unit js')"
     runs-on: ubuntu-latest
     strategy:
       matrix:
         pg_role: [chemotion_test]
         pg_database: [chemotion_test]
         pg_password: [123456]
-    container: 
+    container:
       image: complat/complat-ubuntu-runner:development-5.c44d0c2d4
     env:
       HOME: /home/gitlab-runner
@@ -26,9 +25,9 @@ jobs:
         env:
           POSTGRES_PASSWORD: postgres
         options: >-
-          --health-cmd pg_isready 
-          --health-interval 10s 
-          --health-timeout 5s 
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
           --health-retries 5
 
     steps:
@@ -63,4 +62,3 @@ jobs:
             /bin/bash -l -c "RAILS_ENV=test bundle exec rake db:test:prepare > /dev/null"
             echo "NPM TEST"
             /bin/bash -l -c "npm test"
-            

--- a/.github/workflows/testrb.yml
+++ b/.github/workflows/testrb.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         pg_role: [chemotion_test]
         pg_database: [chemotion_test]
+        pg_password: [123456]
     container:
       image: complat/complat-ubuntu-runner:development-5.c44d0c2d4
     env:
@@ -42,7 +43,7 @@ jobs:
             echo "POSTGRES"
             psql -d postgresql://postgres:postgres@postgres/postgres -c "CREATE ROLE ${{ matrix.pg_role }} LOGIN CREATEDB NOSUPERUSER PASSWORD '123456'"
             psql -d postgresql://postgres:postgres@postgres/postgres -c "CREATE DATABASE ${{ matrix.pg_database }} OWNER ${{ matrix.pg_role }};"
-            psql -d postgresql://${{ matrix.pg_role }}:123456@postgres/${{ matrix.pg_database }} -c 'CREATE EXTENSION IF NOT EXISTS "pg_trgm"; CREATE EXTENSION IF NOT EXISTS "hstore"; CREATE EXTENSION IF NOT EXISTS "uuid-ossp";'
+            psql -d postgresql://${{ matrix.pg_role }}:${{ matrix.pg_password }}@postgres/${{ matrix.pg_database }} -c 'CREATE EXTENSION IF NOT EXISTS "pg_trgm"; CREATE EXTENSION IF NOT EXISTS "hstore"; CREATE EXTENSION IF NOT EXISTS "uuid-ossp";'
 
             sudo chmod -R +x chemotion_ELN/spec
             sudo chown -R gitlab-runner:gitlab-runner chemotion_ELN

--- a/.github/workflows/testrb.yml
+++ b/.github/workflows/testrb.yml
@@ -2,6 +2,9 @@ name: Ruby Unit Tests
 
 on: [workflow_dispatch, push, pull_request]
 
+defaults:
+  run:
+    shell: bash
 
 jobs:
   docker_container:
@@ -11,8 +14,7 @@ jobs:
         pg_role: [chemotion_test]
         pg_database: [chemotion_test]
         pg_password: [123456]
-    container:
-      image: complat/complat-ubuntu-runner:development-5.c44d0c2d4
+    container: complat/complat-ubuntu-runner:development-5.c44d0c2d4
     env:
       HOME: /home/gitlab-runner
 
@@ -30,18 +32,22 @@ jobs:
           --health-retries 5
 
     steps:
-      - name: git clone + postgres
+      - name: git clone + postgres    # split into separate steps?
         working-directory: /home/gitlab-runner
         env:
           POSTGRES_HOST: postgres
           POSTGRES_PORT: 5432
         run: |
-            sudo git clone --branch $(echo $GITHUB_REF | cut -d'/' -f 3) --depth 1 https://github.com/$(echo $GITHUB_REPOSITORY).git
+            branch=${GITHUB_REF##*/}
+            if [[ $GITHUB_EVENT_NAME == pull_request ]]; then
+              branch=$GITHUB_HEAD_REF  # GITHUB_HEAD_REF is only set for PR events
+            fi
+            sudo git clone --branch $branch --depth 1 https://github.com/$(echo $GITHUB_REPOSITORY).git    # replace with actions/checkout/@v3?
 
             sudo bash ./chemotion_ELN/.github/workflows/config.sh
 
             echo "POSTGRES"
-            psql -d postgresql://postgres:postgres@postgres/postgres -c "CREATE ROLE ${{ matrix.pg_role }} LOGIN CREATEDB NOSUPERUSER PASSWORD '123456'"
+            psql -d postgresql://postgres:postgres@postgres/postgres -c "CREATE ROLE ${{ matrix.pg_role }} LOGIN CREATEDB NOSUPERUSER PASSWORD '${{ matrix.pg_password }}'"
             psql -d postgresql://postgres:postgres@postgres/postgres -c "CREATE DATABASE ${{ matrix.pg_database }} OWNER ${{ matrix.pg_role }};"
             psql -d postgresql://${{ matrix.pg_role }}:${{ matrix.pg_password }}@postgres/${{ matrix.pg_database }} -c 'CREATE EXTENSION IF NOT EXISTS "pg_trgm"; CREATE EXTENSION IF NOT EXISTS "hstore"; CREATE EXTENSION IF NOT EXISTS "uuid-ossp";'
 
@@ -64,3 +70,26 @@ jobs:
         working-directory: /home/gitlab-runner/chemotion_ELN
         run: |
           /bin/bash -l -c "RAILS_ENV=test bundle exec rspec --exclude-pattern spec/{features}/**/*_spec.rb"
+
+      - name: upload coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: /home/gitlab-runner/chemotion_ELN/coverage/lcov/chemotion_ELN.lcov
+
+  coverage_report:
+    needs: docker_container
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout/@v3  # we need to have the repository checked out in order to generate HTML report
+    - name: download coverage
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage
+    - name: post coverage
+      uses: zgosalvez/github-actions-report-lcov@v1
+      with:
+        coverage-files: chemotion_ELN.lcov
+        minimum-coverage: 50
+        artifact-name: code-coverage-report
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testrb.yml
+++ b/.github/workflows/testrb.yml
@@ -1,8 +1,7 @@
 name: Ruby Unit Tests
 
-on:
-  workflow_dispatch:
-  push:
+on: [workflow_dispatch, push, pull_request]
+
 
 jobs:
   docker_container:

--- a/.github/workflows/testrb.yml
+++ b/.github/workflows/testrb.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   docker_container:
-    if: "!contains(github.event.commits[0].message, 'skip all') && !contains(github.event.commits[0].message, 'skip unit rb')"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -65,4 +64,3 @@ jobs:
         working-directory: /home/gitlab-runner/chemotion_ELN
         run: |
           /bin/bash -l -c "RAILS_ENV=test bundle exec rspec --exclude-pattern spec/{features}/**/*_spec.rb"
-

--- a/Gemfile
+++ b/Gemfile
@@ -186,6 +186,7 @@ group :test do
   gem 'rspec-repeat'
 
   gem 'simplecov', require: false
+  gem 'simplecov-lcov', require: false
 
   gem 'webdrivers'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -701,6 +701,7 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
+    simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
     sixarm_ruby_unaccent (1.2.0)
     slackistrano (3.8.4)
@@ -905,6 +906,7 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   simplecov
+  simplecov-lcov
   slackistrano
   spring
   stackprof

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 require 'simplecov'
+require 'simplecov-lcov'
+
+SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
 
 SimpleCov.start 'rails' do
   add_group 'GraphQL', 'app/graphql'


### PR DESCRIPTION
The PR changes our CI such that on each pull request, the code coverage for the Ruby unit tests is reported.
Coverage is reported using the [report-lcov](https://github.com/marketplace/actions/report-lcov) action. The action requires the additional dependency [simplecov-lcov](https://github.com/fortissimo1997/simplecov-lcov).

Also, the three workflow files (testacceptance.yml, testjs.yml, testrb.yml) have been cleaned up a bit.