### PR TITLE
fix: display the not-accessible panel for 401 status on sample fetched by id

### DIFF
--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -78,9 +78,11 @@ module Chemotion
         requires :id, type: Integer, desc: 'Reaction id'
       end
       route_param :id do
-        before do
+        after_validation do
           @element_policy = ElementPolicy.new(current_user, Reaction.find(params[:id]))
           error!('401 Unauthorized', 401) unless @element_policy.read?
+        rescue ActiveRecord::RecordNotFound
+          error!('404 Not Found', 404)
         end
 
         get do

--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -268,9 +268,11 @@ module Chemotion
         requires :id, type: Integer, desc: "Sample id"
       end
       route_param :id do
-        before do
+        after_validation do
           @element_policy = ElementPolicy.new(current_user, Sample.find(params[:id]))
           error!('401 Unauthorized', 401) unless @element_policy.read?
+        rescue ActiveRecord::RecordNotFound
+          error!('404 Not Found', 404)
         end
 
         get do

--- a/app/packs/src/models/Sample.js
+++ b/app/packs/src/models/Sample.js
@@ -7,7 +7,7 @@ import UserStore from 'src/stores/alt/stores/UserStore';
 import Container from 'src/models/Container.js';
 import Segment from 'src/models/Segment';
 
-const prepareRangeBound = (args, field) => {
+const prepareRangeBound = (args = {}, field) => {
   const argsNew = args;
   if (args[field] && typeof args[field] === 'string') {
     const bounds = args[field].split(/\.{2,3}/);


### PR DESCRIPTION
* fix navigation to existing sample without permission:
 when a query to  fetch sample by id returns 401, the _not accessible_ panel should be rendered

![image](https://github.com/ComPlat/chemotion_ELN/assets/15799181/476310fb-5ee6-462b-8e44-dbf50d8519e4)


* now also render the info panel for record (sample/reaction) not found (404)

![image](https://github.com/ComPlat/chemotion_ELN/assets/15799181/41b0cfe3-1e6b-456b-bc3d-d5f1fd227a07)
