### PR TITLE
changed max values of rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,3 +54,16 @@ RSpec/ExampleLength:
 RSpec/MultipleMemoizedHelpers:
   Enabled: true
   Max: 10
+
+RSpec/ClassLength:
+  Max: 200
+
+Metrics/AbcSize:
+  Max: 25
+
+RSpec/MultipleExpectations:
+  Max: 3 
+
+Metrics/MethodLength:
+  Max: 30
+


### PR DESCRIPTION
changed some rubocop rules after internal discussion

* ClassLength: 100 -> 200
* AbcSize : 17 -> 25
* MultipleExpections: 1 -> 3
* MethodLength: 10 -> 30
