### PR TITLE
enable save reaction without samples

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -295,7 +295,7 @@ export default class ReactionDetails extends Component {
             bsSize="xsmall"
             className="button-right"
             onClick={() => this.handleSubmit(true)}
-            disabled={!permitOn(reaction) || !this.reactionIsValid() || reaction.isNew}
+            // disabled={!permitOn(reaction) || !this.reactionIsValid() || reaction.isNew}
             style={{ display: hasChanged }}
           >
             <i className="fa fa-floppy-o" />
@@ -306,7 +306,7 @@ export default class ReactionDetails extends Component {
           overlay={<Tooltip id="saveReaction">Save Reaction</Tooltip>}>
           <Button bsStyle="warning" bsSize="xsmall" className="button-right"
             onClick={() => this.handleSubmit()}
-            disabled={!permitOn(reaction) || !this.reactionIsValid()}
+            // disabled={!permitOn(reaction) || !this.reactionIsValid()}
             style={{ display: hasChanged }} >
             <i className="fa fa-floppy-o "></i>
           </Button>


### PR DESCRIPTION

- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
