### PR TITLE
Add delayed job worker to tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,6 +15,11 @@
       "command": "RAILS_ENV=test $(which bundle) exec rails server -b 0.0.0.0 -p 3000"
     },
     {
+      "label": "Rails - delayed job worker",
+      "type": "shell",
+      "command": "RAILS_ENV=development $(which bundle) exec rake jobs:work"
+    },
+    {
       "label": "RSpec - all",
       "type": "shell",
       "command": "RAILS_ENV=test $(which bundle) exec rspec"


### PR DESCRIPTION
Enabled starting the delayed job worker in the devcontainer; doesn't require a separate / additional container during development.