### PR TITLE
Activate admin account during seeding

### DIFF
--- a/db/seeds/shared/admin.seed.rb
+++ b/db/seeds/shared/admin.seed.rb
@@ -7,5 +7,6 @@ attributes = {
   type: 'Admin'
 }
 
-User.create!(attributes) unless User.find_by(type: 'Admin', name_abbreviation: 'ADM')
-
+user = User.find_by(type: 'Admin', name_abbreviation: 'ADM') || User.create!(attributes) 
+user.update!(account_active: true)
+user.update!(confirmed_at: DateTime.now)


### PR DESCRIPTION
Currently, the admin account isn't activated during seeding. Therefore, if I want to log into the account in the test or development environment, I have to manually activate the account first, which is tedious.

With the fix in this PR, the admin account is activated when seeding the database (e.g., with `bundle exec rake db:setup`).