### PR TITLE
Update information for hot fix version of chemspectra

### DIFF
--- a/.service-dependencies
+++ b/.service-dependencies
@@ -1,4 +1,4 @@
 #syntax=v1
 CONVERTER=ComPlat/chemotion-converter-app@v0.6.0
 KETCHER=ptrxyz/chemotion-ketchersvc@main
-SPECTRA=ComPlat/chem-spectra-app@0.10.15
+SPECTRA=ComPlat/chem-spectra-app@0.10.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
   * ketcherservice: server generation of sample svg
   * Reaction coefficient: improve yield calculation (https://github.com/ComPlat/chemotion_ELN/issues/544)
   * Metadata-converter: v0.6.0
-  * Chemspectra: v0.10.15 (allow reprocessing, read Bruker processed files if present)
+  * Chemspectra: v0.10.16 (allow reprocessing, read Bruker processed files if present)
   * Inbox: delete multiple attachments at once (https://github.com/ComPlat/chemotion_ELN/issues/571)
   * research-plan: improve context-menu in tables
 


### PR DESCRIPTION
Chemspectra should be version 0.10.16 in case of process jcamp files with multiple `LINK` valued



- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [x] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [x] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [x] testing coverage improvement is improved.

- [x] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [x] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
