### PR TITLE
1076 bug fix theoretical mass not shown

### DIFF
--- a/app/assets/stylesheets/reaction.scss
+++ b/app/assets/stylesheets/reaction.scss
@@ -213,10 +213,6 @@ table.reaction-scheme-solvent {
 
 }
 
-.display-linebreak {
-  white-space: pre-line;
-}
-
 /* Safari 4.0 - 8.0 */
 @-webkit-keyframes reaction-status-color-change {
   from { background-color: aliceblue;}

--- a/app/assets/stylesheets/reaction.scss
+++ b/app/assets/stylesheets/reaction.scss
@@ -213,6 +213,10 @@ table.reaction-scheme-solvent {
 
 }
 
+.display-linebreak {
+  white-space: pre-line;
+}
+
 /* Safari 4.0 - 8.0 */
 @-webkit-keyframes reaction-status-color-change {
   from { background-color: aliceblue;}

--- a/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -59,8 +59,7 @@ export default class ReactionDetails extends Component {
     this.handleSegmentsChange = this.handleSegmentsChange.bind(this);
     if (!reaction.reaction_svg_file) {
       this.updateReactionSvg();
-    }
-    reaction.updateMaxAmountOfProducts();
+    }   
   }
 
 

--- a/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -60,6 +60,7 @@ export default class ReactionDetails extends Component {
     if (!reaction.reaction_svg_file) {
       this.updateReactionSvg();
     }
+    reaction.updateMaxAmountOfProducts();
   }
 
 

--- a/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -128,6 +128,7 @@ export default class ReactionDetails extends Component {
   }
 
   handleReactionChange(reaction, options = {}) {
+    reaction.updateMaxAmountOfProducts();
     reaction.changed = true;
     if (options.schemaChanged) {
       this.setState({ reaction }, () => this.updateReactionSvg());

--- a/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -59,7 +59,7 @@ export default class ReactionDetails extends Component {
     this.handleSegmentsChange = this.handleSegmentsChange.bind(this);
     if (!reaction.reaction_svg_file) {
       this.updateReactionSvg();
-    }   
+    }
   }
 
 

--- a/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
@@ -573,15 +573,15 @@ class Material extends Component {
     );
   }
 
-  generateMolecularWeightTooltipText(sample,reaction){
-    const isProduct=reaction.products.includes(sample)
+  generateMolecularWeightTooltipText(sample, reaction) {
+    const isProduct = reaction.products.includes(sample)
     const molecularWeight = sample.decoupled ?
       (sample.molecular_mass) : (sample.molecule && sample.molecule.molecular_weight);
-      let theoreticalMassPart="";
-      if (isProduct&&sample.maxAmount){
-        theoreticalMassPart=`, max theoretical mass: ${Math.round(sample.maxAmount * 10000) / 10} mg`
-      }
-      return `molar mass: ${molecularWeight} g/mol`+theoreticalMassPart;
+    let theoreticalMassPart = "";
+    if (isProduct && sample.maxAmount) {
+      theoreticalMassPart = `, max theoretical mass: ${Math.round(sample.maxAmount * 10000) / 10} mg`
+    }
+    return `molar mass: ${molecularWeight} g/mol` + theoreticalMassPart;
   }
 
   toggleTarget(isTarget) {

--- a/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
@@ -580,7 +580,7 @@ class Material extends Component {
       (sample.molecular_mass) : (sample.molecule && sample.molecule.molecular_weight);
       let theoreticalMassPart="";
       if (isProduct&&sample.maxAmount){
-        theoreticalMassPart=`, theoretical mass: ${Math.round(sample.maxAmount * 10000) / 10} mg`
+        theoreticalMassPart=`, max theoretical mass: ${Math.round(sample.maxAmount * 10000) / 10} mg`
       }
       return `molar mass: ${molecularWeight} g/mol`+theoreticalMassPart;
   }

--- a/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
@@ -507,7 +507,6 @@ class Material extends Component {
             }>
             <div>
               <NumeralInputWithUnitsCompo
-                data-html="true"
                 key={material.id}
                 value={material.amount_g}
                 unit="g"

--- a/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
@@ -224,11 +224,7 @@ class Material extends Component {
           />
         );
       } else {
-        return (
-          <OverlayTrigger
-            placement="top"
-            overlay={<Tooltip id="product-max-amount-info">max theoretical mass {Math.round(material.maxAmount * 10000) / 10} mg</Tooltip>}
-          >
+        return (         
             <div>
               <FormControl
                 name='yield'
@@ -239,7 +235,6 @@ class Material extends Component {
                 disabled
               />
             </div>
-          </OverlayTrigger>
         );
       }
     }
@@ -508,7 +503,7 @@ class Material extends Component {
             delay="100"
             placement="top" 
             overlay={
-              <Tooltip id="molecular-weight-info">{this.generateMolecularWeightTooltipText(material)}</Tooltip>
+              <Tooltip id="molecular-weight-info">{this.generateMolecularWeightTooltipText(material,reaction)}</Tooltip>
             }>
             <div>
               <NumeralInputWithUnitsCompo
@@ -579,11 +574,15 @@ class Material extends Component {
     );
   }
 
-  generateMolecularWeightTooltipText(sample){
+  generateMolecularWeightTooltipText(sample,reaction){
+    const isProduct=reaction.products.includes(sample)
     const molecularWeight = sample.decoupled ?
       (sample.molecular_mass) : (sample.molecule && sample.molecule.molecular_weight);
-
-      return `molar mass: ${molecularWeight} g/mol \n Das ist ein Test`;
+      let theoreticalMassPart="";
+      if (isProduct&&sample.maxAmount){
+        theoreticalMassPart=`, theoretical mass: ${Math.round(sample.maxAmount * 10000) / 10} mg`
+      }
+      return `molar mass: ${molecularWeight} g/mol`+theoreticalMassPart;
   }
 
   toggleTarget(isTarget) {

--- a/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
@@ -468,7 +468,7 @@ class Material extends Component {
     };
 
     return (
-      <tr className="general-material">
+      <tr className="general-material display-linebreak">
         {compose(connectDragSource, connectDropTarget)(
           <td className={`drag-source ${permitCls(reaction)}`} style={style}>
             <span className="text-info fa fa-arrows" />
@@ -504,9 +504,15 @@ class Material extends Component {
         </td>
 
         <td>
-          <OverlayTrigger placement="top" overlay={<Tooltip id="molecular-weight-info">{mw} g/mol</Tooltip>}>
+          <OverlayTrigger
+            delay="100"
+            placement="top" 
+            overlay={
+              <Tooltip id="molecular-weight-info">{this.generateMolecularWeightTooltipText(material)}</Tooltip>
+            }>
             <div>
               <NumeralInputWithUnitsCompo
+                data-html="true"
                 key={material.id}
                 value={material.amount_g}
                 unit="g"
@@ -571,6 +577,13 @@ class Material extends Component {
         </td>
       </tr>
     );
+  }
+
+  generateMolecularWeightTooltipText(sample){
+    const molecularWeight = sample.decoupled ?
+      (sample.molecular_mass) : (sample.molecule && sample.molecule.molecular_weight);
+
+      return `molar mass: ${molecularWeight} g/mol \n Das ist ein Test`;
   }
 
   toggleTarget(isTarget) {

--- a/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
@@ -463,7 +463,7 @@ class Material extends Component {
     };
 
     return (
-      <tr className="general-material display-linebreak">
+      <tr className="general-material">
         {compose(connectDragSource, connectDropTarget)(
           <td className={`drag-source ${permitCls(reaction)}`} style={style}>
             <span className="text-info fa fa-arrows" />

--- a/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
@@ -464,7 +464,7 @@ export default class ReactionDetailsScheme extends Component {
       mFull = referenceM.amount_mol * mwb;
       const maxTheoAmount = mFull * (updatedS.coefficient || 1.0 / referenceM.coefficient || 1.0);
       if (updatedS.amount_g > maxTheoAmount) {
-        errorMsg = 'Experimental mass value is more than possible\n' +
+        errorMsg = 'Experimental mass value is larger than possible\n' +
           'by 100% conversion! Please check your data.';
       }
     } else {
@@ -476,7 +476,7 @@ export default class ReactionDetailsScheme extends Component {
 
       if (deltaM > 0) { // expect weight gain
         if (massExperimental > mFull) {
-          errorMsg = 'Experimental mass value is more than possible\n' +
+          errorMsg = 'Experimental mass value is larger than possible\n' +
             'by 100% conversion! Please check your data.';
         } else if (massExperimental < massA) {
           errorMsg = 'Material loss! ' +
@@ -601,7 +601,7 @@ export default class ReactionDetailsScheme extends Component {
         } else if (materialGroup === 'products' && sample.amount_g > sample.maxAmount) {
           // eslint-disable-next-line no-param-reassign
           sample.equivalent = 1;
-          const errorMsg = 'Experimental mass value is more than possible\n' +
+          const errorMsg = 'Experimental mass value is larger than possible\n' +
           'by 100% conversion! Please check your data.';
           NotificationActions.add({
             message: errorMsg,
@@ -643,7 +643,7 @@ export default class ReactionDetailsScheme extends Component {
           sample.equivalent = sample.maxAmount !== 0 ? (sample.amount_g / sample.maxAmount) : 0;
           if (sample.amount_g > sample.maxAmount) {
             sample.equivalent = 1;
-            const errorMsg = 'Experimental mass value is more than possible\n' +
+            const errorMsg = 'Experimental mass value is larger than possible\n' +
             'by 100% conversion! Please check your data.';
             NotificationActions.add({
               message: errorMsg,

--- a/app/packs/src/fetchers/ReactionsFetcher.js
+++ b/app/packs/src/fetchers/ReactionsFetcher.js
@@ -21,6 +21,7 @@ export default class ReactionsFetcher {
             const lits = tliteratures.reduce((acc, l) => acc.set(l.literal_id, l), new Immutable.Map());
             reaction.literatures = lits;
           }
+          reaction.updateMaxAmountOfProducts();
           return reaction;
         }
         const rReaction = new Reaction(json.reaction);

--- a/app/packs/src/models/Reaction.js
+++ b/app/packs/src/models/Reaction.js
@@ -864,5 +864,4 @@ export default class Reaction extends Element {
     this.products.forEach(product => product.calculateMaxAmount(referenceSample));
 
   }
-
 }

--- a/app/packs/src/models/Reaction.js
+++ b/app/packs/src/models/Reaction.js
@@ -856,13 +856,13 @@ export default class Reaction extends Element {
     return this._segments || [];
   }
 
-  updateMaxAmountOfProducts(){   
-    const startingMaterialsList=this.starting_materials.filter(sample=>sample.reference);
-    if(startingMaterialsList.length==0){return;}
-    const referenceSample=startingMaterialsList[0];
+  updateMaxAmountOfProducts() {
+    const startingMaterialsList = this.starting_materials.filter(sample => sample.reference);
+    if (startingMaterialsList.length == 0) { return; }
+    const referenceSample = startingMaterialsList[0];
 
     this.products.forEach(product => product.calculateMaxAmount(referenceSample));
-    
+
   }
 
 }

--- a/app/packs/src/models/Reaction.js
+++ b/app/packs/src/models/Reaction.js
@@ -856,4 +856,13 @@ export default class Reaction extends Element {
     return this._segments || [];
   }
 
+  updateMaxAmountOfProducts(){   
+    const startingMaterialsList=this.starting_materials.filter(sample=>sample.reference);
+    if(startingMaterialsList.length==0){return;}
+    const referenceSample=startingMaterialsList[0];
+
+    this.products.forEach(product => product.calculateMaxAmount(referenceSample));
+    
+  }
+
 }

--- a/app/packs/src/models/Sample.js
+++ b/app/packs/src/models/Sample.js
@@ -959,8 +959,13 @@ export default class Sample extends Element {
     return target;
   }
 
-  calculateMaxAmount(referenceSample){
-    this.maxAmount=referenceSample.amount_mol * (this.coefficient || 1.0) / (referenceSample.coefficient || 1.0) * this.molecule_molecular_weight;
+  calculateMaxAmount(referenceSample) {
+    const refAmount = referenceSample.amount_mol;
+    const sampleCoeff = this.coefficient || 1.0;
+    const refCoeff = (referenceSample.coefficient || 1.0)
+    const coeffQuotient = sampleCoeff / refCoeff;
+
+    this.maxAmount = refAmount * coeffQuotient * this.molecule_molecular_weight;
   }
 
   get solvent() {

--- a/app/packs/src/models/Sample.js
+++ b/app/packs/src/models/Sample.js
@@ -959,6 +959,10 @@ export default class Sample extends Element {
     return target;
   }
 
+  calculateMaxAmount(referenceSample){
+    this.maxAmount=referenceSample.amount_mol * (this.coefficient || 1.0) / (referenceSample.coefficient || 1.0) * this.molecule_molecular_weight;
+  }
+
   get solvent() {
     try {
       //handle the old solvent data

--- a/spec/features/reaction_coefficiency_spec.rb
+++ b/spec/features/reaction_coefficiency_spec.rb
@@ -68,7 +68,7 @@ describe 'Coeffiency Reactions' do
       expect(find("input[name='yield']").value).to eq('50%')
     end
 
-    it 'Mass value is more than possible', js: true do
+    it 'Mass value is larger than possible', js: true do
       find('.tree-view', text: 'chemotion-repository.net').click
       first('i.icon-reaction').click
       first('span.isvg.loaded.reaction').click
@@ -76,7 +76,7 @@ describe 'Coeffiency Reactions' do
       coefficients[0].set(2)
       coefficients[1].set(1)
       coefficients[2].set(1)
-      messages = find_all('.notification-message', text: 'Experimental mass value is more than possible')
+      messages = find_all('.notification-message', text: 'Experimental mass value is larger than possible')
       expect(messages.length).to be >= 1
     end
   end
@@ -141,7 +141,7 @@ describe 'Coeffiency Reactions' do
       expect(find("input[name='yield']").value).to eq('49%')
     end
 
-    it 'Mass value is more than possible', js: true do
+    it 'Mass value is larger than possible', js: true do
       find('.tree-view', text: 'chemotion-repository.net').click
       first('i.icon-reaction').click
       first('span.isvg.loaded.reaction').click
@@ -149,7 +149,7 @@ describe 'Coeffiency Reactions' do
       coefficients[0].set(4)
       coefficients[1].set(2)
       coefficients[2].set(2)
-      messages = find_all('.notification-message', text: 'Experimental mass value is more than possible')
+      messages = find_all('.notification-message', text: 'Experimental mass value is larger than possible')
       expect(messages.length).to be >= 1
     end
   end

--- a/spec/javascripts/factories/ReactionFactory.js
+++ b/spec/javascripts/factories/ReactionFactory.js
@@ -1,0 +1,38 @@
+import { factory } from 'factory-bot';
+import Reaction from 'src/models/Reaction';
+import SampleFactory from "factories/SampleFactory";
+
+export default class ReactionFactory {
+    static instance = undefined;
+
+    static build(...args) {
+
+        if (ReactionFactory.instance === undefined) {
+            ReactionFactory.instance = new ReactionFactory();
+        }
+
+        return this.instance.factory.build(...args);
+    }
+
+    constructor() {
+        this.factory = factory;
+
+        this.factory.define("water+water=>water+water", Reaction, async () => {
+            const startingMaterial_1 = await SampleFactory.build("water_100g")
+            startingMaterial_1.coefficient = 1;
+            const startingMaterial_2 = await SampleFactory.build("water_100g")
+            startingMaterial_1.coefficient = 5;
+            const product_1 = await SampleFactory.build("water_100g")
+            product_1.coefficient = 2;
+            const product_2 = await SampleFactory.build("water_100g")
+            product_2.coefficient = 4;
+
+            const reaction = Reaction.buildEmpty();
+            reaction.starting_materials = [startingMaterial_1, startingMaterial_2];
+            reaction.products = [product_1, product_2];
+
+            return reaction;
+        });
+
+    }
+}

--- a/spec/javascripts/factories/SampleFactory.js
+++ b/spec/javascripts/factories/SampleFactory.js
@@ -1,0 +1,34 @@
+import { factory } from 'factory-bot';
+import Sample from 'src/models/Sample';
+import Molecule from 'src/models/Molecule';
+
+export default class SampleFactory {
+    static instance = undefined;
+  
+    static build(...args) {
+        
+      if (SampleFactory.instance === undefined) {
+        SampleFactory.instance = new SampleFactory();
+      }
+  
+      return this.instance.factory.build(...args);
+    }
+  
+    constructor() {
+      this.factory = factory;
+  
+      this.factory.define("water_100g", Sample, async () => {
+        const sample = Sample.buildEmpty(0);
+        sample.amount_value=100;
+        sample.molecule=new Molecule()
+        sample.molecule.exact_molecular_weight=18.010564684
+        sample.molecule.molecular_weight=18.010564684
+        sample.amountType="target";
+        sample.amount_unit="g";
+        sample.coefficient=1;
+
+        return sample;
+      });
+
+    }
+  }

--- a/spec/javascripts/packs/src/models/Reaction.spec.js
+++ b/spec/javascripts/packs/src/models/Reaction.spec.js
@@ -1,0 +1,61 @@
+import ReactionFactory from "factories/ReactionFactory";
+import expect from 'expect';
+
+const a = 0
+
+describe('Reaction', async () => {
+
+    const reaction = await ReactionFactory.build("water+water=>water+water")
+    describe('Reaction.updateMaxAmountOfProducts()', () => {
+
+        context('when no referenceStartingMaterial is available', () => {
+            it('no change of product maxAmounts', () => {
+                reaction.starting_materials[0].reference = false;
+                reaction.starting_materials[1].reference = false;
+
+                reaction.updateMaxAmountOfProducts();
+
+                expect(reaction.products[0].maxAmount).toBe(undefined)
+                expect(reaction.products[1].maxAmount).toBe(undefined)
+            });
+
+        });
+
+        context('when first starting material is reference', () => {
+            it('correct max amounts calculated (40,80)', () => {
+                reaction.starting_materials[0].reference = true;
+                reaction.starting_materials[1].reference = false;
+
+                reaction.updateMaxAmountOfProducts();
+
+                expect(reaction.products[0].maxAmount).toBeCloseTo(40, 5);
+                expect(reaction.products[1].maxAmount).toBeCloseTo(80, 5);
+            });
+
+        });
+        context('when second starting material is reference', () => {
+            it('correct max amounts calculated (200,400)', () => {
+                reaction.starting_materials[0].reference = false;
+                reaction.starting_materials[1].reference = true;
+
+                reaction.updateMaxAmountOfProducts();
+
+                expect(reaction.products[0].maxAmount).toBeCloseTo(200, 5);
+                expect(reaction.products[1].maxAmount).toBeCloseTo(400, 5);
+            });
+
+        });
+
+        context('when no product present', () => {
+            it('no changes happened', () => {
+                reaction.starting_materials[0].reference = true;
+                reaction.starting_materials[1].reference = false;
+                const products = reaction.products;
+                reaction.products = [];
+                reaction.updateMaxAmountOfProducts();
+
+                reaction.products = products;
+            });
+        });
+    });
+});

--- a/spec/javascripts/packs/src/models/Sample.spec.js
+++ b/spec/javascripts/packs/src/models/Sample.spec.js
@@ -5,7 +5,7 @@ describe('Sample', async () => {
     const referenceSample = await SampleFactory.build("water_100g")
     const product = await SampleFactory.build("water_100g")
 
-    describe('.calculateMaxAmount()', () => {
+    describe('Sample.calculateMaxAmount()', () => {
         context('when input is valid', () => {
             it('returns amount of 100', () => {
                 product.coefficient = 1;

--- a/spec/javascripts/packs/src/models/Sample.spec.js
+++ b/spec/javascripts/packs/src/models/Sample.spec.js
@@ -1,0 +1,47 @@
+import expect from 'expect';
+import SampleFactory from "factories/SampleFactory";
+
+describe('Sample', async () => {
+    const referenceSample = await SampleFactory.build("water_100g")
+    const product = await SampleFactory.build("water_100g")
+
+    describe('.calculateMaxAmount()', () => {
+        context('when input is valid', () => {
+            it('returns amount of 100', () => {
+                product.coefficient = 1;
+                referenceSample.coefficient = 1;
+                product.calculateMaxAmount(referenceSample);
+
+                expect(product.maxAmount).toBeCloseTo(100, 5);
+            });
+        })
+
+        context('when product coefficient is two', () => {
+            it('returns amount of 200', () => {
+                product.coefficient = 2;
+                referenceSample.coefficient = 1;
+                product.calculateMaxAmount(referenceSample);
+                expect(product.maxAmount).toBeCloseTo(200, 5);
+            });
+        })
+
+        context('when product coefficient is zero', () => {
+            it('amount is 100 because zero coefficient was set to one', () => {
+                product.coefficient = 0;
+                referenceSample.coefficient = 1;
+                product.calculateMaxAmount(referenceSample)
+                expect(product.maxAmount).toBeCloseTo(100, 5);
+            });
+        })
+
+        context('when reference coefficient is four', () => {
+            it('returns amount of 25', () => {
+                product.coefficient = 1;
+                referenceSample.coefficient = 4;
+                product.calculateMaxAmount(referenceSample);
+
+                expect(product.maxAmount).toBeCloseTo(25, 5);
+            });
+        })
+    });
+});


### PR DESCRIPTION
This pull request aims to fix the issue https://github.com/ComPlat/chemotion_ELN/issues/1076 . 

The theoretical mass of the products in a reaction was sometimes not shown anymore or a NaN value was printed out. 
If one switched the reference sample the values were not updated.
A second aim was to move the tooltip from the yield textbox to the amount textbox

Changes done:

- added the possibility to calculate the max theoretical amount in a reaction to the reaction and sample model
- fixed some typos
- added an initial calculation of the max amounts right after fetching a reaction from the server
- added an calculation of the max amount on a change of the reaction
- removed the tooltip from the yield textbox and added it on the amount textbox


- [x] added code is linted

- [x] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [x] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

![grafik](https://user-images.githubusercontent.com/23172219/220853432-f3cfadbd-c9b8-4ba8-8e25-aee2d5081c73.png)


- [x] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release:  **not needed in my opinion**

