### PR TITLE
AttachmentAPI: quote filename in content-dispostion header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   * Shibboleth authentication [#1239](https://github.com/ComPlat/chemotion_ELN/pull/1239)
 
 * Fixes
-
+  * content-disposition header preventing fetching image properly [#1250](https://github.com/ComPlat/chemotion_ELN/pull/1250)
 
 
 ## [v1.5.1]

--- a/app/api/chemotion/attachment_api.rb
+++ b/app/api/chemotion/attachment_api.rb
@@ -305,7 +305,7 @@ module Chemotion
       get 'image/:attachment_id' do
         data = Usecases::Attachments::LoadImage.execute!(@attachment, params[:annotated])
         content_type @attachment.content_type
-        header['Content-Disposition'] = "attachment; filename=#{@attachment.filename}"
+        header['Content-Disposition'] = "attachment; filename=\"#{@attachment.filename}\""
         header['Content-Transfer-Encoding'] = 'binary'
         env['api.format'] = :binary
         data

--- a/app/api/chemotion/public_api.rb
+++ b/app/api/chemotion/public_api.rb
@@ -78,7 +78,7 @@ module Chemotion
           @attachment = Attachment.find_by(id: att_id)
           @user = User.find_by(id: user_id)
           error!('401 Unauthorized', 401) if @attachment.nil? || @user.nil?
-          header['Content-Disposition'] = "attachment; filename=#{@attachment.filename}"
+          header['Content-Disposition'] = "attachment; filename=\"#{@attachment.filename}\""
           env['api.format'] = :binary
           @attachment.read_file
         end


### PR DESCRIPTION
so that to avoid Err_Response_Headers_Multiple_Content_Disposition in chrome



