### PR TITLE
Skip actions triggered by Dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   linting:
-    if: github.event.pull_request
+    if: github.event.pull_request && (github.triggering_actor != 'dependabot[bot]')
     runs-on: ubuntu-latest
     env:
       PRONTO_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}
@@ -115,7 +115,7 @@ jobs:
         run: RAILS_ENV=test bundle exec rspec --exclude-pattern spec/{features}/**/*_spec.rb
 
       - name: coverage rspec unit
-        if: github.event.pull_request && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)    # don't run on PRs from forks because of missing write permission: https://github.com/orgs/community/discussions/26829
+        if: github.event.pull_request && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) && (github.triggering_actor != 'dependabot[bot]')  # don't run on PRs from forks because of missing write permission: https://github.com/orgs/community/discussions/26829
         uses: zgosalvez/github-actions-report-lcov@v1
         with:
           coverage-files: coverage/lcov/${{ github.event.repository.name }}.lcov


### PR DESCRIPTION
Currently, CI breaks on PRs that are triggered by Dependabot, since Dependabot doesn't have write permissions:
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events
