### PR TITLE
BugFix of #1106 - UI crash when editing table in researchplan

### DIFF
--- a/app/packs/src/models/ResearchPlan.js
+++ b/app/packs/src/models/ResearchPlan.js
@@ -193,7 +193,7 @@ export default class ResearchPlan extends Element {
     return this._wellplates || [];
   }
 
-  upsertAttachments(attachmentsToAdd) {
+  upsertAttachments(attachmentsToAdd=[]) {
     const idsOfAttachmentsInResearchPlan = this.attachments.map(
       (attachmentInResearchPlan) => attachmentInResearchPlan.identifier
     );

--- a/spec/javascripts/packs/src/models/ResearchPlan.spec.js
+++ b/spec/javascripts/packs/src/models/ResearchPlan.spec.js
@@ -15,6 +15,12 @@ describe('ResearchPlan', () => {
       expect(researchPlan.attachments.length).toEqual(1);
     });
 
+    it('without argument', () => {
+      researchPlan.attachments = [attachmentInResearchPlan];
+      researchPlan.upsertAttachments();
+      expect(researchPlan.attachments.length).toEqual(1);
+    });
+
     it('with two attachments, one already present in researchplan', () => {
       attachmentInResearchPlan.is_deleted = false;
       researchPlan.attachments = [attachmentInResearchPlan];


### PR DESCRIPTION

- [x] rather 1-story 1-commit than sub-atomic commits
- [x] commit title is meaningful => git history search
- [x] commit description is helpful => helps the reviewer to understand the changes
- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => ⏩-merge for linear history is favoured
- [x] added code is linted
- [x] test coverage increased 












