### PR TITLE
Unsaved sample changes retained when reselected from list

### DIFF
--- a/app/packs/src/utilities/routesUtils.js
+++ b/app/packs/src/utilities/routesUtils.js
@@ -97,7 +97,7 @@ const predictionShowFwdRxn = () => {
 const sampleShowOrNew = (e) => {
   const { sampleID, collectionID } = e.params;
   const { selecteds, activeKey } = ElementStore.getState();
-  const index = selecteds.findIndex(el => el.type === 'sample' && el.id === sampleID);
+  const index = selecteds.findIndex((el) => el.type === 'sample' && el.id === sampleID);
 
   if (sampleID === 'new') {
     ElementActions.generateEmptySample(collectionID);
@@ -113,13 +113,17 @@ const sampleShowOrNew = (e) => {
 
 const reactionShow = (e) => {
   const { reactionID, collectionID } = e.params;
+  const { selecteds, activeKey } = ElementStore.getState();
+  const index = selecteds.findIndex((el) => el.type === 'reaction' && el.id === reactionID);
   // UIActions.selectTab(2);
-  if (reactionID !== 'new' && reactionID !== 'copy') {
-    ElementActions.fetchReactionById(reactionID);
+  if (reactionID === 'new') {
+    ElementActions.generateEmptyReaction(collectionID);
   } else if (reactionID === 'copy') {
     //ElementActions.copyReactionFromClipboard(collectionID);
-  } else {
-    ElementActions.generateEmptyReaction(collectionID);
+  } else if (index < 0) {
+    ElementActions.fetchReactionById(reactionID);
+  } else if (index !== activeKey) {
+    DetailActions.select(index);
   }
 };
 
@@ -130,13 +134,17 @@ const reactionShowSample = (e) => {
 
 const wellplateShowOrNew = (e) => {
   const { wellplateID, collectionID } = e.params;
+  const { selecteds, activeKey } = ElementStore.getState();
+  const index = selecteds.findIndex((el) => el.type === 'wellplate' && el.id === wellplateID);
 
   if (wellplateID === 'new') {
     ElementActions.generateEmptyWellplate(collectionID);
   } else if (wellplateID === 'template') {
     ElementActions.generateWellplateFromClipboard.defer(collectionID);
-  } else {
+  } else if (index < 0) {
     ElementActions.fetchWellplateById(wellplateID);
+  } else if (index !== activeKey) {
+    DetailActions.select(index);
   }
 };
 
@@ -147,12 +155,17 @@ const wellplateShowSample = (e) => {
 
 const screenShowOrNew = (e) => {
   const { screenID, collectionID } = e.params;
+  const { selecteds, activeKey } = ElementStore.getState();
+  const index = selecteds.findIndex((el) => el.type === 'screen' && el.id === screenID);
+
   if (screenID === 'new') {
     ElementActions.generateEmptyScreen(collectionID);
   } else if (screenID === 'template') {
     ElementActions.generateScreenFromClipboard.defer(collectionID);
-  } else {
+  } else if (index < 0) {
     ElementActions.fetchScreenById(screenID);
+  } else if (index !== activeKey) {
+    DetailActions.select(index);
   }
 };
 
@@ -177,10 +190,15 @@ const deviceShowDeviceManagement = () => {
 
 const researchPlanShowOrNew = (e) => {
   const { research_planID, collectionID } = e.params;
+  const { selecteds, activeKey } = ElementStore.getState();
+  const index = selecteds.findIndex(el => el.type === 'research_plan' && el.id === research_planID);
+
   if (research_planID === 'new') {
     ElementActions.generateEmptyResearchPlan(collectionID);
-  } else {
+  } else if (index < 0) {
     ElementActions.fetchResearchPlanById(research_planID);
+  } else if (index !== activeKey) {
+    DetailActions.select(index);
   }
 };
 

--- a/app/packs/src/utilities/routesUtils.js
+++ b/app/packs/src/utilities/routesUtils.js
@@ -96,12 +96,17 @@ const predictionShowFwdRxn = () => {
 
 const sampleShowOrNew = (e) => {
   const { sampleID, collectionID } = e.params;
+  const { selecteds, activeKey } = ElementStore.getState();
+  const index = selecteds.findIndex(el => el.type === 'sample' && el.id === sampleID);
+
   if (sampleID === 'new') {
     ElementActions.generateEmptySample(collectionID);
   } else if (sampleID === 'copy') {
     ElementActions.copySampleFromClipboard.defer(collectionID);
-  } else {
+  } else if (index < 0) {
     ElementActions.fetchSampleById(sampleID);
+  } else if (index !== activeKey) {
+    DetailActions.select(index);
   }
   // UIActions.selectTab(1);
 };


### PR DESCRIPTION
When selecting an already open sample in the sample list, the server reloads and thus the user loses any unsaved changes without a warning (see https://github.com/ComPlat/chemotion/issues/19).

Solution: when the user selects an element in the list, if it is already opened, the server simply switches to the tab without reloading. In this way, the current unsaved changes are retained. 

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
