### PR TITLE
Raise minimum coverage for Ruby unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,6 @@ jobs:
         uses: zgosalvez/github-actions-report-lcov@v1
         with:
           coverage-files: coverage/lcov/${{ github.event.repository.name }}.lcov
-          minimum-coverage: 50
+          minimum-coverage: 57
           artifact-name: code-coverage-report
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Raise minimum coverage such that it equals the current coverage (57%).