### PR TITLE
Bugfix: replace toSorted with manual sorting in SampleTaskInbox

### DIFF
--- a/app/packs/src/apps/mydb/collections/sampleTaskInbox/SampleTaskInbox.js
+++ b/app/packs/src/apps/mydb/collections/sampleTaskInbox/SampleTaskInbox.js
@@ -60,11 +60,9 @@ const SampleTaskInbox = ({}) => {
   }
 
   const openSampleTasks = () => {
-    let sampleTasks = values(sampleTasksStore.sample_tasks);
-
-    return sampleTasks.toSorted(
-      (taskA, taskB) => { return taskB.id - taskA.id } // sort descending by task id to override Map sorting by insert order
-    ).map(sampleTask => (<SampleTaskCard sampleTask={sampleTask} key={`sampleTask_${sampleTask.id}`} />));
+    return sampleTasksStore.sortedSampleTasks.map(
+      sampleTask => (<SampleTaskCard sampleTask={sampleTask} key={`sampleTask_${sampleTask.id}`} />)
+    );
   }
 
   const sampleDropzone = (dropRef, text) => {

--- a/app/packs/src/stores/mobx/SampleTasksStore.jsx
+++ b/app/packs/src/stores/mobx/SampleTasksStore.jsx
@@ -68,5 +68,6 @@ export const SampleTasksStore = types
     get inboxVisible() { return self.inbox_visible },
     sampleTaskForSample(sampleId) {
       return values(self.sample_tasks).find(task => task.sample_id == sampleId)
-    }
+    },
+    get sortedSampleTasks() { return values(self.sample_tasks).sort((taskA, taskB) => taskB.id - taskA.id) },
   }));


### PR DESCRIPTION
toSorted is only available in really new browsers, which is unfortunately not a given within academia.
Therefore the function call was replaced with another sorting routine that uses basic JS array sort()