### PR TITLE
1340 download of annotated image not working

### DIFF
--- a/app/api/chemotion/attachment_api.rb
+++ b/app/api/chemotion/attachment_api.rb
@@ -44,8 +44,8 @@ module Chemotion
       error!(message, 404)
     end
 
-    resource :attachments do # rubocop:disable Metrics/BlockLength
-      before do # rubocop:disable Metrics/BlockLength       
+    resource :attachments do
+      before do
         @attachment = Attachment.find_by(id: params[:attachment_id])
 
         @attachment = Attachment.find_by(identifier: params[:identifier]) if @attachment.nil? && params[:identifier]
@@ -163,7 +163,9 @@ module Chemotion
 
         env['api.format'] = :binary
         store = @attachment.attachment.storage.directory
-        file_location = store.join(@attachment.attachment_data['derivatives']['annotation']['annotated_file_location'] ||'not available')
+        file_location = store.join(
+          @attachment.attachment_data['derivatives']['annotation']['annotated_file_location'] || 'not available',
+        )
 
         uploaded_file = if file_location.present? && File.file?(file_location)
                           extension_of_annotation = File.extname(@attachment.filename)
@@ -238,20 +240,30 @@ module Chemotion
       end
 
       desc 'Download the zip attachment file'
-      get 'zip/:container_id' do # rubocop:disable Metrics/BlockLength
+      get 'zip/:container_id' do
         env['api.format'] = :binary
         content_type('application/zip, application/octet-stream')
         filename = CGI.escape("#{@container.parent&.name&.gsub(/\s+/, '_')}-#{@container.name.gsub(/\s+/, '_')}.zip")
         header('Content-Disposition', "attachment; filename=\"#{filename}\"")
         zip = Zip::OutputStream.write_buffer do |zip| # rubocop:disable Lint/ShadowingOuterLocalVariable
+          file_text = ''
           @container.attachments.each do |att|
             zip.put_next_entry att.filename
             zip.write att.read_file
-          end
-          file_text = ''
-          @container.attachments.each do |att|
             file_text += "#{att.filename} #{att.checksum}\n"
+            next unless att.annotated?
+
+            begin
+              annotated_file_name = "#{File.basename(att.filename, '.*')}_annotated#{File.extname(att.filename)}"
+              zip.put_next_entry annotated_file_name
+              file = File.open(att.annotated_file_location)
+              zip.write file.read
+              file_text += "#{annotated_file_name} #{file.size}\n"
+            ensure
+              file.close
+            end
           end
+
           hyperlinks_text = ''
           JSON.parse(@container.extended_metadata.fetch('hyperlinks', '[]')).each do |link|
             hyperlinks_text += "#{link} \n"

--- a/app/api/chemotion/attachment_api.rb
+++ b/app/api/chemotion/attachment_api.rb
@@ -45,7 +45,7 @@ module Chemotion
     end
 
     resource :attachments do # rubocop:disable Metrics/BlockLength
-      before do # rubocop:disable Metrics/BlockLength
+      before do # rubocop:disable Metrics/BlockLength       
         @attachment = Attachment.find_by(id: params[:attachment_id])
 
         @attachment = Attachment.find_by(identifier: params[:identifier]) if @attachment.nil? && params[:identifier]

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -31,7 +31,7 @@
 #  index_attachments_on_identifier                         (identifier) UNIQUE
 #
 
-class Attachment < ApplicationRecord # rubocop:disable Metrics/ClassLength
+class Attachment < ApplicationRecord
   include AttachmentJcampAasm
   include AttachmentJcampProcess
   include AttachmentConverter
@@ -233,6 +233,13 @@ class Attachment < ApplicationRecord # rubocop:disable Metrics/ClassLength
     attachment['mime_type'].to_s == 'application/pdf'
   end
 
+  def annotated_file_location
+    return '' unless annotated?
+
+    attachment.storage.directory +
+      attachment_data&.dig('derivatives', 'annotation', 'annotated_file_location')
+  end
+
   private
 
   def generate_key
@@ -269,7 +276,7 @@ class Attachment < ApplicationRecord # rubocop:disable Metrics/ClassLength
     update_column('attachment_data', attachment_data) # rubocop:disable Rails/SkipsModelValidations
   end
 
-  def check_file_size # rubocop:disable Metrics/AbcSize
+  def check_file_size
     return if file_path.nil?
     return unless File.exist?(file_path)
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -235,9 +235,11 @@ class Attachment < ApplicationRecord
 
   def annotated_file_location
     return '' unless annotated?
+
     File.join(
       attachment.storage.directory,
-      attachment_data&.dig('derivatives', 'annotation', 'annotated_file_location'))
+      attachment_data&.dig('derivatives', 'annotation', 'annotated_file_location'),
+    )
   end
 
   private

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -235,9 +235,9 @@ class Attachment < ApplicationRecord
 
   def annotated_file_location
     return '' unless annotated?
-
-    attachment.storage.directory +
-      attachment_data&.dig('derivatives', 'annotation', 'annotated_file_location')
+    File.join(
+      attachment.storage.directory,
+      attachment_data&.dig('derivatives', 'annotation', 'annotated_file_location'))
   end
 
   private

--- a/spec/api/chemotion/attachment_api_spec.rb
+++ b/spec/api/chemotion/attachment_api_spec.rb
@@ -288,7 +288,6 @@ describe Chemotion::AttachmentAPI do
     let(:file_name) { response.header['Content-Disposition'].split('=').last.tr('"', '') }
     let(:file_path) { Rails.root.join("public/zip/#{file_name}") }
     let(:download_file) do
-      binding
       FileUtils.rm_f(file_path)
       response.stream.each do |e|
         File.write(file_path, e.force_encoding('UTF-8'))
@@ -349,17 +348,9 @@ describe Chemotion::AttachmentAPI do
 
       context 'when attachment is image and annotated' do
         let(:sample2) { create(:sample_with_annotated_image_in_analysis) }
-        let(:attachment) { sample2.container.children[0].children[0].attachments.first }
         let(:execute) { get "/api/v1/attachments/zip/#{sample2.container.children[0].children[0].id}" }
-        let(:update_annotation) do
-          updater = Usecases::Attachments::Annotation::AnnotationUpdater.new(ThumbnailerMock.new)
-          updater.update_annotation(
-            Rails.root.join('spec/fixtures/annotations/20221207_valide_annotation_edited.svg').read, attachment.id
-          )
-        end
 
         before do
-          update_annotation
           execute
           download_file
         end

--- a/spec/api/chemotion/attachment_api_spec.rb
+++ b/spec/api/chemotion/attachment_api_spec.rb
@@ -284,63 +284,96 @@ describe Chemotion::AttachmentAPI do
   describe 'GET /api/v1/attachments/zip/{container_id}' do
     let(:container_id) { sample.container.children[0].children[0].id }
     let(:sample) { create(:sample_with_image_in_analysis) }
+    let(:execute) { get "/api/v1/attachments/zip/#{container_id}" }
+    let(:file_name) { response.header['Content-Disposition'].split('=').last.tr('"', '') }
+    let(:file_path) { Rails.root.join("public/zip/#{file_name}") }
+    let(:download_file) do
+      binding
+      FileUtils.rm_f(file_path)
+      response.stream.each do |e|
+        File.write(file_path, e.force_encoding('UTF-8'))
+      end
+      response.stream.close
+    end
 
     before do |example|
       if example.metadata[:enable_download_access].present?
         allow_any_instance_of(ElementPolicy).to receive(:read?).and_return(true)
         allow_any_instance_of(ElementPermissionProxy).to receive(:read_dataset?).and_return(true)
-
       end
-
-      get "/api/v1/attachments/zip/#{container_id}"
     end
 
     context 'when attachment is not available' do
+      before do
+        execute
+      end
+
       it 'returns error' do
         expect(response).to have_http_status :unauthorized
       end
     end
 
-    context 'when attachment is image and not annotated', :enable_download_access do
-      let(:file_name) { response.header['Content-Disposition'].split('=').last.tr('"', '') }
-      let(:file_path) { Rails.root.join("public/zip/#{file_name}") }
-      let!(:download_file) do
-        FileUtils.rm_f(file_path)
-        response.stream.each do |e|
-          File.write(file_path, e.force_encoding('UTF-8'))
+    context 'when attachment is available', :enable_download_access do
+      context 'when attachment is image and not annotated' do
+        before do
+          execute
+          download_file
         end
-        response.stream.close
-      end
 
-      it 'returns correct statuscode' do
-        expect(response).to have_http_status :ok
-      end
-
-      it 'zip file contains 2 files' do
-        Zip::File.open(file_path) do |entry|
-          expect(entry.entries.length).to be 2
+        it 'returns correct statuscode' do
+          expect(response).to have_http_status :ok
         end
-      end
 
-      it 'image has correct size' do
-        Zip::File.open(file_path) do |entry|
-          entry.entries.each do |inner_entry|
-            expect(inner_entry.compressed_size).to be 163_143 if inner_entry.name == 'upload.jpg'
+        it 'zip file contains 2 files' do
+          Zip::File.open(file_path) do |entry|
+            expect(entry.entries.length).to be 2
+          end
+        end
+
+        it 'image has correct size' do
+          Zip::File.open(file_path) do |entry|
+            entry.entries.each do |inner_entry|
+              expect(inner_entry.compressed_size).to be 163_143 if inner_entry.name == 'upload.jpg'
+            end
+          end
+        end
+
+        it 'description has correct size' do
+          Zip::File.open(file_path) do |entry|
+            entry.entries.each do |inner_entry|
+              expect(inner_entry.compressed_size).to be 110 if inner_entry.name == 'dataset_description.txt'
+            end
           end
         end
       end
 
-      it 'description has correct size' do
-        Zip::File.open(file_path) do |entry|
-          entry.entries.each do |inner_entry|
-            expect(inner_entry.compressed_size).to be 110 if inner_entry.name == 'dataset_description.txt'
+      context 'when attachment is image and annotated' do
+        let(:sample2) { create(:sample_with_annotated_image_in_analysis) }
+        let(:attachment) { sample2.container.children[0].children[0].attachments.first }
+        let(:execute) { get "/api/v1/attachments/zip/#{sample2.container.children[0].children[0].id}" }
+        let(:update_annotation) do
+          updater = Usecases::Attachments::Annotation::AnnotationUpdater.new(ThumbnailerMock.new)
+          updater.update_annotation(
+            Rails.root.join('spec/fixtures/annotations/20221207_valide_annotation_edited.svg').read, attachment.id
+          )
+        end
+
+        before do
+          update_annotation
+          execute
+          download_file
+        end
+
+        it 'returns correct statuscode' do
+          expect(response).to have_http_status :ok
+        end
+
+        it 'zip file contains 3 files' do
+          Zip::File.open(file_path) do |entry|
+            expect(entry.entries.length).to be 3
           end
         end
       end
-    end
-
-    context 'when attachment is image and annotated' do
-      pending 'not yet implemented'
     end
   end
 
@@ -640,6 +673,12 @@ describe Chemotion::AttachmentAPI do
         end
       end
     end
+  end
+end
+
+class ThumbnailerMock
+  def create_thumbnail(tmp_path)
+    tmp_path
   end
 end
 # rubocop:enable Rspec/NestedGroups

--- a/spec/api/chemotion/attachment_api_spec.rb
+++ b/spec/api/chemotion/attachment_api_spec.rb
@@ -282,7 +282,66 @@ describe Chemotion::AttachmentAPI do
   end
 
   describe 'GET /api/v1/attachments/zip/{container_id}' do
-    pending 'not yet implemented'
+    let(:container_id) { sample.container.children[0].children[0].id }
+    let(:sample) { create(:sample_with_image_in_analysis) }
+
+    before do |example|
+      if example.metadata[:enable_download_access].present?
+        allow_any_instance_of(ElementPolicy).to receive(:read?).and_return(true)
+        allow_any_instance_of(ElementPermissionProxy).to receive(:read_dataset?).and_return(true)
+
+      end
+
+      get "/api/v1/attachments/zip/#{container_id}"
+    end
+
+    context 'when attachment is not available' do
+      it 'returns error' do
+        expect(response).to have_http_status :unauthorized
+      end
+    end
+
+    context 'when attachment is image and not annotated', :enable_download_access do
+      let(:file_name) { response.header['Content-Disposition'].split('=').last.tr('"', '') }
+      let(:file_path) { Rails.root.join("public/zip/#{file_name}") }
+      let!(:download_file) do
+        FileUtils.rm_f(file_path)
+        response.stream.each do |e|
+          File.write(file_path, e.force_encoding('UTF-8'))
+        end
+        response.stream.close
+      end
+
+      it 'returns correct statuscode' do
+        expect(response).to have_http_status :ok
+      end
+
+      it 'zip file contains 2 files' do
+        Zip::File.open(file_path) do |entry|
+          expect(entry.entries.length).to be 2
+        end
+      end
+
+      it 'image has correct size' do
+        Zip::File.open(file_path) do |entry|
+          entry.entries.each do |inner_entry|
+            expect(inner_entry.compressed_size).to be 163_143 if inner_entry.name == 'upload.jpg'
+          end
+        end
+      end
+
+      it 'description has correct size' do
+        Zip::File.open(file_path) do |entry|
+          entry.entries.each do |inner_entry|
+            expect(inner_entry.compressed_size).to be 110 if inner_entry.name == 'dataset_description.txt'
+          end
+        end
+      end
+    end
+
+    context 'when attachment is image and annotated' do
+      pending 'not yet implemented'
+    end
   end
 
   describe 'GET /api/v1/attachments/sample_analyses/{sample_id}' do

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -58,10 +58,11 @@ FactoryBot.define do
     trait :with_annotation do
       filename { 'upload.jpg' }
       file_path { Rails.root.join('spec/fixtures/upload.jpg') }
-      
+
       after(:create) do |attachment|
-        attachment.attachment_data["derivatives"]["annotation"]["annotated_file_location"]=attachment.attachment.id
-        attachment.update_columns(attachment_data: attachment.attachment_data)
+        attachment.attachment_data['derivatives']['annotation']['annotated_file_location'] = attachment.attachment.id
+
+        attachment.update_columns(attachment_data: attachment.attachment_data) # rubocop:disable Rails/SkipsModelValidations
       end
     end
 

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -58,9 +58,10 @@ FactoryBot.define do
     trait :with_annotation do
       filename { 'upload.jpg' }
       file_path { Rails.root.join('spec/fixtures/upload.jpg') }
+      
       after(:create) do |attachment|
-        attachment.attachment_data["derivatives"]["annotation"]["annotated_file_location"]
-          =attachment.attachment.id
+        attachment.attachment_data["derivatives"]["annotation"]["annotated_file_location"]=attachment.attachment.id
+        attachment.update_columns(attachment_data: attachment.attachment_data)
       end
     end
 

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -55,22 +55,12 @@ FactoryBot.define do
       file_path { Rails.root.join('spec/fixtures/upload.tif') }
     end
 
-    # TODO: fix this trait - cant be used atm
     trait :with_annotation do
       filename { 'upload.jpg' }
-      FileUtils.cp(Rails.root.join('spec/fixtures/upload.jpg'), '/tmp/tmp.jpg')
-      FileUtils.cp(Rails.root.join('spec/fixtures/upload.svg'), '/tmp/tmp.svg')
-      attachment_data do
-        {
-          'id' => '/tmp/tmp.svg',
-          'storage' => 'store',
-          'derivatives' => {
-            'annotation' => {
-              'id' => File.join('/tmp/tmp.svg'),
-              'storage' => 'store',
-            },
-          },
-        }
+      file_path { Rails.root.join('spec/fixtures/upload.jpg') }
+      after(:create) do |attachment|
+        attachment.attachment_data["derivatives"]["annotation"]["annotated_file_location"]
+          =attachment.attachment.id
       end
     end
 

--- a/spec/factories/samples.rb
+++ b/spec/factories/samples.rb
@@ -47,4 +47,23 @@ FactoryBot.define do
       sample.molecule = FactoryBot.build(:molecule) unless sample.molecule
     end
   end
+
+  factory :sample_with_image_in_analysis, class: Sample do
+    sequence(:name) { |i| "Sample #{i}" }
+
+    target_amount_value { 100 }
+    target_amount_unit { 'mg' }
+    callback(:before_create) do |sample|
+      user =  sample.creator || FactoryBot.create(:user)
+      sample.creator = user
+      sample.collections << FactoryBot.build(:collection) # if sample.collections.blank?
+      sample.molecule = FactoryBot.create(:molecule) unless sample.molecule || sample.molfile
+      sample.container = FactoryBot.create(:container, :with_analysis) unless sample.container
+      attachment = FactoryBot.create(:attachment, :with_image,
+        attachable_id: sample.container.children[0].children[0],
+        created_for: user.id,
+        attachable_type: 'Container')
+        sample.container.children[0].children[0].attachments<<attachment;
+    end
+  end
 end

--- a/spec/factories/samples.rb
+++ b/spec/factories/samples.rb
@@ -78,7 +78,7 @@ FactoryBot.define do
       sample.collections << FactoryBot.build(:collection) # if sample.collections.blank?
       sample.molecule = FactoryBot.create(:molecule) unless sample.molecule || sample.molfile
       sample.container = FactoryBot.create(:container, :with_analysis) unless sample.container
-      attachment = FactoryBot.create(:attachment, :with_annotation,
+      attachment = FactoryBot.create(:attachment, :with_png_image,
         attachable_id: sample.container.children[0].children[0],
         created_for: user.id,
         attachable_type: 'Container')

--- a/spec/factories/samples.rb
+++ b/spec/factories/samples.rb
@@ -66,4 +66,23 @@ FactoryBot.define do
         sample.container.children[0].children[0].attachments<<attachment;
     end
   end
+
+  factory :sample_with_annotated_image_in_analysis, class: Sample do
+    sequence(:name) { |i| "Sample #{i}" }
+
+    target_amount_value { 100 }
+    target_amount_unit { 'mg' }
+    callback(:before_create) do |sample|
+      user =  sample.creator || FactoryBot.create(:user)
+      sample.creator = user
+      sample.collections << FactoryBot.build(:collection) # if sample.collections.blank?
+      sample.molecule = FactoryBot.create(:molecule) unless sample.molecule || sample.molfile
+      sample.container = FactoryBot.create(:container, :with_analysis) unless sample.container
+      attachment = FactoryBot.create(:attachment, :with_annotation,
+        attachable_id: sample.container.children[0].children[0],
+        created_for: user.id,
+        attachable_type: 'Container')
+        sample.container.children[0].children[0].attachments<<attachment;
+    end
+  end
 end

--- a/spec/factories/samples.rb
+++ b/spec/factories/samples.rb
@@ -72,17 +72,19 @@ FactoryBot.define do
 
     target_amount_value { 100 }
     target_amount_unit { 'mg' }
+
     callback(:before_create) do |sample|
       user =  sample.creator || FactoryBot.create(:user)
       sample.creator = user
       sample.collections << FactoryBot.build(:collection) # if sample.collections.blank?
       sample.molecule = FactoryBot.create(:molecule) unless sample.molecule || sample.molfile
       sample.container = FactoryBot.create(:container, :with_analysis) unless sample.container
-      attachment = FactoryBot.create(:attachment, :with_png_image,
-        attachable_id: sample.container.children[0].children[0],
+
+      attachment = FactoryBot.create(:attachment, :with_annotation,
+        attachable_id: sample.container.children[0].children[0].id,
         created_for: user.id,
-        attachable_type: 'Container')
-        sample.container.children[0].children[0].attachments<<attachment;
+        attachable_type: 'Container'
+      )
     end
   end
 end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -308,13 +308,12 @@ RSpec.describe Attachment do
     end
   end
 
-  # TODO: fix with_annotation factory: currently this test deletes the attached file
   describe 'annotated?' do
     let(:annotated_attachment) { create(:attachment, :with_annotation) }
     let(:unannotated_attachment) { create(:attachment) }
 
-    xit 'returns true if the attachment is annotated, or false if not' do
-      expect(puts(annotated_attachment.attachment_attacher.derivatives) && annotated_attachment.annotated?).to be true
+    it 'returns true if the attachment is annotated, or false if not' do
+      expect(annotated_attachment.annotated?).to be true
       expect(unannotated_attachment.annotated?).to be false
     end
   end
@@ -853,7 +852,7 @@ RSpec.describe Attachment do
       it 'returns the result of #auto_infer_n_clear_json' do
         expect(attachment).to receive(:auto_infer_n_clear_json).with('MS', false)
 
-        attachment.update_prediction(params = { foo: :bar }, spc_type = 'MS', is_regen = false)
+        attachment.update_prediction({ foo: :bar }, 'MS', false)
       end
     end
 
@@ -865,7 +864,7 @@ RSpec.describe Attachment do
       it 'calls #write_infer_to_file with the value of params["predict"]' do
         expect(attachment).to receive(:write_infer_to_file).with('foobar')
 
-        attachment.update_prediction(params = { 'predict' => 'foobar' }, spc_type = 'foo', is_regen = false)
+        attachment.update_prediction({ 'predict' => 'foobar' }, 'foo', false)
       end
     end
   end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -70,13 +70,13 @@ RSpec.describe Attachment do
   end
 
   describe '#for_container?' do
-    subject { attachment.for_container? }
+    subject(:for_container) { attachment.for_container? }
 
     context 'when not attached to container' do
       let(:attachment) { create(:attachment, :attached_to_research_plan) }
 
       it 'returns false' do
-        expect(subject).to be(false)
+        expect(for_container).to be(false)
       end
     end
 
@@ -84,7 +84,7 @@ RSpec.describe Attachment do
       let(:attachment) { create(:attachment, :attached_to_container) }
 
       it 'returns true' do
-        expect(subject).to be(true)
+        expect(for_container).to be(true)
       end
     end
   end
@@ -186,7 +186,7 @@ RSpec.describe Attachment do
       let(:old_file_content) { 'Foo Bar' }
       let(:attachment) { create(:attachment, file_data: old_file_content) }
 
-      let(:new_file_path) { File.join("#{Rails.root}/spec/fixtures/upload.txt") }
+      let(:new_file_path) { Rails.root.join('spec/fixtures/upload.txt') }
       let(:new_file_content) { File.binread(new_file_path) }
 
       it 'overwrites the attachment file with the new file' do
@@ -329,7 +329,7 @@ RSpec.describe Attachment do
       # Thumbnails are only generated when a file is attached, having file_data does not suffice
 
       context 'when the file is not thumbnailable' do
-        let(:attachment) { create(:attachment, file_path: Rails.root.join('spec', 'fixtures', 'upload.txt')) }
+        let(:attachment) { create(:attachment, file_path: Rails.root.join('spec/fixtures/upload.txt')) }
 
         it 'saves the file' do
           expect(attachment.read_file).not_to be_nil

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable RSpec/NestedGroups
+# rubocop:disable RSpec/MessageSpies
 
 require 'rails_helper'
 
@@ -607,7 +608,7 @@ RSpec.describe Attachment do
   describe '#generate_att' do
     let(:attachment) { build(:attachment) }
     let(:ext) { 'jpg' }
-    let(:new_attachment) { attachment.generate_att(tempfile, addon = 'foo', to_edit = false, ext) }
+    let(:new_attachment) { attachment.generate_att(tempfile, 'foo', false, ext) }
 
     context 'without tempfile' do
       let(:tempfile) { nil }
@@ -648,7 +649,7 @@ RSpec.describe Attachment do
 
       context 'with spectra file and to_edit = true' do
         let(:attachment) { create(:attachment, :with_spectra_file) }
-        let(:new_attachment) { attachment.generate_att(tempfile, addon = nil, to_edit = true) }
+        let(:new_attachment) { attachment.generate_att(tempfile, nil, true) }
 
         it 'sets the new attachment\'s aasm_state to edited' do
           expect(new_attachment.edited?).to be true
@@ -919,3 +920,4 @@ RSpec.describe Attachment do
 end
 
 # rubocop:enable RSpec/NestedGroups
+# rubocop:enable RSpec/MessageSpies


### PR DESCRIPTION

This pull request will fix the bug https://github.com/ComPlat/chemotion_ELN/issues/1340 .

It will add annotated images into the zip folder if user downloads a container dataset.
