### PR TITLE
separate aasm states for document editing on onlyoffice

### DIFF
--- a/app/api/chemotion/editor_api.rb
+++ b/app/api/chemotion/editor_api.rb
@@ -5,45 +5,47 @@
 module Chemotion
   # Editor API
   class EditorAPI < Grape::API
-    # rubocop:disable Metrics/BlockLength
     namespace :editor do
-      namespace :initial do
-        get do
-          docserver = Rails.configuration.editors&.docserver
-          { installed: docserver && docserver[:enable] || false, ext: docserver && docserver[:ext] }
-        end
+      desc 'get editor config'
+      get :initial do
+        docserver = Rails.configuration.editors&.docserver
+        { installed: (docserver && docserver[:enable]) || false, ext: docserver && docserver[:ext] }
       end
 
-      namespace :start do
-        desc 'start editing a document'
+      route_param :id do
+        desc 'start/stop editing a document'
         params do
-          requires :attachment_id, type: Integer, desc: 'attachment id'
+          requires :id, type: Integer, desc: 'attachment id'
         end
-        before do
-          @attachment = Attachment.find_by(id: params[:attachment_id])
-          unless ElementPolicy.new(current_user, ResearchPlan.find_by(id: @attachment[:attachable_id])).update?
-            error!('401 Unauthorized', 401)
-          end
-          # error!('401 Unauthorized', 401) if @attachment.oo_editing?
+
+        after_validation do
+          @attachment = Attachment.find_by(id: params[:id])
+          error!('404 Not Found', 404) unless @attachment
+          # TODO: ElementPolicy is not yet implemented for other elements than ResearchPlan
+          error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, @attachment.attachable).update?
         end
-        post do
+
+        get 'start' do
+          error!('401 Unauthorized', 401) unless @attachment.editable_document?
+          error!('401 Document is already being edited', 401) if @attachment.editing?
           payload = {
             att_id: @attachment.id,
             user_id: current_user.id,
             exp: (Time.zone.now + 15.minutes).to_i,
           }
-          @attachment.oo_editing_start!
-          token = JWT.encode payload, Rails.application.secrets.secret_key_base
+          @attachment.editing_start!
+          file_extension = @attachment.editable_document? && @attachment.file_extension
+          token = JsonWebToken.encode(payload)
           only_office_payload = {
             width: '100%',
-            height: '950px',
+            height: '100%',
             type: 'desktop',
             document: {
               att_id: @attachment.id,
-              fileType: 'docx',
+              fileType: file_extension,
               key: token,
               title: @attachment.filename,
-              url: "#{Application.config.root_url}/api/v1/public/download?token=#{token}",
+              url: "#{Rails.application.config.root_url}/api/v1/public/download?token=#{token}",
               permissions: {
                 download: true,
                 edit: true,
@@ -52,7 +54,7 @@ module Chemotion
               },
             },
             editorConfig: {
-              callbackUrl: "#{Application.config.root_url}/api/v1/public/callback",
+              callbackUrl: "#{Rails.application.config.root_url}/api/v1/public/callback",
               mode: 'edit',
               lang: 'en',
               customization: {
@@ -85,6 +87,11 @@ module Chemotion
           only_office_token = JWT.encode only_office_payload, Rails.application.secrets.only_office_secret_key_base
 
           { token: token, only_office_token: only_office_token }
+        end
+
+        get :end do
+          @attachment.editing_end!
+          { message: 'ok' }
         end
       end
     end

--- a/app/api/chemotion/public_api.rb
+++ b/app/api/chemotion/public_api.rb
@@ -78,10 +78,11 @@ module Chemotion
         end
         get do
           content_type 'application/octet-stream'
-          payload = JWT.decode(params[:token], Rails.application.secrets.secret_key_base) unless params[:token].nil?
-          error!('401 Unauthorized', 401) if payload&.length == 0
-          att_id = payload[0]['att_id']&.to_i
-          user_id = payload[0]['user_id']&.to_i
+          payload = JsonWebToken.decode(params[:token])
+          error!('401 Unauthorized', 401) if payload.empty?
+
+          att_id = payload['att_id']&.to_i
+          user_id = payload['user_id']&.to_i
           @attachment = Attachment.find_by(id: att_id)
           @user = User.find_by(id: user_id)
           error!('401 Unauthorized', 401) if @attachment.nil? || @user.nil?
@@ -101,19 +102,20 @@ module Chemotion
         # 4 - document is closed with no changes,
         # 6 - document is being edited, but the current document state is saved,
         # 7 - error has occurred while force saving the document.
-        before do
+        after_validation do
           error!('401 Unauthorized', 401) if params[:key].nil?
-          payload = JWT.decode(params[:key], Rails.application.secrets.secret_key_base) unless params[:key].nil?
+          payload = JsonWebToken.decode(params[:key])
           error!('401 Unauthorized', 401) if payload.empty?
           @status = params[:status].is_a?(Integer) ? params[:status] : 0
 
           if @status > 1
-            attach_id = payload[0]['att_id']&.to_i
+            attach_id = payload['att_id']&.to_i
             @url = params[:url]
-            @attachment = Attachment.find_by(id: attach_id)
-            user_id = payload[0]['user_id']&.to_i
+            @attachment = Attachment.editing.find_by(id: attach_id)
+            error!("404 Not Found, edited attachment id: #{attach_id}", 404) unless @attachment
+            user_id = payload['user_id']&.to_i
             @user = User.find_by(id: user_id)
-            error!('401 Unauthorized', 401) if @attachment.nil? || @user.nil?
+            error!('401 Unauthorized', 401) if @user.nil?
           end
         end
 
@@ -132,11 +134,14 @@ module Chemotion
           case @status
           when 1
           when 2
+            # prevent saving if the file is not locked for editing
+            error!('401 Unauthorized', 401) if @attachment.not_editing?
+
             @attachment.file_data = open(@url).read
             @attachment.rewrite_file_data!
-            @attachment.oo_editing_end!
+            @attachment.editing_end!
           else
-            @attachment.oo_editing_end!
+            @attachment.editing_end!
           end
           send_notification(@attachment, @user, @status) unless @status <= 1
           # rescue StandardError => err

--- a/app/api/entities/attachment_entity.rb
+++ b/app/api/entities/attachment_entity.rb
@@ -3,6 +3,6 @@
 module Entities
   class AttachmentEntity < Grape::Entity
     expose :id, documentation: { type: 'Integer', desc: "Attachment's unique id" }
-    expose :filename, :identifier, :content_type, :thumb, :aasm_state, :filesize
+    expose :filename, :identifier, :content_type, :thumb, :aasm_state, :filesize, :edit_state
   end
 end

--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -8,7 +8,6 @@ module AttachmentJcampAasm
   extend ActiveSupport::Concern
 
   included do
-    include AASM
     before_create :init_aasm
     before_update :require_peaks_generation?
 
@@ -18,15 +17,6 @@ module AttachmentJcampAasm
       state :peaked, :edited, :backup, :image, :json, :csv, :nmrium
       state :failure
       state :non_jcamp
-      state :oo_editing
-
-      event :oo_editing_start do
-        transitions from: %i[oo_editing non_jcamp idle], to: :oo_editing
-      end
-
-      event :oo_editing_end do
-        transitions from: :oo_editing, to: :non_jcamp
-      end
 
       event :set_queueing do
         transitions from: %i[idle done backup failure non_jcamp queueing regenerating nmrium],

--- a/app/packs/src/apps/mydb/elements/details/wellplates/attachmentsTab/WellplateDetailsAttachments.js
+++ b/app/packs/src/apps/mydb/elements/details/wellplates/attachmentsTab/WellplateDetailsAttachments.js
@@ -76,13 +76,13 @@ export default class WellplateDetailsAttachments extends Component {
     const fileType = last(attachment.filename.split('.'));
     const docType = this.documentType(attachment.filename);
 
-    EditorFetcher.startEditing({ attachment_id: attachment.id })
+    EditorFetcher.startEditing({ attachmentId: attachment.id })
       .then((result) => {
         if (result.token) {
           const url = `/editor?id=${attachment.id}&docType=${docType}&fileType=${fileType}&title=${attachment.filename}&key=${result.token}`;
           window.open(url, '_blank');
 
-          attachment.aasm_state = 'oo_editing';
+          attachment.edit_state = 'editing';
           attachment.updated_at = new Date();
 
           onEdit(attachment);
@@ -202,7 +202,7 @@ export default class WellplateDetailsAttachments extends Component {
     const fetchId = attachment.id;
 
     const previewImg = previewAttachmentImage(attachment);
-    const isEditing = attachment.aasm_state === 'oo_editing' && new Date().getTime() < updateTime;
+    const isEditing = attachment.edit_state === 'editing' && new Date().getTime() < updateTime;
 
     const docType = this.documentType(attachment.filename);
     const editDisable = !attachmentEditor || isEditing || attachment.is_new || docType === null;

--- a/app/packs/src/components/generic/GenericAttachments.js
+++ b/app/packs/src/components/generic/GenericAttachments.js
@@ -45,12 +45,12 @@ export default class GenericAttachments extends Component {
     const attachment = att;
     const fileType = last(attachment.filename.split('.'));
     const docType = this.documentType(attachment.filename);
-    EditorFetcher.startEditing({ attachment_id: attachment.id })
+    EditorFetcher.startEditing({ attachmentId: attachment.id })
       .then((result) => {
         if (result.token) {
           const url = `/editor?id=${attachment.id}&docType=${docType}&fileType=${fileType}&title=${attachment.filename}&key=${result.token}`;
           window.open(url, '_blank');
-          attachment.aasm_state = 'oo_editing';
+          attachment.edit_state = 'editing';
           attachment.updated_at = new Date();
           onEdit(attachment);
         } else {
@@ -84,7 +84,7 @@ export default class GenericAttachments extends Component {
       hasPop = false;
       fetchNeeded = false;
     }
-    const isEditing = attachment.aasm_state === 'oo_editing' && new Date().getTime() < updateTime;
+    const isEditing = attachment.edit_state === 'editing' && new Date().getTime() < updateTime;
     const docType = this.documentType(attachment.filename);
     const editDisable = !attachmentEditor || isEditing || attachment.is_new || docType === null;
     const styleEditor = !attachmentEditor || docType === null ? 'none' : '';

--- a/app/packs/src/fetchers/EditorFetcher.js
+++ b/app/packs/src/fetchers/EditorFetcher.js
@@ -12,16 +12,12 @@ export default class EditorFetcher {
   }
 
   static startEditing(params) {
-    const promise = fetch('/api/v1/editor/start/', {
+    const { attachmentId, forceStop } = params;
+    const promise = fetch(`/api/v1/editor/${attachmentId}/${forceStop ? 'end' : 'start'}/`, {
       credentials: 'same-origin',
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(params)
+      method: 'GET',
     })
-      .then(response => response.json()).then(json => json).catch((errorMessage) => {
+      .then(response => response.json()).catch((errorMessage) => {
         console.log(errorMessage);
       });
     return promise;

--- a/config/initializers/editors.rb
+++ b/config/initializers/editors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   editors_config = Rails.application.config_for :editors
 
@@ -11,7 +13,10 @@ begin
     else
       config.editors = nil
     end
+    available_extensions = config.editors.docserver&.fetch(:ext, [])&.flatten(2)&.filter { |ext| ext.is_a?(String) }
+    config.editors.available_extensions = available_extensions
   end
+
 rescue StandardError => e
   Rails.logger.error e.message
   Rails.application.configure do

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -19,7 +19,7 @@
 
 development:
   secret_key_base: 2de67b6ea84b3dbe43a40813b747fb6cb8a3c93ef4135b737ee4c6fb4e3e758fcc030e33c78fc6f7db180ea9b6d7a31081a61678d614142198cbafd37aaa6c09
-  only_office_secret_key_base: ece3002fc1
+  only_office_secret_key_base: my_jwt_secret
 
 test:
   secret_key_base: b1b52f3f9c80554019996ccac1d8d6fca40b7ec927acae2f53086f2d5dc8981ada4043d85ca05a27b6fdbcb969f529be14782c7a63a26abd9e6b13772ab01950

--- a/db/migrate/20230706134320_add_edit_state_attachment.rb
+++ b/db/migrate/20230706134320_add_edit_state_attachment.rb
@@ -1,0 +1,5 @@
+class AddEditStateAttachment < ActiveRecord::Migration[6.1]
+  def change
+    add_column :attachments, :edit_state, :integer, default: 0
+  end
+end

--- a/db/migrate/20230710140714_attachment_aasm_state_clean_up.rb
+++ b/db/migrate/20230710140714_attachment_aasm_state_clean_up.rb
@@ -1,0 +1,8 @@
+class AttachmentAasmStateCleanUp < ActiveRecord::Migration[6.1]
+  # update any attachment having the former aasm_state 'oo_editing' to 'idle'
+  def change
+    Attachment.where(aasm_state: 'oo_editing').find_each do |attachment|
+      attachment.update_columns(aasm_state: 'idle')
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_13_063121) do
+ActiveRecord::Schema.define(version: 2023_07_10_140714) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2023_06_13_063121) do
     t.string "aasm_state"
     t.bigint "filesize"
     t.jsonb "attachment_data"
+    t.integer "edit_state", default: 0
     t.index ["attachable_type", "attachable_id"], name: "index_attachments_on_attachable_type_and_attachable_id"
     t.index ["identifier"], name: "index_attachments_on_identifier", unique: true
   end


### PR DESCRIPTION
this should prevent conflict with  spectra or converter transition.

API: add stop endpoint: this allow users to prevent the remote editor to update the attachment

clean up aasm_state from former editing state

TODO
unify editor btn


