### PR TITLE
Fix tab layout popups

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/ElementDetailSortTab.js
+++ b/app/packs/src/apps/mydb/elements/details/ElementDetailSortTab.js
@@ -136,7 +136,7 @@ export default class ElementDetailSortTab extends Component {
         style={{ maxWidth: 'none', width: 'auto' }}
       >
         <div>
-          <h3 className="popover-title">Tabs Layout</h3>
+          <h3 className="popover-title">Tab Layout</h3>
           <div className="popover-content">
             {tabLayoutContainerElement}
           </div>
@@ -155,7 +155,7 @@ export default class ElementDetailSortTab extends Component {
           <i className="fa fa-sliders" aria-hidden="true" />
         </Button>
         <Overlay
-          container={this}
+          container={this.button}
           onHide={this.onCloseTabLayoutContainer}
           placement="bottom"
           rootClose

--- a/app/packs/src/apps/mydb/elements/details/ElementDetailSortTab.js
+++ b/app/packs/src/apps/mydb/elements/details/ElementDetailSortTab.js
@@ -152,7 +152,7 @@ export default class ElementDetailSortTab extends Component {
       </Popover>
     );
     return (
-      <div>
+      <div style={{position: 'relative'}}>
         <Button
           bsStyle="info"
           bsSize="xsmall"
@@ -163,7 +163,7 @@ export default class ElementDetailSortTab extends Component {
           <i className="fa fa-sliders" aria-hidden="true" />
         </Button>
         <Overlay
-          container={this.button}
+          container={this}
           onHide={this.onCloseTabLayoutContainer}
           placement="bottom"
           rootClose

--- a/app/packs/src/apps/mydb/elements/details/ElementDetailSortTab.js
+++ b/app/packs/src/apps/mydb/elements/details/ElementDetailSortTab.js
@@ -129,11 +129,13 @@ export default class ElementDetailSortTab extends Component {
         ref={(tabLayoutContainerElement) => this.tabLayoutContainerElement = tabLayoutContainerElement}
       />
     );
+    const {visible, hidden} = this.state;
+    const wd = 200 + ((visible && visible.size * 50) || 0) + ((hidden && hidden.size * 50) || 0);
     const popoverSettings = (
       <Popover
         className="collection-overlay"
         id="popover-layout"
-        style={{ maxWidth: 'none', width: 'auto' }}
+        style={{ maxWidth: 'none', width: `${wd}px` }}
       >
         <div>
           <h3 className="popover-title">Tab Layout</h3>
@@ -161,6 +163,7 @@ export default class ElementDetailSortTab extends Component {
           rootClose
           show={this.state.showTabLayoutContainer}
           target={() => ReactDOM.findDOMNode(this.tabLayoutButton)}
+          shouldUpdatePosition
         >
           {popoverSettings}
         </Overlay>

--- a/app/packs/src/apps/mydb/elements/details/ElementDetailSortTab.js
+++ b/app/packs/src/apps/mydb/elements/details/ElementDetailSortTab.js
@@ -129,8 +129,8 @@ export default class ElementDetailSortTab extends Component {
         ref={(tabLayoutContainerElement) => this.tabLayoutContainerElement = tabLayoutContainerElement}
       />
     );
-    const {visible, hidden} = this.state;
-    const wd = 200 + ((visible && visible.size * 50) || 0) + ((hidden && hidden.size * 50) || 0);
+    const { visible, hidden } = this.state;
+    const wd = 35 + ((visible && visible.size * 75) || 0) + ((hidden && hidden.size * 75) || 0);
     const popoverSettings = (
       <Popover
         className="collection-overlay"
@@ -163,7 +163,7 @@ export default class ElementDetailSortTab extends Component {
           rootClose
           show={this.state.showTabLayoutContainer}
           target={() => ReactDOM.findDOMNode(this.tabLayoutButton)}
-          shouldUpdatePosition
+          shouldUpdatePosition // TODO: not working when reactions are open
         >
           {popoverSettings}
         </Overlay>

--- a/app/packs/src/apps/mydb/elements/details/ElementDetailSortTab.js
+++ b/app/packs/src/apps/mydb/elements/details/ElementDetailSortTab.js
@@ -136,7 +136,7 @@ export default class ElementDetailSortTab extends Component {
       />
     );
     const { visible, hidden } = this.state;
-    const wd = 35 + ((visible && visible.size * 75) || 0) + ((hidden && hidden.size * 75) || 0);
+    const wd = 200 + ((visible && visible.size * 75) || 0) + ((hidden && hidden.size * 75) || 0);
     const popoverSettings = (
       <Popover
         className="collection-overlay"

--- a/app/packs/src/apps/mydb/elements/details/ElementDetailSortTab.js
+++ b/app/packs/src/apps/mydb/elements/details/ElementDetailSortTab.js
@@ -75,12 +75,18 @@ export default class ElementDetailSortTab extends Component {
     UserActions.fetchCurrentUser();
   }
 
+  // to force popups to stay anchored to button
+  // as shouldUpdatePosition prop for Overlay does not work for reactions
+  resize = () => this.forceUpdate()
+
   componentDidMount() {
     UserStore.listen(this.onChangeUser);
+    window.addEventListener('resize', this.resize);
   }
 
   componentWillUnmount() {
     UserStore.unlisten(this.onChangeUser);
+    window.removeEventListener('resize', this.resize);
   }
 
   onChangeUser(state) {
@@ -163,7 +169,7 @@ export default class ElementDetailSortTab extends Component {
           rootClose
           show={this.state.showTabLayoutContainer}
           target={() => ReactDOM.findDOMNode(this.tabLayoutButton)}
-          shouldUpdatePosition // TODO: not working when reactions are open
+          shouldUpdatePosition // works alongside resize event listener
         >
           {popoverSettings}
         </Overlay>

--- a/app/packs/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/packs/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -1325,10 +1325,10 @@ export default class SampleDetails extends React.Component {
 
     const tabTitlesMap = {
       literature: 'References',
-      qc_curation: 'qc curation',
+      qc_curation: 'QC curation',
       computed_props: 'computed props',
       nmr_sim: 'NMR Simulation',
-      measurements: 'Measurements!'
+      measurements: 'Measurements'
     };
 
 

--- a/app/packs/src/apps/mydb/elements/list/ElementsTableSettings.js
+++ b/app/packs/src/apps/mydb/elements/list/ElementsTableSettings.js
@@ -212,7 +212,7 @@ export default class ElementsTableSettings extends React.Component {
         style={{ maxWidth: 'none', width: `${wd}px` }}
       >
         <div>
-          <h3 className="popover-title">Table Layout</h3>
+          <h3 className="popover-title">Tab Layout</h3>
           <div className="popover-content">
             {tabLayoutContainerElement}
           </div>
@@ -232,7 +232,7 @@ export default class ElementsTableSettings extends React.Component {
           <i className="fa fa-sliders" />
         </Button>
         <Overlay
-          container={this}
+          container={this.button}
           onHide={this.onCloseTabLayoutContainer}
           placement="bottom"
           rootClose

--- a/app/packs/src/apps/mydb/elements/list/ElementsTableSettings.js
+++ b/app/packs/src/apps/mydb/elements/list/ElementsTableSettings.js
@@ -157,7 +157,7 @@ export default class ElementsTableSettings extends React.Component {
       tableSchemePreviews, showSampleExternalLabel, showSampleShortLabel, showSampleName,
     } = this.state;
 
-    const wd = 35 + ((visible && visible.size * 50) || 0) + ((hidden && hidden.size * 50) || 0);
+    const wd = ((visible && visible.size * 50) || 0) + ((hidden && hidden.size * 50) || 0);
 
     let sampleSettings = (<span />);
     if (currentType == "sample" || currentType == "reaction") {
@@ -238,7 +238,7 @@ export default class ElementsTableSettings extends React.Component {
           rootClose
           show={this.state.showTabLayoutContainer}
           target={() => ReactDOM.findDOMNode(this.tabLayoutButton)}
-          shouldUpdatePosition // does not work, for some unknown reason.
+          shouldUpdatePosition //TODO: does not work?
         >
           {popoverSettings}
         </Overlay>

--- a/app/packs/src/apps/mydb/elements/list/ElementsTableSettings.js
+++ b/app/packs/src/apps/mydb/elements/list/ElementsTableSettings.js
@@ -227,7 +227,7 @@ export default class ElementsTableSettings extends React.Component {
     )
 
     return (
-      <div>
+      <div style={{position: 'relative'}}>
         <Button
           bsSize="xsmall"
           style={{ margin: '10px 10px 10px 0', float: 'right' }}
@@ -237,7 +237,7 @@ export default class ElementsTableSettings extends React.Component {
           <i className="fa fa-sliders" />
         </Button>
         <Overlay
-          container={this.button}
+          container={this}
           onHide={this.onCloseTabLayoutContainer}
           placement="bottom"
           rootClose

--- a/app/packs/src/apps/mydb/elements/list/ElementsTableSettings.js
+++ b/app/packs/src/apps/mydb/elements/list/ElementsTableSettings.js
@@ -36,14 +36,19 @@ export default class ElementsTableSettings extends React.Component {
     this.toggleTabLayoutContainer = this.toggleTabLayoutContainer.bind(this);
   }
 
+  // to force popups to stay anchored to button
+  resize = () => this.forceUpdate()
+
   componentDidMount() {
     UserStore.listen(this.onChangeUser);
     UIStore.listen(this.onChangeUI);
+    window.addEventListener('resize', this.resize);
   }
 
   componentWillUnmount() {
     UserStore.unlisten(this.onChangeUser);
     UIStore.unlisten(this.onChangeUI);
+    window.removeEventListener('resize', this.resize);
   }
 
   onChangeUI(state) {
@@ -238,7 +243,7 @@ export default class ElementsTableSettings extends React.Component {
           rootClose
           show={this.state.showTabLayoutContainer}
           target={() => ReactDOM.findDOMNode(this.tabLayoutButton)}
-          shouldUpdatePosition //TODO: does not work?
+          shouldUpdatePosition // works alongside resize event listener
         >
           {popoverSettings}
         </Overlay>

--- a/app/packs/src/apps/mydb/elements/list/ElementsTableSettings.js
+++ b/app/packs/src/apps/mydb/elements/list/ElementsTableSettings.js
@@ -238,6 +238,7 @@ export default class ElementsTableSettings extends React.Component {
           rootClose
           show={this.state.showTabLayoutContainer}
           target={() => ReactDOM.findDOMNode(this.tabLayoutButton)}
+          shouldUpdatePosition // does not work, for some unknown reason.
         >
           {popoverSettings}
         </Overlay>

--- a/app/packs/src/apps/mydb/elements/list/ElementsTableSettings.js
+++ b/app/packs/src/apps/mydb/elements/list/ElementsTableSettings.js
@@ -162,7 +162,7 @@ export default class ElementsTableSettings extends React.Component {
       tableSchemePreviews, showSampleExternalLabel, showSampleShortLabel, showSampleName,
     } = this.state;
 
-    const wd = ((visible && visible.size * 50) || 0) + ((hidden && hidden.size * 50) || 0);
+    const wd = 35 + ((visible && visible.size * 50) || 0) + ((hidden && hidden.size * 50) || 0);
 
     let sampleSettings = (<span />);
     if (currentType == "sample" || currentType == "reaction") {

--- a/app/packs/src/apps/mydb/elements/tabLayout/TabLayoutCell.js
+++ b/app/packs/src/apps/mydb/elements/tabLayout/TabLayoutCell.js
@@ -53,7 +53,7 @@ class TabLayoutCell extends Component {
 
     const content = isElementDetails ? (
       <div style={{ width: '100%' }}>
-        <i style={styleObj}>{title === 'hidden' ? '-' : title}</i>
+        <p style={styleObj}>{title === 'hidden' ? '-' : title}</p>
       </div>
     ) : (
       <div>

--- a/app/packs/src/apps/mydb/elements/tabLayout/TabLayoutCell.js
+++ b/app/packs/src/apps/mydb/elements/tabLayout/TabLayoutCell.js
@@ -35,7 +35,8 @@ class TabLayoutCell extends Component {
       fontSize: 12,
       color: '#000000',
       textAlign: 'center',
-      wordWrap: 'break-word'
+      wordWrap: 'break-word',
+      width: '85px'
     };
 
     const elnElements = ['sample', 'reaction', 'screen', 'wellplate', 'research_plan'];


### PR DESCRIPTION
Fixes #1203

Issues with tab layout popups:

- [x] change to "Tab Layout"
- [x] remove italics
- [x] correct positioning of popup relative to button
- [x] equal width and height for all divs in popup (currently 85px)
- [x] popups resizing, should maintain one size
- [x] popups end up out of bounds when window is resized - they do not move with the rest of the webpage
- Partially fixed - `shouldUpdatePosition` not working for
    - `ElementsTableSettings`' popup
    - `ElementDetailSortTab` when reaction details are open
    **- 21/03 - This can be fixed by forcing the components to update when window is resized.**
- Minor UI fixes as of 22/03, popups now within their respective sections, and now move with button when windows are scrolled.

![Screenshot 2023-03-22 172715](https://user-images.githubusercontent.com/67055123/226972450-bf1697eb-9eba-4f65-a713-943a76a4de04.png)
![Screenshot 2023-03-22 172727](https://user-images.githubusercontent.com/67055123/226972453-e4715ae1-1843-4b50-96ef-1571f006ec53.png)

