### PR TITLE
updating group admin ui

### DIFF
--- a/app/packs/src/components/navigation/GroupElement.js
+++ b/app/packs/src/components/navigation/GroupElement.js
@@ -65,24 +65,27 @@ export default class GroupElement extends React.Component {
   }
 
   renderDeleteButton(type, groupRec, userRec) {
-    let msg = 'remove yourself from the group';
+    let msg = 'Remove yourself from the group';
     if (type === 'user') {
       if (userRec.id === this.state.currentUser.id) {
-        msg = 'remove yourself from the group';
+        msg = 'Remove yourself from the group';
       } else {
-        msg = `remove user: ${userRec.name}`;
+        msg = `Remove user: ${userRec.name}`;
       }
     } else {
-      msg = `remove group: ${groupRec.name}`;
+      msg = `Remove group: ${groupRec.name}`;
     }
 
     const popover = (
       <Popover id="popover-positioned-scrolling-left">
-        {msg} ?<br />
+        {msg}
+        ?
+        <br />
         <div className="btn-toolbar">
           <Button bsSize="xsmall" bsStyle="danger" onClick={() => this.confirmDelete(type, groupRec, userRec)}>
             Yes
-          </Button><span>&nbsp;&nbsp;</span>
+          </Button>
+          <span>&nbsp;&nbsp;</span>
           <Button bsSize="xsmall" bsStyle="warning" onClick={this.handleClick} >
             No
           </Button>
@@ -107,19 +110,20 @@ export default class GroupElement extends React.Component {
 
   renderAdminButtons(group) {
     const { selectedUsers, showRowAdd } = this.state;
-    if (group.admins && group.admins.length > 0 && group.admins[0].id === this.state.currentUser.id) {
+    if (group.admins && group.admins.some(admin => admin.id === this.state.currentUser.id)) {
       return (
         <td>
           <OverlayTrigger placement='top' overlay={<Tooltip>View users</Tooltip>}>
             <Button bsSize="xsmall" type="button" bsStyle="info" className="fa fa-list" onClick={this.toggleUsers} />
-          </OverlayTrigger>
+          </OverlayTrigger>{' '}
           <OverlayTrigger placement='top' overlay={<Tooltip>Add user</Tooltip>}>
             <Button bsSize="xsmall" type="button" bsStyle="success" className="fa fa-plus" onClick={this.toggleRowAdd} />
-          </OverlayTrigger>
+          </OverlayTrigger>{' '}
           <OverlayTrigger placement='top' overlay={<Tooltip>Remove group</Tooltip>}>
             {this.renderDeleteButton('group', group)}
           </OverlayTrigger>
           <span className={'collapse' + (showRowAdd ? 'in' : '')}>
+            {' '}
             <Select.AsyncCreatable
               multi
               isLoading
@@ -132,7 +136,7 @@ export default class GroupElement extends React.Component {
               promptTextCreator={this.promptTextCreator}
               loadOptions={this.loadUserByName}
               onChange={this.handleSelectUser}
-            />
+            />{' '}
             <Button bsSize="xsmall" type="button" bsStyle="warning" onClick={() => this.addUser(group)}>Save to group</Button>
           </span>
         </td>
@@ -144,8 +148,15 @@ export default class GroupElement extends React.Component {
   }
 
   renderUserButtons(groupRec, userRec = null) {
-    if ((groupRec.admins && groupRec.admins.length > 0 && groupRec.admins[0].id === this.state.currentUser.id) || userRec.id === this.state.currentUser.id) {
-      return this.renderDeleteButton('user', groupRec, userRec);
+    if (
+      (groupRec.admins && groupRec.admins.some(admin => admin.id === this.state.currentUser.id))
+      || (userRec.id === this.state.currentUser.id)
+    ) {
+      return (
+        <OverlayTrigger placement='top' overlay={<Tooltip>Remove</Tooltip>}>
+          {this.renderDeleteButton('user', groupRec, userRec)}
+        </OverlayTrigger>
+      );
     }
     return (<div />);
   }
@@ -193,7 +204,7 @@ export default class GroupElement extends React.Component {
         <tr key={`row_${groupElement.id}`} style={{ fontWeight: 'bold' }}>
           <td>{groupElement.name}</td>
           <td>{groupElement.initials}</td>
-          <td>{groupElement.admins && groupElement.admins.length > 0 && groupElement.admins[0].name}</td>
+          <td>{groupElement.admins && groupElement.admins.length > 0 && groupElement.admins.map(admin => admin.name).join(', ')}</td>
           {this.renderAdminButtons(groupElement)}
         </tr>
         <tr className={'collapse' + (showInfo ? 'in' : '')}>

--- a/app/packs/src/components/navigation/GroupElement.js
+++ b/app/packs/src/components/navigation/GroupElement.js
@@ -65,10 +65,10 @@ export default class GroupElement extends React.Component {
   }
 
   renderDeleteButton(type, groupRec, userRec) {
-    let msg = 'Remove yourself from the group';
+    let msg = 'Leave this group';
     if (type === 'user') {
       if (userRec.id === this.state.currentUser.id) {
-        msg = 'Remove yourself from the group';
+        msg = 'Leave this group';
       } else {
         msg = `Remove user: ${userRec.name}`;
       }

--- a/app/packs/src/components/navigation/GroupElement.js
+++ b/app/packs/src/components/navigation/GroupElement.js
@@ -65,28 +65,25 @@ export default class GroupElement extends React.Component {
   }
 
   renderDeleteButton(type, groupRec, userRec) {
-    let msg = 'Leave this group';
+    let msg = 'Leave this group?';
     if (type === 'user') {
       if (userRec.id === this.state.currentUser.id) {
-        msg = 'Leave this group';
+        msg = 'Leave this group?';
       } else {
-        msg = `Remove user: ${userRec.name}`;
+        msg = `Remove user: ${userRec.name}?`;
       }
     } else {
-      msg = `Remove group: ${groupRec.name}`;
+      msg = `Remove group: ${groupRec.name}?`;
     }
 
     const popover = (
       <Popover id="popover-positioned-scrolling-left">
         {msg}
-        ?
-        <br />
-        <div className="btn-toolbar">
+        <div style={{ display: 'flex', flexDirection: 'row', gap: '10px' }}>
           <Button bsSize="xsmall" bsStyle="danger" onClick={() => this.confirmDelete(type, groupRec, userRec)}>
             Yes
           </Button>
-          <span>&nbsp;&nbsp;</span>
-          <Button bsSize="xsmall" bsStyle="warning" onClick={this.handleClick} >
+          <Button bsSize="xsmall" bsStyle="warning" onClick={this.handleClick}>
             No
           </Button>
         </div>
@@ -113,32 +110,33 @@ export default class GroupElement extends React.Component {
     if (group.admins && group.admins.some(admin => admin.id === this.state.currentUser.id)) {
       return (
         <td>
-          <OverlayTrigger placement='top' overlay={<Tooltip>View users</Tooltip>}>
-            <Button bsSize="xsmall" type="button" bsStyle="info" className="fa fa-list" onClick={this.toggleUsers} />
-          </OverlayTrigger>{' '}
-          <OverlayTrigger placement='top' overlay={<Tooltip>Add user</Tooltip>}>
-            <Button bsSize="xsmall" type="button" bsStyle="success" className="fa fa-plus" onClick={this.toggleRowAdd} />
-          </OverlayTrigger>{' '}
-          <OverlayTrigger placement='top' overlay={<Tooltip>Remove group</Tooltip>}>
-            {this.renderDeleteButton('group', group)}
-          </OverlayTrigger>
-          <span className={'collapse' + (showRowAdd ? 'in' : '')}>
-            {' '}
-            <Select.AsyncCreatable
-              multi
-              isLoading
-              backspaceRemoves
-              value={selectedUsers}
-              valueKey="value"
-              labelKey="label"
-              matchProp="name"
-              placeholder="Select users"
-              promptTextCreator={this.promptTextCreator}
-              loadOptions={this.loadUserByName}
-              onChange={this.handleSelectUser}
-            />{' '}
-            <Button bsSize="xsmall" type="button" bsStyle="warning" onClick={() => this.addUser(group)}>Save to group</Button>
-          </span>
+          <div style={{ display: 'flex', gap: '5px' }}>
+            <OverlayTrigger placement='top' overlay={<Tooltip>View users</Tooltip>}>
+              <Button bsSize="xsmall" type="button" bsStyle="info" className="fa fa-list" onClick={this.toggleUsers} />
+            </OverlayTrigger>
+            <OverlayTrigger placement='top' overlay={<Tooltip>Add user</Tooltip>}>
+              <Button bsSize="xsmall" type="button" bsStyle="success" className="fa fa-plus" onClick={this.toggleRowAdd} />
+            </OverlayTrigger>
+            <OverlayTrigger placement='top' overlay={<Tooltip>Remove group</Tooltip>}>
+              {this.renderDeleteButton('group', group)}
+            </OverlayTrigger>
+            <span className={'collapse' + (showRowAdd ? 'in' : '')}>
+              <Select.AsyncCreatable
+                multi
+                isLoading
+                backspaceRemoves
+                value={selectedUsers}
+                valueKey="value"
+                labelKey="label"
+                matchProp="name"
+                placeholder="Select users"
+                promptTextCreator={this.promptTextCreator}
+                loadOptions={this.loadUserByName}
+                onChange={this.handleSelectUser}
+              />
+              <Button bsSize="xsmall" type="button" bsStyle="warning" onClick={() => this.addUser(group)}>Save to group</Button>
+            </span>
+          </div>
         </td>
       );
     }

--- a/app/packs/src/components/navigation/GroupElement.js
+++ b/app/packs/src/components/navigation/GroupElement.js
@@ -110,33 +110,32 @@ export default class GroupElement extends React.Component {
     if (group.admins && group.admins.some(admin => admin.id === this.state.currentUser.id)) {
       return (
         <td>
-          <div style={{ display: 'flex', gap: '5px' }}>
-            <OverlayTrigger placement='top' overlay={<Tooltip>View users</Tooltip>}>
-              <Button bsSize="xsmall" type="button" bsStyle="info" className="fa fa-list" onClick={this.toggleUsers} />
-            </OverlayTrigger>
-            <OverlayTrigger placement='top' overlay={<Tooltip>Add user</Tooltip>}>
-              <Button bsSize="xsmall" type="button" bsStyle="success" className="fa fa-plus" onClick={this.toggleRowAdd} />
-            </OverlayTrigger>
-            <OverlayTrigger placement='top' overlay={<Tooltip>Remove group</Tooltip>}>
-              {this.renderDeleteButton('group', group)}
-            </OverlayTrigger>
-            <span className={'collapse' + (showRowAdd ? 'in' : '')}>
-              <Select.AsyncCreatable
-                multi
-                isLoading
-                backspaceRemoves
-                value={selectedUsers}
-                valueKey="value"
-                labelKey="label"
-                matchProp="name"
-                placeholder="Select users"
-                promptTextCreator={this.promptTextCreator}
-                loadOptions={this.loadUserByName}
-                onChange={this.handleSelectUser}
-              />
-              <Button bsSize="xsmall" type="button" bsStyle="warning" onClick={() => this.addUser(group)}>Save to group</Button>
-            </span>
-          </div>
+          <OverlayTrigger placement='top' overlay={<Tooltip>View users</Tooltip>}>
+            <Button bsSize="xsmall" type="button" bsStyle="info" className="fa fa-list" onClick={this.toggleUsers} />
+          </OverlayTrigger>
+          <OverlayTrigger placement='top' overlay={<Tooltip>Add user</Tooltip>}>
+            <Button bsSize="xsmall" type="button" bsStyle="success" className="fa fa-plus" onClick={this.toggleRowAdd} />
+          </OverlayTrigger>
+          <OverlayTrigger placement='top' overlay={<Tooltip>Remove group</Tooltip>}>
+            {this.renderDeleteButton('group', group)}
+          </OverlayTrigger>
+          <span className={'collapse' + (showRowAdd ? 'in' : '')}>
+            {' '}
+            <Select.AsyncCreatable
+              multi
+              isLoading
+              backspaceRemoves
+              value={selectedUsers}
+              valueKey="value"
+              labelKey="label"
+              matchProp="name"
+              placeholder="Select users"
+              promptTextCreator={this.promptTextCreator}
+              loadOptions={this.loadUserByName}
+              onChange={this.handleSelectUser}
+            />
+            <Button bsSize="xsmall" type="button" bsStyle="warning" onClick={() => this.addUser(group)}>Save to group</Button>
+          </span>
         </td>
       );
     }

--- a/app/packs/src/components/navigation/UserAuth.js
+++ b/app/packs/src/components/navigation/UserAuth.js
@@ -356,7 +356,7 @@ export default class UserAuth extends Component {
                   <thead>
                     <tr style={{ backgroundColor: '#ddd' }}>
                       <th width="20%">Name</th>
-                      <th width="10%">Kürzel</th>
+                      <th width="10%">Abbreviaton</th>
                       <th width="20%">Admin by</th>
                       <th width="50%">&nbsp;</th>
                     </tr>
@@ -376,7 +376,7 @@ export default class UserAuth extends Component {
                   <thead>
                     <tr style={{ backgroundColor: '#ddd' }}>
                       <th width="40%">Name</th>
-                      <th width="10%">Kürzel</th>
+                      <th width="10%">Abbreviation</th>
                       <th width="50%">&nbsp;</th>
                     </tr>
                   </thead>


### PR DESCRIPTION
- Updated ui admin rights

- All admins can now delete/add members from/to the group or delete the groups

- Normal users can only delete themselves

- The "admin by" field now have all the admins and not only the creator

- Creating change to admin button for admins is complicated and is like a new feature. Was not implemented at all? Should it be implemented?

Fixes ComPlat/chemotion#10

