### PR TITLE
Calendar allday events not shown consistently

### DIFF
--- a/app/packs/src/components/calendar/Calendar.js
+++ b/app/packs/src/components/calendar/Calendar.js
@@ -100,7 +100,8 @@ function getWindowStyleOffsets(state) {
 
 const allDayAccessor = (event) => {
   if ((event.start && event.start.getHours() === 0 && event.start.getMinutes() === 0)
-  && (event.end && event.end.getHours() === 0 && event.end.getMinutes() === 0)) {
+  && (event.end && event.end.getHours() === 0 && event.end.getMinutes() === 0) &&
+  moment(event.start).format() !== moment(event.end).format()) {
     return true;
   }
   return false;

--- a/app/packs/src/components/calendar/Calendar.js
+++ b/app/packs/src/components/calendar/Calendar.js
@@ -98,6 +98,14 @@ function getWindowStyleOffsets(state) {
   }
 }
 
+const allDayAccessor = (event) => {
+  if ((event.start && event.start.getHours() === 0 && event.start.getMinutes() === 0)
+  && (event.end && event.end.getHours() === 0 && event.end.getMinutes() === 0)) {
+    return true;
+  }
+  return false;
+};
+
 // see:
 //  https://react-bootstrap-v3.netlify.app/components/modal/
 //  https://jquense.github.io/react-big-calendar/examples/?path=/docs/props-full-prop-list--page
@@ -891,6 +899,7 @@ export default class Calendar extends React.Component {
                 eventPropGetter={(eventStyleGetter)}
                 showMultiDayTimes={false}
                 formats={formats}
+                allDayAccessor={allDayAccessor}
                 // enableAutoScroll={true}
               />
 

--- a/app/packs/src/components/calendar/Calendar.js
+++ b/app/packs/src/components/calendar/Calendar.js
@@ -637,6 +637,12 @@ export default class Calendar extends React.Component {
 
   saveEntry() {
     const { currentEntry } = this.state;
+    const { title } = currentEntry;
+    if (!title) {
+      // eslint-disable-next-line no-alert
+      alert('Please enter a title.');
+      return;
+    }
     if (currentEntry.id) {
       CalendarActions.updateEntry(currentEntry);
     } else {


### PR DESCRIPTION
In the agenda tab of the calendar feature, all-day events were not consistently displaying 'all day' (see https://github.com/ComPlat/chemotion/issues/26). For example, a two day event displayed '12:00 am' for day 1 and 'all day' for day 2. For clarity, this has been corrected. 

An alert for the user to enter a title (mandatory field) when creating events has also been added.
- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
