### PR TITLE
Only mount visible tab in reaction detail modal

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -464,7 +464,7 @@ export default class ReactionDetails extends Component {
             onTabPositionChanged={this.onTabPositionChanged}
           />
           {this.state.sfn ? <ScifinderSearch el={reaction} /> : null}
-          <Tabs activeKey={activeTab} onSelect={this.handleSelect.bind(this)} id="reaction-detail-tab">
+          <Tabs activeKey={activeTab} onSelect={this.handleSelect.bind(this)} id="reaction-detail-tab" unmountOnExit={true}>
             {tabContents}
           </Tabs>
           <hr />


### PR DESCRIPTION
Fixes #1052.

The warning
`AG Grid: tried to call sizeColumnsToFit() but the grid is coming back with zero width, maybe the grid is not visible yet on the screen? `
was displayed whenever `sizeColumnsToFit()` was called on components that were part of a tab that wasn't currently rendered:

https://github.com/ComPlat/chemotion_ELN/blob/02b6702a7ce21e5d4f40c048ea280cf0769d40a6/app/packs/src/apps/mydb/elements/details/reactions/greenChemistryTab/GreenMetrics.js#L43

https://github.com/ComPlat/chemotion_ELN/blob/02b6702a7ce21e5d4f40c048ea280cf0769d40a6/app/packs/src/apps/mydb/elements/details/reactions/greenChemistryTab/GreenMaterialGroup.js#L84

The problem is fixed by unmounting all tabs (and their associated components) that are currently not rendered.
Note that this has the nice side effect of making the DOM smaller since now only one tab of the `ReactionDetails` component is mounted at any given time.
