### PR TITLE
Unify datetime format

### DIFF
--- a/app/api/chemotion/message_api.rb
+++ b/app/api/chemotion/message_api.rb
@@ -124,8 +124,7 @@ module Chemotion
             message_from: current_user.id,
             message_to: params[:user_ids]
           )
-
-          present message, with: Entities::MessageEntity, root: :message
+          status 204 if message
         end
       end
     end

--- a/app/api/entities/application_entity.rb
+++ b/app/api/entities/application_entity.rb
@@ -5,6 +5,7 @@ module Entities
     CUSTOM_ENTITY_OPTIONS = %i[anonymize_below anonymize_with].freeze
 
     format_with(:eln_timestamp) do |datetime|
+      # datetime.present? ? I18n.l(datetime, format: :eln_iso8601) : nil
       datetime.present? ? I18n.l(datetime, format: :eln_timestamp) : nil
     end
 

--- a/app/api/entities/channel_entity.rb
+++ b/app/api/entities/channel_entity.rb
@@ -2,18 +2,11 @@
 
 module Entities
   # Publish-Subscription Entities
-  class ChannelEntity < Grape::Entity
+  class ChannelEntity < ApplicationEntity
     expose :id, :subject, :channel_type
-    expose :created_at, :updated_at
     expose :msg_template, if: ->(obj, _opts) { obj.respond_to? :msg_template }
     expose :user_id, if: ->(obj, _opts) { obj.respond_to? :user_id }
 
-    def created_at
-      object.created_at.strftime('%d.%m.%Y, %H:%M:%S')
-    end
-
-    def updated_at
-      object.updated_at.strftime('%d.%m.%Y, %H:%M:%S')
-    end
+    expose_timestamps
   end
 end

--- a/app/api/entities/comment_entity.rb
+++ b/app/api/entities/comment_entity.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Entities
-  class CommentEntity < Grape::Entity
+  class CommentEntity < ApplicationEntity
     expose :id
     expose :content
     expose :created_by
@@ -9,7 +9,8 @@ module Entities
     expose :status
     expose :submitter
     expose :resolver_name
-    expose :created_at, :updated_at
     expose :commentable_id, :commentable_type
+
+    expose_timestamps
   end
 end

--- a/app/api/entities/device_metadata_entity.rb
+++ b/app/api/entities/device_metadata_entity.rb
@@ -20,5 +20,13 @@ module Entities
     expose :data_cite_created_at, documentation: { type: 'DateTime', desc: 'created_at DataCite ' }
     expose :data_cite_updated_at, documentation: { type: 'DateTime', desc: 'updated_at DataCite' }
     expose :data_cite_version, documentation: { type: 'Integer', desc: 'version at DataCite' }
+
+    def data_cite_created_at
+      object.data_cite_created_at.present? ? I18n.l(object.data_cite_created_at, format: :eln_timestamp) : nil
+    end
+
+    def data_cite_updated_at
+      object.data_cite_updated_at.present? ? I18n.l(object.data_cite_updated_at, format: :eln_timestamp) : nil
+    end
   end
 end

--- a/app/api/entities/inbox_entity.rb
+++ b/app/api/entities/inbox_entity.rb
@@ -34,7 +34,7 @@ module Entities
           name: container.name,
           container_type: container.container_type,
           attachments: current_attachments,
-          created_at: container.created_at,
+          created_at: I18n.l(container.created_at, format: :eln_timestamp),
           children: serialize_children(subcontainers).compact,
         }
       end

--- a/app/api/entities/matrice_entity.rb
+++ b/app/api/entities/matrice_entity.rb
@@ -1,6 +1,8 @@
 module Entities
-  class MatriceEntity < Grape::Entity
-    expose :id, :enabled, :name, :label, :include_ids, :exclude_ids, :created_at, :updated_at, :include_users, :exclude_users, :configs
+  class MatriceEntity < ApplicationEntity
+    expose :id, :enabled, :name, :label, :include_ids, :exclude_ids, :include_users, :exclude_users, :configs
+
+    expose_timestamps
 
     def include_users
       [] if object&.include_ids.nil?

--- a/app/api/entities/message_entity.rb
+++ b/app/api/entities/message_entity.rb
@@ -2,18 +2,11 @@
 
 module Entities
   # Publish-Subscription Entities
-  class MessageEntity < Grape::Entity
+  class MessageEntity < ApplicationEntity
     expose :id, :message_id
     expose :subject, :content, :channel_type
     expose :sender_id, :sender_name, :receiver_id, :is_ack
-    expose :created_at, :updated_at
 
-    def created_at
-      object.created_at.strftime('%d.%m.%Y, %H:%M:%S')
-    end
-
-    def updated_at
-      object.updated_at.strftime('%d.%m.%Y, %H:%M:%S')
-    end
+    expose_timestamps
   end
 end

--- a/app/api/entities/private_note_entity.rb
+++ b/app/api/entities/private_note_entity.rb
@@ -3,19 +3,12 @@
 module Entities
 
   # Publish-Subscription Entities
-  class PrivateNoteEntity < Grape::Entity
+  class PrivateNoteEntity < ApplicationEntity
     expose :id
     expose :content
     expose :created_by
-    expose :created_at, :updated_at
     expose :noteable_id, :noteable_type
 
-    def created_at
-      object.created_at&.strftime('%d.%m.%Y, %H:%M')
-    end
-
-    def updated_at
-      object.updated_at&.strftime('%d.%m.%Y, %H:%M')
-    end
+    expose_timestamps
   end
 end

--- a/app/packs/src/apps/admin/GroupsDevices.js
+++ b/app/packs/src/apps/admin/GroupsDevices.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import { Modal, Panel, Table, Button, FormGroup, ControlLabel, Form, Tooltip, FormControl, OverlayTrigger, Col, Row } from 'react-bootstrap';
 import Select from 'react-select';
-import moment from 'moment';
 import { findIndex, filter } from 'lodash';
 import AdminFetcher from 'src/fetchers/AdminFetcher';
 import { selectUserOptionFormater } from 'src/utilities/selectHelper';
 
 import AdminGroupElement from 'src/apps/admin/AdminGroupElement';
 import AdminDeviceElement from 'src/apps/admin/AdminDeviceElement';
+import { formatDate } from 'src/utilities/timezoneHelper';
+
 export default class GroupsDevices extends React.Component {
   constructor(props) {
     super(props);
@@ -700,7 +701,7 @@ export default class GroupsDevices extends React.Component {
                   <Col smOffset={0} sm={12}>
                     <p className="text-right">
                       DataCiteVersion: {deviceMetadata.data_cite_version}<br />
-                      DataCiteUpdatedAt: {moment(deviceMetadata.data_cite_updated_at).format('YYYY-MM-DD HH:mm')}<br />
+                      DataCiteUpdatedAt: {formatDate(deviceMetadata.data_cite_updated_at)}<br />
                     </p>
                   </Col>
                 </Row>

--- a/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -38,6 +38,7 @@ import HeaderCommentSection from 'src/components/comments/HeaderCommentSection';
 import CommentSection from 'src/components/comments/CommentSection';
 import CommentActions from 'src/stores/alt/actions/CommentActions';
 import CommentModal from 'src/components/common/CommentModal';
+import { formatTimeStampsOfElement } from 'src/utilities/timezoneHelper';
 
 export default class ReactionDetails extends Component {
   constructor(props) {
@@ -254,7 +255,7 @@ export default class ReactionDetails extends Component {
 
   reactionHeader(reaction) {
     const hasChanged = reaction.changed ? '' : 'none';
-    const titleTooltip = `Created at: ${reaction.created_at} \n Updated at: ${reaction.updated_at}`;
+    const titleTooltip = formatTimeStampsOfElement(reaction || {});
 
     const { currentCollection } = UIStore.getState();
     const defCol = currentCollection && currentCollection.is_shared === false &&

--- a/app/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
@@ -30,6 +30,7 @@ import HeaderCommentSection from 'src/components/comments/HeaderCommentSection';
 import CommentSection from 'src/components/comments/CommentSection';
 import CommentActions from 'src/stores/alt/actions/CommentActions';
 import CommentModal from 'src/components/common/CommentModal';
+import { formatTimeStampsOfElement } from 'src/utilities/timezoneHelper';
 
 export default class ResearchPlanDetails extends Component {
   constructor(props) {
@@ -454,7 +455,7 @@ export default class ResearchPlanDetails extends Component {
   } /* eslint-enable */
 
   renderPanelHeading(researchPlan) {
-    const titleTooltip = `Created at: ${researchPlan.created_at} \n Updated at: ${researchPlan.updated_at}`;
+    const titleTooltip = formatTimeStampsOfElement(researchPlan || {});
 
     return (
       <Panel.Heading>

--- a/app/packs/src/apps/mydb/elements/details/researchPlans/wellplatesTab/EmbeddedWellplate.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/wellplatesTab/EmbeddedWellplate.js
@@ -7,6 +7,7 @@ import { wellplateShowOrNew } from 'src/utilities/routesUtils';
 import ElementCollectionLabels from 'src/apps/mydb/elements/labels/ElementCollectionLabels';
 import ResearchPlan from 'src/models/ResearchPlan';
 import Wellplate from 'src/models/Wellplate';
+import { formatTimeStampsOfElement } from 'src/utilities/timezoneHelper';
 
 export default class EmbeddedWellplate extends Component {
   constructor(props) {
@@ -167,7 +168,7 @@ export default class EmbeddedWellplate extends Component {
 
   renderPanelHeading(wellplate) {
     const { deleteWellplate } = this.props;
-    const titleTooltip = `Created at: ${wellplate.created_at} \n Updated at: ${wellplate.updated_at}`;
+    const titleTooltip = formatTimeStampsOfElement(wellplate || {});
     const expandIconClass = this.state.expanded ? 'fa fa-compress' : 'fa fa-expand';
 
     const popover = (

--- a/app/packs/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/packs/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -72,6 +72,7 @@ import HeaderCommentSection from 'src/components/comments/HeaderCommentSection';
 import CommentSection from 'src/components/comments/CommentSection';
 import CommentActions from 'src/stores/alt/actions/CommentActions';
 import CommentModal from 'src/components/common/CommentModal';
+import { formatTimeStampsOfElement } from 'src/utilities/timezoneHelper';
 
 const MWPrecision = 6;
 
@@ -510,7 +511,7 @@ export default class SampleDetails extends React.Component {
 
   sampleHeader(sample) {
     const saveBtnDisplay = sample.isEdited ? '' : 'none';
-    const titleTooltip = `Created at: ${sample.created_at} \n Updated at: ${sample.updated_at}`;
+    const titleTooltip = formatTimeStampsOfElement(sample || {});
 
     const { currentCollection } = UIStore.getState();
     const defCol = currentCollection && currentCollection.is_shared === false &&

--- a/app/packs/src/apps/mydb/elements/details/screens/ScreenDetails.js
+++ b/app/packs/src/apps/mydb/elements/details/screens/ScreenDetails.js
@@ -30,6 +30,7 @@ import HeaderCommentSection from 'src/components/comments/HeaderCommentSection';
 import CommentSection from 'src/components/comments/CommentSection';
 import CommentActions from 'src/stores/alt/actions/CommentActions';
 import CommentModal from 'src/components/common/CommentModal';
+import { formatTimeStampsOfElement } from 'src/utilities/timezoneHelper';
 
 export default class ScreenDetails extends Component {
   constructor(props) {
@@ -178,7 +179,7 @@ export default class ScreenDetails extends Component {
 
   screenHeader(screen) {
     const saveBtnDisplay = screen.isEdited ? '' : 'none';
-    const datetp = `Created at: ${screen.created_at} \n Updated at: ${screen.updated_at}`;
+    const datetp = formatTimeStampsOfElement(screen || {});
     const { showCommentSection, comments } = this.props;
 
     return (

--- a/app/packs/src/apps/mydb/elements/details/screens/researchPlansTab/EmbeddedResearchPlanDetails.js
+++ b/app/packs/src/apps/mydb/elements/details/screens/researchPlansTab/EmbeddedResearchPlanDetails.js
@@ -9,6 +9,7 @@ import ResearchPlansFetcher from 'src/fetchers/ResearchPlansFetcher';
 import ResearchPlan from 'src/models/ResearchPlan';
 import ResearchPlanDetailsBody from 'src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsBody';
 import ResearchPlanDetailsName from 'src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsName';
+import { formatTimeStampsOfElement } from 'src/utilities/timezoneHelper';
 
 const InfoLabel = ({ iconClass, text, style, tooltip }) => {
   style ||= 'info'
@@ -238,7 +239,7 @@ export default class EmbeddedResearchPlanDetails extends Component {
 
   renderPanelHeading(researchPlan) {
     const { deleteResearchPlan, saveResearchPlan } = this.props;
-    const titleTooltip = `Created at: ${researchPlan.created_at} \n Updated at: ${researchPlan.updated_at}`;
+    const titleTooltip = formatTimeStampsOfElement(researchPlan || {});
     const expandIconClass = this.state.expanded ? 'fa fa-compress' : 'fa fa-expand';
 
     const popover = (

--- a/app/packs/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
+++ b/app/packs/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
@@ -30,6 +30,7 @@ import HeaderCommentSection from 'src/components/comments/HeaderCommentSection';
 import CommentSection from 'src/components/comments/CommentSection';
 import CommentActions from 'src/stores/alt/actions/CommentActions';
 import CommentModal from 'src/components/common/CommentModal';
+import { formatTimeStampsOfElement } from 'src/utilities/timezoneHelper';
 
 const cols = 12;
 
@@ -219,7 +220,7 @@ export default class WellplateDetails extends Component {
 
   wellplateHeader(wellplate) {
     const saveBtnDisplay = wellplate.isEdited ? '' : 'none';
-    const datetp = `Created at: ${wellplate.created_at} \n Updated at: ${wellplate.updated_at}`;
+    const datetp = formatTimeStampsOfElement(wellplate || {});
     const { showCommentSection, comments } = this.props;
 
     return (

--- a/app/packs/src/apps/mydb/inbox/AttachmentContainer.js
+++ b/app/packs/src/apps/mydb/inbox/AttachmentContainer.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
 import { DragSource } from 'react-dnd';
 import { Button, ButtonGroup, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import InboxActions from 'src/stores/alt/actions/InboxActions';
@@ -10,6 +9,7 @@ import Utils from 'src/utilities/Functions';
 import MoveToAnalysisButton from 'src/apps/mydb/inbox/MoveToAnalysisButton';
 import InboxStore from 'src/stores/alt/stores/InboxStore';
 import ArrayUtils from 'src/utilities/ArrayUtils';
+import { formatDate } from 'src/utilities/timezoneHelper';
 
 const dataSource = {
   beginDrag(props) {
@@ -160,7 +160,7 @@ class AttachmentContainer extends Component {
           </span>
         </OverlayTrigger>
         <span className="text-info" style={{ float: 'right', display: largerInbox ? '' : 'none' }}>
-          {moment(attachment.created_at).format('DD.MM.YYYY HH:mm')}
+          {formatDate(attachment.created_at)}
         </span>
       </div>,
       { dropEffect: 'move' }

--- a/app/packs/src/apps/mydb/inbox/DatasetContainer.js
+++ b/app/packs/src/apps/mydb/inbox/DatasetContainer.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
 import { DragSource } from 'react-dnd';
 import { Button, ButtonGroup, Tooltip } from 'react-bootstrap';
 import AttachmentContainer from 'src/apps/mydb/inbox/AttachmentContainer';
 import DragDropItemTypes from 'src/components/DragDropItemTypes';
 import InboxActions from 'src/stores/alt/actions/InboxActions';
+import { formatDate } from 'src/utilities/timezoneHelper';
 
 const dataSource = {
   beginDrag(props) {
@@ -128,7 +128,7 @@ class DatasetContainer extends Component {
               <span style={{ marginLeft: '8px' }}>{dataset.name}</span>
             </button>
             <span className="text-info" style={{ float: 'right', display: largerInbox ? '' : 'none' }}>
-              {moment(dataset.created_at).format('DD.MM.YYYY HH:mm')}
+              {formatDate(dataset.created_at)}
             </span>
           </div>
           <div>{visible ? attachments : null}</div>

--- a/app/packs/src/components/comments/CommentDetails.js
+++ b/app/packs/src/components/comments/CommentDetails.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Button, ButtonToolbar, Table } from 'react-bootstrap';
-import moment from 'moment';
 import UserStore from 'src/stores/alt/stores/UserStore';
 import { formatSection, getAllComments, selectCurrentUser } from 'src/utilities/CommentHelper';
 import CommentStore from 'src/stores/alt/stores/CommentStore';
 import DeleteComment from 'src/components/common/DeleteComment';
+import { formatDate } from 'src/utilities/timezoneHelper';
 
 export default class CommentDetails extends Component {
   constructor(props) {
@@ -50,7 +50,7 @@ export default class CommentDetails extends Component {
           <td width="10%">{formatSection(comment.section, element.type)}</td>
           <td width="10%">
             <span className="text-info">
-              {moment(comment.created_at).format('DD.MM.YYYY HH:mm')}
+              {formatDate(comment.created_at)}
             </span>
           </td>
           <td width="34%">{comment.content}</td>

--- a/app/packs/src/components/comments/CommentList.js
+++ b/app/packs/src/components/comments/CommentList.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Table } from 'react-bootstrap';
-import moment from 'moment';
 import CommentStore from 'src/stores/alt/stores/CommentStore';
 import { getSectionComments } from 'src/utilities/CommentHelper';
+import { formatDate } from 'src/utilities/timezoneHelper';
 
 export default function CommentList(props) {
   const { section } = props;
@@ -16,7 +16,7 @@ export default function CommentList(props) {
   if (sectionComments?.length > 0) {
     commentsTbl = sectionComments.map((comment) => (
       <tr key={comment.id}>
-        <td style={{ width: '15%' }}>{moment(comment.created_at).format('DD.MM.YYYY HH:mm')}</td>
+        <td style={{ width: '15%' }}>{formatDate(comment.created_at)}</td>
         <td style={{ width: '40%' }}>{comment.content}</td>
         <td style={{ width: '15%' }}>{comment.submitter}</td>
       </tr>

--- a/app/packs/src/components/common/CommentModal.js
+++ b/app/packs/src/components/common/CommentModal.js
@@ -4,7 +4,6 @@ import {
   Button, ButtonToolbar, FormControl, Glyphicon, Modal, Table
 } from 'react-bootstrap';
 import Draggable from 'react-draggable';
-import moment from 'moment';
 import CommentFetcher from 'src/fetchers/CommentFetcher';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
 import LoadingActions from 'src/stores/alt/actions/LoadingActions';
@@ -19,6 +18,7 @@ import {
   getSectionComments,
   selectCurrentUser,
 } from 'src/utilities/CommentHelper';
+import { formatDate } from 'src/utilities/timezoneHelper';
 
 export default class CommentModal extends Component {
   constructor(props) {
@@ -168,7 +168,7 @@ export default class CommentModal extends Component {
         <tr key={comment.id}>
           <td width="20%">
             <span className="text-info">
-              {moment(comment.created_at).format('DD.MM.YYYY HH:mm')}
+              {formatDate(comment.created_at)}
             </span>
           </td>
           <td width="35%">{comment.content}</td>

--- a/app/packs/src/components/contextActions/NoticeButton.js
+++ b/app/packs/src/components/contextActions/NoticeButton.js
@@ -12,7 +12,7 @@ import ReportActions from 'src/stores/alt/actions/ReportActions';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
 import CalendarActions from 'src/stores/alt/actions/CalendarActions';
 import InboxStore from 'src/stores/alt/stores/InboxStore';
-import formatDate from 'src/utilities/timezoneHelper';
+import { formatDate } from 'src/utilities/timezoneHelper';
 
 const changeUrl = (url, urlTitle) => (url ? (
   <a href={url} target="_blank" rel="noopener noreferrer">

--- a/app/packs/src/components/generic/GenericElDetails.js
+++ b/app/packs/src/components/generic/GenericElDetails.js
@@ -22,6 +22,7 @@ import { SegmentTabs } from 'src/components/generic/SegmentDetails';
 import PreviewModal from 'src/components/generic/PreviewModal';
 import GenericElsFetcher from 'src/fetchers/GenericElsFetcher';
 import OpenCalendarButton from 'src/components/calendar/OpenCalendarButton';
+import { formatTimeStampsOfElement } from 'src/utilities/timezoneHelper';
 
 export default class GenericElDetails extends Component {
   constructor(props) {
@@ -406,7 +407,7 @@ export default class GenericElDetails extends Component {
       <CopyElementModal element={genericEl} defCol={defCol} />
     ) : null;
     const saveBtnDisplay = genericEl.changed ? '' : 'none';
-    const datetp = `Created at: ${genericEl.created_at} \n Updated at: ${genericEl.updated_at}`;
+    const datetp = formatTimeStampsOfElement(genericEl || {});
     return (
       <div>
         <OverlayTrigger placement="bottom" overlay={<Tooltip id="genericElDatesx">{datetp}</Tooltip>}>

--- a/app/packs/src/components/navigation/UserAuth.js
+++ b/app/packs/src/components/navigation/UserAuth.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types'
 import 'whatwg-fetch';
 import { Nav, NavDropdown, NavItem, MenuItem, Glyphicon, Modal, Button, Table, Panel, Form, FormControl, FormGroup, ControlLabel, Col, Row } from 'react-bootstrap';
-import moment from 'moment';
 import _ from 'lodash';
 
 import UserActions from 'src/stores/alt/actions/UserActions';
@@ -14,6 +13,7 @@ import NotificationActions from 'src/stores/alt/actions/NotificationActions';
 import { UserLabelModal } from 'src/components/UserLabels';
 import MatrixCheck from 'src/components/common/MatrixCheck';
 import GroupElement from 'src/components/navigation/GroupElement';
+import { formatDate } from 'src/utilities/timezoneHelper';
 
 export default class UserAuth extends Component {
   constructor(props) {
@@ -539,7 +539,7 @@ export default class UserAuth extends Component {
                   <Col smOffset={0} sm={12}>
                     <p class="text-right">
                       DataCiteVersion: {deviceMetadata.data_cite_version}<br />
-                      DataCiteUpdatedAt: {moment(deviceMetadata.data_cite_updated_at).format('YYYY-MM-DD HH:mm')}<br />
+                      DataCiteUpdatedAt: {formatDate(deviceMetadata.data_cite_updated_at)}<br />
                     </p>
                   </Col>
                 </Row>

--- a/app/packs/src/utilities/timezoneHelper.js
+++ b/app/packs/src/utilities/timezoneHelper.js
@@ -10,4 +10,15 @@ const formatDate = (dateString) => {
   return formattedDate;
 };
 
-export default formatDate;
+// return `Created at: ${formattedCreatedAt} | Updated at: ${formattedUpdatedAt}`;
+const formatTimeStampsOfElement = (element) => {
+  const { created_at, updated_at } = element;
+  const formattedCreatedAt = formatDate(created_at);
+  const formattedUpdatedAt = formatDate(updated_at);
+  return `Created ${formattedCreatedAt} - Updated ${formattedUpdatedAt}`;
+};
+
+export {
+  formatDate,
+  formatTimeStampsOfElement,
+};

--- a/app/packs/src/utilities/timezoneHelper.js
+++ b/app/packs/src/utilities/timezoneHelper.js
@@ -1,11 +1,27 @@
 import moment from 'moment';
 
+// see config/locale/en.yml for the format
+const elnTimestampFormat = 'DD.MM.YYYY, HH:mm:ss Z';
+
+const regExpTimestamp = /^\d{2}\.\d{2}\.\d{4}, \d{2}:\d{2}:\d{2}/;
+
+const parseDate = (dateString) => {
+  if (regExpTimestamp.test(dateString)) {
+    const date = moment(dateString, elnTimestampFormat);
+    if (date.isValid()) {
+      return date;
+    }
+  }
+  // assume ISO 8601 format
+  return moment(dateString);
+};
+
 const formatDate = (dateString) => {
-  const date = moment(dateString, 'DD.MM.YYYY, HH:mm:ss Z');
+  const date = parseDate(dateString);
 
   const localDate = date.local();
 
-  const formattedDate = localDate.format('LLLL');
+  const formattedDate = localDate.format('llll');
 
   return formattedDate;
 };
@@ -19,6 +35,8 @@ const formatTimeStampsOfElement = (element) => {
 };
 
 export {
+  elnTimestampFormat,
+  parseDate,
   formatDate,
   formatTimeStampsOfElement,
 };

--- a/app/packs/src/utilities/timezoneHelper.js
+++ b/app/packs/src/utilities/timezoneHelper.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 const formatDate = (dateString) => {
-  const date = moment(dateString, 'DD.MM.YYYY, HH:mm Z');
+  const date = moment(dateString, 'DD.MM.YYYY, HH:mm:ss Z');
 
   const localDate = date.local();
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,7 +33,8 @@ en:
   hello: "Hello world"
   time:
     formats:
-      eln_timestamp: "%d.%m.%Y, %H:%M:%S %Z"
+      eln_timestamp: "%d.%m.%Y, %H:%M:%S %z"
+      eln_iso8601: "%Y-%m-%dT%H:%M:%S%z"
   activerecord:
     errors:
       models:

--- a/spec/javascripts/utils/timezoneHelper.spec.js
+++ b/spec/javascripts/utils/timezoneHelper.spec.js
@@ -1,12 +1,44 @@
 import expect from 'expect';
 import moment from 'moment';
-import formatDate from 'src/utilities/timezoneHelper';
+import {
+  elnTimestampFormat,
+  parseDate,
+  formatDate,
+  formatTimeStampsOfElement
+} from 'src/utilities/timezoneHelper';
+
+describe('parseDate', () => {
+  it('should return a valid moment instance when date is iso8601', () => {
+    const testDateString = '2023-07-03T07:53:37.123+0000';
+    const parsedDate = parseDate(testDateString);
+    expect(parsedDate.isValid()).toEqual(true);
+  });
+
+  it('should return a valid moment instance when date is not iso8601', () => {
+    const testDateString = '03.07.2023, 07:53:37 +0000';
+    const parsedDate = parseDate(testDateString);
+    expect(parsedDate.isValid()).toEqual(true);
+  });
+});
 
 describe('formatDate', () => {
   it('should correctly format the date', () => {
-    const testDate = moment().format('DD.MM.YYYY, HH:mm Z');
-    const expectedOutput = moment(testDate, 'DD.MM.YYYY, HH:mm Z').local().format('LLLL');
+    const testDate = moment().format(elnTimestampFormat);
+    const expectedOutput = moment(testDate, elnTimestampFormat).local().format('llll');
     const actualOutput = formatDate(testDate);
+
+    expect(actualOutput).toEqual(expectedOutput);
+  });
+});
+
+describe('formatTimeStampsOfElement', () => {
+  it('should correctly format the timestamps of an element', () => {
+    const testElement = {
+      created_at: moment().format(elnTimestampFormat),
+      updated_at: moment().format(elnTimestampFormat),
+    };
+    const expectedOutput = `Created ${moment(testElement.created_at, elnTimestampFormat).local().format('llll')} - Updated ${moment(testElement.updated_at, elnTimestampFormat).local().format('llll')}`;
+    const actualOutput = formatTimeStampsOfElement(testElement);
 
     expect(actualOutput).toEqual(expectedOutput);
   });


### PR DESCRIPTION
- use formatDate utility to format displayed timestamps
 (reduce the number of  'import  moment.js' )

- Entity: return time zone in timestamp

- more entities are now using  the same exposure (expose_timestamp) for timestamps

- shoudl resolve timezone diff in comment-feature  and notification-feature
