### PR TITLE
opening a dataset without making changes

### DIFF
--- a/app/packs/src/components/container/ContainerDataset.js
+++ b/app/packs/src/components/container/ContainerDataset.js
@@ -39,13 +39,12 @@ export default class ContainerDataset extends Component {
     this.handleRemoveLink = this.handleRemoveLink.bind(this);
   }
 
-  componentDidMount() {
-    this.createAttachmentPreviews(this.state.dataset_container);
-  }
 
   createAttachmentPreviews(dataset_container) {
     const { attachments } = dataset_container;
-    let updatedAttachments = attachments.map((attachment) => {
+    const newAttachments = attachments.filter((attachment) => !attachment.preview);
+
+    const updatedAttachments = newAttachments.map(attachment => {
       return attachment.thumb ? AttachmentFetcher.fetchThumbnail({ id: attachment.id }).then((result) => {
         if (result != null) {
           attachment.preview = `data:image/png;base64,${result}`;


### PR DESCRIPTION
Fix for https://github.com/ComPlat/chemotion/issues/18.

Solution: the attachment preview for each dataset is created just once so that it doesn't incorrectly trigger the 'unsaved data will be lost' warning. 

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
