### PR TITLE
1398 image annotation tool image preview does not work as expected

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
@@ -63,6 +63,7 @@ export default class ResearchPlanDetailsAttachments extends Component {
     }
   }
 
+  /* eslint-disable no-param-reassign */
   handleEdit(attachment) {
     const fileType = last(attachment.filename.split('.'));
     const docType = this.documentType(attachment.filename);
@@ -104,6 +105,7 @@ export default class ResearchPlanDetailsAttachments extends Component {
       return attachment;
     });
   }
+  /* eslint-enable no-param-reassign */
 
   onImport(attachment) {
     const { researchPlan, onAttachmentImportComplete } = this.props;
@@ -256,7 +258,7 @@ export default class ResearchPlanDetailsAttachments extends Component {
           <Col md={8}>{attachment.filename}</Col>
           <Col md={3}>
             {this.renderRemoveAttachmentButton(attachment)}
-            {this.renderDownloadOriginalButton(attachment, downloadTooltip)}
+            {this.renderDownloadOriginalButton(attachment)}
             {this.renderEditAttachmentButton(
               attachment,
               extension,
@@ -294,7 +296,7 @@ export default class ResearchPlanDetailsAttachments extends Component {
     );
   }
 
-  renderDownloadOriginalButton(attachment, downloadTooltip) {
+  renderDownloadOriginalButton(attachment) {
     const { onDownload } = this.props;
     return (
       <OverlayTrigger placement="top" overlay={downloadTooltip}>

--- a/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
@@ -123,11 +123,13 @@ export default class ResearchPlanDetailsAttachments extends Component {
           (result) => {
             if (result != null) {
               attachment.preview = `data:image/png;base64,${result}`;
+              this.forceUpdate();
             }
           }
         );
       } else {
         attachment.preview = '/images/wild_card/not_available.svg';
+        this.forceUpdate();
       }
       return attachment;
     });

--- a/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
@@ -57,7 +57,7 @@ export default class ResearchPlanDetailsAttachments extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { attachments } = this.props.attachments;
+    const { attachments } = this.props;
     if (attachments !== prevProps.attachments) {
       this.createAttachmentPreviews();
     }
@@ -134,24 +134,26 @@ export default class ResearchPlanDetailsAttachments extends Component {
   }
 
   onImport(attachment) {
-    const researchPlanId = this.props.researchPlan.id;
+    const { researchPlan, onAttachmentImportComplete } = this.props;
+    const researchPlanId = researchPlan.id;
     LoadingActions.start();
     ElementActions.importTableFromSpreadsheet(
       researchPlanId,
       attachment.id,
-      this.props.onAttachmentImportComplete
+      onAttachmentImportComplete
     );
     LoadingActions.stop();
   }
 
   renderRemoveAttachmentButton(attachment) {
+    const { onDelete, readOnly } = this.props;
     return (
       <Button
         bsSize="xsmall"
         bsStyle="danger"
         className="button-right"
-        onClick={() => this.props.onDelete(attachment)}
-        disabled={this.props.readOnly}
+        onClick={() => onDelete(attachment)}
+        disabled={readOnly}
       >
         <i className="fa fa-trash-o" aria-hidden="true" />
       </Button>
@@ -159,16 +161,18 @@ export default class ResearchPlanDetailsAttachments extends Component {
   }
 
   renderImageEditModal() {
+    const { choosenAttachment, imageEditModalShown } = this.state;
+    const { onEdit } = this.props;
     return (
       <ImageAnnotationModalSVG
-        attachment={this.state.choosenAttachment}
-        isShow={this.state.imageEditModalShown}
+        attachment={choosenAttachment}
+        isShow={imageEditModalShown}
         handleSave={
           () => {
             const newAnnotation = document.getElementById('svgEditId').contentWindow.svgEditor.svgCanvas.getSvgString();
-            this.state.choosenAttachment.updatedAnnotation = newAnnotation;
+            choosenAttachment.updatedAnnotation = newAnnotation;
             this.setState({ imageEditModalShown: false });
-            this.props.onEdit(this.state.choosenAttachment);
+            onEdit(choosenAttachment);
           }
         }
         handleOnClose={() => { this.setState({ imageEditModalShown: false }); }}
@@ -188,6 +192,7 @@ export default class ResearchPlanDetailsAttachments extends Component {
 
   renderListGroupItem(attachment) {
     const { attachmentEditor, extension } = this.state;
+    const { onUndoDelete } = this.props;
 
     const updateTime = new Date(attachment.updated_at);
     updateTime.setTime(updateTime.getTime() + 15 * 60 * 1000);
@@ -215,7 +220,7 @@ export default class ResearchPlanDetailsAttachments extends Component {
                 bsSize="xsmall"
                 bsStyle="danger"
                 className="button-right"
-                onClick={() => this.props.onUndoDelete(attachment)}
+                onClick={() => onUndoDelete(attachment)}
               >
                 <i className="fa fa-undo" aria-hidden="true" />
               </Button>
@@ -290,13 +295,14 @@ export default class ResearchPlanDetailsAttachments extends Component {
   }
 
   renderDownloadOriginalButton(attachment, downloadTooltip) {
+    const { onDownload } = this.props;
     return (
       <OverlayTrigger placement="top" overlay={downloadTooltip}>
         <Button
           bsSize="xsmall"
           className="button-right"
           bsStyle="primary"
-          onClick={() => this.props.onDownload(attachment)}
+          onClick={() => onDownload(attachment)}
         >
           <i className="fa fa-download" aria-hidden="true" />
         </Button>
@@ -328,12 +334,12 @@ export default class ResearchPlanDetailsAttachments extends Component {
   }
 
   renderAttachments() {
-    const { attachments } = this.props;
+    const { attachments, researchPlan } = this.props;
     if (attachments && attachments.length > 0) {
       const filter = new ImageAttachmentFilter();
       const filteredAttachments = filter.filterAttachmentsWhichAreInBody(
-        this.props.researchPlan.body,
-        this.props.researchPlan.attachments
+        researchPlan.body,
+        researchPlan.attachments
       );
 
       return (
@@ -355,10 +361,11 @@ export default class ResearchPlanDetailsAttachments extends Component {
   }
 
   renderDropzone() {
+    const { onDrop, readOnly } = this.props;
     return (
       <Dropzone
-        onDrop={(files) => this.props.onDrop(files)}
-        className={`research-plan-dropzone-${this.props.readOnly ? 'disable' : 'enable'}`}
+        onDrop={(files) => onDrop(files)}
+        className={`research-plan-dropzone-${readOnly ? 'disable' : 'enable'}`}
       >
         <div className="zone">Drop Files, or Click to Select.</div>
       </Dropzone>
@@ -366,9 +373,11 @@ export default class ResearchPlanDetailsAttachments extends Component {
   }
 
   renderImportAttachmentButton(attachment) {
-    const show = this.state.showImportConfirm[attachment.id];
+    const { showImportConfirm } = this.state;
+    const { researchPlan } = this.props;
+    const show = showImportConfirm[attachment.id];
     // TODO: import disabled when?
-    const importDisabled = this.props.researchPlan.changed;
+    const importDisabled = researchPlan.changed;
     const extension = last(attachment.filename.split('.'));
 
     const importTooltip = importDisabled

--- a/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
@@ -37,6 +37,35 @@ const downloadAnnotationTooltip = <Tooltip id="download_tooltip">Download annota
 const imageStyle = { position: 'absolute', width: 60, height: 60 };
 
 export default class ResearchPlanDetailsAttachments extends Component {
+  static isImageFile(fileName) {
+    const acceptedImageTypes = ['png', 'jpg', 'bmp', 'tif', 'svg', 'jpeg', 'tiff'];
+    const dataType = last(fileName.split('.'));
+    return acceptedImageTypes.includes(dataType);
+  }
+
+  static renderDownloadAnnotatedImageButton(attachment) {
+    if (!ResearchPlanDetailsAttachments.isImageFile(attachment.filename)) {
+      return null;
+    }
+    return (
+      <OverlayTrigger placement="top" overlay={downloadAnnotationTooltip}>
+        <div className="research-plan-attachments-annotation-download">
+          <Button
+            bsSize="xsmall"
+            className="button-right"
+            bsStyle="primary"
+            disabled={attachment.isNew}
+            onClick={() => {
+              Utils.downloadFile({ contents: `/api/v1/attachments/${attachment.id}/annotated_image`, name: attachment.filename });
+            }}
+          >
+            <i className="fa fa-download" aria-hidden="true" />
+          </Button>
+        </div>
+      </OverlayTrigger>
+    );
+  }
+
   constructor(props) {
     super(props);
     this.importButtonRefs = [];
@@ -120,12 +149,6 @@ export default class ResearchPlanDetailsAttachments extends Component {
     });
   }
   /* eslint-enable no-param-reassign */
-
-  isImageFile(fileName) {
-    const acceptedImageTypes = ['png', 'jpg', 'bmp', 'tif', 'svg', 'jpeg', 'tiff'];
-    const dataType = last(fileName.split('.'));
-    return acceptedImageTypes.includes(dataType);
-  }
 
   documentType(filename) {
     const { extension } = this.state;
@@ -287,7 +310,7 @@ export default class ResearchPlanDetailsAttachments extends Component {
               styleEditorBtn,
               editDisable
             )}
-            {this.renderDownloadAnnotatedImageButton(attachment)}
+            {ResearchPlanDetailsAttachments.renderDownloadAnnotatedImageButton(attachment)}
             {this.renderAnnotateImageButton(attachment)}
             {this.renderImportAttachmentButton(attachment)}
           </Col>
@@ -327,29 +350,6 @@ export default class ResearchPlanDetailsAttachments extends Component {
         >
           <i className="fa fa-download" aria-hidden="true" />
         </Button>
-      </OverlayTrigger>
-    );
-  }
-
-  renderDownloadAnnotatedImageButton(attachment) {
-    if (!this.isImageFile(attachment.filename)) {
-      return null;
-    }
-    return (
-      <OverlayTrigger placement="top" overlay={downloadAnnotationTooltip}>
-        <div className="research-plan-attachments-annotation-download">
-          <Button
-            bsSize="xsmall"
-            className="button-right"
-            bsStyle="primary"
-            disabled={attachment.isNew}
-            onClick={() => {
-              Utils.downloadFile({ contents: `/api/v1/attachments/${attachment.id}/annotated_image`, name: attachment.filename });
-            }}
-          >
-            <i className="fa fa-download" aria-hidden="true" />
-          </Button>
-        </div>
       </OverlayTrigger>
     );
   }

--- a/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
@@ -72,8 +72,8 @@ export default class ResearchPlanDetailsAttachments extends Component {
       .then((result) => {
         if (result.token) {
           const url = `/editor?id=${attachment.id}&docType=${docType}
-        &fileType=${fileType}&title=${attachment.filename}&key=${result.token}
-        &only_office_token=${result.only_office_token}`;
+          &fileType=${fileType}&title=${attachment.filename}&key=${result.token}
+          &only_office_token=${result.only_office_token}`;
           window.open(url, '_blank');
 
           attachment.aasm_state = 'oo_editing';
@@ -85,7 +85,21 @@ export default class ResearchPlanDetailsAttachments extends Component {
         }
       });
   }
+  /* eslint-enable no-param-reassign */
 
+  onImport(attachment) {
+    const { researchPlan, onAttachmentImportComplete } = this.props;
+    const researchPlanId = researchPlan.id;
+    LoadingActions.start();
+    ElementActions.importTableFromSpreadsheet(
+      researchPlanId,
+      attachment.id,
+      onAttachmentImportComplete
+    );
+    LoadingActions.stop();
+  }
+
+  /* eslint-disable no-param-reassign */
   createAttachmentPreviews() {
     const { attachments } = this.props;
     attachments.map((attachment) => {
@@ -106,18 +120,6 @@ export default class ResearchPlanDetailsAttachments extends Component {
     });
   }
   /* eslint-enable no-param-reassign */
-
-  onImport(attachment) {
-    const { researchPlan, onAttachmentImportComplete } = this.props;
-    const researchPlanId = researchPlan.id;
-    LoadingActions.start();
-    ElementActions.importTableFromSpreadsheet(
-      researchPlanId,
-      attachment.id,
-      onAttachmentImportComplete
-    );
-    LoadingActions.stop();
-  }
 
   isImageFile(fileName) {
     const acceptedImageTypes = ['png', 'jpg', 'bmp', 'tif', 'svg', 'jpeg', 'tiff'];
@@ -145,6 +147,23 @@ export default class ResearchPlanDetailsAttachments extends Component {
         extension: result.ext,
       });
     });
+  }
+
+  showImportConfirm(attachmentId) {
+    const { showImportConfirm } = this.state;
+    showImportConfirm[attachmentId] = true;
+    this.setState({ showImportConfirm });
+  }
+
+  hideImportConfirm(attachmentId) {
+    const { showImportConfirm } = this.state;
+    showImportConfirm[attachmentId] = false;
+    this.setState({ showImportConfirm });
+  }
+
+  confirmAttachmentImport(attachment) {
+    this.onImport(attachment);
+    this.hideImportConfirm(attachment.id);
   }
 
   renderRemoveAttachmentButton(attachment) {
@@ -442,23 +461,6 @@ export default class ResearchPlanDetailsAttachments extends Component {
       );
     }
     return true;
-  }
-
-  showImportConfirm(attachmentId) {
-    const { showImportConfirm } = this.state;
-    showImportConfirm[attachmentId] = true;
-    this.setState({ showImportConfirm });
-  }
-
-  hideImportConfirm(attachmentId) {
-    const { showImportConfirm } = this.state;
-    showImportConfirm[attachmentId] = false;
-    this.setState({ showImportConfirm });
-  }
-
-  confirmAttachmentImport(attachment) {
-    this.onImport(attachment);
-    this.hideImportConfirm(attachment.id);
   }
 
   render() {

--- a/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
@@ -63,34 +63,6 @@ export default class ResearchPlanDetailsAttachments extends Component {
     }
   }
 
-  editorInitial() {
-    EditorFetcher.initial().then((result) => {
-      this.setState({
-        attachmentEditor: result.installed,
-        extension: result.ext,
-      });
-    });
-  }
-
-  documentType(filename) {
-    const { extension } = this.state;
-
-    const ext = last(filename.split('.'));
-    const docType = findKey(extension, (o) => o.includes(ext));
-
-    if (typeof docType === 'undefined' || !docType) {
-      return null;
-    }
-
-    return docType;
-  }
-
-  isImageFile(fileName) {
-    const acceptedImageTypes = ['png', 'jpg', 'bmp', 'tif', 'svg', 'jpeg', 'tiff'];
-    const dataType = last(fileName.split('.'));
-    return acceptedImageTypes.includes(dataType);
-  }
-
   handleEdit(attachment) {
     const fileType = last(attachment.filename.split('.'));
     const docType = this.documentType(attachment.filename);
@@ -143,6 +115,34 @@ export default class ResearchPlanDetailsAttachments extends Component {
       onAttachmentImportComplete
     );
     LoadingActions.stop();
+  }
+
+  isImageFile(fileName) {
+    const acceptedImageTypes = ['png', 'jpg', 'bmp', 'tif', 'svg', 'jpeg', 'tiff'];
+    const dataType = last(fileName.split('.'));
+    return acceptedImageTypes.includes(dataType);
+  }
+
+  documentType(filename) {
+    const { extension } = this.state;
+
+    const ext = last(filename.split('.'));
+    const docType = findKey(extension, (o) => o.includes(ext));
+
+    if (typeof docType === 'undefined' || !docType) {
+      return null;
+    }
+
+    return docType;
+  }
+
+  editorInitial() {
+    EditorFetcher.initial().then((result) => {
+      this.setState({
+        attachmentEditor: result.installed,
+        extension: result.ext,
+      });
+    });
   }
 
   renderRemoveAttachmentButton(attachment) {

--- a/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
@@ -56,7 +56,10 @@ export default class ResearchPlanDetailsAttachments extends Component {
             bsStyle="primary"
             disabled={attachment.isNew}
             onClick={() => {
-              Utils.downloadFile({ contents: `/api/v1/attachments/${attachment.id}/annotated_image`, name: attachment.filename });
+              Utils.downloadFile({
+                contents: `/api/v1/attachments/${attachment.id}/annotated_image`,
+                name: attachment.filename
+              });
             }}
           >
             <i className="fa fa-download" aria-hidden="true" />

--- a/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
@@ -483,8 +483,40 @@ export default class ResearchPlanDetailsAttachments extends Component {
 }
 
 ResearchPlanDetailsAttachments.propTypes = {
-  researchPlan: PropTypes.object.isRequired,
-  attachments: PropTypes.array,
+  researchPlan: PropTypes.shape({
+    id: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ]).isRequired,
+    changed: PropTypes.bool.isRequired,
+    body: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        title: PropTypes.string.isRequired,
+        type: PropTypes.string.isRequired,
+      })
+    ).isRequired,
+    attachments: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number.isRequired,
+        aasm_state: PropTypes.string.isRequired,
+        content_type: PropTypes.string.isRequired,
+        filename: PropTypes.string.isRequired,
+        filesize: PropTypes.number.isRequired,
+        identifier: PropTypes.string.isRequired,
+        thumb: PropTypes.bool.isRequired
+      })
+    )
+  }).isRequired,
+  attachments: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    aasm_state: PropTypes.string.isRequired,
+    content_type: PropTypes.string.isRequired,
+    filename: PropTypes.string.isRequired,
+    filesize: PropTypes.number.isRequired,
+    identifier: PropTypes.string.isRequired,
+    thumb: PropTypes.bool.isRequired
+  })),
   onDrop: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
   onUndoDelete: PropTypes.func.isRequired,

--- a/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
@@ -40,9 +40,6 @@ export default class ResearchPlanDetailsAttachments extends Component {
   constructor(props) {
     super(props);
     this.importButtonRefs = [];
-    const {
-      attachments, onDrop, onDelete, onUndoDelete, onDownload, onEdit
-    } = props;
 
     this.state = {
       attachmentEditor: false,
@@ -60,7 +57,8 @@ export default class ResearchPlanDetailsAttachments extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.attachments !== prevProps.attachments) {
+    const { attachments } = this.props.attachments;
+    if (attachments !== prevProps.attachments) {
       this.createAttachmentPreviews();
     }
   }
@@ -98,21 +96,21 @@ export default class ResearchPlanDetailsAttachments extends Component {
     const docType = this.documentType(attachment.filename);
 
     EditorFetcher.startEditing({ attachment_id: attachment.id })
-    .then((result) => {
-      if (result.token) {
-        const url = `/editor?id=${attachment.id}&docType=${docType}
+      .then((result) => {
+        if (result.token) {
+          const url = `/editor?id=${attachment.id}&docType=${docType}
         &fileType=${fileType}&title=${attachment.filename}&key=${result.token}
         &only_office_token=${result.only_office_token}`;
-        window.open(url, '_blank');
+          window.open(url, '_blank');
 
-        attachment.aasm_state = 'oo_editing';
-        attachment.updated_at = new Date();
+          attachment.aasm_state = 'oo_editing';
+          attachment.updated_at = new Date();
 
-        this.props.onEdit(attachment);
-      } else {
-        alert('Unauthorized to edit this file.');
-      }
-    });
+          this.props.onEdit(attachment);
+        } else {
+          alert('Unauthorized to edit this file.');
+        }
+      });
   }
 
   createAttachmentPreviews() {
@@ -281,9 +279,10 @@ export default class ResearchPlanDetailsAttachments extends Component {
           className="button-right"
           bsStyle="success"
           disabled={editDisable}
-          onClick={() => this.handleEdit(attachment)}>
+          onClick={() => this.handleEdit(attachment)}
+        >
 
-          <SpinnerPencilIcon spinningLock={!attachmentEditor || isEditing}/>
+          <SpinnerPencilIcon spinningLock={!attachmentEditor || isEditing} />
         </Button>
       </OverlayTrigger>
 
@@ -310,21 +309,21 @@ export default class ResearchPlanDetailsAttachments extends Component {
       return null;
     }
     return (
-    <OverlayTrigger placement="top" overlay={downloadAnnotationTooltip}>
-      <div className="research-plan-attachments-annotation-download">
-        <Button
-          bsSize="xsmall"
-          className="button-right"
-          bsStyle="primary"
-          disabled={attachment.isNew}
-          onClick={() =>{
-            Utils.downloadFile({ contents: `/api/v1/attachments/${attachment.id}/annotated_image`, name: attachment.filename });
-          }}
-        >
-          <i className="fa fa-download" aria-hidden="true" />
-        </Button>
-      </div>
-    </OverlayTrigger>
+      <OverlayTrigger placement="top" overlay={downloadAnnotationTooltip}>
+        <div className="research-plan-attachments-annotation-download">
+          <Button
+            bsSize="xsmall"
+            className="button-right"
+            bsStyle="primary"
+            disabled={attachment.isNew}
+            onClick={() => {
+              Utils.downloadFile({ contents: `/api/v1/attachments/${attachment.id}/annotated_image`, name: attachment.filename });
+            }}
+          >
+            <i className="fa fa-download" aria-hidden="true" />
+          </Button>
+        </div>
+      </OverlayTrigger>
     );
   }
 

--- a/spec/javascripts/factories/AttachmentFactory.js
+++ b/spec/javascripts/factories/AttachmentFactory.js
@@ -18,7 +18,16 @@ export default class AttachmentFactory {
 
     this.factory.define('new', Attachment, {
       id : Element.buildID(),
-      is_new : true
+      is_new : true,
+      updated_at: new Date(),
+      filename: "test.png",
+      updatedAnnotation: false,
+      is_deleted: false,
+      preview: "originalPreviewData",
+      content_type: "none",
+      aasm_state: "",
+      filesize: 123456,
+      thumb: true
     });
   }
 }

--- a/spec/javascripts/factories/ResearchPlanFactory.js
+++ b/spec/javascripts/factories/ResearchPlanFactory.js
@@ -27,6 +27,7 @@ export default class ResearchPlanFactory {
       changed: true,
       can_update: true,
       attachments: [],
+      title: "test_research_plan",
       wellplates: [],
       segments: [],
     });
@@ -37,6 +38,12 @@ export default class ResearchPlanFactory {
         type: "no-image",
         value: {}
       }],
+      changed: false,
+      attachments : [ AttachmentFactory.build("new")]
+
+    });
+    this.factory.extend("empty", "with attachment_not_in_body",{
+      body: [],
       changed: false,
       attachments : [ AttachmentFactory.build("new")]
 

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.spec.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import expect from 'expect';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+
+import AttachmentFetcher from 'src/fetchers/AttachmentFetcher';
+import sinon from 'sinon';
+import ResearchPlanFactory from 'factories/ResearchPlanFactory';
+// eslint-disable-next-line no-unused-vars
+import ElementStore from 'src/stores/alt/stores/ElementStore';
+
+import EditorFetcher from 'src/fetchers/EditorFetcher';
+import ResearchPlanDetailsAttachments from 'src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('ResearchPlanDetailsAttachments', async () => {
+  describe('.createAttachmentPreviews()', async () => {
+    describe('.when preview was changed', async () => {
+      it('new preview is rendered', async () => {
+        const researchPlanWithAttachment = await ResearchPlanFactory.build(
+          'with attachment_not_in_body'
+        );
+        sinon
+          .stub(EditorFetcher, 'initial')
+          .callsFake(() => new Promise(() => {}));
+        sinon
+          .stub(AttachmentFetcher, 'fetchThumbnail')
+          .callsFake(() => Promise.resolve('reloadedPreviewData'));
+
+        const wrapper = shallow(<ResearchPlanDetailsAttachments
+          researchPlan={researchPlanWithAttachment}
+          attachments={researchPlanWithAttachment.attachments}
+          onDrop={(() => {})}
+          onDelete={(() => {})}
+          onUndoDelete={(() => {})}
+          onDownload={(() => {})}
+          onAttachmentImportComplete={(() => {})}
+          onEdit={(() => {})}
+          readOnly={false}
+        />);
+
+        await new Promise(process.nextTick);
+        const expectedPreviewComponent = '<img src="data:image/png;base64,reloadedPreviewData"';
+
+        expect(wrapper.html().includes(expectedPreviewComponent)).toBe(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR solves the issue #1398. 

After saving a researchplan the preview images were not visible anymore. That came from an asynchronous reloading of the preview image by changing the property "preview" of an attachment. But then the frontend was not refreshed by a setState (..). 

I fixed the problem by forcing a rerendering after the property was changed.

I also fixed several eslint errors but one, because i could not check the functionality ( openOffice editing) on my local machine.
