### PR TITLE
1260 report UI to not break if a report template cannot be found

### DIFF
--- a/app/api/chemotion/report_api.rb
+++ b/app/api/chemotion/report_api.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 module Chemotion
@@ -219,6 +218,7 @@ module Chemotion
       requires :imgFormat, type: String, default: 'png', values: %w[png eps emf]
       requires :fileName, type: String, default: 'ELN_Report_' + Time.now.strftime('%Y-%m-%dT%H-%M-%S')
       requires :templateId, type: String
+      optional :templateType, type: String, default: 'standard', values: ReportTemplate::REPORT_TYPES
       optional :fileDescription
     end
     post :reports do
@@ -238,7 +238,7 @@ module Chemotion
         prd_atts: params[:prdAtts],
         objects: params[:objTags],
         img_format: params[:imgFormat],
-        template: params[:templateId],
+        template: params[:templateType],
         report_templates_id: !!/\A\d+\z/.match(params[:templateId]) ? params[:templateId].to_i : nil,
         author_id: current_user.id
       }

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -54,17 +54,16 @@ class Report < ApplicationRecord
 
   def create_docx
     template = self.template
-
     if ReportTemplate.where(id: report_templates_id).present?
       report_template = ReportTemplate.includes(:attachment).find(report_templates_id)
       template = report_template.report_type
-      tpl_path = if report_template.attachment
-                   report_template.attachment.attachment_url
-                 else
-                   report_template.report_type
-                 end
+#     tpl_path = if report_template.attachment
+#                  report_template.attachment.attachment_url
+#                else
+#                  report_template.report_type
+#                end
+      tpl_path = self.class.template_path(template)
     else
-      template = self.class.template_path(template)
       tpl_path = self.class.template_path(template)
     end
     case template

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -53,7 +53,6 @@ class Report < ApplicationRecord
   after_destroy :delete_job
 
   def create_docx
-    template = self.template
     if ReportTemplate.where(id: report_templates_id).present?
       report_template = ReportTemplate.includes(:attachment).find(report_templates_id)
       template = report_template.report_type

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -97,7 +97,7 @@ class Report < ApplicationRecord
       ).process
     end
   end
-  handle_asynchronously :create_docx, run_at: proc { 30.seconds.from_now }
+  handle_asynchronously(:create_docx, run_at: proc { 30.seconds.from_now }) unless Rails.env.development?
 
   def queue_name
     "report_#{id}"

--- a/app/models/report_template.rb
+++ b/app/models/report_template.rb
@@ -21,6 +21,16 @@
 #
 
 class ReportTemplate < ApplicationRecord
+  REPORT_TYPES = %w[
+    standard
+    spectrum
+    supporting_information
+    supporting_information_std_rxn
+    rxn_list_xlsx
+    rxn_list_csv
+    rxn_list_html
+  ].freeze
+
   belongs_to :attachment, foreign_key: :attachment_id, class_name: 'Attachment', dependent: :destroy, optional: true
   accepts_nested_attributes_for :attachment
 

--- a/app/packs/src/apps/admin/AdminHome.js
+++ b/app/packs/src/apps/admin/AdminHome.js
@@ -15,7 +15,7 @@ import GenericElementAdmin from 'src/apps/admin/GenericElementAdmin';
 import SegmentElementAdmin from 'src/apps/admin/SegmentElementAdmin';
 import DatasetElementAdmin from 'src/apps/admin/DatasetElementAdmin';
 import DelayedJobs from 'src/apps/admin/DelayedJobs';
-import TemplateManagement from 'src/apps/admin/TemplateManagement';
+// import TemplateManagement from 'src/apps/admin/TemplateManagement';
 
 class AdminHome extends React.Component {
   constructor(props) {
@@ -100,7 +100,7 @@ class AdminHome extends React.Component {
             <NavItem eventKey={11}>Generic Dataset (BETA)</NavItem>
             <NavItem eventKey={2}>Message Publish</NavItem>
             <NavItem eventKey={5}>Load OLS Terms</NavItem>
-            <NavItem eventKey={12}>Report-template Management</NavItem>
+	    {/* <NavItem eventKey={12}>Report-template Management</NavItem> */}
             <NavItem eventKey={13}>Delayed Jobs </NavItem>
           </Nav>
         </Col>

--- a/app/packs/src/apps/mydb/elements/details/reports/Paramize.js
+++ b/app/packs/src/apps/mydb/elements/details/reports/Paramize.js
@@ -42,9 +42,9 @@ const paramize = (state) => {
     fileName,
     fileDescription,
     templateId: template.id || template,
+    templateType: template?.value,
     molSerials: selMolSerials,
   };
-
   return params;
 };
 

--- a/app/packs/src/apps/mydb/elements/details/reports/ReportContainer.js
+++ b/app/packs/src/apps/mydb/elements/details/reports/ReportContainer.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Panel, Tabs, Tab } from 'react-bootstrap';
+import { Alert, Panel, Tabs, Tab } from 'react-bootstrap';
 import LoadingActions from 'src/stores/alt/actions/LoadingActions';
 import ReportActions from 'src/stores/alt/actions/ReportActions';
 import ReportStore from 'src/stores/alt/stores/ReportStore';
@@ -118,8 +118,14 @@ export default class ReportContainer extends Component {
     } = this.state;
 
     let { template } = this.state;
+    let alertTemplateNotFound = false;
+
     if (templateOpts.length > 0 && template && typeof template != 'object') {
-      const templateOpt = templateOpts.find(x => x.id == template || x.report_type == template);
+      let templateOpt = templateOpts.find(x => x.id == template || x.report_type == template);
+      if (!templateOpt) {
+        alertTemplateNotFound = true;
+        templateOpt = templateOpts.find(x => x.report_type === 'standard')
+      }
       template = { id: templateOpt.id, label: templateOpt.name, value: templateOpt.report_type };
     }
 
@@ -129,6 +135,11 @@ export default class ReportContainer extends Component {
       <Panel
         bsStyle="default"
       >
+        {alertTemplateNotFound && (
+          <Alert variant="warning">
+            Report Template not found. Set to Standard. Please check your config settings.
+          </Alert>
+        )}
         <Panel.Heading>{this.panelHeader()}</Panel.Heading>
         <Tabs
           activeKey={activeKey}


### PR DESCRIPTION
- disabled Admin Report Template management  and set paths for report type (do not use the report_template.attachment (also due to #1259 ))

- save report type  in report (fix wrong assignment)

- fall back to standard report if the report-template does not exist anymore in the db