### PR TITLE
Minor image annotation fixes

### DIFF
--- a/app/usecases/attachments/annotation/annotation_updater.rb
+++ b/app/usecases/attachments/annotation/annotation_updater.rb
@@ -20,7 +20,7 @@ module Usecases
           create_annotated_flat_image(attachment, sanitized_svg_string)
         end
 
-        def sanitize_svg_string(svg_string) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+        def sanitize_svg_string(svg_string)
           scrubber = Rails::Html::PermitScrubber.new
           scrubber.tags = %w[svg image g title rect text path line ellipse]
           scrubber.attributes = %w[height id width href class fill stroke stroke-dasharray stroke-linecap transform

--- a/app/usecases/attachments/annotation/annotation_updater.rb
+++ b/app/usecases/attachments/annotation/annotation_updater.rb
@@ -25,7 +25,7 @@ module Usecases
           scrubber.tags = %w[svg image g title rect text path line ellipse]
           scrubber.attributes = %w[height id width href class fill stroke stroke-dasharray stroke-linecap transform
                                    stroke-linejoin stroke-width x y font-family font-size font-weight text-anchor
-                                   space d x1 x2 y1 y2 cx cy rx ry text-decoration]
+                                   space d x1 x2 y1 y2 cx cy rx ry text-decoration opacity fill-opacity]
           sanitized_svg_string = Loofah.xml_fragment(svg_string).scrub!(scrubber).to_s
 
           sanitize_rest_call = Loofah::Scrubber.new do |node|


### PR DESCRIPTION
Add opacity as styling element to svg allowlist. 

The original reason why i created the branch was the issue found by Silvia that free hand drawings without a filling got a filling after the save. But i can not reproduce it. 

@reviewer, please check if you can reproduce the problem.
