### PR TITLE
Always sort new sample tasks on top of list

### DIFF
--- a/app/api/chemotion/sample_task_api.rb
+++ b/app/api/chemotion/sample_task_api.rb
@@ -20,7 +20,7 @@ module Chemotion
         optional :status, type: String, values: %w[open with_missing_scan_results done], default: 'open'
       end
       get do
-        tasks = SampleTask.for(current_user).public_send(params[:status])
+        tasks = SampleTask.for(current_user).public_send(params[:status]).order(created_at: :desc)
 
         present tasks, with: Entities::SampleTaskEntity
       end

--- a/app/packs/src/apps/mydb/collections/sampleTaskInbox/SampleTaskInbox.js
+++ b/app/packs/src/apps/mydb/collections/sampleTaskInbox/SampleTaskInbox.js
@@ -62,9 +62,9 @@ const SampleTaskInbox = ({}) => {
   const openSampleTasks = () => {
     let sampleTasks = values(sampleTasksStore.sample_tasks);
 
-    return sampleTasks.map(sampleTask => (
-      <SampleTaskCard sampleTask={sampleTask} key={`sampleTask_${sampleTask.id}`} />
-    ));
+    return sampleTasks.toSorted(
+      (taskA, taskB) => { return taskB.id - taskA.id } // sort descending by task id to override Map sorting by insert order
+    ).map(sampleTask => (<SampleTaskCard sampleTask={sampleTask} key={`sampleTask_${sampleTask.id}`} />));
   }
 
   const sampleDropzone = (dropRef, text) => {


### PR DESCRIPTION
Small convenience feature: newly created sample tasks will appear on top of the sample task list within the sample task inbox