### PR TITLE
1285 do no cache the welcome message

### DIFF
--- a/app/packs/src/apps/home/WelcomeMessage.js
+++ b/app/packs/src/apps/home/WelcomeMessage.js
@@ -3,29 +3,36 @@ import { Jumbotron } from 'react-bootstrap';
 import ReactMarkdown from 'react-markdown';
 
 function Message(props) {
-  const input = props.post;
-  if (input != null && input !== undefined) {
-    return (<Jumbotron>
-      <ReactMarkdown children={input} />
-    </Jumbotron>);
+  const { post } = props;
+  if (post != null && post !== undefined) {
+    return (
+      <Jumbotron>
+        <ReactMarkdown children={post} />
+      </Jumbotron>
+    );
   }
   return null;
 }
 
 class WelcomeMessage extends Component {
-  state = {
-    post: null
+  constructor(props) {
+    super(props);
+    this.state = {
+      post: null
+    };
   }
+
   componentDidMount() {
-    fetch('welcome-message.md')
+    fetch(`welcome-message.md?${Date.now()}`) // Prevent caching
       .then((res) => {
         if (res.ok) {
           return res.text();
         }
         return null;
-      }).then(post => this.setState(state => ({ ...state, post })))
+      }).then((post) => this.setState((state) => ({ ...state, post })))
       .catch((errorMessage) => { console.error(errorMessage); });
   }
+
   render() {
     const { post } = this.state;
     return (

--- a/app/views/pages/about.haml
+++ b/app/views/pages/about.haml
@@ -1,14 +1,22 @@
-- @changelog = File.read("#{Rails.root}/CHANGELOG.md")
 
 .container
   %h2
-    Chemotion ELN
-    %br/
-    - Chemotion::Application.config.version.each do |k, v|
-      %h3= "#{k.humanize}: #{v}"
-
-  = markdown @changelog
+    Chemotion ELN - About
 
   %br/
+  - Chemotion::Application.config.version.each do |k, v|
+    - next if v.to_s == '0'
+    %h4= "#{k.humanize}: #{v}"
+  %br/
+  %br/
+  %span
+    See
+    = link_to "CHANGELOG.md", "https://github.com/ComPlat/chemotion_ELN/blob/main/CHANGELOG.md##{Chemotion::Application.config.version["version"]&.gsub(/\./,'')}"
+    for more details.
+  %br/
+  %br/
+  %br/
+
+
 
   = link_to "Back", root_path


### PR DESCRIPTION
- avoid caching the welcome message  on the **Home** page

- replace changelog content with external link from the **About** page 