### PR TITLE
Improve Dev setup for M1 macs

### DIFF
--- a/Dockerfile.chemotion-dev
+++ b/Dockerfile.chemotion-dev
@@ -3,7 +3,7 @@
 # WARNING: Building this container initially takes a lot of time, due to gem compiling, so grab a coffee
 # and write some documentation meanwhile ;)
 
-FROM ubuntu:focal
+FROM --platform=linux/amd64 ubuntu:focal
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG VRUBY=2.7.6

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,7 +73,12 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # to allow development on M1 based Macs, use a simpler FileWatcher that does not rely on inotify (which does
+  # currently not work with docker on M1 macs as the used qemu backend does not support inotify).
+  # see https://github.com/evilmartians/terraforming-rails/issues/34#issuecomment-1347442704
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 
   # Stop the development & test logs from taking up to much space
   # https://stackoverflow.com/questions/7784057/ruby-on-rails-log-file-size-too-large/37499682#37499682

--- a/run-ruby-dev.sh
+++ b/run-ruby-dev.sh
@@ -3,4 +3,18 @@
 gem install bundler -v 2.1.4 && bundle install
 
 rm -f tmp/pids/server.pid
+
+if [ "$( psql -h postgres -U postgres -XtAc "SELECT 1 FROM pg_database WHERE datname='chemotion_dev'" )" = '1' ]
+then
+    echo "================================================"
+    echo "Database already exists, skipping Database setup"
+    echo "================================================"
+else
+    echo "================================================"
+    echo "Database does not exist, running 'rake db:setup'"
+    echo "================================================"
+    bundle exec rake db:setup
+fi
+
+
 bundle exec rails s -p 3000 -b 0.0.0.0


### PR DESCRIPTION
M1 macs use an ARM-based processor architecture, which will be picked up by docker generating ARM linux images by default. So we specifically use the linux/amd64 image to create a non-ARM image to work with.  This way all compilation and package installations (google-chrome-stable does not have ARM packages for example) run the expected way.

Another issue is that docker for mac uses qemu as backend on M1 macs, which does not support inotify. Because of that, the EventedFileWatcher used in the development environment does not work and had to be replaced by a FileWatcher without usage of inotify
