### PR TITLE
Groups ui revamp and making group admins set/unset admins 

### DIFF
--- a/app/api/chemotion/user_api.rb
+++ b/app/api/chemotion/user_api.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
+
 module Chemotion
+  # rubocop:disable Metrics/ClassLength
   class UserAPI < Grape::API
     resource :users do
       desc 'Find top 3 matched user names'
@@ -32,12 +34,14 @@ module Chemotion
       desc 'list structure editors'
       get 'list_editors' do
         editors = []
-        %w[chemdrawEditor marvinjsEditor ketcher2Editor].each { |str| editors.push(str) if current_user.matrix_check_by_name(str) }
+        %w[chemdrawEditor marvinjsEditor ketcher2Editor].each do |str|
+          editors.push(str) if current_user.matrix_check_by_name(str)
+        end
         present Matrice.where(name: editors).order('name'), with: Entities::MatriceEntity, root: 'matrices'
       end
 
       namespace :omniauth_providers do
-        desc "get omniauth providers"
+        desc 'get omniauth providers'
         get do
           { providers: Devise.omniauth_configs.keys, current_user: current_user }
         end
@@ -59,7 +63,7 @@ module Chemotion
             access_level: params[:access_level] || 0,
             title: params[:title],
             description: params[:description],
-            color: params[:color]
+            color: params[:color],
           }
           label = nil
           if params[:id].present?
@@ -90,7 +94,8 @@ module Chemotion
       namespace :scifinder do
         desc 'scifinder-n credential'
         get do
-          present(ScifinderNCredential.find_by(created_by: current_user.id) || {}, with: Entities::ScifinderNCredentialEntity)
+          present(ScifinderNCredential.find_by(created_by: current_user.id) || {},
+                  with: Entities::ScifinderNCredentialEntity)
         end
       end
 
@@ -103,7 +108,7 @@ module Chemotion
     resource :groups do
       rescue_from ActiveRecord::RecordInvalid do |error|
         message = error.record.errors.messages.map do |attr, msg|
-          "%s %s" % [attr, msg.first]
+          format('%<attr>s %<msg>s', attr: attr, msg: msg.first)
         end
         error!(message.join(', '), 404)
       end
@@ -123,7 +128,7 @@ module Chemotion
         after_validation do
           users = params[:group_param][:users] || []
           @group_params = declared(params, include_missing: false).deep_symbolize_keys[:group_param]
-          @group_params[:email] ||= "%i@eln.edu" % [Time.now.getutc.to_i]
+          @group_params[:email] ||= format('%i@eln.edu', Time.now.getutc.to_i)
           @group_params[:password] = Devise.friendly_token.first(8)
           @group_params[:password_confirmation] = @group_params[:password]
           @group_params[:users] = User.where(id: [current_user.id] + users)
@@ -159,7 +164,8 @@ module Chemotion
         end
         route_param :device_id do
           get do
-            present DeviceMetadata.find_by(device_id: params[:device_id]), with: Entities::DeviceMetadataEntity, root: 'device_metadata'
+            present DeviceMetadata.find_by(device_id: params[:device_id]), with: Entities::DeviceMetadataEntity,
+                                                                           root: 'device_metadata'
           end
         end
       end
@@ -187,26 +193,23 @@ module Chemotion
             @group.users.delete(User.where(id: rm_user_id))
             User.gen_matrix([@rm_current_user_id])
             present @group, with: Entities::GroupEntity, root: 'group'
+          elsif params[:destroy_group]
+            @group.destroy! && { destroyed_id: params[:id] }
           else
-            if params[:destroy_group]
-              { destroyed_id: params[:id] } if @group.destroy!
-            else
-              # add new admins
-              params[:add_admin].delete(@group.admins.pluck(:id)) # ensure that admins are not added twice
-              @group.admins << User.where(id: params[:add_admin])
-              # remove admins
-              params[:rm_admin].delete(current_user.id) # ensure that current_user is not removed from admins
-              @group.users_admins.where(admin_id: params[:rm_admin]).destroy_all
+            # add new admins
+            params[:add_admin].delete(@group.admins.pluck(:id)) # ensure that admins are not added twice
+            @group.admins << User.where(id: params[:add_admin])
+            # remove admins
+            params[:rm_admin].delete(current_user.id) # ensure that current_user is not removed from admins
+            @group.users_admins.where(admin_id: params[:rm_admin]).destroy_all
+            # add new users
+            params[:add_users].delete(@group.users.pluck(:id))
+            @group.users << Person.where(id: params[:add_users])
+            # remove users
+            @group.users.delete(User.where(id: params[:rm_users]))
+            User.gen_matrix(params[:rm_users]) if params[:rm_users].length.positive?
 
-              # add new users
-              params[:add_users].delete(@group.users.pluck(:id))
-              @group.users << Person.where(id: params[:add_users])
-              # remove users
-              @group.users.delete(User.where(id: params[:rm_users]))
-              User.gen_matrix(params[:rm_users]) if params[:rm_users].length.positive?
-
-              present @group, with: Entities::GroupEntity, root: 'group'
-            end
+            present @group, with: Entities::GroupEntity, root: 'group'
           end
         end
       end
@@ -219,19 +222,21 @@ module Chemotion
       end
 
       get :novnc do
-        if params[:id] != '0'
-          devices = Device.by_user_ids(user_ids).novnc.where(id: params[:id]).includes(:profile)
-        else
-          devices = Device.by_user_ids(user_ids).novnc.includes(:profile)
-        end
+        devices = if params[:id] == '0'
+                    Device.by_user_ids(user_ids).novnc.includes(:profile)
+                  else
+                    Device.by_user_ids(user_ids).novnc.where(id: params[:id]).includes(:profile)
+                  end
         present devices, with: Entities::DeviceNovncEntity, root: 'devices'
       end
 
       get 'current_connection' do
         path = Rails.root.join('tmp/novnc_devices', params[:id])
-        cmd = "echo '#{current_user.id},#{params[:status] == 'true' ? 1 : 0}' >> #{path};LINES=$(tail -n 8 #{path});echo \"$LINES\" | tee #{path}"
-        { result: Open3.popen3(cmd) { |i, o, e, t| o.read.split(/\s/) } }
+        cmd = "echo '#{current_user.id},#{params[:status] == 'true' ? 1 : 0}' >> #{path};"
+        cmd += "LINES=$(tail -n 8 #{path});echo \"$LINES\" | tee #{path}"
+        { result: Open3.popen3(cmd) { |_i, o, _e, _t| o.read.split(/\s/) } }
       end
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/api/chemotion/user_api.rb
+++ b/app/api/chemotion/user_api.rb
@@ -200,7 +200,8 @@ module Chemotion
             params[:add_admin].delete(@group.admins.pluck(:id)) # ensure that admins are not added twice
             @group.admins << User.where(id: params[:add_admin])
             # remove admins
-            params[:rm_admin].delete(current_user.id) # ensure that current_user is not removed from admins
+            # ensure that current_user is not removed from admins when being last admin
+            params[:rm_admin].delete(current_user.id) if Group.last.admins.count == 1
             @group.users_admins.where(admin_id: params[:rm_admin]).destroy_all
             # add new users
             params[:add_users].delete(@group.users.pluck(:id))

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -488,7 +488,13 @@ class Group < User
   has_many :users, class_name: 'User', through: :users_groups
 
   has_many :users_admins, dependent: :destroy, foreign_key: :user_id
-  has_many :admins,  through: :users_admins, source: :admin # ,  foreign_key:    association_foreign_key: :admin_id
+  has_many :admins, through: :users_admins, source: :admin # ,  foreign_key:    association_foreign_key: :admin_id
+
+  before_destroy :remove_from_matrices
+
+  def administrated_by?(user)
+    users_admins.where(admin: user).present?
+  end
 
   private
 

--- a/app/packs/src/components/navigation/GroupElement.js
+++ b/app/packs/src/components/navigation/GroupElement.js
@@ -13,6 +13,39 @@ import Select from 'react-select';
 import _ from 'lodash';
 import { selectUserOptionFormater } from 'src/utilities/selectHelper';
 
+const styles = {
+  button: {
+    width: '25px', height: '25px', marginRight: '10px', textAlign: 'center',
+  },
+  popover: {
+    display: 'flex', flexDirection: 'row', gap: '10px',
+  },
+  confirmButton: {
+    marginTop: '5px', textAlign: 'center', width: '35px', fontWeight: 'Bold',
+  },
+  gotItButton: {
+    marginTop: '5px', textAlign: 'center', fontWeight: 'Bold',
+  },
+  addUserButton: {
+    marginLeft: '10px', marginTop: '5px', textAlign: 'center', width: '25px', height: '25px',
+  },
+  select: {
+    marginTop: '5px', width: '300px',
+  },
+  flexRow: {
+    display: 'flex', flexDirection: 'row', alignItems: 'center'
+  },
+  lightRow: {
+    backgroundColor: '#e1edf2',
+  },
+  darkRow: {
+    backgroundColor: '#c8d6dc',
+  },
+  tableData: {
+    verticalAlign: 'middle'
+  }
+};
+
 export default class GroupElement extends React.Component {
   constructor(props) {
     super(props);
@@ -39,11 +72,8 @@ export default class GroupElement extends React.Component {
   componentWillUnmount() { }
 
   handleSelectUser(val) {
-    if (val && val.length > 0) {
-      this.setState({ selectedUsers: val });
-    } else {
-      this.setState({ selectedUsers: null });
-    }
+    if (val && val.length > 0) { this.setState({ selectedUsers: val }); }
+    else { this.setState({ selectedUsers: null }); }
   }
 
   setGroupAdmin(groupRec, userRec, setAdmin = true) {
@@ -90,9 +120,7 @@ export default class GroupElement extends React.Component {
     });
   }
 
-  hideAdminAlert = () => {
-    this.setState({ showAdminAlert: false });
-  };
+  hideAdminAlert = () => { this.setState({ showAdminAlert: false }); };
 
   toggleUsers() {
     this.setState((prevState) => ({
@@ -154,9 +182,7 @@ export default class GroupElement extends React.Component {
       const isUserInGroup = groupRec.users.some((user) => user.id === g.value);
 
       // only add users not already in group
-      if (!isUserInGroup) {
-        userIds.push(g.value);
-      }
+      if (!isUserInGroup) { userIds.push(g.value); }
     });
 
     UsersFetcher.updateGroup({
@@ -189,23 +215,12 @@ export default class GroupElement extends React.Component {
     const popover = (
       <Popover id="popover-positioned-scrolling-left">
         {msg}
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'row',
-            gap: '10px',
-          }}
-        >
+        <div style={styles.popover}>
           <Button
             bsSize="xsmall"
             bsStyle="danger"
             onClick={() => this.confirmDelete(type, groupRec, userRec)}
-            style={{
-              marginTop: '5px',
-              textAlign: 'center',
-              width: '35px',
-              fontWeight: 'Bold',
-            }}
+            style={styles.confirmButton}
           >
             Yes
           </Button>
@@ -213,12 +228,7 @@ export default class GroupElement extends React.Component {
             bsSize="xsmall"
             bsStyle="warning"
             onClick={this.handleClick}
-            style={{
-              marginTop: '5px',
-              textAlign: 'center',
-              width: '35px',
-              fontWeight: 'Bold',
-            }}
+            style={styles.confirmButton}
           >
             No
           </Button>
@@ -237,12 +247,7 @@ export default class GroupElement extends React.Component {
         >
           <Button
             bsSize="xsmall"
-            style={{
-              width: '25px',
-              height: '25px',
-              marginRight: '10px',
-              textAlign: 'center',
-            }}
+            style={styles.button}
             type="button"
             bsStyle="danger"
             className="fa fa-trash-o"
@@ -267,12 +272,7 @@ export default class GroupElement extends React.Component {
           >
             <Button
               bsSize="xsmall"
-              style={{
-                width: '25px',
-                height: '25px',
-                marginRight: '10px',
-                textAlign: 'center',
-              }}
+              style={styles.button}
               type="button"
               bsStyle="info"
               className="fa fa-list"
@@ -282,12 +282,7 @@ export default class GroupElement extends React.Component {
           <OverlayTrigger placement="top" overlay={<Tooltip>Add user</Tooltip>}>
             <Button
               bsSize="xsmall"
-              style={{
-                width: '25px',
-                height: '25px',
-                marginRight: '10px',
-                textAlign: 'center',
-              }}
+              style={styles.button}
               type="button"
               bsStyle="success"
               className="fa fa-plus"
@@ -301,14 +296,11 @@ export default class GroupElement extends React.Component {
             {this.renderDeleteButton('group', group)}
           </OverlayTrigger>
           <span className={`collapse${showRowAdd ? 'in' : ''}`}>
-            <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+            <div style={styles.flexRow}>
               {' '}
               <Select.AsyncCreatable
                 multi
-                style={{
-                  marginTop: '5px',
-                  width: '300px',
-                }}
+                style={styles.select}
                 isLoading
                 backspaceRemoves
                 value={selectedUsers}
@@ -328,13 +320,7 @@ export default class GroupElement extends React.Component {
               <Button
                 bsSize="xsmall"
                 type="button"
-                style={{
-                  marginLeft: '10px',
-                  marginTop: '5px',
-                  textAlign: 'center',
-                  width: '25px',
-                  height: '25px',
-                }}
+                style={styles.addUserButton}
                 bsStyle="success"
                 className="fa fa-user-plus"
                 onClick={() => this.addUser(group)}
@@ -350,12 +336,7 @@ export default class GroupElement extends React.Component {
         <Button
           bsSize="xsmall"
           type="button"
-          style={{
-            width: '25px',
-            height: '25px',
-            marginRight: '10px',
-            textAlign: 'center',
-          }}
+          style={styles.button}
           bsStyle="info"
           className="fa fa-list"
           onClick={this.toggleUsers}
@@ -376,18 +357,10 @@ export default class GroupElement extends React.Component {
     return (
       <span>
         {isCurrentUserAdmin && (
-          <OverlayTrigger
-            placement="top"
-            overlay={<Tooltip>{adminTooltip}</Tooltip>}
-          >
+          <OverlayTrigger placement="top" overlay={<Tooltip>{adminTooltip}</Tooltip>}>
             <Button
               bsSize="xsmall"
-              style={{
-                width: '25px',
-                height: '25px',
-                marginRight: '10px',
-                textAlign: 'center',
-              }}
+              style={styles.button}
               type="button"
               bsStyle={adminButtonStyle}
               className="fa fa-key"
@@ -405,22 +378,14 @@ export default class GroupElement extends React.Component {
   }
 
   render() {
-    const styles = {
-      lightRow: {
-        backgroundColor: '#e1edf2',
-      },
-      darkRow: {
-        backgroundColor: '#c8d6dc',
-      },
-    };
     const { groupElement } = this.props;
     const { showUsers: showInfo } = this.state;
     return (
       <tbody key={`tbody_${groupElement.id}`}>
         <tr key={`row_${groupElement.id}`} style={{ fontWeight: 'Bold' }}>
-          <td style={{ verticalAlign: 'middle' }}>{groupElement.name}</td>
-          <td style={{ verticalAlign: 'middle' }}>{groupElement.initials}</td>
-          <td style={{ verticalAlign: 'middle' }}>
+          <td style={styles.tableData}>{groupElement.name}</td>
+          <td style={styles.tableData}>{groupElement.initials}</td>
+          <td style={styles.tableData}>
             {groupElement.admins
               && groupElement.admins.length > 0
               && groupElement.admins.map((admin) => admin.name).join(', ')}
@@ -436,16 +401,10 @@ export default class GroupElement extends React.Component {
                     key={`row_${groupElement.id}_${u.id}`}
                     style={index % 2 === 0 ? styles.lightRow : styles.darkRow}
                   >
-                    <td width="20%" style={{ verticalAlign: 'middle' }}>
-                      {u.name}
-                    </td>
-                    <td width="10%" style={{ verticalAlign: 'middle' }}>
-                      {u.initials}
-                    </td>
-                    <td width="20%" style={{ verticalAlign: 'middle' }} />
-                    <td width="50%" style={{ verticalAlign: 'middle' }}>
-                      {this.renderUserButtons(groupElement, u)}
-                    </td>
+                    <td width="20%" style={styles.tableData}>{u.name}</td>
+                    <td width="10%" style={styles.tableData}>{u.initials}</td>
+                    <td width="20%" style={styles.tableData} />
+                    <td width="50%" style={styles.tableData}>{this.renderUserButtons(groupElement, u)}</td>
                   </tr>
                 ))}
               </tbody>
@@ -460,22 +419,12 @@ export default class GroupElement extends React.Component {
         >
           <Popover id="popover-contained">
             At least one admin is required.
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'row',
-                gap: '10px',
-              }}
-            >
+            <div style={styles.popover}>
               <Button
                 bsSize="xsmall"
                 bsStyle="primary"
                 onClick={this.hideAdminAlert}
-                style={{
-                  marginTop: '5px',
-                  textAlign: 'center',
-                  fontWeight: 'Bold',
-                }}
+                style={styles.gotItButton}
               >
                 Got it!
               </Button>

--- a/app/packs/src/components/navigation/GroupElement.js
+++ b/app/packs/src/components/navigation/GroupElement.js
@@ -10,7 +10,7 @@ import {
 } from 'react-bootstrap';
 import UsersFetcher from 'src/fetchers/UsersFetcher';
 import Select from 'react-select';
-import { _, findIndex } from 'lodash';
+import _ from 'lodash';
 import AdminFetcher from 'src/fetchers/AdminFetcher';
 import { selectUserOptionFormater } from 'src/utilities/selectHelper';
 
@@ -31,6 +31,7 @@ export default class GroupElement extends React.Component {
     this.loadUserByName = this.loadUserByName.bind(this);
     this.handleSelectUser = this.handleSelectUser.bind(this);
     this.hideAdminAlert = this.hideAdminAlert.bind(this);
+    this.setGroupAdmin = this.setGroupAdmin.bind(this);
   }
 
   componentDidMount() { }
@@ -71,10 +72,10 @@ export default class GroupElement extends React.Component {
         if (setAdmin) {
           groupRec.admins.splice(1, 0, userRec);
         } else {
-          const usrIdx = findIndex(groupRec.admins, (o) => o.id === userRec.id);
+          const usrIdx = _.findIndex(groupRec.admins, (o) => o.id === userRec.id);
           groupRec.admins.splice(usrIdx, 1);
         }
-        const idx = findIndex(groups, (o) => o.id === groupRec.id);
+        const idx = _.findIndex(groups, (o) => o.id === groupRec.id);
         groups.splice(idx, 1, groupRec);
         this.props.onChangeGroupData(groups);
       });
@@ -278,7 +279,7 @@ export default class GroupElement extends React.Component {
               multi
               style={{
                 marginTop: '10px',
-                width: '200px',
+                width: '300px',
               }}
               isLoading
               backspaceRemoves
@@ -357,7 +358,7 @@ export default class GroupElement extends React.Component {
                 type="button"
                 bsStyle={adminButtonStyle}
                 className="fa fa-key"
-                onClick={(e) => this.setGroupAdmin(groupRec, userRec, !isAdmin, e)}
+                onClick={() => this.setGroupAdmin(groupRec, userRec, !isAdmin)}
               />
             </OverlayTrigger>
           )}

--- a/app/packs/src/components/navigation/UserAuth.js
+++ b/app/packs/src/components/navigation/UserAuth.js
@@ -1,7 +1,23 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types'
+import PropTypes from 'prop-types';
 import 'whatwg-fetch';
-import { Nav, NavDropdown, NavItem, MenuItem, Glyphicon, Modal, Button, Table, Panel, Form, FormControl, FormGroup, ControlLabel, Col, Row } from 'react-bootstrap';
+import {
+  Nav,
+  NavDropdown,
+  NavItem,
+  MenuItem,
+  Glyphicon,
+  Modal,
+  Button,
+  Table,
+  Panel,
+  Form,
+  FormControl,
+  FormGroup,
+  ControlLabel,
+  Col,
+  Row,
+} from 'react-bootstrap';
 import _ from 'lodash';
 
 import UserActions from 'src/stores/alt/actions/UserActions';
@@ -30,8 +46,8 @@ export default class UserAuth extends Component {
       showDeviceMetadataModal: false,
       device: {},
       deviceMetadata: {
-        dates: []
-      }
+        dates: [],
+      },
     };
 
     this.onChange = this.onChange.bind(this);
@@ -49,7 +65,6 @@ export default class UserAuth extends Component {
     this.handleInputChange = this.handleInputChange.bind(this);
     this.handleClick = this.handleClick.bind(this);
     this.handleChange = this.handleChange.bind(this);
-
   }
 
   componentDidMount() {
@@ -63,7 +78,7 @@ export default class UserAuth extends Component {
 
   onChange(state) {
     this.setState({
-      currentUser: state.currentUser
+      currentUser: state.currentUser,
     });
   }
 
@@ -72,35 +87,33 @@ export default class UserAuth extends Component {
   }
 
   promptTextCreator(label) {
-    return ("Share with \"" + label + "\"");
+    return `Share with "${label}"`;
   }
 
   handlefetchDeviceMetadataByDeviceId(deviceID) {
-    UsersFetcher.fetchDeviceMetadataByDeviceId(deviceID)
-      .then((result) => {
-        if (result.device_metadata) {
-          this.setState({
-            deviceMetadata: result.device_metadata
-          });
-        }
-      });
+    UsersFetcher.fetchDeviceMetadataByDeviceId(deviceID).then((result) => {
+      if (result.device_metadata) {
+        this.setState({
+          deviceMetadata: result.device_metadata,
+        });
+      }
+    });
   }
+
   // show modal
   handleShow() {
-    UsersFetcher.fetchCurrentGroup()
-      .then((result) => {
-        this.setState({
-          currentGroups: result.currentGroups,
-          showModal: true,
-          selectedUsers: null
-        });
+    UsersFetcher.fetchCurrentGroup().then((result) => {
+      this.setState({
+        currentGroups: result.currentGroups,
+        showModal: true,
+        selectedUsers: null,
       });
-    UsersFetcher.fetchCurrentDevices()
-      .then((result) => {
-        this.setState({
-          currentDevices: result.currentDevices
-        });
+    });
+    UsersFetcher.fetchCurrentDevices().then((result) => {
+      this.setState({
+        currentDevices: result.currentDevices,
       });
+    });
   }
 
   // hide modal
@@ -111,7 +124,7 @@ export default class UserAuth extends Component {
   handleDeviceMetadataModalShow(device) {
     this.setState({
       showDeviceMetadataModal: true,
-      device
+      device,
     });
     this.handlefetchDeviceMetadataByDeviceId(device.id);
   }
@@ -120,13 +133,13 @@ export default class UserAuth extends Component {
     this.setState({
       showDeviceMetadataModal: false,
       device: {},
-      deviceMetadata: {}
+      deviceMetadata: {},
     });
   }
 
   handleLabelShow() {
     this.setState({
-      showLabelModal: true
+      showLabelModal: true,
     });
   }
 
@@ -136,13 +149,12 @@ export default class UserAuth extends Component {
 
   // show modal Subscription
   handleSubscriptionShow() {
-    MessagesFetcher.fetchChannelWithUser()
-      .then((result) => {
-        this.setState({
-          showSubscription: true,
-          currentSubscriptions: result.channels
-        });
+    MessagesFetcher.fetchChannelWithUser().then((result) => {
+      this.setState({
+        showSubscription: true,
+        currentSubscriptions: result.channels,
       });
+    });
   }
 
   // hide modal Subscription
@@ -175,96 +187,127 @@ export default class UserAuth extends Component {
   subscribe(node) {
     const { currentSubscriptions } = this.state;
 
-    MessagesFetcher.subscribeChannel({ channel_id: node.id, subscribe: node.user_id == null })
-      .then((result) => {
-        if (result.error) {
-          // alert(result.error);
-          NotificationActions.add({
-            message: result.error,
-            level: 'error'
-          });
+    MessagesFetcher.subscribeChannel({
+      channel_id: node.id,
+      subscribe: node.user_id == null,
+    }).then((result) => {
+      if (result.error) {
+        // alert(result.error);
+        NotificationActions.add({
+          message: result.error,
+          level: 'error',
+        });
+      } else {
+        const actSubscription = _.filter(
+          this.state.currentSubscriptions,
+          (o) => o.id === result.channel_id
+        );
+        if (node.user_id != null) {
+          actSubscription[0].user_id = null;
         } else {
-          const actSubscription = _.filter(
-            this.state.currentSubscriptions,
-            o => o.id === result.channel_id
-          );
-          if (node.user_id != null) {
-            actSubscription[0].user_id = null;
-          } else {
-            actSubscription[0].user_id = result.user_id;
-          }
-          const idx = _.findIndex(this.state.currentSubscriptions, o => o.id === result.channel_id);
-          currentSubscriptions.splice(idx, 1, actSubscription[0]);
-          this.setState({ currentSubscriptions });
+          actSubscription[0].user_id = result.user_id;
         }
-      });
+        const idx = _.findIndex(
+          this.state.currentSubscriptions,
+          (o) => o.id === result.channel_id
+        );
+        currentSubscriptions.splice(idx, 1, actSubscription[0]);
+        this.setState({ currentSubscriptions });
+      }
+    });
   }
 
   // create new group
   // need to use the wording 'group_param' because of the definition of current api
   createGroup() {
     const {
-      groupFirstName, groupLastName, groupAbbreviation, currentUser, currentGroups
+      groupFirstName,
+      groupLastName,
+      groupAbbreviation,
+      currentUser,
+      currentGroups,
     } = this.state;
     const group_param = {
       first_name: groupFirstName,
       last_name: groupLastName,
       name_abbreviation: groupAbbreviation,
-      users: [currentUser.id]
+      users: [currentUser.id],
     };
 
-    UsersFetcher.createGroup({ group_param })
-      .then((result) => {
-        if (result.error) {
-          alert(result.error);
-        } else {
-          currentGroups.push(result.group);
-          this.setState({
-            currentGroups,
-          });
-        }
-      });
+    UsersFetcher.createGroup({ group_param }).then((result) => {
+      if (result.error) {
+        alert(result.error);
+      } else {
+        currentGroups.push(result.group);
+        this.setState({
+          currentGroups,
+        });
+      }
+    });
   }
 
   renderDeviceButtons(device) {
     return (
       <td>
-        <Button bsSize="xsmall" type="button" bsStyle="info" className="fa fa-laptop" onClick={() => this.handleDeviceMetadataModalShow(device)} />&nbsp;&nbsp;
+        <Button
+          bsSize="xsmall"
+          type="button"
+          bsStyle="info"
+          className="fa fa-laptop"
+          onClick={() => this.handleDeviceMetadataModalShow(device)}
+        />
+        &nbsp;&nbsp;
       </td>
     );
   }
 
   handleChange(currentGroups) {
-    this.setState({ currentGroups: currentGroups });
+    this.setState({ currentGroups });
   }
 
-  handleDeleteGroup = currentGroupId => {
-    const currentGroups = this.state.currentGroups.filter(cg => cg.id !== currentGroupId);
-    UsersFetcher.updateGroup({ id: currentGroupId, destroy_group: true })
+  handleDeleteGroup = (currentGroupId) => {
+    const currentGroups = this.state.currentGroups.filter(
+      (cg) => cg.id !== currentGroupId
+    );
+    UsersFetcher.updateGroup({ id: currentGroupId, destroy_group: true });
     this.setState({ currentGroups });
   };
 
   handleDeleteUser = (groupRec, userRec) => {
     let { currentGroups, currentUser } = this.state;
-    UsersFetcher.updateGroup({ id: groupRec.id, destroy_group: false, rm_users: [userRec.id] })
-      .then((result) => {
-        const findIdx = _.findIndex(result.group.users, function (o) { return o.id == currentUser.id; });
-        const findAdmin = _.findIndex(result.group.admins, function (o) { return o.id == currentUser.id; });
-        if (findIdx == -1 && findAdmin == -1) {
-          currentGroups = _.filter(this.state.currentGroups, o => o.id != result.group.id);
-        } else {
-          const idx = _.findIndex(currentGroups, function (o) { return o.id == result.group.id; });
-          currentGroups.splice(idx, 1, result.group);
-        }
-        this.setState({ currentGroups: currentGroups });
-      });
-  }
+    UsersFetcher.updateGroup({
+      id: groupRec.id,
+      destroy_group: false,
+      rm_users: [userRec.id],
+    }).then((result) => {
+      const findIdx = _.findIndex(
+        result.group.users,
+        (o) => o.id == currentUser.id
+      );
+      const findAdmin = _.findIndex(
+        result.group.admins,
+        (o) => o.id == currentUser.id
+      );
+      if (findIdx == -1 && findAdmin == -1) {
+        currentGroups = _.filter(
+          this.state.currentGroups,
+          (o) => o.id != result.group.id
+        );
+      } else {
+        const idx = _.findIndex(currentGroups, (o) => o.id == result.group.id);
+        currentGroups.splice(idx, 1, result.group);
+      }
+      this.setState({ currentGroups });
+    });
+  };
 
   // render modal
   renderModal() {
     const { showModal, currentGroups, currentDevices } = this.state;
 
     const modalStyle = {
+      justifyContent: 'center',
+      alignItems: 'center',
       overflowY: 'auto',
     };
 
@@ -274,27 +317,39 @@ export default class UserAuth extends Component {
     if (Object.keys(currentGroups).length <= 0) {
       tBodyGroups = '';
     } else {
-      tBodyGroups = currentGroups ? currentGroups.map(g => (
-        <GroupElement groupElement={g} key={g.id} currentState={this.state}
-          currentGroup={this.state.currentGroups}
-          onDeleteGroup={this.handleDeleteGroup}
-          onDeleteUser={this.handleDeleteUser}
-          onChangeData={this.handleChange}></GroupElement>
-      )) : '';
+      tBodyGroups = currentGroups
+        ? currentGroups.map((g) => (
+          <GroupElement
+            groupElement={g}
+            key={g.id}
+            currentState={this.state}
+            currentGroup={this.state.currentGroups}
+            onDeleteGroup={this.handleDeleteGroup}
+            onDeleteUser={this.handleDeleteUser}
+            onChangeData={this.handleChange}
+          />
+        ))
+        : '';
     }
 
     if (Object.keys(currentDevices).length <= 0) {
       tBodyDevices = '';
     } else {
-      tBodyDevices = currentDevices ? currentDevices.map(g => (
-        <tbody key={`tbody_${g.id}`}>
-          <tr key={`row_${g.id}`} id={`row_${g.id}`} style={{ fontWeight: 'bold' }}>
-            <td>{g.name}</td>
-            <td>{g.name_abbreviation}</td>
-            {this.renderDeviceButtons(g)}
-          </tr>
-        </tbody>
-      )) : '';
+      tBodyDevices = currentDevices
+        ? currentDevices.map((g) => (
+          <tbody key={`tbody_${g.id}`}>
+            <tr
+              key={`row_${g.id}`}
+              id={`row_${g.id}`}
+              style={{ fontWeight: 'bold' }}
+            >
+              <td>{g.name}</td>
+              <td>{g.name_abbreviation}</td>
+              {this.renderDeviceButtons(g)}
+            </tr>
+          </tbody>
+        ))
+        : '';
     }
 
     return (
@@ -302,6 +357,12 @@ export default class UserAuth extends Component {
         show={showModal}
         dialogClassName="importChemDrawModal"
         onHide={this.handleClose}
+        style={{
+          maxWidth: '80%',
+          maxHeight: '80%',
+          margin: 'auto',
+          overflowY: 'auto',
+        }}
       >
         <Modal.Header closeButton>
           <Modal.Title>My Groups & Devices</Modal.Title>
@@ -310,16 +371,18 @@ export default class UserAuth extends Component {
           <div>
             <Panel bsStyle="success">
               <Panel.Heading>
-                <Panel.Title>
-                  Create new group
-                </Panel.Title>
+                <Panel.Title>Create new group</Panel.Title>
               </Panel.Heading>
               <Panel.Body>
                 <Form inline>
                   <FormGroup controlId="formInlineFname">
-                    <ControlLabel>Name</ControlLabel>&nbsp;&nbsp;
+                    <ControlLabel>Name:</ControlLabel>
+                    &nbsp;&nbsp;
                     <FormControl
                       type="text"
+                      style={{
+                        marginRight: '5px',
+                      }}
                       placeholder="eg: AK"
                       onChange={this.handleInputChange.bind(this, 'first')}
                     />
@@ -328,18 +391,36 @@ export default class UserAuth extends Component {
                     <FormControl
                       type="text"
                       placeholder="J. Moriarty"
+                      style={{
+                        marginRight: '20px',
+                      }}
                       onChange={this.handleInputChange.bind(this, 'last')}
                     />
-                  </FormGroup>&nbsp;&nbsp;
+                  </FormGroup>
+                  &nbsp;&nbsp;
                   <FormGroup controlId="formInlineNameAbbr">
-                    <ControlLabel>Name abbreviation</ControlLabel>&nbsp;&nbsp;
+                    <ControlLabel>Name abbreviation:</ControlLabel>
+                    &nbsp;&nbsp;
                     <FormControl
                       type="text"
                       placeholder="AK-JM"
+                      style={{
+                        marginRight: '10px',
+                      }}
                       onChange={this.handleInputChange.bind(this, 'abbr')}
                     />
-                  </FormGroup>&nbsp;&nbsp;
-                  <Button bsSize="xsmall" bsStyle="success" onClick={() => this.createGroup()}>
+                  </FormGroup>
+                  &nbsp;&nbsp;
+                  <Button
+                    bsSize="small"
+                    bsStyle="success"
+                    onClick={() => this.createGroup()}
+                    style={{
+                      height: '32px',
+                      fontWeight: 'Bold',
+                      fontSize: '12px',
+                    }}
+                  >
                     Create new group
                   </Button>
                 </Form>
@@ -347,9 +428,7 @@ export default class UserAuth extends Component {
             </Panel>
             <Panel bsStyle="info">
               <Panel.Heading>
-                <Panel.Title>
-                  My Groups
-                </Panel.Title>
+                <Panel.Title>My Groups</Panel.Title>
               </Panel.Heading>
               <Panel.Body>
                 <Table responsive condensed hover>
@@ -367,9 +446,7 @@ export default class UserAuth extends Component {
             </Panel>
             <Panel bsStyle="info">
               <Panel.Heading>
-                <Panel.Title>
-                  My Devices
-                </Panel.Title>
+                <Panel.Title>My Devices</Panel.Title>
               </Panel.Heading>
               <Panel.Body>
                 <Table responsive condensed hover>
@@ -393,7 +470,7 @@ export default class UserAuth extends Component {
   // render modal
   renderSubscribeModal() {
     if (this.state.showSubscription) {
-      const tbody = this.state.currentSubscriptions.map(g => (
+      const tbody = this.state.currentSubscriptions.map((g) => (
         <tr key={`row_${g.id}`} style={{ fontWeight: 'bold' }}>
           <td width="10%" style={{ border: 'none' }}>
             <Button
@@ -404,7 +481,9 @@ export default class UserAuth extends Component {
               {g.user_id == null ? 'Subscribe' : 'Unsubscribe'}
             </Button>
           </td>
-          <td width="90%" style={{ border: 'none' }}><div>{g.subject}</div></td>
+          <td width="90%" style={{ border: 'none' }}>
+            <div>{g.subject}</div>
+          </td>
         </tr>
       ));
 
@@ -419,16 +498,14 @@ export default class UserAuth extends Component {
           <Modal.Body style={{ overflow: 'auto' }}>
             <div>
               <Table>
-                <tbody>
-                  {tbody}
-                </tbody>
+                <tbody>{tbody}</tbody>
               </Table>
             </div>
           </Modal.Body>
         </Modal>
       );
     }
-    return (<div />);
+    return <div />;
   }
 
   renderDeviceMetadataModal() {
@@ -440,19 +517,22 @@ export default class UserAuth extends Component {
         onHide={this.handleDeviceMetadataModalClose}
       >
         <Modal.Header closeButton>
-          <Modal.Title>{device.name} Metadata</Modal.Title>
+          <Modal.Title>
+            {device.name}
+            {' '}
+            Metadata
+          </Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <Panel bsStyle="success">
             <Panel.Heading>
-              <Panel.Title>
-                {title}
-              </Panel.Title>
+              <Panel.Title>{title}</Panel.Title>
             </Panel.Heading>
             <Panel.Body>
               <Form>
                 <FormGroup controlId="metadataFormDOI">
-                  <ControlLabel>DOI</ControlLabel>&nbsp;&nbsp;
+                  <ControlLabel>DOI</ControlLabel>
+                  &nbsp;&nbsp;
                   <FormControl
                     type="text"
                     defaultValue={deviceMetadata.doi}
@@ -486,7 +566,8 @@ export default class UserAuth extends Component {
                   />
                 </FormGroup>
                 <FormGroup controlId="metadataFormName">
-                  <ControlLabel>Name</ControlLabel>&nbsp;&nbsp;
+                  <ControlLabel>Name</ControlLabel>
+                  &nbsp;&nbsp;
                   <FormControl
                     type="text"
                     defaultValue={deviceMetadata.name}
@@ -510,36 +591,43 @@ export default class UserAuth extends Component {
                   />
                 </FormGroup>
 
-                {deviceMetadata.dates && deviceMetadata.dates.map((dateItem, index) => (
-                  <div key={index}>
-                    <Col smOffset={0} sm={6}>
-                      <FormGroup>
-                        <ControlLabel>Date</ControlLabel>
-                        <FormControl
-                          type="text"
-                          defaultValue={dateItem.date}
-                          readonly="true"
-                        />
-                      </FormGroup>
-                    </Col>
-                    <Col smOffset={0} sm={6}>
-                      <FormGroup>
-                        <ControlLabel>DateType</ControlLabel>
-                        <FormControl
-                          type="text"
-                          defaultValue={dateItem.dateType}
-                          readonly="true"
-                        />
-                      </FormGroup>
-                    </Col>
-                  </div>
-                ))}
+                {deviceMetadata.dates
+                  && deviceMetadata.dates.map((dateItem, index) => (
+                    <div key={index}>
+                      <Col smOffset={0} sm={6}>
+                        <FormGroup>
+                          <ControlLabel>Date</ControlLabel>
+                          <FormControl
+                            type="text"
+                            defaultValue={dateItem.date}
+                            readonly="true"
+                          />
+                        </FormGroup>
+                      </Col>
+                      <Col smOffset={0} sm={6}>
+                        <FormGroup>
+                          <ControlLabel>DateType</ControlLabel>
+                          <FormControl
+                            type="text"
+                            defaultValue={dateItem.dateType}
+                            readonly="true"
+                          />
+                        </FormGroup>
+                      </Col>
+                    </div>
+                  ))}
 
                 <Row>
                   <Col smOffset={0} sm={12}>
-                    <p class="text-right">
-                      DataCiteVersion: {deviceMetadata.data_cite_version}<br />
-                      DataCiteUpdatedAt: {formatDate(deviceMetadata.data_cite_updated_at)}<br />
+                    <p className="text-right">
+                      DataCiteVersion:
+                      {' '}
+                      {deviceMetadata.data_cite_version}
+                      <br />
+                      DataCiteUpdatedAt:
+                      {' '}
+                      {formatDate(deviceMetadata.data_cite_updated_at)}
+                      <br />
                     </p>
                   </Col>
                 </Row>
@@ -553,43 +641,72 @@ export default class UserAuth extends Component {
 
   render() {
     const templatesLink = (
-      <MenuItem eventKey="2" href="/ketcher/common_templates">Template Management</MenuItem>
+      <MenuItem eventKey="2" href="/ketcher/common_templates">
+        Template Management
+      </MenuItem>
     );
     const moderatorLink = (
-      <MenuItem eventKey="6" href="/molecule_moderator">Molecule Moderator</MenuItem>
+      <MenuItem eventKey="6" href="/molecule_moderator">
+        Molecule Moderator
+      </MenuItem>
     );
 
-    let userLabel = (<span />);
+    let userLabel = <span />;
     if (MatrixCheck(this.state.currentUser.matrix, 'userLabel')) {
-      userLabel = (<MenuItem onClick={this.handleLabelShow}>My Labels</MenuItem>);
+      userLabel = <MenuItem onClick={this.handleLabelShow}>My Labels</MenuItem>;
     }
-    let converterBtn = (<span />);
+    let converterBtn = <span />;
     if (UIStore.getState().hasConverter === true) {
-      converterBtn = (<MenuItem eventKey="12" href="/converter_admin">Converter Profile</MenuItem>);
+      converterBtn = (
+        <MenuItem eventKey="12" href="/converter_admin">
+          Converter Profile
+        </MenuItem>
+      );
     }
 
     return (
       <div>
         <Nav navbar pullRight>
-          <NavDropdown title={`${this.state.currentUser.name}`} id="bg-nested-dropdown">
-            <MenuItem eventKey="1" href="/pages/settings" >Account &amp; Profile</MenuItem>
-            {this.state.currentUser.is_templates_moderator ? templatesLink : null}
-            <MenuItem eventKey="3" href="/users/edit" >Change Password</MenuItem>
-            <MenuItem eventKey="5" href="/pages/affiliations" >My Affiliations</MenuItem>
+          <NavDropdown
+            title={`${this.state.currentUser.name}`}
+            id="bg-nested-dropdown"
+          >
+            <MenuItem eventKey="1" href="/pages/settings">
+              Account &amp; Profile
+            </MenuItem>
+            {this.state.currentUser.is_templates_moderator
+              ? templatesLink
+              : null}
+            <MenuItem eventKey="3" href="/users/edit">
+              Change Password
+            </MenuItem>
+            <MenuItem eventKey="5" href="/pages/affiliations">
+              My Affiliations
+            </MenuItem>
             <MenuItem onClick={this.handleShow}>My Groups & Devices</MenuItem>
             {userLabel}
             {/* <MenuItem onClick={this.handleSubscriptionShow}>My Subscriptions</MenuItem>
                 Disable for now as there is no subsciption channel yet (Paggy) */}
             {converterBtn}
-            <MenuItem eventKey="7" href="/command_n_control" >My Devices</MenuItem>
+            <MenuItem eventKey="7" href="/command_n_control">
+              My Devices
+            </MenuItem>
             {this.state.currentUser.molecule_editor ? moderatorLink : null}
           </NavDropdown>
-          <NavItem onClick={() => this.logout()} style={{ marginRight: '5px' }} className="" title="Log out">
+          <NavItem
+            onClick={() => this.logout()}
+            style={{ marginRight: '5px' }}
+            className=""
+            title="Log out"
+          >
             <Glyphicon glyph="log-out" />
           </NavItem>
         </Nav>
         {this.renderModal()}
-        <UserLabelModal showLabelModal={this.state.showLabelModal} onHide={() => this.handleLabelClose()} />
+        <UserLabelModal
+          showLabelModal={this.state.showLabelModal}
+          onHide={() => this.handleLabelClose()}
+        />
         {this.renderSubscribeModal()}
         {this.renderDeviceMetadataModal()}
       </div>
@@ -600,4 +717,4 @@ export default class UserAuth extends Component {
 UserAuth.propTypes = {
   currentUser: PropTypes.object,
   selectUsers: PropTypes.bool,
-}
+};

--- a/app/packs/src/fetchers/UsersFetcher.js
+++ b/app/packs/src/fetchers/UsersFetcher.js
@@ -166,6 +166,8 @@ export default class UsersFetcher {
         destroy_group: params.destroy_group,
         rm_users: params.rm_users,
         add_users: params.add_users,
+        add_admin: params.add_admin,
+        rm_admin: params.rm_admin,
       })
     }).then(response => response.json()).then(json => json).catch((errorMessage) => {
       console.log(errorMessage);


### PR DESCRIPTION
- New endpoint to allow UsersFetcher to change group admins
- New set/unset button
- Users have more friendly groups.
- Window is set now to 80%

Possible user errors that are handled:
- Unsetting yourself as admin if you are the only admin -> Not allowed and shows info popup
- Deleting a user if he is admin -> Allowed, but will also remove his admin status -> Instead of unsetting admin and then deleting, this can be done just by deleting
- Adding user where, when no user is selected to add. -> Add button is turned off, until a user is selected.

Images:
Old UI:
![image](https://github.com/ComPlat/chemotion_ELN/assets/59936007/324fb062-e47c-46eb-aece-672b1fdec8a4)

New UI:
![image](https://github.com/ComPlat/chemotion_ELN/assets/59936007/f2846319-7165-4bdf-a4aa-a9fb9fc3d7d2)

Popup when removing yourself as admin, if you are the only admin:
![image](https://github.com/ComPlat/chemotion_ELN/assets/59936007/6fa50dee-42a9-4c7d-9bc7-1d07974752dd)
