### PR TITLE
Fix buttons enabled/disabled for read only elements in shared collections

### DIFF
--- a/app/api/chemotion/permission_api.rb
+++ b/app/api/chemotion/permission_api.rb
@@ -57,7 +57,8 @@ module Chemotion
               move_allowed = false
             end
           end
-          { deletion_allowed: deletion_allowed, sharing_allowed: sharing_allowed, is_top_secret: is_top_secret, assign_allowed: assign_allowed, move_allowed: move_allowed }
+          { deletion_allowed: deletion_allowed, sharing_allowed: sharing_allowed, is_top_secret: is_top_secret,
+            assign_allowed: assign_allowed, move_allowed: move_allowed }
         end
       end
     end

--- a/app/api/chemotion/permission_api.rb
+++ b/app/api/chemotion/permission_api.rb
@@ -37,6 +37,8 @@ module Chemotion
 
           deletion_allowed = true
           sharing_allowed = true
+          assign_allowed = true
+          move_allowed = true
           if (params[:currentCollection][:is_sync_to_me] || params[:currentCollection][:is_shared])
             deletion_allowed = has_sel['sample'] ? ElementsPolicy.new(current_user, sel['sample']).destroy? : true
             deletion_allowed = deletion_allowed && (has_sel['reaction'] ? ElementsPolicy.new(current_user, sel['reaction']).destroy? : true)
@@ -44,14 +46,18 @@ module Chemotion
             deletion_allowed = deletion_allowed && (has_sel['screen'] ? ElementsPolicy.new(current_user, sel['screen']).destroy? : true)
             if deletion_allowed
               sharing_allowed = true
+              assign_allowed = true
+              move_allowed = true
             else
               sharing_allowed = has_sel['sample'] ? ElementsPolicy.new(current_user, sel['sample']).share? : true
               sharing_allowed = sharing_allowed && has_sel['reaction'] ? ElementsPolicy.new(current_user, sel['reaction']).share? : true
               sharing_allowed = sharing_allowed && has_sel['wellplate'] ? ElementsPolicy.new(current_user, sel['wellplate']).share? : true
               sharing_allowed = sharing_allowed && has_sel['screen'] ? ElementsPolicy.new(current_user, sel['screen']).share? : true
+              assign_allowed = false
+              move_allowed = false
             end
           end
-          { deletion_allowed: deletion_allowed, sharing_allowed: sharing_allowed, is_top_secret: is_top_secret }
+          { deletion_allowed: deletion_allowed, sharing_allowed: sharing_allowed, is_top_secret: is_top_secret, assign_allowed: assign_allowed, move_allowed: move_allowed }
         end
       end
     end

--- a/app/packs/src/components/managingActions/ManagingActions.js
+++ b/app/packs/src/components/managingActions/ManagingActions.js
@@ -214,7 +214,7 @@ export default class ManagingActions extends React.Component {
     const assignDisabled = noSel || !assign_allowed;
     const removeDisabled = noSel || isAll || !deletion_allowed; //!remove_allowed
     const deleteDisabled = noSel || !deletion_allowed;
-    const shareDisabled = noSel || !sharing_allowed;
+    const shareDisabled = noSel || !sharing_allowed || !move_allowed;
 
     return (
       <div style={{ display: 'inline', float: 'left', marginRight: 10 }}>

--- a/app/packs/src/components/managingActions/ManagingActions.js
+++ b/app/packs/src/components/managingActions/ManagingActions.js
@@ -66,6 +66,8 @@ export default class ManagingActions extends React.Component {
     this.state = {
       currentUser,
       currentCollection: { id: 0 },
+      move_allowed: false,
+      assign_allowed: false,
       sharing_allowed: false,
       deletion_allowed: false,
       remove_allowed: false,
@@ -100,6 +102,8 @@ export default class ManagingActions extends React.Component {
     } = state;
     if (this.collectionChanged(state)) {
       this.setState({
+        move_allowed: false,
+        assign_allowed: false,
         sharing_allowed: false,
         deletion_allowed: false,
         remove_allowed: false,
@@ -199,14 +203,15 @@ export default class ManagingActions extends React.Component {
 
   render() {
     const {
-      currentCollection, sharing_allowed, deletion_allowed, remove_allowed, is_top_secret, hasSel
+      currentCollection, sharing_allowed, deletion_allowed, remove_allowed, is_top_secret, hasSel, 
+      move_allowed, assign_allowed
     } = this.state;
     const { is_locked, is_shared, sharer, is_sync_to_me, label } = currentCollection;
     const isAll = is_locked && label === 'All';
     const noSel = !hasSel
 
-    const moveDisabled = noSel || isAll;
-    const assignDisabled = noSel;
+    const moveDisabled = noSel || !move_allowed;
+    const assignDisabled = noSel || !assign_allowed;
     const removeDisabled = noSel || isAll || !deletion_allowed; //!remove_allowed
     const deleteDisabled = noSel || !deletion_allowed;
     const shareDisabled = noSel || !sharing_allowed;

--- a/app/packs/src/stores/alt/stores/PermissionStore.js
+++ b/app/packs/src/stores/alt/stores/PermissionStore.js
@@ -5,6 +5,8 @@ class PermissionStore {
   constructor() {
     this.state = {
       is_top_secret: false,
+      move_allowed: false,
+      assign_allowed: false,
       sharing_allowed: false,
       deletion_allowed: false,
       remove_allowed: false,
@@ -21,6 +23,8 @@ class PermissionStore {
     if (result.sharing_allowed !=null) {this.state.sharing_allowed = result.sharing_allowed}
     if (result.deletion_allowed !=null) {this.state.deletion_allowed = result.deletion_allowed}
     if (result.remove_allowed !=null) {this.state.remove_allowed = result.remove_allowed}
+    if (result.move_allowed !=null) {this.state.move_allowed = result.move_allowed}
+    if (result.assign_allowed !=null) {this.state.assign_allowed = result.assign_allowed}
   }
 }
 


### PR DESCRIPTION
Disable buttons for moving/assigning/deleting/sharing when user is not the owner of the shared collection.  

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
