### PR TITLE
Expose target amount in sample task api

### DIFF
--- a/app/api/entities/sample_task_entity.rb
+++ b/app/api/entities/sample_task_entity.rb
@@ -14,13 +14,22 @@ module Entities
     expose :sample_svg_file
     expose :short_label
     expose :scan_results, using: 'Entities::ScanResultEntity'
+    expose :target_amount_value
+    expose :target_amount_unit
     expose :done
 
     expose_timestamps
 
     private
 
-    delegate(:short_label, :sample_svg_file, to: :'object.sample', allow_nil: true)
+    delegate(
+      :short_label,
+      :sample_svg_file,
+      :target_amount_value,
+      :target_amount_unit,
+      to: :'object.sample',
+      allow_nil: true
+    )
 
     def display_name
       object.sample&.showed_name

--- a/app/api/entities/sample_task_entity.rb
+++ b/app/api/entities/sample_task_entity.rb
@@ -28,7 +28,7 @@ module Entities
       :target_amount_value,
       :target_amount_unit,
       to: :'object.sample',
-      allow_nil: true
+      allow_nil: true,
     )
 
     def display_name


### PR DESCRIPTION
The target amount for the given sample should be displayed in the Chemobile app.
So we need to expose the field via api.