### PR TITLE
fix: fixed wrong literatures mapping

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/literature/DetailsTabLiteratures.js
+++ b/app/packs/src/apps/mydb/elements/details/literature/DetailsTabLiteratures.js
@@ -84,7 +84,7 @@ export default class DetailsTabLiteratures extends Component {
         const sortedIds = groupByCitation(fetchedLiterature);
         this.setState((prevState) => ({
           ...prevState,
-          fetchedLiterature,
+          literatures: fetchedLiterature,
           sortedIds,
           sorting: 'literature_id'
         }));


### PR DESCRIPTION
This PR fixes #1505.

It fix the wrong mapping of fetched literature to the component state.