### PR TITLE
Skip linting job on push triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   linting:
+    if: github.event.pull_request
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
The linting action (https://github.com/HeRoMo/pronto-action) seems to crash with push triggers.
Run it only when the workflow was triggered by a PR.
