### PR TITLE
Allow deletion of SampleTasks and fix SampleTask Inbox scroll issues

### DIFF
--- a/app/api/chemotion/sample_task_api.rb
+++ b/app/api/chemotion/sample_task_api.rb
@@ -60,6 +60,17 @@ module Chemotion
         present updater.sample_task, with: Entities::SampleTaskEntity
       end
 
+      # delete an open sample task
+      delete ':id' do
+        task = SampleTask.for(current_user).open.find(params[:id])
+
+        if task.destroy
+          { deleted: task.id }
+        else
+          { error: 'Task could not be deleted' }
+        end
+      end
+
       route_param :id do
         resource :scan_results do
           params do

--- a/app/api/chemotion/sample_task_api.rb
+++ b/app/api/chemotion/sample_task_api.rb
@@ -62,13 +62,10 @@ module Chemotion
 
       # delete an open sample task
       delete ':id' do
-        task = SampleTask.for(current_user).open.find(params[:id])
+        task = SampleTask.for(current_user).open.find_by(id: params[:id])
+        error!('Task could not be deleted', 400) unless task.present? && task.destroy
 
-        if task.destroy
-          { deleted: task.id }
-        else
-          { error: 'Task could not be deleted' }
-        end
+        { deleted: task.id }
       end
 
       route_param :id do

--- a/app/packs/src/apps/mydb/collections/sampleTaskInbox/SampleTaskCard.js
+++ b/app/packs/src/apps/mydb/collections/sampleTaskInbox/SampleTaskCard.js
@@ -1,8 +1,9 @@
 import React, { useContext, useState } from 'react';
 import { useDrop } from 'react-dnd';
-import { Panel } from 'react-bootstrap';
+import { Button, Panel } from 'react-bootstrap';
 import DragDropItemTypes from 'src/components/DragDropItemTypes';
 import { StoreContext } from 'src/stores/mobx/RootStore';
+import NotificationActions from 'src/stores/alt/actions/NotificationActions';
 
 const SampleTaskCard = ({ sampleTask }) => {
   const sampleTasksStore = useContext(StoreContext).sampleTasks;
@@ -92,16 +93,49 @@ const SampleTaskCard = ({ sampleTask }) => {
   };
 
   const contentForSample = () => {
-    console.debug(sampleTask)
     if (sampleTask.sample_id) { return sampleImage() }
     else if (sample) { return droppedSample() }
     else { return sampleDropzone() }
+  }
+
+  const deleteButton = () => {
+    return (
+      <Button bsStyle="danger" className="pull-right" bsSize="xsmall" onClick={() => deleteSampleTask() }>
+        <i className="fa fa-trash-o" />
+      </Button>
+    );
+  }
+
+  const deleteSampleTask = () => {
+    sampleTasksStore
+      .deleteSampleTask(sampleTask)
+      .then(result => {
+        let level = 'success'
+        let message = 'Sample task successfully deleted'
+
+        if (result.error) {
+          level = 'error'
+          message = result.error
+        }
+
+        const notification = {
+          title: message,
+          message: message,
+          level: level,
+          dismissible: 'button',
+          autoDismiss: 5,
+          position: 'tr',
+          uid: 'SampleTaskInbox'
+        };
+        NotificationActions.add(notification);
+      });
   }
 
   return (
     <Panel bsStyle="info">
       <Panel.Heading>
         {panelHeading()}
+        {deleteButton()}
       </Panel.Heading>
       <Panel.Body>
         <div className="row">

--- a/app/packs/src/apps/mydb/collections/sampleTaskInbox/SampleTaskCard.js
+++ b/app/packs/src/apps/mydb/collections/sampleTaskInbox/SampleTaskCard.js
@@ -4,10 +4,12 @@ import { Button, Panel } from 'react-bootstrap';
 import DragDropItemTypes from 'src/components/DragDropItemTypes';
 import { StoreContext } from 'src/stores/mobx/RootStore';
 import NotificationActions from 'src/stores/alt/actions/NotificationActions';
+import { ConfirmModal } from 'src/components/common/ConfirmModal';
 
 const SampleTaskCard = ({ sampleTask }) => {
   const sampleTasksStore = useContext(StoreContext).sampleTasks;
   const [sample, setSample] = useState(null);
+  const [showDeletionConfirmationDialog, setShowDeletionConfirmationDialog] = useState(false);
   const [_spec, dropRef] = useDrop({
     accept: [
       DragDropItemTypes.SAMPLE,
@@ -100,13 +102,16 @@ const SampleTaskCard = ({ sampleTask }) => {
 
   const deleteButton = () => {
     return (
-      <Button bsStyle="danger" className="pull-right" bsSize="xsmall" onClick={() => deleteSampleTask() }>
+      <Button bsStyle="danger" className="pull-right" bsSize="xsmall" onClick={() => setShowDeletionConfirmationDialog(true) }>
         <i className="fa fa-trash-o" />
       </Button>
     );
   }
 
-  const deleteSampleTask = () => {
+  const deleteSampleTask = (confirmationResult) => {
+    setShowDeletionConfirmationDialog(false);
+    if (confirmationResult != true) return;
+
     sampleTasksStore
       .deleteSampleTask(sampleTask)
       .then(result => {
@@ -147,6 +152,12 @@ const SampleTaskCard = ({ sampleTask }) => {
           </div>
         </div>
       </Panel.Body>
+      <ConfirmModal
+        showModal={showDeletionConfirmationDialog}
+        title="Are you sure?"
+        content="Deletion of a Sample Task cannot be undone. Please check carefully"
+        onClick={ deleteSampleTask }
+      />
     </Panel>
   )
 }

--- a/app/packs/src/apps/mydb/collections/sampleTaskInbox/SampleTaskCard.js
+++ b/app/packs/src/apps/mydb/collections/sampleTaskInbox/SampleTaskCard.js
@@ -136,6 +136,30 @@ const SampleTaskCard = ({ sampleTask }) => {
       });
   }
 
+  const sampleTaskStillOpenReasons = () => {
+    let reasons = [];
+    if (sampleTask.sample_id == null) reasons.push('The task has no sample assigned');
+    if (sampleTask.required_scan_results > sampleTask.scan_results.length) {
+      let missing_scan_results = sampleTask.required_scan_results - sampleTask.scan_results.length;
+      if (missing_scan_results == 1) reasons.push('The task needs one more scan result');
+      if (missing_scan_results > 1) reasons.push(`The tasks needs ${missing_scan_results} more scan results`);
+    }
+
+    return reasons;
+  }
+
+  const deletionConfirmationContent = () => {
+    return (
+      <div>
+        <p>Deletion of a Scan Task cannot be undone. Please check carefully</p>
+        <p>The task is missing the following to be completed:</p>
+        <ul>
+          {sampleTaskStillOpenReasons().map((reason) => (<li>{reason}</li>))}
+        </ul>
+      </div>
+    );
+  }
+
   return (
     <Panel bsStyle="info">
       <Panel.Heading>
@@ -155,7 +179,7 @@ const SampleTaskCard = ({ sampleTask }) => {
       <ConfirmModal
         showModal={showDeletionConfirmationDialog}
         title="Are you sure?"
-        content="Deletion of a Sample Task cannot be undone. Please check carefully"
+        content={deletionConfirmationContent()}
         onClick={ deleteSampleTask }
       />
     </Panel>

--- a/app/packs/src/apps/mydb/collections/sampleTaskInbox/SampleTaskInbox.js
+++ b/app/packs/src/apps/mydb/collections/sampleTaskInbox/SampleTaskInbox.js
@@ -100,7 +100,7 @@ const SampleTaskInbox = ({}) => {
         className="sampleTaskInbox small-col col-md-6"
         style={{
           zIndex: 10, position: 'absolute', top: '70px', left: '10px', display: display_value,
-          maxHeight: '80%', overflow: 'scroll'
+          maxHeight: '80%'
         }}
       >
         <Panel.Heading className="handle">
@@ -127,7 +127,9 @@ const SampleTaskInbox = ({}) => {
               {sampleDropzone(doubleScanDropRef, 'Double Scan (weighing vessel and vessel+compound to calculate difference')}
             </div>
           </div>
-          {openSampleTasks()}
+          <div class="openSampleTasks" style={{ maxHeight: '500px', overflow: 'scroll' }}>
+            {openSampleTasks()}
+          </div>
         </Panel.Body>
       </Panel>
     </Draggable>

--- a/app/packs/src/fetchers/SampleTasksFetcher.js
+++ b/app/packs/src/fetchers/SampleTasksFetcher.js
@@ -32,6 +32,14 @@ export default class SampleTaskFetcher {
       .catch(errorMessage => console.log(errorMessage));
   }
 
+  static deleteSampleTask(sample_task_id) {
+    return fetch(
+      `/api/v1/sample_tasks/${sample_task_id}`,
+      { ...this._httpOptions('DELETE') }
+    ).then(response => response.json())
+     .catch(errorMessage => console.log(errorMessage));
+  }
+
   static _fetchSampleTasks(status) {
     return fetch(
       `/api/v1/sample_tasks?status=${status}`,

--- a/app/packs/src/stores/mobx/SampleTasksStore.jsx
+++ b/app/packs/src/stores/mobx/SampleTasksStore.jsx
@@ -54,6 +54,13 @@ export const SampleTasksStore = types
         let createdSampleTask = SampleTask.create({ ...result });
         self.sample_tasks.set(createdSampleTask.id, createdSampleTask)
       }
+    }),
+    deleteSampleTask: flow(function* deleteSampleTask(sampleTask) {
+      let result = yield SampleTasksFetcher.deleteSampleTask(sampleTask.id)
+      if (result.deleted == sampleTask.id) {
+        self.sample_tasks.delete(sampleTask.id)
+      }
+      return result
     })
   }))
   .views(self => ({

--- a/app/packs/src/stores/mobx/SampleTasksStore.jsx
+++ b/app/packs/src/stores/mobx/SampleTasksStore.jsx
@@ -19,7 +19,7 @@ const SampleTask = types.model({
   display_name: types.maybeNull(types.string),
   short_label: types.maybeNull(types.string),
   sample_svg_file: types.maybeNull(types.string),
-  image: types.maybeNull(types.string),
+  required_scan_results: types.number,
   scan_results: types.array(ScanResult)
 });
 

--- a/app/usecases/sample_tasks/create.rb
+++ b/app/usecases/sample_tasks/create.rb
@@ -24,7 +24,7 @@ module Usecases
 
       def default_description
         description = "Scan Task from #{DateTime.current}"
-        description += " for #{sample.showed_name}" if sample
+        description += " for #{sample.showed_name}" if sample && sample.showed_name.present?
 
         description
       end

--- a/spec/api/chemotion/sample_task_api_spec.rb
+++ b/spec/api/chemotion/sample_task_api_spec.rb
@@ -144,7 +144,7 @@ describe Chemotion::SampleTaskAPI do
       it 'deletes the sample task and its related scan results and attachments' do
         delete "/api/v1/sample_tasks/#{new_sample_task.id}"
 
-        expect(parsed_json_response).to include("deleted" => new_sample_task.id)
+        expect(parsed_json_response).to include('deleted' => new_sample_task.id)
       end
     end
 

--- a/spec/api/chemotion/sample_task_api_spec.rb
+++ b/spec/api/chemotion/sample_task_api_spec.rb
@@ -138,4 +138,22 @@ describe Chemotion::SampleTaskAPI do
       end
     end
   end
+
+  describe 'DELETE /api/v1/sample_tasks/:id' do
+    context 'when sample task is open' do
+      it 'deletes the sample task and its related scan results and attachments' do
+        delete "/api/v1/sample_tasks/#{new_sample_task.id}"
+
+        expect(parsed_json_response).to include("deleted" => new_sample_task.id)
+      end
+    end
+
+    context 'when sample task is not open' do
+      it 'returns a 400' do
+        delete "/api/v1/sample_tasks/#{finished_scan.id}"
+
+        expect(parsed_json_response).to include('error' => 'Task could not be deleted')
+      end
+    end
+  end
 end


### PR DESCRIPTION
While reviewing the current state of the Chemobile App, the wish came up to be able to delete open sample tasks.

This PR implements the ELN-side of this feature request.

It adds a delete button on sample tasks in the inbox, which in turn deletes the sample task and any associated scan results.
Please take note, that this only applies to open (i.e. not yet applied) sample tasks and scan results. Once a sample task is completed (meaning that the resulting value has been written into the real_amount fields within the sample), the sample task is no longer available for deletion (otherwise we would lose the ability to check if the real_amount_value was set by a sample task).

Additionally, this pull request includes some cosmetic changes to the sample task inbox, that came up within review.

TODO: Specs for Delete Endpoint