### PR TITLE
Skip linting and coverage on PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   linting:
-    if: github.event.pull_request
+    if: github.event.pull_request && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)    # don't run on PRs from forks because of missing write permission: https://github.com/orgs/community/discussions/26829
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -97,6 +97,7 @@ jobs:
         run: RAILS_ENV=test bundle exec rspec --exclude-pattern spec/{features}/**/*_spec.rb
 
       - name: coverage rspec unit
+        if: github.event.pull_request && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)    # don't run on PRs from forks because of missing write permission: https://github.com/orgs/community/discussions/26829
         uses: zgosalvez/github-actions-report-lcov@v1
         with:
           coverage-files: coverage/lcov/${{ github.event.repository.name }}.lcov


### PR DESCRIPTION
Our linting (https://github.com/HeRoMo/pronto-action ) and coverage (https://github.com/zgosalvez/github-actions-report-lcov) actions require write access to the base repository in order to comment on PRs. 
However, when these actions are run in the context of a PR from a fork, they fail since forks don't have write access.
This is why we're skipping these actions in case of PRs from forks.

See https://github.com/orgs/community/discussions/26829 and https://github.com/nyurik/auto_pr_comments_from_forks.