### PR TITLE
Calendar Notification: rescue SMTP error to avoid repeat notif

### DIFF
--- a/app/jobs/send_calendar_entry_notification_job.rb
+++ b/app/jobs/send_calendar_entry_notification_job.rb
@@ -3,11 +3,16 @@
 class SendCalendarEntryNotificationJob < ApplicationJob
   queue_as :send_calendar_entry_notification
 
+  def max_attempts
+    1
+  end
+
   def perform(calendar_entry_id, user_ids, type)
     entry = CalendarEntry.find_by(id: calendar_entry_id)
     return true if entry.nil? || user_ids&.none?
 
     entry.create_messages(user_ids, type)
     entry.send_emails(user_ids, type)
+  rescue Net::SMTPError
   end
 end


### PR DESCRIPTION
also set Job's `max_attempts` to 1

when email sending fails (eg wrong configuration), avoid client notification to be repeated.


