### PR TITLE
adding missing asterisks while signing up

### DIFF
--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -13,14 +13,14 @@
       = f.email_field :email, autofocus: true, class: 'form-control', required: true, readonly: !resource.password_required?
     - if resource.password_required?
       .form-group.field
-        = f.label :password
+        = f.label :password, 'Password *'
         - if @validatable
           %em
             (#{@minimum_password_length} characters minimum)
         %br/
         = f.password_field :password, autocomplete: "off", class: 'form-control'
       .form-group.field
-        = f.label :password_confirmation
+        = f.label :password_confirmation, 'Password confirmation *'
         %br/
         = f.password_field :password_confirmation, autocomplete: "off", class: 'form-control'
     .form-group.field


### PR DESCRIPTION
- adding asterisks for the Password and Password confirmation fields-

Before:

![](https://cdn.discordapp.com/attachments/1119247770864328788/1123267683421540503/image.png)

After:

![](https://cdn.discordapp.com/attachments/1119247770864328788/1123267790082683020/image.png)
