### PR TITLE
Remove redundant command from devcontainer configuration

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -6,7 +6,3 @@ yarn install
 
 # set up database
 bundle exec rake db:setup
-
-# link svg editor to public folder
-ln -s ~/node_modules/svgedit/dist/editor ~/app/public/svgedit
-


### PR DESCRIPTION
The removed command is a duplicate of https://github.com/ComPlat/chemotion_ELN/blob/cd7cb6c597b155be0e6506e4e6137e429ad9f3be/package_postinstall.sh#L36
