### PR TITLE
http callback for onlyoffice updated

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,3 @@
-PUBLIC_URL='http://localhost:3000' 
 SFTP_HOST=sftp
 SFTP_PORT=22
 SFTP_UPLOAD_FOLDER=uploads

--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
+PUBLIC_URL='http://localhost:3000' 
 SFTP_HOST=sftp
 SFTP_PORT=22
 SFTP_UPLOAD_FOLDER=uploads

--- a/app/api/chemotion/editor_api.rb
+++ b/app/api/chemotion/editor_api.rb
@@ -43,7 +43,7 @@ module Chemotion
               fileType: 'docx',
               key: token,
               title: @attachment.filename,
-              url: "#{ENV.fetch('PUBLIC_URL')}/api/v1/public/download?token=#{token}",
+              url: "#{Application.config.root_url}/api/v1/public/download?token=#{token}",
               permissions: {
                 download: true,
                 edit: true,
@@ -52,7 +52,7 @@ module Chemotion
               },
             },
             editorConfig: {
-              callbackUrl: "#{ENV.fetch('PUBLIC_URL')}/api/v1/public/callback",
+              callbackUrl: "#{Application.config.root_url}/api/v1/public/callback",
               mode: 'edit',
               lang: 'en',
               customization: {

--- a/app/api/chemotion/editor_api.rb
+++ b/app/api/chemotion/editor_api.rb
@@ -43,7 +43,7 @@ module Chemotion
               fileType: 'docx',
               key: token,
               title: @attachment.filename,
-              url: "http://#{request.host_with_port}/api/v1/public/download?token=#{token}",
+              url: "#{ENV.fetch('PUBLIC_URL')}/api/v1/public/download?token=#{token}",
               permissions: {
                 download: true,
                 edit: true,
@@ -52,7 +52,7 @@ module Chemotion
               },
             },
             editorConfig: {
-              callbackUrl: "http://#{request.host_with_port}/api/v1/public/callback",
+              callbackUrl: "#{ENV.fetch('PUBLIC_URL')}/api/v1/public/callback",
               mode: 'edit',
               lang: 'en',
               customization: {


### PR DESCRIPTION
The editor api has been updated to use PUBLIC_URL 

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
