### PR TITLE
renamed app.root_url in delayed jobs (v1.4 backport)

### DIFF
--- a/app/jobs/download_analyses_job.rb
+++ b/app/jobs/download_analyses_job.rb
@@ -38,7 +38,7 @@ class DownloadAnalysesJob < ApplicationJob
     @file_path = Rails.public_path.join('zip', @filename)
 
     begin
-      @link = "#{app.root_url}/zip/#{@filename}"
+      @link = "#{Rails.application.config.root_url}/zip/#{@filename}"
       @expires_at = Time.now + 24.hours
 
       zip = Zip::OutputStream.write_buffer do |zip|

--- a/app/jobs/export_collections_job.rb
+++ b/app/jobs/export_collections_job.rb
@@ -36,7 +36,7 @@ class ExportCollectionsJob < ApplicationJob
     @user_id = user_id
     begin
       @labels = Collection.where(id: collection_ids[0..9]).pluck(:label)
-      @link = "#{app.root_url}/zip/#{job_id}.#{extname}"
+      @link = "#{Rails.application.config.root_url}/zip/#{job_id}.#{extname}"
       @expires_at = Time.now + 24.hours
 
       export = Export::ExportCollections.new(job_id, collection_ids, extname, nested)


### PR DESCRIPTION
This patch fixes a bug, where the delayed_job was referring to the wrong property.
This caused the delayed_job to fail, when the user requested to download all analysis files
or to recreate `.edit.jdx` files.