### PR TITLE
fix: quill_to_html when type HashWithIndifferentAccess

### DIFF
--- a/lib/chemotion/meta_schmooze/meta_schmooze.rb
+++ b/lib/chemotion/meta_schmooze/meta_schmooze.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'schmooze'
+
+module Chemotion
+  class MetaSchmooze
+    attr_reader :schmooze_klass, :root, :env, :schmooze_methods, :schmooze_dependencies
+
+    def initialize(schmooze_methods: {}, schmooze_dependencies: {}, var: {}, root: __dir__, env: {})
+      @root = root
+      @env = env
+      @schmooze_methods = schmooze_methods
+      @schmooze_dependencies = schmooze_dependencies
+      compose_schmooze_class
+      compose_schmooze_methods(var)
+    end
+
+    # rubocop:disable Style/OptionalBooleanParameter
+    def execute(method, var = {}, recompose_all = false)
+      if recompose_all
+        compose_schmooze_methods(var)
+      elsif var.present?
+        var.each { |method_name, v| recompose_schmooze_method(method_name, v) }
+      end
+      schmooze_klass.new(root, env).send(method)
+    end
+    # rubocop:enable Style/OptionalBooleanParameter
+
+    def recompose_schmooze_method(method_name, var = nil)
+      script = schmooze_methods[method_name]
+      compose_schmooze_method(method_name, script, var)
+    end
+
+    def respond_to_missing?(method, include_private = false)
+      super
+    end
+
+    def method_missing(method_name, arg = nil)
+      var = {}
+      var[method_name] = arg
+      execute(method_name, var)
+    end
+
+    private
+
+    def compose_schmooze_class
+      @schmooze_klass = Class.new(Schmooze::Base) do
+        # dependencies schmooze_dependencies
+      end
+      @schmooze_klass.send(:dependencies, schmooze_dependencies)
+    end
+
+    def compose_schmooze_methods(var = {})
+      schmooze_methods.each do |method_name, script|
+        compose_schmooze_method(method_name, script, var[method_name])
+      end
+    end
+
+    def compose_schmooze_method(method_name, script, var = nil)
+      case script
+      when String
+        schmooze_klass.send(:method, method_name, script)
+      when Proc
+        schmooze_klass.send(:method, method_name, script[var])
+      end
+    end
+  end
+end

--- a/lib/chemotion/quill_to_html.rb
+++ b/lib/chemotion/quill_to_html.rb
@@ -1,79 +1,28 @@
+# frozen_string_literal: true
+
 require 'schmooze'
+require 'meta_schmooze'
 
 module Chemotion
-  class MetaSchmooze
-    attr_reader :schmooze_klass, :root, :env, :schmooze_methods, :schmooze_dependencies
-
-    def initialize(schmooze_methods: {}, schmooze_dependencies: {}, var: {}, root: __dir__, env: {})
-      @root = root
-      @env = env
-      @schmooze_methods = schmooze_methods
-      @schmooze_dependencies = schmooze_dependencies
-      compose_schmooze_class
-      compose_schmooze_methods(var)
-    end
-
-    def execute(method, var = {}, recompose_all = false)
-      if recompose_all
-        compose_schmooze_methods(var)
-      elsif var.present?
-        var.each { |method_name, v| recompose_schmooze_method(method_name, v) }
-      end
-      schmooze_klass.new(root, env).send(method)
-    end
-
-    def recompose_schmooze_method(method_name, var = nil)
-      script = schmooze_methods[method_name]
-      compose_schmooze_method(method_name, script, var)
-    end
-
-    def method_missing(method_name, arg = nil )
-      var = {}
-      var[method_name] = arg
-      execute(method_name, var)
-    end
-
-    private
-    def compose_schmooze_class
-      @schmooze_klass = Class.new(Schmooze::Base) do
-        # dependencies schmooze_dependencies
-      end
-      @schmooze_klass.send(:dependencies, schmooze_dependencies)
-    end
-
-    def compose_schmooze_methods(var = {})
-      schmooze_methods.each do |method_name, script|
-        compose_schmooze_method(method_name, script, var[method_name])
-      end
-    end
-
-    def compose_schmooze_method(method_name, script, var = nil)
-      if script.is_a?(String)
-        schmooze_klass.send('method', method_name, script)
-      elsif script.is_a?(Proc)
-        schmooze_klass.send('method', method_name, script[var])
-      end
-    end
-  end
-
   class QuillToHtml < MetaSchmooze
     def initialize(schmooze_methods: {}, schmooze_dependencies: {}, root: Rails.root.to_s, env: {}, var: {})
+      super
       @root = root
       @env = env
-      @schmooze_dependencies = schmooze_dependencies.merge( delta: 'quill-delta-to-html')
+      @schmooze_dependencies = schmooze_dependencies.merge(delta: 'quill-delta-to-html')
       @schmooze_methods = schmooze_methods.merge(
-        convert: lambda_convert = -> (delta_ops = []) {
+        convert: lambda { |delta_ops = []|
           delta_ops = JSON.parse delta_ops if delta_ops.is_a?(String)
           delta_ops = case delta_ops.class.name
                       when 'Array'
                         delta_ops.to_json
-                      when 'Hash'
-                        delta_ops.fetch('ops',[]).to_json
+                      when 'Hash', 'ActiveSupport::HashWithIndifferentAccess'
+                        delta_ops.fetch('ops', []).to_json
                       else
                         '[]'
                       end
           return "function(){  var converter = new delta(#{delta_ops}, {});  return converter.convert(); } "
-        }
+        },
       )
       compose_schmooze_class
       compose_schmooze_methods(var)

--- a/spec/lib/chemotion/quill_to_html_spec.rb
+++ b/spec/lib/chemotion/quill_to_html_spec.rb
@@ -3,24 +3,36 @@
 require 'rails_helper'
 
 RSpec.describe 'QuillToHtml' do
-  subject { Chemotion::QuillToHtml }
+  subject(:quill_to_html) { Chemotion::QuillToHtml.new }
 
   describe 'convert' do
     let(:delta_ops) do
       [
         { insert: "Hello\n" },
-        { insert: 'This is colorful', attributes: { color: '#f00' } }
+        { insert: 'This is colorful', attributes: { color: '#f00' } },
       ]
+    end
+    let(:delta_ops_as_hash) do
+      { 'ops' => delta_ops }
     end
     let(:html) do
       '<p>Hello<br/><span style="color:#f00">This is colorful</span></p>'
     end
 
     it 'converts a quill delta ops as ruby array to html' do
-      expect(subject.new.convert(delta_ops)).to match(html)
+      expect(quill_to_html.convert(delta_ops)).to match(html)
     end
-    it 'converts a quill delta ops as ruby json string to html' do
-      expect(subject.new.convert(delta_ops.to_json)).to match(html)
+
+    it 'converts a quill delta ops as json string to html' do
+      expect(quill_to_html.convert(delta_ops.to_json)).to match(html)
+    end
+
+    it 'converts a quill delta ops as Hash to html' do
+      expect(quill_to_html.convert(delta_ops_as_hash)).to match(html)
+    end
+
+    it 'converts a quill delta ops as ActiveSupport::HashWithIndifferentAccess to html' do
+      expect(quill_to_html.convert(delta_ops_as_hash.with_indifferent_access)).to match(html)
     end
   end
 end


### PR DESCRIPTION
*  quill_to_html to process delta ops that were saved as HashWithIndifferentAccess, 
 so that description content is converted and can be inserted in reports.
 
* also refactor: schmooze implementation

