### PR TITLE
Ease shrine deriv access

### DIFF
--- a/app/usecases/attachments/annotation/annotation_loader.rb
+++ b/app/usecases/attachments/annotation/annotation_loader.rb
@@ -5,13 +5,13 @@ module Usecases
   module Attachments
     module Annotation
       class AnnotationLoader
-        def get_annotation_of_attachment(attachment_id) # rubocop:disable Metrics/AbcSize
+        def get_annotation_of_attachment(attachment_id)
           att = Attachment.find(attachment_id)
           raise 'could not find attachment' unless att
           raise 'could not find annotation of attachment' unless annotatable?(att.attachment_data)
 
           att = create_empty_annotation(att) unless annotation_json_present(att.attachment_data)
-          location_of_annotation = att.attachment_attacher.derivatives[:annotation].url
+          location_of_annotation = att.attachment(:annotation).url
           annotation = File.open(location_of_annotation, 'rb') if File.exist?(location_of_annotation)
           raise 'could not find annotation of attachment (file not found)' unless annotation
 

--- a/app/usecases/attachments/annotation/annotation_updater.rb
+++ b/app/usecases/attachments/annotation/annotation_updater.rb
@@ -38,7 +38,7 @@ module Usecases
         end
 
         def save_svg_string_to_file_system(sanitized_svg_string, attachment)
-          location = attachment.attachment_attacher.derivatives[:annotation].url
+          location = attachment.attachment(:annotation).url
           f = File.new(location, 'w')
           f.write(sanitized_svg_string)
           f.close

--- a/app/usecases/attachments/annotation/annotation_updater.rb
+++ b/app/usecases/attachments/annotation/annotation_updater.rb
@@ -61,7 +61,7 @@ module Usecases
 
           xml = replace_link_with_base64(location_of_file, svg_string, attachment.attachment.mime_type)
           extention = File.extname(attachment.filename)
-          extention = '.png' if ['.tif', '.tiff','.svg'].include?(extention)
+          extention = '.png' if ['.tif', '.tiff', '.svg'].include?(extention)
           annotated_image_location = "#{location_of_file.split('.')[0]}_annotated" + extention
           image = MiniMagick::Image.read(xml.to_s)
           image.format(extention.delete('.'))

--- a/app/usecases/attachments/annotation/annotation_updater.rb
+++ b/app/usecases/attachments/annotation/annotation_updater.rb
@@ -45,7 +45,7 @@ module Usecases
         end
 
         def update_thumbnail(attachment, svg_string)
-          location_of_thumbnail = attachment.attachment_attacher.derivatives[:thumbnail].url
+          location_of_thumbnail = attachment.attachment(:thumbnail).url
           tmp_thumbnail_location = "#{location_of_thumbnail.split('.')[0]}_thumb.svg"
           xml = replace_link_with_base64(attachment.attachment.url, svg_string, attachment.attachment.mime_type)
           File.write(tmp_thumbnail_location, xml.to_xml)

--- a/app/usecases/attachments/annotation/annotation_updater.rb
+++ b/app/usecases/attachments/annotation/annotation_updater.rb
@@ -61,7 +61,7 @@ module Usecases
 
           xml = replace_link_with_base64(location_of_file, svg_string, attachment.attachment.mime_type)
           extention = File.extname(attachment.filename)
-          extention = '.png' if ['.tif', '.tiff'].include?(extention)
+          extention = '.png' if ['.tif', '.tiff','.svg'].include?(extention)
           annotated_image_location = "#{location_of_file.split('.')[0]}_annotated" + extention
           image = MiniMagick::Image.read(xml.to_s)
           image.format(extention.delete('.'))

--- a/app/usecases/attachments/load_image.rb
+++ b/app/usecases/attachments/load_image.rb
@@ -5,11 +5,9 @@ module Usecases
     class LoadImage
       @@types_convert = ['.tif', '.tiff'] # rubocop:disable Style/ClassVars
 
-      def self.execute!(attachment, annotated) # rubocop:disable  Metrics/AbcSize,Metrics/MethodLength,Metrics/PerceivedComplexity
+      def self.execute!(attachment, annotated) # rubocop:disable  Metrics/PerceivedComplexity
         # to allow reading of PDF files
-        unless attachment.type_image? || attachment.type_pdf?
-          raise "no image / PDF attachment: #{attachment.id}"
-        end
+        raise "no image / PDF attachment: #{attachment.id}" unless attachment.type_image? || attachment.type_pdf?
 
         conversion = attachment.type_image_tiff?
 
@@ -41,10 +39,10 @@ module Usecases
 
         update_attachment_data_column(attachment, result)
 
-        File.open(attachment.attachment_attacher.derivatives[:conversion].url)
+        File.open(attachment.attachment(:conversion).url)
       end
 
-      def self.update_attachment_data_column(attachment, result) # rubocop:disable Metrics/AbcSize
+      def self.update_attachment_data_column(attachment, result)
         attachment.attachment_data['derivatives']['conversion'] = {}
         root_path = attachment.attachment.storage.directory.to_s
         attachment.attachment_data['derivatives']['conversion']['id'] =
@@ -52,7 +50,7 @@ module Usecases
         attachment.update_column('attachment_data', attachment.attachment_data) # rubocop:disable Rails/SkipsModelValidations
       end
 
-      def self.load_annotated_image(attachment, _attachment_file) # rubocop:disable Metrics/AbcSize
+      def self.load_annotated_image(attachment, _attachment_file)
         return File.open(attachment.attachment.url) unless attachment.annotated?
 
         store = Rails.application.config_for :shrine
@@ -68,7 +66,7 @@ module Usecases
 
       def self.get_file_of_converted_image(attachment)
         create_converted_image(attachment) unless attachment.attachment_data['derivatives']['conversion']
-        File.open(attachment.attachment_attacher.derivatives[:conversion].url)
+        File.open(attachment.attachment(:conversion).url)
       end
     end
   end

--- a/spec/usecases/attachments/annotation/annotation_updater_spec.rb
+++ b/spec/usecases/attachments/annotation/annotation_updater_spec.rb
@@ -25,7 +25,7 @@ describe Usecases::Attachments::Annotation::AnnotationUpdater do
           updater = described_class.new(ThumbnailerMock.new)
           updater.update_annotation(svg_string2, attachment.id)
 
-          annotation = File.read(attachment.attachment_attacher.derivatives[:annotation].url)
+          annotation = File.read(attachment.attachment(:annotation).url)
 
           expect(Loofah.xml_fragment(svg_string2).to_s).to eq Loofah.xml_fragment(annotation).to_s
         end
@@ -35,12 +35,12 @@ describe Usecases::Attachments::Annotation::AnnotationUpdater do
     context 'when annotation is undefined' do
       let(:svg_filename) { '20230111_invalide_annotation_undefined.svg' }
       let(:attachment) { create(:attachment, :with_png_image) }
-      let(:original_annotation) { File.read(attachment.attachment_attacher.derivatives[:annotation].url) }
+      let(:original_annotation) { File.read(attachment.attachment(:annotation).url) }
 
       it 'annotation was not changed' do
         updater = described_class.new(ThumbnailerMock.new)
         updater.update_annotation(svg_string, attachment.id)
-        annotation = File.read(attachment.attachment_attacher.derivatives[:annotation].url)
+        annotation = File.read(attachment.attachment(:annotation).url)
 
         expect(Loofah.xml_fragment(original_annotation).to_s).to eq Loofah.xml_fragment(annotation).to_s
       end

--- a/spec/usecases/attachments/load_image_spec.rb
+++ b/spec/usecases/attachments/load_image_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Usecases::Attachments::LoadImage do
       let(:attachment) { create(:attachment, :with_tif_file) }
 
       it 'size of returned image equals size of converted image' do
-        expect(tmp_file.size).to eq File.open(attachment.attachment_attacher.derivatives[:conversion].url).size
+        expect(tmp_file.size).to eq File.open(attachment.attachment(:conversion).url).size
       end
     end
 
@@ -59,13 +59,13 @@ RSpec.describe Usecases::Attachments::LoadImage do
       let(:updated_attachment) { Attachment.find(attachment.id) }
 
       before do
-        File.delete(attachment.attachment_attacher.derivatives[:conversion].url)
+        File.delete(attachment.attachment(:conversion).url)
         attachment.attachment_data['derivatives'].delete('conversion')
         attachment.update_column('attachment_data', attachment.attachment_data) # rubocop:disable Rails/SkipsModelValidations
       end
 
       it 'size of returned image equals size of converted image' do
-        expect(tmp_file.size).to eq File.open(attachment.attachment_attacher.derivatives[:conversion].url).size
+        expect(tmp_file.size).to eq File.open(attachment.attachment(:conversion).url).size
       end
     end
 
@@ -91,7 +91,8 @@ RSpec.describe Usecases::Attachments::LoadImage do
       end
 
       it 'size of returned image equals size of converted image' do
-        expect(tmp_file.size).to eq File.open(updated_attachment.attachment.storage.directory + updated_attachment.attachment_data['derivatives']['annotation']['annotated_file_location']).size # rubocop:disable  Layout/LineLength
+        annotated_file_location = updated_attachment.attachment_data['derivatives']['annotation']['annotated_file_location'] # rubocop:disable  Layout/LineLength
+        expect(tmp_file.size).to eq File.open(updated_attachment.attachment.storage.directory + annotated_file_location).size # rubocop:disable  Layout/LineLength
       end
     end
   end


### PR DESCRIPTION
Eased the access to derivatives in the shrine context. (https://shrinerb.com/docs/plugins/derivatives)

Also fixed a bug that prevents converting a annotated svg file into another svg file.
