### PR TITLE
make cas number searchable via general search field and enhance advan…

### DIFF
--- a/app/api/chemotion/suggestion_api.rb
+++ b/app/api/chemotion/suggestion_api.rb
@@ -61,11 +61,13 @@ module Chemotion
           sample_short_label = dl_s.positive? && search_by_field.call(Sample, :short_label, qry) || []
           sample_external_label = dl_s > -1 && search_by_field.call(Sample, :external_label, qry) || []
           sample_name = dl_s.positive? && search_by_field.call(Sample, :name, qry) || []
-          polymer_type = dl_s.positive? && d_for.call(Sample)
-                                                .by_residues_custom_info('polymer_type', qry)
-                                                .pluck("residues.custom_info -> 'polymer_type'").uniq || []
+          # polymer_type = dl_s.positive? && d_for.call(Sample)
+          #                                       .by_residues_custom_info('polymer_type', qry)
+          #                                       .pluck("residues.custom_info -> 'polymer_type'").uniq || []
           sum_formula = dl_s.positive? && search_by_field.call(Sample, :molecule_sum_formular, qry) || []
           iupac_name = dl_s.positive? && search_by_field.call(Molecule, :iupac_name, qry) || []
+          # cas = dl_s.positive? && search_by_field.call(Molecule, :cas, qry) || []
+          cas = dl_s.positive? && search_by_field.call(Sample, :sample_xref_cas, qry) || []
           inchistring = dl_s.positive? && search_by_field.call(Molecule, :inchistring, qry) || []
           inchikey = dl_s.positive? && search_by_field.call(Molecule, :inchikey, qry) || []
           cano_smiles = dl_s.positive? && search_by_field.call(Molecule, :cano_smiles, qry) || []
@@ -73,9 +75,10 @@ module Chemotion
             sample_short_label: sample_short_label,
             sample_external_label: sample_external_label,
             sample_name: sample_name,
-            polymer_type: polymer_type,
+            # polymer_type: polymer_type,
             sum_formula: sum_formula,
             iupac_name: iupac_name,
+            cas: cas,
             inchistring: inchistring,
             inchikey: inchikey,
             cano_smiles: cano_smiles
@@ -126,11 +129,13 @@ module Chemotion
           sample_name = dl_s.positive? && search_by_field.call(Sample, :name, qry) || []
           sample_short_label = dl_s.positive? && search_by_field.call(Sample, :short_label, qry) || []
           sample_external_label = dl_s > -1 && search_by_field.call(Sample, :external_label, qry) || []
-          polymer_type = dl_s.positive? && d_for.call(Sample)
-                                                .by_residues_custom_info('polymer_type', qry)
-                                                .pluck("residues.custom_info -> 'polymer_type'").uniq || []
+          # polymer_type = dl_s.positive? && d_for.call(Sample)
+          #                                       .by_residues_custom_info('polymer_type', qry)
+          #                                       .pluck("residues.custom_info -> 'polymer_type'").uniq || []
           sum_formula = dl_s.positive? && search_by_field.call(Sample, :molecule_sum_formular, qry) || []
           iupac_name = dl_s.positive? && search_by_field.call(Molecule, :iupac_name, qry) || []
+          # cas = dl_s.positive? && search_by_field.call(Molecule, :cas, qry) || []
+          cas = dl_s.positive? && search_by_field.call(Sample, :sample_xref_cas, qry) || []
           inchistring = dl_s.positive? && search_by_field.call(Molecule, :inchistring, qry) || []
           inchikey = dl_s.positive? && search_by_field.call(Molecule, :inchikey, qry) || []
           cano_smiles = dl_s.positive? && search_by_field.call(Molecule, :cano_smiles, qry) || []
@@ -148,9 +153,10 @@ module Chemotion
             sample_name: sample_name,
             sample_short_label: sample_short_label,
             sample_external_label: sample_external_label,
-            polymer_type: polymer_type,
+            # polymer_type: polymer_type,
             sum_formula: sum_formula,
             iupac_name: iupac_name,
+            cas: cas,
             inchistring: inchistring,
             inchikey: inchikey,
             cano_smiles: cano_smiles,

--- a/app/api/chemotion/suggestion_api.rb
+++ b/app/api/chemotion/suggestion_api.rb
@@ -61,9 +61,9 @@ module Chemotion
           sample_short_label = dl_s.positive? && search_by_field.call(Sample, :short_label, qry) || []
           sample_external_label = dl_s > -1 && search_by_field.call(Sample, :external_label, qry) || []
           sample_name = dl_s.positive? && search_by_field.call(Sample, :name, qry) || []
-          # polymer_type = dl_s.positive? && d_for.call(Sample)
-          #                                       .by_residues_custom_info('polymer_type', qry)
-          #                                       .pluck("residues.custom_info -> 'polymer_type'").uniq || []
+          polymer_type = dl_s.positive? && d_for.call(Sample)
+                                                .by_residues_custom_info('polymer_type', qry)
+                                                .pluck(Arel.sql("residues.custom_info->'polymer_type'")).uniq || []
           sum_formula = dl_s.positive? && search_by_field.call(Sample, :molecule_sum_formular, qry) || []
           iupac_name = dl_s.positive? && search_by_field.call(Molecule, :iupac_name, qry) || []
           # cas = dl_s.positive? && search_by_field.call(Molecule, :cas, qry) || []
@@ -75,7 +75,7 @@ module Chemotion
             sample_short_label: sample_short_label,
             sample_external_label: sample_external_label,
             sample_name: sample_name,
-            # polymer_type: polymer_type,
+            polymer_type: polymer_type,
             sum_formula: sum_formula,
             iupac_name: iupac_name,
             cas: cas,
@@ -129,9 +129,9 @@ module Chemotion
           sample_name = dl_s.positive? && search_by_field.call(Sample, :name, qry) || []
           sample_short_label = dl_s.positive? && search_by_field.call(Sample, :short_label, qry) || []
           sample_external_label = dl_s > -1 && search_by_field.call(Sample, :external_label, qry) || []
-          # polymer_type = dl_s.positive? && d_for.call(Sample)
-          #                                       .by_residues_custom_info('polymer_type', qry)
-          #                                       .pluck("residues.custom_info -> 'polymer_type'").uniq || []
+          polymer_type = dl_s.positive? && d_for.call(Sample)
+                                                .by_residues_custom_info('polymer_type', qry)
+                                                .pluck(Arel.sql("residues.custom_info->'polymer_type'")).uniq || []
           sum_formula = dl_s.positive? && search_by_field.call(Sample, :molecule_sum_formular, qry) || []
           iupac_name = dl_s.positive? && search_by_field.call(Molecule, :iupac_name, qry) || []
           # cas = dl_s.positive? && search_by_field.call(Molecule, :cas, qry) || []

--- a/app/api/chemotion/suggestion_api.rb
+++ b/app/api/chemotion/suggestion_api.rb
@@ -153,7 +153,7 @@ module Chemotion
             sample_name: sample_name,
             sample_short_label: sample_short_label,
             sample_external_label: sample_external_label,
-            # polymer_type: polymer_type,
+            polymer_type: polymer_type,
             sum_formula: sum_formula,
             iupac_name: iupac_name,
             cas: cas,

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -108,7 +108,7 @@ class Sample < ApplicationRecord
   # scopes for suggestions
   scope :by_residues_custom_info, ->(info, val) { joins(:residues).where("residues.custom_info -> '#{info}' ILIKE ?", "%#{sanitize_sql_like(val)}%")}
   scope :by_name, ->(query) { where('name ILIKE ?', "%#{sanitize_sql_like(query)}%") }
-  scope :by_sample_xref_cas, ->(query) { where("xref ? 'cas'").where("xref ->> 'cas' ILIKE ?", "%#{sanitize_sql_like(query)}%") }
+  scope :by_sample_xref_cas, ->(query) { where("xref ? 'cas'").where("xref -> 'cas' ->> 'value' ILIKE ?", "%#{sanitize_sql_like(query)}%") }
   scope :by_exact_name, ->(query) { where('lower(name) ~* lower(?) or lower(external_label) ~* lower(?)', "^([a-zA-Z0-9]+-)?#{sanitize_sql_like(query)}(-?[a-zA-Z])$", "^([a-zA-Z0-9]+-)?#{sanitize_sql_like(query)}(-?[a-zA-Z])$") }
   scope :by_short_label, ->(query) { where('short_label ILIKE ?', "%#{sanitize_sql_like(query)}%") }
   scope :by_external_label, ->(query) { where('external_label ILIKE ?', "%#{sanitize_sql_like(query)}%") }
@@ -252,7 +252,7 @@ class Sample < ApplicationRecord
   end
 
   def sample_xref_cas
-    self.xref && self.xref['cas'] ? self.xref['cas'] : ''
+    xref&.dig('cas', 'value') || ''
   end
 
   def molecule_inchikey

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -69,7 +69,8 @@ class Sample < ApplicationRecord
 
   multisearchable against: [
     :name, :short_label, :external_label, :molecule_sum_formular,
-    :molecule_iupac_name, :molecule_inchistring, :molecule_inchikey, :molecule_cano_smiles
+    :molecule_iupac_name, :molecule_inchistring, :molecule_inchikey, :molecule_cano_smiles,
+    :sample_xref_cas
   ]
 
   # search scopes for exact matching
@@ -102,10 +103,12 @@ class Sample < ApplicationRecord
   pg_search_scope :search_by_sample_name, against: :name
   pg_search_scope :search_by_sample_short_label, against: :short_label
   pg_search_scope :search_by_sample_external_label, against: :external_label
+  pg_search_scope :search_by_cas, against: { xref: 'cas' }
 
   # scopes for suggestions
   scope :by_residues_custom_info, ->(info, val) { joins(:residues).where("residues.custom_info -> '#{info}' ILIKE ?", "%#{sanitize_sql_like(val)}%")}
   scope :by_name, ->(query) { where('name ILIKE ?', "%#{sanitize_sql_like(query)}%") }
+  scope :by_sample_xref_cas, ->(query) { where("xref ? 'cas'").where("xref ->> 'cas' ILIKE ?", "%#{sanitize_sql_like(query)}%") }
   scope :by_exact_name, ->(query) { where('lower(name) ~* lower(?) or lower(external_label) ~* lower(?)', "^([a-zA-Z0-9]+-)?#{sanitize_sql_like(query)}(-?[a-zA-Z])$", "^([a-zA-Z0-9]+-)?#{sanitize_sql_like(query)}(-?[a-zA-Z])$") }
   scope :by_short_label, ->(query) { where('short_label ILIKE ?', "%#{sanitize_sql_like(query)}%") }
   scope :by_external_label, ->(query) { where('external_label ILIKE ?', "%#{sanitize_sql_like(query)}%") }
@@ -224,6 +227,10 @@ class Sample < ApplicationRecord
 
   attr_writer :skip_reaction_svg_update
 
+  def self.rebuild_pg_search_documents
+    find_each(&:update_pg_search_document)
+  end
+
   def skip_reaction_svg_update?
     @skip_reaction_svg_update.present?
   end
@@ -242,6 +249,10 @@ class Sample < ApplicationRecord
 
   def molecule_inchistring
     self.molecule ? self.molecule.inchistring : ''
+  end
+
+  def sample_xref_cas
+    self.xref && self.xref['cas'] ? self.xref['cas'] : ''
   end
 
   def molecule_inchikey

--- a/app/packs/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/packs/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -241,6 +241,7 @@ export default class SampleDetails extends React.Component {
   handleMoleculeBySmile(cas) {
     const smi = this.smilesInput.value;
     const { sample } = this.state;
+    const casObj = {};
     MoleculesFetcher.fetchBySmi(smi)
       .then((result) => {
         if (!result || result == null) {
@@ -253,9 +254,9 @@ export default class SampleDetails extends React.Component {
           sample.molecule = result;
           this.molfileInput.value = result.molfile;
           this.inchistringInput.value = result.inchistring;
-          console.log(result);
-          sample.xref = { ...sample.xref, cas: result.cas[0] || cas };
-          console.log(sample.xref);
+          casObj.value = result.cas[0] || cas;
+          casObj.label = result.cas[0] || cas;
+          sample.xref = { ...sample.xref, cas: casObj };
           this.setState({
             quickCreator: true,
             sample,
@@ -764,12 +765,11 @@ export default class SampleDetails extends React.Component {
   isCASNumberValid(cas, boolean) {
     const { sample } = this.state;
     const result = validateCas(cas, boolean);
-    this.setState({ validCas: result });
-    console.log(result);
     if (result !== false) {
-      console.log('what is going on');
-      sample.xref = { ...sample.xref, cas: result };
-      this.setState({ sample });
+      sample.xref = { ...sample.xref, cas: { value: result, label: result } };
+      this.setState({ sample, validCas: result });
+    } else {
+      this.setState({ validCas: result });
     }
   }
 

--- a/app/packs/src/components/navigation/search/AutoCompleteInput.js
+++ b/app/packs/src/components/navigation/search/AutoCompleteInput.js
@@ -88,7 +88,7 @@ export default class AutoCompleteInput extends React.Component {
     newState.value = suggestions[newFocus].name
 
     if (!isString(newState.value)) {
-      newState.value = suggestions[newFocus].name.name;
+      newState.value = suggestions[newFocus].name.name || suggestions[newFocus].name.value;
     }
 
     newState.suggestionFocus = newFocus
@@ -222,10 +222,9 @@ export default class AutoCompleteInput extends React.Component {
       showSuggestions: false,
       valueBeforeFocus: null
     })
-
-    if (!isString(value)) {
-      value = value.name;
-      this.setState({ value });
+    if (!isString(value) && value) {
+      value = value.name || value.value;
+      this.setState({ value })
     }
 
     if (!value || value.trim() === '') {
@@ -252,6 +251,7 @@ export default class AutoCompleteInput extends React.Component {
       if (selectedName && selectedName.trim() != '' && this.state.value == selectedName)
         if (selectedSuggestion.search_by_method == 'element_short_label') {
           selection = {name: selectedSuggestion.name.name, search_by_method: `element_short_label_${selectedSuggestion.name.klass}`}
+
         } else {
           selection = selectedSuggestion
         }
@@ -307,14 +307,16 @@ export default class AutoCompleteInput extends React.Component {
             let inchiString = 'InChI=';
             let inchiMatch = '';
 
-            if (suggestion.search_by_method == 'element_short_label') {
+            if (suggestion.search_by_method === 'element_short_label') {
               icon = suggestion.name.icon;
               typeLabel = suggestion.name.label;
               name = suggestion.name.name;
+            } else if (suggestion.search_by_method === 'cas') {
+              name = suggestion.name.value;
             } else {
               name = suggestion.name;
               inchiMatch = suggestion.name.substring(0, inchiString.length)
-              if (inchiMatch==inchiString) {
+              if (inchiMatch === inchiString) {
                 suggestion.name = suggestion.name.replace(inchiString, "")
               }
             }

--- a/app/packs/src/components/navigation/search/AutoCompleteInput.js
+++ b/app/packs/src/components/navigation/search/AutoCompleteInput.js
@@ -289,6 +289,7 @@ export default class AutoCompleteInput extends React.Component {
       inchikey: { icon: 'icon-sample', label: 'InChIKey'},
       cano_smiles : {icon: 'icon-sample', label: 'Canonical Smiles'},
       sum_formula : {icon: 'icon-sample', label: 'Sum Formula'},
+      cas: { icon: 'icon-sample', label: 'cas' },
       requirements : {icon: 'icon-screen', label: 'Requirement'},
       conditions : {icon: 'icon-screen', label: 'Condition'},
       element_short_label: {icon: 'icon-element', label: 'Element Short Label'}

--- a/spec/api/chemotion/sample_api_spec.rb
+++ b/spec/api/chemotion/sample_api_spec.rb
@@ -495,7 +495,7 @@ describe Chemotion::SampleAPI do
       let(:c3) { create(:collection, user_id: user.id, is_shared: true, permission_level: 1) }
       let(:s1) { create(:sample, name: 'old', target_amount_value: 0.1) }
       let(:s2) { create(:sample, name: 'old2', target_amount_value: 0.2) }
-      let(:cas) { 'test_cas' }
+      let(:cas) { { 'value' => '58-08-2', 'label' => '58-08-2' } }
 
       let(:params) do
         {

--- a/spec/api/chemotion/sample_api_spec.rb
+++ b/spec/api/chemotion/sample_api_spec.rb
@@ -590,7 +590,7 @@ describe Chemotion::SampleAPI do
   end
 
   describe 'POST /api/v1/samples' do
-    let(:cas) { 'test_cas' }
+    let(:cas) { { 'value' => '58-08-2', 'label' => '58-08-2' } }
     let(:params) do
       {
         name: 'test',

--- a/spec/api/chemotion/suggestion_api_spec.rb
+++ b/spec/api/chemotion/suggestion_api_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Chemotion::SuggestionAPI do
+  let!(:user) { create(:person, first_name: 'tam', last_name: 'M') }
+  let(:collection) { create(:collection, user: user, is_shared: true, permission_level: 1) }
+  let(:query) { 'query' }
+
+  context 'when user is authenticated' do
+    include_context 'api request authorization context'
+    it 'returns suggestions object with the correct structure' do
+      get '/api/v1/suggestions/all',
+      params: { 
+        collection_id: collection.id,
+        query: query,
+        is_sync: false,
+      }
+      expect(response).to have_http_status(:success)
+      json_response = JSON.parse(response.body)
+      expect(json_response.keys).to contain_exactly('suggestions')
+      suggestions = json_response['suggestions']
+      expect(suggestions).to be_an(Array)
+    end
+  end
+
+  context 'when user is not authenticated' do
+    it 'returns unauthorized error' do
+      get '/api/v1/suggestions/all',
+      params:
+        {
+          collection_id: collection.id,
+          query: query,
+          is_sync: false,
+        }
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end


### PR DESCRIPTION
 cas searchable via general search field

- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [x] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [x] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [x] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
