### PR TITLE
Fix bug in `Export reaction from selection`

### DIFF
--- a/app/packs/src/components/contextActions/ModalReactionExport.js
+++ b/app/packs/src/components/contextActions/ModalReactionExport.js
@@ -71,7 +71,7 @@ const exportSelections = (uiState, userState, e) => {
   ReportsFetcher.createDownloadFile({
     exportType: e,
     uiState: filterUIState(uiState),
-    columns: []
+    columns: {}
   }, '', 'export_reactions_from_selections');
 }
 


### PR DESCRIPTION
How to reproduce the bug:
* select a collection as well as one or multiple reactions from that collection
* click `Export reactions from selection` in the upper task bar / menu
* click `Smiles Export` in the  `Reaction Smiles Export` modal that's popping up
* the generated file is empty except for "{"error":"columns is invalid"}"

Once the bug is fixed (see diff in this PR), repeat the procedure above.
Now the generated file contains the expected Smiles output.