### PR TITLE
clickable reaction links in research plab table

### DIFF
--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -108,6 +108,20 @@ module Chemotion
         end
       end
 
+      namespace :findByShortLabel do
+        desc 'Fetch reaction id and collection based on short label'
+        params do
+          requires :short_label, type: String, desc: 'Unique short label of sample'
+        end
+        route_param :short_label do
+          get do
+            finder = Usecases::Reactions::FindByShortLabel.new(params[:short_label], current_user)
+
+            finder.result
+          end
+        end
+      end
+
       desc 'Update reaction by id'
       params do
         requires :id, type: Integer, desc: 'Reaction id'

--- a/app/packs/src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsFieldTable.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsFieldTable.js
@@ -13,6 +13,7 @@ import ResearchPlanDetailsFieldTableMeasurementExportModal from 'src/apps/mydb/e
 import ResearchPlanDetailsFieldTableSchemasModal from 'src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsFieldTableSchemasModal';
 import ResearchPlansFetcher from 'src/fetchers/ResearchPlansFetcher';
 import SamplesFetcher from 'src/fetchers/SamplesFetcher';
+import ReactionsFetcher from 'src/fetchers/ReactionsFetcher'
 
 
 // regexp to parse tap separated paste from the clipboard
@@ -509,14 +510,27 @@ export default class ResearchPlanDetailsFieldTable extends Component {
     const tr = rows.map((row, index) => {
       const td = columns.map((column) => {
         let cellContent = row[column.colId];
-        let cellContentIsShortLabel = column.headerName == 'Sample' && (cellContent || '').length > 3;
-        if (cellContentIsShortLabel) {
-          let shortLabel = cellContent;
-          cellContent = <a
-            onClick={(e) => { e.preventDefault(); this.openSampleByShortLabel(shortLabel) }}
-          >
-            {shortLabel}
-          </a>
+        if(column.headerName == 'Sample') {
+          let cellContentIsShortLabel = column.headerName == 'Sample' && (cellContent || '').length > 3;
+          if (cellContentIsShortLabel) {
+            let shortLabel = cellContent;
+            cellContent = <a
+              onClick={(e) => { e.preventDefault(); this.openSampleByShortLabel(shortLabel) }}
+            >
+              {shortLabel}
+            </a>
+          }
+        }
+        else if(column.headerName == 'Reaction') {
+          let cellContentIsShortLabel = column.headerName == 'Reaction' && (cellContent || '').length > 3;
+          if (cellContentIsShortLabel) {
+            let shortLabel = cellContent;
+            cellContent = <a
+              onClick={(e) => { e.preventDefault(); this.openReactionByShortLabel(shortLabel) }}
+            >
+              {shortLabel}
+            </a>
+          }
         }
         return <td style={{ 'height': '37px' }} key={column.colId}>{cellContent}</td>;
       });
@@ -553,8 +567,21 @@ export default class ResearchPlanDetailsFieldTable extends Component {
     SamplesFetcher.findByShortLabel(shortLabel).then((result) => {
       console.debug('got Result', result);
       if (result.sample_id && result.collection_id) {
-        Aviator.navigate(`api/v1/collection/${result.collection_id}/sample/${result.sample_id}`, { silent: true });
+        Aviator.navigate(`/collection/${result.collection_id}/sample/${result.sample_id}`, { silent: true });
         ElementActions.fetchSampleById(result.sample_id);
+      } else {
+        console.debug('No valid data returned for short label', shortLabel, result);
+      }
+    });
+  }
+
+  openReactionByShortLabel(shortLabel) {
+    console.debug('opening reaction by short label', shortLabel);
+    ReactionsFetcher.findByShortLabel(shortLabel).then((result) => {
+      console.debug('got Result', result);
+      if (result.reaction_id && result.collection_id) {
+        Aviator.navigate(`/collection/${result.collection_id}/reaction/${result.reaction_id}`, { silent: true });
+        ElementActions.fetchReactionById(result.reaction_id);
       } else {
         console.debug('No valid data returned for short label', shortLabel, result);
       }

--- a/app/packs/src/fetchers/ReactionsFetcher.js
+++ b/app/packs/src/fetchers/ReactionsFetcher.js
@@ -37,6 +37,16 @@ export default class ReactionsFetcher {
     return BaseFetcher.fetchByCollectionId(id, queryParams, isSync, 'reactions', Reaction);
   }
 
+  static findByShortLabel(shortLabel) {
+    return fetch(
+      `/api/v1/reactions/findByShortLabel/${shortLabel}.json`,
+      {
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' }
+      }
+    ).then((response) => response.json()).catch(errorMessage => console.log(errorMessage))
+  }
+
   static create(reaction, method = 'post') {
     const reactionFiles = AttachmentFetcher.getFileListfrom(reaction.container);
     let productsFiles = [];

--- a/app/usecases/reactions/find_by_short_label.rb
+++ b/app/usecases/reactions/find_by_short_label.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Usecases
+  module Reactions
+    class FindByShortLabel
+      attr_accessor :result
+      attr_reader :short_label, :current_user
+
+      def initialize(short_label, current_user)
+        @current_user = current_user
+        @short_label = short_label
+        @result = {
+          reaction_id: nil,
+          collection_id: nil,
+        }
+          find_reaction
+        end
+  
+        private
+  
+        def find_reaction
+          reaction = current_user.reactions.find_by(short_label: short_label)
+          return unless reaction
+  
+          collections_containing_reaction = current_user.collections.ids & reaction.collections.ids
+          return if collections_containing_reaction.none?
+  
+          self.result = {
+            reaction_id: reaction.id,
+            collection_id: collections_containing_reaction.first,
+          }
+        end
+      end
+    end
+  end
+  


### PR DESCRIPTION
Resolves #823.

Reopened PR due to rebase/merge error with PR #825 

Enhancement of inital code for clickable sample links in research plan tables - now possible for reactions also:

https://user-images.githubusercontent.com/67055123/181255115-a02c738f-493b-47a4-8121-83b8faa956c2.mp4