### PR TITLE
Development container for Visual Studio Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/docker-existing-dockerfile
+{
+  "name": "Chemotion Dockerfile",
+  "dockerComposeFile": [
+    "../docker-compose.dev.yml"
+  ],
+  "service": "app",
+  "workspaceFolder": "/home/chemotion-dev/app",
+  "extensions": [
+    "castwide.solargraph",
+    "rebornix.ruby",
+    "mtxr.sqltools",
+    "mtxr.sqltools-driver-pg",
+    "eamodio.gitlens",
+    "streetsidesoftware.code-spell-checker"
+  ],
+  "forwardPorts": [
+    3000,
+    5432
+  ],
+  "postCreateCommand": [
+    "/bin/bash",
+    ".devcontainer/post_create.sh"
+  ],
+  "remoteUser": "chemotion-dev", // see https: //aka.ms/vscode-remote/containers/non-root
+  "shutdownAction": "stopCompose", // stop compose when quitting
+  "overrideCommand": true, // override the commands in the compose file
+  "containerEnv": {
+    "RAILS_ENV": "development"
+  }
+}

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# install dependencies
+bundle update --bundler # update the bundler version in Gemfile.lock to the installed version
+bundle install
+yarn install
+
+# enable configuration files
+cp public/welcome-message-sample.md public/welcome-message.md
+cp config/datacollectors.yml.example config/datacollectors.yml
+cp config/storage.yml.example config/storage.yml
+cp config/database.yml.example config/database.yml
+cp config/shrine_config.yml.example config/shrine_config.yml
+
+# set up database
+bundle exec rake db:setup

--- a/.gitignore
+++ b/.gitignore
@@ -149,7 +149,6 @@ backup/weekly_backup
 # vim tags
 tags
 tags.temp
-.vscode/*
 
 coverage
 spec/examples.txt
@@ -175,7 +174,6 @@ yarn-debug.log*
 vendor/bundle/*
 vendor/cache/*
 .idea/*
-.devcontainer
 shrine/*
 .docker-sync/
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,58 @@
+// https://code.visualstudio.com/docs/editor/debugging#_launchjson-attributes
+// https://code.visualstudio.com/docs/editor/variables-reference
+// https://github.com/microsoft/vscode-recipes/tree/master/debugging-Ruby-on-Rails
+// https://github.com/rubyide/vscode-ruby/blob/main/docs/debugger.md
+// Debug configurations requires..
+// the solargraph, debase, and ruby-debug-ide gems to be (bundle) installed, and
+// the castwide.solargraph, and rebornix.ruby extensions to be installed.
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Rails server",
+      "type": "Ruby",
+      "request": "launch",
+      "cwd": "${workspaceRoot}",
+      "useBundler": true,
+      "pathToBundler": "${env:BUNDLER_PATH}",
+      "pathToRDebugIDE": "${env:RUBY_DEBUG_IDE_PATH}",
+      "program": "${workspaceRoot}/bin/rails",
+      "args": [
+        "server",
+        "-b",
+        "0.0.0.0",
+        "-p",
+        "3000"
+      ],
+      "env": {
+        "RAILS_ENV": "development"
+      }
+    },
+    {
+      "name": "Debug RSpec - selected line, active file",
+      "type": "Ruby",
+      "request": "launch",
+      "cwd": "${workspaceRoot}",
+      "useBundler": true,
+      "pathToBundler": "${env:BUNDLER_PATH}",
+      "pathToRDebugIDE": "${env:RUBY_DEBUG_IDE_PATH}",
+      "program": "/home/chemotion-dev/.asdf/installs/ruby/2.7.6/bin/rspec", // "program" doesn't support env variable substitution
+      "args": [
+        "${file}:${lineNumber}"
+      ],
+      "env": {
+        "RAILS_ENV": "test"
+      }
+    },
+  ],
+  "environment": [
+    {
+      "name": "BUNDLER_PATH",
+      "value": "$(which bundle)",
+    },
+    {
+      "name": "RUBY_DEBUG_IDE_PATH",
+      "value": "$(bundle info --path ruby-debug-ide)"
+    },
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,24 @@
+{
+  "sqltools.connections": [
+    {
+      "previewLimit": 50,
+      "server": "postgres",
+      "port": 5432,
+      "driver": "PostgreSQL",
+      "name": "development",
+      "database": "chemotion_dev",
+      "username": "postgres",
+      "password": ""
+    }
+    {
+      "previewLimit": 50,
+      "server": "postgres",
+      "port": 5432,
+      "driver": "PostgreSQL",
+      "name": "test",
+      "database": "chemotion_test",
+      "username": "postgres",
+      "password": ""
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,7 +17,7 @@
     {
       "label": "RSpec - unit",
       "type": "shell",
-      "command": "RAILS_ENV=test $(which bundle) exec rspec --exclude-pattern spec/{features}/**/*_spec.rb"
+      "command": "RAILS_ENV=test $(which bundle) exec rspec --exclude-pattern \"spec/{features}/**/*_spec.rb\""
     },
     {
       "label": "RSpec - acceptance",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,38 @@
+// https://code.visualstudio.com/docs/editor/variables-reference
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Rails - server",
+      "type": "shell",
+      "command": "RAILS_ENV=development $(which bundle) exec rails server -b 0.0.0.0 -p 3000"
+    },
+    {
+      "label": "RSpec - all",
+      "type": "shell",
+      "command": "RAILS_ENV=test $(which bundle) exec rspec"
+    },
+    {
+      "label": "RSpec - unit",
+      "type": "shell",
+      "command": "RAILS_ENV=test $(which bundle) exec rspec --exclude-pattern spec/{features}/**/*_spec.rb"
+    },
+    {
+      "label": "RSpec - acceptance",
+      "type": "shell",
+      "command": "RAILS_ENV=test $(which bundle) exec rspec spec/features"
+    },
+    {
+      "label": "RSpec - selected line, active file",
+      "type": "shell",
+      "command": "RAILS_ENV=test $(which bundle) exec rspec ${file}:${lineNumber}",
+    },
+    {
+      "label": "RuboCop autocorrect active file",
+      "type": "shell",
+      "command": "$(which bundle) exec rubocop -c .rubocop.yml -a ${file}",
+    },
+  ]
+}


### PR DESCRIPTION
This PR adds a development container for Visual Studio Code (in the following referred to as "devcontainer" for brevity):
https://code.visualstudio.com/docs/devcontainers/containers.

The PR is meant to unify our existing attempts at providing a devcontainer:
* https://github.com/JanCBrammer/Chemotion_ELN_devcontainer
* https://github.com/ptrxyz/chemotion/tree/v1.0.3D0.1/client-vscode-remote-container

Those attempts are fragmented and not as well maintained as they could be. By providing the devcontainer as part of the ELN repo, I'm hoping that it'll be more accessible and salient, and therefore easier to use and maintain.

The devcontainer uses the Dockerfile and compose configuration that are already in the repository:
* https://github.com/ComPlat/chemotion_ELN/blob/1709c2edcb9ecf7dd4471b2e44558de6ef07eb3a/Dockerfile.chemotion-dev
* https://github.com/ComPlat/chemotion_ELN/blob/1709c2edcb9ecf7dd4471b2e44558de6ef07eb3a/docker-compose.dev.yml

I.e., the present changes are merely a configuration layer on top of the existing containerization.

If this proposal is accepted, I'll update our documentation about using devcontainers:
https://www.chemotion.net/chemotionsaurus/docs/eln/development_docker_installation#eln-in-docker