### PR TITLE
Fix link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ of the **[Karlsruhe Institute of Technology]**.
 <!----------------------------------------------------------------------------->
 
 [Installation]: https://www.chemotion.net/chemotionsaurus/docs/category/installation
-[Documentation]: https://www.chemotion.net/chemotionsaurus/docs/category/manual
+[Documentation]: https://www.chemotion.net/chemotionsaurus/docs/eln/intro
 [Changelog]: CHANGELOG.md
 
 [DFG]: https://www.dfg.de/en/


### PR DESCRIPTION
Current link to docs (https://www.chemotion.net/chemotionsaurus/docs/category/manual) is broken, returns 500.