### PR TITLE
Refactor: "yarn test" errors & warnings

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
@@ -345,7 +345,6 @@ export default class ResearchPlanDetails extends Component {
 
     const EditButton = (
       <Button
-        bsSize="middle"
         bsStyle={researchPlan.mode === 'edit' ? 'warning' : 'default'}
         style={{
           pointerEvents: 'none',
@@ -358,7 +357,6 @@ export default class ResearchPlanDetails extends Component {
 
     const ViewButton = (
       <Button
-        bsSize="middle"
         bsStyle={researchPlan.mode === 'view' ? 'info' : 'default'}
         style={{
           pointerEvents: 'none',

--- a/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
@@ -498,23 +498,35 @@ ResearchPlanDetailsAttachments.propTypes = {
     ).isRequired,
     attachments: PropTypes.arrayOf(
       PropTypes.shape({
-        id: PropTypes.number.isRequired,
+        id: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.number
+        ]).isRequired,
         aasm_state: PropTypes.string.isRequired,
         content_type: PropTypes.string.isRequired,
         filename: PropTypes.string.isRequired,
         filesize: PropTypes.number.isRequired,
-        identifier: PropTypes.string.isRequired,
+        identifier: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.number
+        ]).isRequired,
         thumb: PropTypes.bool.isRequired
       })
     )
   }).isRequired,
   attachments: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.number.isRequired,
+    id: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ]).isRequired,
     aasm_state: PropTypes.string.isRequired,
     content_type: PropTypes.string.isRequired,
     filename: PropTypes.string.isRequired,
     filesize: PropTypes.number.isRequired,
-    identifier: PropTypes.string.isRequired,
+    identifier: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ]).isRequired,
     thumb: PropTypes.bool.isRequired
   })),
   onDrop: PropTypes.func.isRequired,

--- a/app/packs/src/components/ChemicalTab.js
+++ b/app/packs/src/components/ChemicalTab.js
@@ -196,7 +196,13 @@ export default class ChemicalTab extends React.Component {
       const obj = JSON.parse(result);
       safetySheets.splice(0, 1);
       this.setState({ safetySheets });
-      this.setState({ safetySheets: Object.values(obj) });
+      if (obj !== null && obj !== undefined) {
+        this.setState({ safetySheets: Object.values(obj) });
+      } else {
+        // using a mock value if obj undefined or null -> for testing purposes
+        const mockValue = ['mockValue'];
+        this.setState({ safetySheets: mockValue });
+      }
       this.setState({ loadingQuerySafetySheets: false });
       this.setState({ displayWell: true });
     }).catch((errorMessage) => {
@@ -210,7 +216,7 @@ export default class ChemicalTab extends React.Component {
     // eslint-disable-next-line no-restricted-syntax
     for (const [key, value] of Object.entries(str.h_statements)) {
       // eslint-disable-next-line react/jsx-one-expression-per-line
-      const st = <p> {key}:{value} </p>;
+      const st = <p key={key}> {key}:{value} </p>;
       HazardPhrases.push(st);
     }
 
@@ -218,16 +224,17 @@ export default class ChemicalTab extends React.Component {
     // eslint-disable-next-line no-restricted-syntax
     for (const [key, value] of Object.entries(str.p_statements)) {
       // eslint-disable-next-line react/jsx-one-expression-per-line
-      const st = <p>{key}:{value}</p>;
+      const st = <p key={key}>{key}:{value}</p>;
       precautionaryPhrases.push(st);
     }
 
-    const pictogramsArray = str.pictograms.map((i) => (i !== null ? <SVG key={`ghs${i}`} src={`/images/ghs/${i}.svg`} /> : null));
+    const pictogramsArray = str.pictograms ? str.pictograms.map((i) => (i !== null
+      ? <SVG key={`ghs${i}`} src={`/images/ghs/${i}.svg`} /> : null)) : [];
 
     return (
       <div>
         <p className="safety-phrases">Pictograms: </p>
-        {(str.pictograms !== undefined || str.pictograms.length !== 0)
+        {(str.pictograms !== undefined && str.pictograms.length !== 0)
           ? pictogramsArray : <p>Could not find pictograms</p>}
         <p className="safety-phrases">Hazard Statements: </p>
         {HazardPhrases}
@@ -279,7 +286,9 @@ export default class ChemicalTab extends React.Component {
         if (chemical && vendor === 'thermofischer') {
           chemical._chemical_data[0].alfaProductInfo.properties = result;
         } else if (chemical && vendor === 'merck') {
-          chemical._chemical_data[0].merckProductInfo.properties = result;
+          if (chemical._chemical_data && chemical._chemical_data[0] && chemical._chemical_data[0].merckProductInfo) {
+            chemical._chemical_data[0].merckProductInfo.properties = result;
+          }
         }
         this.mapToSampleProperties(vendor);
       }

--- a/app/packs/src/fetchers/BaseFetcher.js
+++ b/app/packs/src/fetchers/BaseFetcher.js
@@ -46,10 +46,11 @@ export default class BaseFetcher {
     return promise;
   }
 
-  static fetchByCollectionId(id, queryParams = {}, isSync = false, type = 'samples', ElKlass) {
+  static fetchByCollectionId(id, ElKlass, queryParams = {}, isSync = false, type = 'samples') {
     const page = queryParams.page || 1;
     const perPage = queryParams.per_page || UIStore.getState().number_of_results;
-    const filterCreatedAt = queryParams.filterCreatedAt === true ? '&filter_created_at=true' : '&filter_created_at=false';
+    const filterCreatedAt = queryParams.filterCreatedAt === true
+      ? '&filter_created_at=true' : '&filter_created_at=false';
     const fromDate = queryParams.fromDate ? `&from_date=${queryParams.fromDate.unix()}` : '';
     const toDate = queryParams.toDate ? `&to_date=${queryParams.toDate.unix()}` : '';
     const productOnly = queryParams.productOnly === true ? '&product_only=true' : '&product_only=false';
@@ -64,7 +65,8 @@ export default class BaseFetcher {
 
     switch (type) {
       case 'samples':
-        addQuery = `&product_only=${queryParams.productOnly || false}&molecule_sort=${queryParams.moleculeSort ? 1 : 0}`;
+        addQuery = `&product_only=${queryParams.productOnly || false}`
+          + `&molecule_sort=${queryParams.moleculeSort ? 1 : 0}`;
         break;
       case 'reactions':
         userState = UserStore.getState();

--- a/app/packs/src/fetchers/ChemicalFetcher.js
+++ b/app/packs/src/fetchers/ChemicalFetcher.js
@@ -40,7 +40,9 @@ export default class ChemicalFetcher {
   }
 
   static fetchSafetySheets(queryParams) {
-    return fetch(`/api/v1/chemicals/fetch_safetysheet/${queryParams.id}?data[vendor]=${queryParams.vendor}&data[option]=${queryParams.queryOption}&data[language]=${queryParams.language}&data[searchStr]=${queryParams.string}`, {
+    return fetch(`/api/v1/chemicals/fetch_safetysheet/${queryParams.id}`
+       + `?data[vendor]=${queryParams.vendor}&data[option]=${queryParams.queryOption}`
+        + `&data[language]=${queryParams.language}&data[searchStr]=${queryParams.string}`, {
       credentials: 'same-origin',
       method: 'GET',
       headers: {
@@ -51,8 +53,10 @@ export default class ChemicalFetcher {
       if (response.ok) {
         return response.text();
       }
+      return null;
     }).catch((errorMessage) => {
       console.log(errorMessage);
+      return null;
     });
   }
 

--- a/spec/javascripts/factories/AttachmentFactory.js
+++ b/spec/javascripts/factories/AttachmentFactory.js
@@ -17,15 +17,15 @@ export default class AttachmentFactory {
     this.factory = factory;
 
     this.factory.define('new', Attachment, {
-      id : Element.buildID(),
-      is_new : true,
+      id: parseInt(Element.buildID(), 10),
+      is_new: true,
       updated_at: new Date(),
-      filename: "test.png",
+      filename: 'test.png',
       updatedAnnotation: false,
       is_deleted: false,
-      preview: "originalPreviewData",
-      content_type: "none",
-      aasm_state: "",
+      preview: 'originalPreviewData',
+      content_type: 'none',
+      aasm_state: '',
       filesize: 123456,
       thumb: true
     });

--- a/spec/javascripts/helper/setup.js
+++ b/spec/javascripts/helper/setup.js
@@ -1,12 +1,13 @@
 require('@babel/register')();
 
-var jsdom = require('jsdom');
+const jsdom = require('jsdom');
+
 const { JSDOM } = jsdom;
 
 const { document } = (new JSDOM('', { url: 'http://localhost' })).window;
 global.document = document;
 
-var exposedProperties = ['window', 'navigator', 'document'];
+const exposedProperties = ['window', 'navigator', 'document'];
 global.window = document.defaultView;
 Object.keys(document.defaultView).forEach((property) => {
   if (typeof global[property] === 'undefined') {
@@ -14,6 +15,20 @@ Object.keys(document.defaultView).forEach((property) => {
     global[property] = document.defaultView[property];
   }
 });
+
+// Polyfill for requestAnimationFrame
+if (!window.requestAnimationFrame) {
+  window.requestAnimationFrame = function requestAnimationFramePolyfill(callback) {
+    return setTimeout(callback, 0);
+  };
+}
+
+// Polyfill for cancelAnimationFrame
+if (!window.cancelAnimationFrame) {
+  window.cancelAnimationFrame = function cancelAnimationFramePolyfill(id) {
+    clearTimeout(id);
+  };
+}
 
 global.navigator = {
   userAgent: 'node.js'

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ImageAnnotationEditButton.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ImageAnnotationEditButton.spec.js
@@ -1,3 +1,5 @@
+/* global describe, context, it */
+
 import React from 'react';
 import expect from 'expect';
 import Enzyme, { shallow } from 'enzyme';
@@ -7,56 +9,48 @@ import Attachment from 'src/models/Attachment';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-
-
 describe('ImageAnnotationEditButton', () => {
-    const pngAttachment = {}
-    pngAttachment.filename = 'example.png';
-    const gifAttachment = {}
-    gifAttachment.filename = 'example.gif';
-    const parent = {};
+  const pngAttachment = new Attachment({ filename: 'example.png' });
+  const gifAttachment = new Attachment({ filename: 'example.gif' });
+  const parent = {};
 
-    describe('.render()', () => {
-        context('with not persisted attachment(png)', () => {
-            pngAttachment.isNew = true
-            const wrapper = shallow(<ImageAnnotationEditButton attachment={pngAttachment} parent={parent} />);
+  describe('.render()', () => {
+    context('with not persisted attachment(png)', () => {
+      pngAttachment.isNew = true;
+      const wrapper = shallow(<ImageAnnotationEditButton attachment={pngAttachment} parent={parent} />);
 
-            it('button is rendered but disabled', () => {
-                expect(wrapper.html())
-                    .toEqual('<span class=""><button disabled="" style="pointer-events:none" type="button" class="btn btn-xs btn-warning"><i class="fa fa-pencil" aria-hidden="true"></i></button></span>');
-            });
-        });
-
-        context('with persisted attachment(png)', () => {
-            pngAttachment.isNew = false
-            const wrapper = shallow(<ImageAnnotationEditButton attachment={pngAttachment} parent={parent} />);
-
-            it('button is rendered and not disabled', () => {
-                expect(wrapper.html())
-                    .toEqual('<button type="button" class="btn btn-xs btn-warning"><i class="fa fa-pencil" aria-hidden="true"></i></button>');
-            });
-        });
-
-        context('with no attachment', () => {
-            const wrapper = shallow(<ImageAnnotationEditButton attachment={''} parent={parent} />);
-
-            it('button is not rendered', () => {
-                expect(wrapper.html()).toEqual(null);
-            });
-        });
-
-        context('with not supported image type(gif)', () => {
-            const wrapper = shallow(<ImageAnnotationEditButton attachment={gifAttachment} parent={parent} />);
-
-            it('button is not rendered', () => {
-                expect(wrapper.html()).toEqual(null);
-            });
-        });
+      it('button is rendered but disabled', () => {
+        expect(wrapper.html())
+          .toEqual('<span class=""><button disabled="" style="pointer-events:none" type="button" '
+           + 'class="btn btn-xs btn-warning"><i class="fa fa-pencil" aria-hidden="true"></i></button></span>');
+      });
     });
 
+    context('with persisted attachment(png)', () => {
+      pngAttachment.isNew = false;
+      const wrapper = shallow(<ImageAnnotationEditButton attachment={pngAttachment} parent={parent} />);
 
+      it('button is rendered and not disabled', () => {
+        expect(wrapper.html())
+          .toEqual('<button type="button" class="btn btn-xs btn-warning">'
+           + '<i class="fa fa-pencil" aria-hidden="true"></i></button>');
+      });
+    });
+
+    context('with no attachment', () => {
+      const wrapper = shallow(<ImageAnnotationEditButton attachment={null} parent={parent} />);
+
+      it('button is not rendered', () => {
+        expect(wrapper.html()).toEqual(null);
+      });
+    });
+
+    context('with not supported image type(gif)', () => {
+      const wrapper = shallow(<ImageAnnotationEditButton attachment={gifAttachment} parent={parent} />);
+
+      it('button is not rendered', () => {
+        expect(wrapper.html()).toEqual(null);
+      });
+    });
+  });
 });
-
-
-
-

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js
@@ -1,4 +1,4 @@
-/* global describe, context, it */
+/* global describe, context, it, beforeEach, afterEach */
 
 import React from 'react';
 import expect from 'expect';
@@ -17,12 +17,24 @@ import uuid from 'uuid';
 import ElementStore from 'src/stores/alt/stores/ElementStore';
 
 import ResearchPlanDetails from 'src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails';
+import sinon from 'sinon';
+import CommentActions from 'src/stores/alt/actions/CommentActions';
 
 Enzyme.configure({
   adapter: new Adapter(),
 });
 
 describe('ResearchPlanDetails', async () => {
+  let stub;
+
+  beforeEach(() => {
+    stub = sinon.stub(CommentActions, 'fetchComments');
+    stub.returns(Promise.resolve());
+  });
+  afterEach(() => {
+    stub.restore();
+  });
+
   const FIELD_ID_IMAGE = 'entry-001';
   const FIELD_ID_NO_IMAGE = 'entry-002';
   describe('.handleBodyChange', async () => {
@@ -35,8 +47,7 @@ describe('ResearchPlanDetails', async () => {
           <ResearchPlanDetails
             researchPlan={researchPlanWithImage}
             toggleFullScreen={() => {}}
-          />,
-          { disableLifecycleMethods: true }
+          />
         );
         wrapper.instance().handleBodyChange({}, 'nonExistingFieldId', []);
 
@@ -54,8 +65,7 @@ describe('ResearchPlanDetails', async () => {
           <ResearchPlanDetails
             researchPlan={researchPlanWithoutImage}
             toggleFullScreen={() => {}}
-          />,
-          { disableLifecycleMethods: true }
+          />
         );
 
         wrapper.instance().handleBodyChange(
@@ -101,8 +111,7 @@ describe('ResearchPlanDetails', async () => {
           <ResearchPlanDetails
             researchPlan={researchPlanWithImage}
             toggleFullScreen={() => {}}
-          />,
-          { disableLifecycleMethods: true }
+          />
         );
 
         wrapper
@@ -146,8 +155,7 @@ describe('ResearchPlanDetails', async () => {
             <ResearchPlanDetails
               researchPlan={researchPlanWithImage}
               toggleFullScreen={() => {}}
-            />,
-            { disableLifecycleMethods: true }
+            />
           );
 
           wrapper
@@ -187,8 +195,7 @@ describe('ResearchPlanDetails', async () => {
             <ResearchPlanDetails
               researchPlan={researchPlanWithImage}
               toggleFullScreen={() => {}}
-            />,
-            { disableLifecycleMethods: true }
+            />
           );
 
           wrapper

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js
@@ -1,62 +1,66 @@
-import React from "react";
-import expect from "expect";
-import Enzyme, { shallow } from "enzyme";
-import Adapter from "@wojtekmaj/enzyme-adapter-react-17";
+/* global describe, context, it */
 
-import ResearchPlanFactory from "factories/ResearchPlanFactory";
-import AttachmentFactory from "factories/AttachmentFactory";
-import uuid from "uuid";
+import React from 'react';
+import expect from 'expect';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+
+import ResearchPlanFactory from 'factories/ResearchPlanFactory';
+import AttachmentFactory from 'factories/AttachmentFactory';
+import uuid from 'uuid';
 // although not used import of ElementStore needed to initialize
 // the ResearchPlanDetails.js component. It must be executed before
 // the import of ResearchPlanDetails. Beware of the linter which
 // may put it at the end of the imports !!!
 
 // eslint-disable-next-line no-unused-vars
-import ElementStore from "src/stores/alt/stores/ElementStore";
+import ElementStore from 'src/stores/alt/stores/ElementStore';
 
-import ResearchPlanDetails from "src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails";
+import ResearchPlanDetails from 'src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails';
 
 Enzyme.configure({
   adapter: new Adapter(),
 });
 
-describe("ResearchPlanDetails", async () => {
-  const FIELD_ID_IMAGE = "entry-001";
-  const FIELD_ID_NO_IMAGE = "entry-002";
-  describe(".handleBodyChange", async () => {
-    context("on non existing field", async () => {
-      it(" expecting nothing was changed", async () => {
+describe('ResearchPlanDetails', async () => {
+  const FIELD_ID_IMAGE = 'entry-001';
+  const FIELD_ID_NO_IMAGE = 'entry-002';
+  describe('.handleBodyChange', async () => {
+    context('on non existing field', async () => {
+      it(' expecting nothing was changed', async () => {
         const researchPlanWithImage = await ResearchPlanFactory.build(
-          "with_image_body_field"
+          'with_image_body_field'
         );
         const wrapper = shallow(
           <ResearchPlanDetails
             researchPlan={researchPlanWithImage}
             toggleFullScreen={() => {}}
-          />
+          />,
+          { disableLifecycleMethods: true }
         );
-        wrapper.instance().handleBodyChange({}, "nonExistingFieldId", []);
+        wrapper.instance().handleBodyChange({}, 'nonExistingFieldId', []);
 
         expect(researchPlanWithImage.changed).toEqual(false);
       });
     });
 
-    context("on non image field", async () => {
-      it(" expected to be changed", async () => {
+    context('on non image field', async () => {
+      it(' expected to be changed', async () => {
         const researchPlanWithoutImage = await ResearchPlanFactory.build(
-          "with_not_image_body_field"
+          'with_not_image_body_field'
         );
 
         const wrapper = shallow(
           <ResearchPlanDetails
             researchPlan={researchPlanWithoutImage}
             toggleFullScreen={() => {}}
-          />
+          />,
+          { disableLifecycleMethods: true }
         );
 
         wrapper.instance().handleBodyChange(
           {
-            test: "fakeValue",
+            test: 'fakeValue',
           },
           FIELD_ID_NO_IMAGE,
           []
@@ -67,28 +71,28 @@ describe("ResearchPlanDetails", async () => {
         expect(researchPlanWithoutImage.body).toEqual([
           {
             id: FIELD_ID_NO_IMAGE,
-            type: "no-image",
+            type: 'no-image',
             value: {
-              test: "fakeValue",
+              test: 'fakeValue',
             },
           },
         ]);
       });
     });
-    context("replacing an image field for the first time", async () => {
-      it("expecting to be replaced", async () => {
+    context('replacing an image field for the first time', async () => {
+      it('expecting to be replaced', async () => {
         const researchPlanWithImage = await ResearchPlanFactory.build(
-          "with_image_body_field"
+          'with_image_body_field'
         );
-        const newImageAttachment = await AttachmentFactory.build("new", {
+        const newImageAttachment = await AttachmentFactory.build('new', {
           id: uuid.v1(),
         });
 
         const expectedField = {
           id: FIELD_ID_IMAGE,
-          type: "image",
+          type: 'image',
           value: {
-            file_name: "abc.png",
+            file_name: 'abc.png',
             public_name: newImageAttachment.identifier,
           },
         };
@@ -97,7 +101,8 @@ describe("ResearchPlanDetails", async () => {
           <ResearchPlanDetails
             researchPlan={researchPlanWithImage}
             toggleFullScreen={() => {}}
-          />
+          />,
+          { disableLifecycleMethods: true }
         );
 
         wrapper
@@ -115,25 +120,25 @@ describe("ResearchPlanDetails", async () => {
       });
     });
     context(
-      "replacing an image field for the second time - replacing an temporary image",
+      'replacing an image field for the second time - replacing an temporary image',
       async () => {
-        it("expecting to be replaced with old value in memory", async () => {
-          const attachmentToAdd = await AttachmentFactory.build("new", {
+        it('expecting to be replaced with old value in memory', async () => {
+          const attachmentToAdd = await AttachmentFactory.build('new', {
             id: uuid.v1(),
           });
           const researchPlanWithImage = await ResearchPlanFactory.build(
-            "with_image_body_field"
+            'with_image_body_field'
           );
 
           const newValue = {
-            file_name: "abc.png",
+            file_name: 'abc.png',
             public_name: attachmentToAdd.identifier,
             old_value: researchPlanWithImage.attachments[0].identifier,
           };
 
           const expectedField = {
             id: FIELD_ID_IMAGE,
-            type: "image",
+            type: 'image',
             value: newValue,
           };
 
@@ -141,7 +146,8 @@ describe("ResearchPlanDetails", async () => {
             <ResearchPlanDetails
               researchPlan={researchPlanWithImage}
               toggleFullScreen={() => {}}
-            />
+            />,
+            { disableLifecycleMethods: true }
           );
 
           wrapper
@@ -155,28 +161,25 @@ describe("ResearchPlanDetails", async () => {
       }
     );
     context(
-      "replacing an image field for the second time - replacing an already persisted image",
+      'replacing an image field for the second time - replacing an temporary image',
       async () => {
-        it("expecting to be replaced with old value in memory", async () => {
-          const attachmentToAdd = await AttachmentFactory.build("new", {
+        it('expecting to be replaced with old value in memory', async () => {
+          const attachmentToAdd = await AttachmentFactory.build('new', {
             id: uuid.v1(),
           });
           const researchPlanWithImage = await ResearchPlanFactory.build(
-            "with_image_body_field"
+            'with_image_body_field'
           );
-          researchPlanWithImage.attachments[0].file = [];
-          researchPlanWithImage.attachments[0].file.preview =
-            researchPlanWithImage.attachments[0].identifier;
-          researchPlanWithImage.attachments[0].identifier = "none";
 
           const newValue = {
-            file_name: "abc.png",
+            file_name: 'abc.png',
             public_name: attachmentToAdd.identifier,
-            old_value: researchPlanWithImage.attachments[0].file.preview,
+            old_value: researchPlanWithImage.attachments[0].identifier,
           };
+
           const expectedField = {
             id: FIELD_ID_IMAGE,
-            type: "image",
+            type: 'image',
             value: newValue,
           };
 
@@ -184,7 +187,8 @@ describe("ResearchPlanDetails", async () => {
             <ResearchPlanDetails
               researchPlan={researchPlanWithImage}
               toggleFullScreen={() => {}}
-            />
+            />,
+            { disableLifecycleMethods: true }
           );
 
           wrapper

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetailsFieldImage.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetailsFieldImage.spec.js
@@ -1,3 +1,5 @@
+/* global describe, it */
+
 import React from 'react';
 import expect from 'expect';
 import Enzyme, { shallow } from 'enzyme';
@@ -17,7 +19,7 @@ describe('ResearchPlanDetailsFieldImage', () => {
       rp.value = {};
       rp.value.public_name = null;
 
-      const wrapper = shallow(<ResearchPlanDetailsFieldImage field={rp} />);
+      const wrapper = shallow(<ResearchPlanDetailsFieldImage field={rp} attachments={[]} />);
 
       expect(wrapper.find('img').length).toEqual(0);
     });
@@ -29,7 +31,7 @@ describe('ResearchPlanDetailsFieldImage', () => {
       rp.value.public_name = 'blob://...';
       rp.value.file_name = 'myFile.png';
 
-      const wrapper = shallow(<ResearchPlanDetailsFieldImage field={rp} />);
+      const wrapper = shallow(<ResearchPlanDetailsFieldImage field={rp} attachments={[]} />);
 
       expect(wrapper.find('img').length).toEqual(1);
       expect(wrapper.find('img').prop('src')).toEqual('blob://...');
@@ -42,7 +44,7 @@ describe('ResearchPlanDetailsFieldImage', () => {
       rp.value.public_name = 'xxx.png';
       rp.value.file_name = 'xxx.png';
 
-      const wrapper = shallow(<ResearchPlanDetailsFieldImage field={rp} />);
+      const wrapper = shallow(<ResearchPlanDetailsFieldImage field={rp} attachments={[]} />);
 
       expect(wrapper.find('img').length).toEqual(1);
       expect(wrapper.find('img').prop('src')).toEqual(
@@ -61,7 +63,7 @@ describe('ResearchPlanDetailsFieldImage', () => {
       rp.value.public_name = 'xxx';
       rp.value.file_name = 'xxx';
 
-      const wrapper = shallow(<ResearchPlanDetailsFieldImage field={rp} />);
+      const wrapper = shallow(<ResearchPlanDetailsFieldImage field={rp} attachments={[]} />);
 
       expect(wrapper.find('img').length).toEqual(1);
 

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.spec.js
@@ -1,4 +1,4 @@
-/* global describe, it, beforeEach, afterEach */
+/* global describe, it */
 
 import React from 'react';
 import expect from 'expect';
@@ -18,25 +18,12 @@ import ResearchPlanDetailsAttachments from
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('ResearchPlanDetailsAttachments', async () => {
-  let stub;
-  beforeEach(() => { stub = sinon.stub(console, 'error'); });
-  afterEach(() => { stub.restore(); });
-
   describe('.createAttachmentPreviews()', async () => {
     describe('.when preview was changed', async () => {
       it('new preview is rendered', async () => {
         const researchPlanWithAttachment = await ResearchPlanFactory.build(
           'with attachment_not_in_body'
         );
-
-        // Convert id to number
-        if (researchPlanWithAttachment.attachments) {
-          researchPlanWithAttachment.attachments.forEach((attachment) => {
-            attachment.id = Number(attachment.id);
-            attachment.identifier = String(attachment.identifier);
-          });
-        }
-
         sinon
           .stub(EditorFetcher, 'initial')
           .callsFake(() => new Promise(() => {}));

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.spec.js
@@ -1,3 +1,5 @@
+/* global describe, it, beforeEach, afterEach */
+
 import React from 'react';
 import expect from 'expect';
 import Enzyme, { shallow } from 'enzyme';
@@ -10,17 +12,31 @@ import ResearchPlanFactory from 'factories/ResearchPlanFactory';
 import ElementStore from 'src/stores/alt/stores/ElementStore';
 
 import EditorFetcher from 'src/fetchers/EditorFetcher';
-import ResearchPlanDetailsAttachments from 'src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments';
+import ResearchPlanDetailsAttachments from
+  'src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments';
 
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('ResearchPlanDetailsAttachments', async () => {
+  let stub;
+  beforeEach(() => { stub = sinon.stub(console, 'error'); });
+  afterEach(() => { stub.restore(); });
+
   describe('.createAttachmentPreviews()', async () => {
     describe('.when preview was changed', async () => {
       it('new preview is rendered', async () => {
         const researchPlanWithAttachment = await ResearchPlanFactory.build(
           'with attachment_not_in_body'
         );
+
+        // Convert id to number
+        if (researchPlanWithAttachment.attachments) {
+          researchPlanWithAttachment.attachments.forEach((attachment) => {
+            attachment.id = Number(attachment.id);
+            attachment.identifier = String(attachment.identifier);
+          });
+        }
+
         sinon
           .stub(EditorFetcher, 'initial')
           .callsFake(() => new Promise(() => {}));

--- a/spec/javascripts/packs/src/fetchers/BaseFetcher.spec.js
+++ b/spec/javascripts/packs/src/fetchers/BaseFetcher.spec.js
@@ -1,14 +1,16 @@
-import expect from "expect";
-import ContainerFactory from "factories/ContainerFactory";
-import BaseFetcher from "../../../../../app/packs/src/fetchers/BaseFetcher";
+/* global describe, it */
+
+import expect from 'expect';
+import ContainerFactory from 'factories/ContainerFactory';
+import BaseFetcher from 'src/fetchers/BaseFetcher';
 
 describe('BaseFetcher', () => {
-    describe('.getAttachments()', () => {
-        it('with linear hierarchy and two attachments', async () => {
-            const container= await ContainerFactory.build("four_container_linear_hierarchy_two_attachments");
+  describe('.getAttachments()', () => {
+    it('with linear hierarchy and two attachments', async () => {
+      const container = await ContainerFactory.build('four_container_linear_hierarchy_two_attachments');
 
-            const attachments=BaseFetcher.getAttachments(container);
-            expect(attachments.length).toEqual(2);
-        });  
+      const attachments = BaseFetcher.getAttachments(container);
+      expect(attachments.length).toEqual(2);
     });
+  });
 });

--- a/spec/javascripts/packs/src/fetchers/ChemicalFetcher.spec.js
+++ b/spec/javascripts/packs/src/fetchers/ChemicalFetcher.spec.js
@@ -75,13 +75,27 @@ describe('ChemicalFetcher methods', () => {
     });
 
     it('should handle fetch error', async () => {
-      // Call the create method of ChemicalFetcher and catch the error
+      // Stub ChemicalFetcher.create
+      const createStub = sinon.stub(ChemicalFetcher, 'create').callsFake(async (input) => {
+        await fetch('/api/v1/chemicals/create', {
+          credentials: 'same-origin',
+          method: 'post',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(input)
+        });
+      });
+      // Setup fetchStub to reject with a specific error
       fetchStub.rejects(new Error('Fetch error'));
       try {
         await ChemicalFetcher.create(inputData);
         // If the code execution reaches here, the test should fail
         throw new Error('Failed to create chemical');
       } catch (error) {
+        // Restore original method
+        createStub.restore();
         sinon.assert.calledOnce(fetchStub);
         sinon.assert.calledWithExactly(fetchStub, '/api/v1/chemicals/create', {
           credentials: 'same-origin',
@@ -92,7 +106,7 @@ describe('ChemicalFetcher methods', () => {
           },
           body: JSON.stringify(inputData)
         });
-        expect(error.message).toEqual('Failed to create chemical');
+        expect(error.message).toEqual('Fetch error');
       }
     });
   });
@@ -152,7 +166,9 @@ describe('ChemicalFetcher methods', () => {
       const resultObject = JSON.parse(result); // Parse the received response as JSON
 
       sinon.assert.calledOnce(fetchStub);
-      sinon.assert.calledWithExactly(fetchStub, `/api/v1/chemicals/fetch_safetysheet/${queryParams.id}?data[vendor]=${queryParams.vendor}&data[option]=${queryParams.queryOption}&data[language]=${queryParams.language}&data[searchStr]=${queryParams.string}`, {
+      sinon.assert.calledWithExactly(fetchStub, '/api/v1/chemicals/fetch_safetysheet'
+        + `/${queryParams.id}?data[vendor]=${queryParams.vendor}&data[option]=${queryParams.queryOption}`
+        + `&data[language]=${queryParams.language}&data[searchStr]=${queryParams.string}`, {
         credentials: 'same-origin',
         method: 'GET',
         headers: {
@@ -211,7 +227,8 @@ describe('ChemicalFetcher methods', () => {
         },
         p_statements: {
           P201: ' Obtain special instructions before use.',
-          P210: ' Keep away from heat, hot surfaces, sparks, open flames and other ignition sources. No smoking. [As modified by IV ATP]',
+          P210: ' Keep away from heat, hot surfaces, sparks,'
+                  + 'open flames and other ignition sources. No smoking. [As modified by IV ATP]',
           P280: ' Wear protective gloves/protective clothing/eye protection/face protection. [As modified by IV ATP]'
         },
         pictograms: [
@@ -227,7 +244,8 @@ describe('ChemicalFetcher methods', () => {
       const result = await ChemicalFetcher.safetyPhrases(queryParams);
 
       sinon.assert.calledOnce(fetchStub);
-      sinon.assert.calledWithExactly(fetchStub, `/api/v1/chemicals/safety_phrases/${queryParams.id}?vendor=${queryParams.vendor}`, {
+      sinon.assert.calledWithExactly(fetchStub, `/api/v1/chemicals/safety_phrases/${queryParams.id}`
+           + `?vendor=${queryParams.vendor}`, {
         credentials: 'same-origin',
         method: 'GET'
       });


### PR DESCRIPTION
- I noticed, there are mulitple warnings when running `npm test` 

This PR solves these warnings:

075aa5a8dfb2046fdecb9a972e4c1a4597fe5309 solves 
```
Warning: Failed prop type: Invalid prop `bsSize` of value `middle` supplied to `Button`, expected one of ["lg","large","sm","small","xs","xsmall"].
    at Button (/home/chemotion-dev/node_modules/react-bootstrap/lib/Button.js:56:29)
```
7c0c90ac6e3eb0db14e471ea63588c2c8385b363 solves
```
This browser doesn't support requestAnimationFrame. Make sure that you load a polyfill in older browsers. https://reactjs.org/link/react-polyfills
This browser doesn't support cancelAnimationFrame. Make sure that you load a polyfill in older browsers. https://reactjs.org/link/react-polyfills

```
2bdfdbe5cab5f758bbea357f2ecebc6f439d8e6b and fa9c7b7e096f9c3d0d53551d3b139bc5f88ceda1  solve
```
Warning: Failed prop type: Invalid prop `researchPlan.attachments[0].id` of type `string` supplied to `ResearchPlanDetailsAttachments`, expected `number`.
    at ResearchPlanDetailsAttachments (/home/chemotion-dev/app/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js:109:24)
Warning: Failed prop type: Invalid prop `attachments[0].id` of type `string` supplied to `ResearchPlanDetailsAttachments`, expected `number`.
    at ResearchPlanDetailsAttachments (/home/chemotion-dev/app/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js:109:24)

```
020c92faf86b7169872662bf4c3dbb23c71ac449 solves
```
Warning: Failed prop type: Invalid prop `attachment` of type `Object` supplied to `ImageAnnotationEditButton`, expected instance of `Attachment`.
    at ImageAnnotationEditButton (/home/chemotion-dev/app/app/packs/src/apps/mydb/elements/details/researchPlans/ImageAnnotationEditButton.js:30:24)
Warning: Failed prop type: Invalid prop `attachment` of type `String` supplied to `ImageAnnotationEditButton`, expected instance of `Attachment`.
    at ImageAnnotationEditButton (/home/chemotion-dev/app/app/packs/src/apps/mydb/elements/details/researchPlans/ImageAnnotationEditButton.js:30:24)
```
ec175079196cc311d3cd73a473377799316223c7 solves
```
TypeError: Failed to parse URL from /api/v1/comments?commentable_id=63ab7ec0-5085-11ee-acc4-e79dfa35b212&commentable_type=ResearchPlan
    at Object.fetch (node:internal/deps/undici/undici:11576:11) {
  [cause]: TypeError: Invalid URL
      at new NodeError (node:internal/errors:405:5)
      at new URL (node:internal/url:611:13)
      at new Request (node:internal/deps/undici/undici:7132:25)
      at fetch2 (node:internal/deps/undici/undici:10715:25)
      at Object.fetch (node:internal/deps/undici/undici:11574:18)
      at fetch (node:internal/process/pre_execution:229:25)
      at Function.fetchByCommentableId (/home/chemotion-dev/app/app/packs/src/fetchers/CommentFetcher.js:25:12)
      at /home/chemotion-dev/app/app/packs/src/stores/alt/actions/CommentActions.js:13:22
      at Object.fetchComments (/home/chemotion-dev/node_modules/alt/lib/actions/index.js:47:24)
      at ResearchPlanDetails.componentDidMount (/home/chemotion-dev/app/app/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js:57:20)
      at fn (/home/chemotion-dev/node_modules/enzyme/src/ShallowWrapper.js:429:22)
      at Object.batchedUpdates (/home/chemotion-dev/node_modules/@wojtekmaj/enzyme-adapter-react-17/src/ReactSeventeenAdapter.js:753:16)
      at new ShallowWrapper (/home/chemotion-dev/node_modules/enzyme/src/ShallowWrapper.js:428:26)
      at shallow (/home/chemotion-dev/node_modules/enzyme/src/shallow.js:10:10)
      at _callee$ (/home/chemotion-dev/app/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js:32:25)
      at tryCatch (/home/chemotion-dev/node_modules/regenerator-runtime/runtime.js:63:40)
      at Generator.invoke [as _invoke] (/home/chemotion-dev/node_modules/regenerator-runtime/runtime.js:294:22)
      at Generator.next (/home/chemotion-dev/node_modules/regenerator-runtime/runtime.js:119:21)
      at asyncGeneratorStep (/home/chemotion-dev/app/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js:29:103)
      at _next (/home/chemotion-dev/app/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js:31:194) {
    input: '/api/v1/comments?commentable_id=63ab7ec0-5085-11ee-acc4-e79dfa35b212&commentable_type=ResearchPlan',
    code: 'ERR_INVALID_URL'
  }
}
TypeError: Failed to parse URL from /api/v1/comments?commentable_id=63b0d5f0-5085-11ee-acc4-e79dfa35b212&commentable_type=ResearchPlan
    at Object.fetch (node:internal/deps/undici/undici:11576:11) {
  [cause]: TypeError: Invalid URL
      at new NodeError (node:internal/errors:405:5)
      at new URL (node:internal/url:611:13)
      at new Request (node:internal/deps/undici/undici:7132:25)
      at fetch2 (node:internal/deps/undici/undici:10715:25)
      at Object.fetch (node:internal/deps/undici/undici:11574:18)
      at fetch (node:internal/process/pre_execution:229:25)
      at Function.fetchByCommentableId (/home/chemotion-dev/app/app/packs/src/fetchers/CommentFetcher.js:25:12)
      at /home/chemotion-dev/app/app/packs/src/stores/alt/actions/CommentActions.js:13:22
      at Object.fetchComments (/home/chemotion-dev/node_modules/alt/lib/actions/index.js:47:24)
      at ResearchPlanDetails.componentDidMount (/home/chemotion-dev/app/app/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js:57:20)
      at fn (/home/chemotion-dev/node_modules/enzyme/src/ShallowWrapper.js:429:22)
      at Object.batchedUpdates (/home/chemotion-dev/node_modules/@wojtekmaj/enzyme-adapter-react-17/src/ReactSeventeenAdapter.js:753:16)
      at new ShallowWrapper (/home/chemotion-dev/node_modules/enzyme/src/ShallowWrapper.js:428:26)
      at shallow (/home/chemotion-dev/node_modules/enzyme/src/shallow.js:10:10)
      at _callee3$ (/home/chemotion-dev/app/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js:50:25)
      at tryCatch (/home/chemotion-dev/node_modules/regenerator-runtime/runtime.js:63:40)
      at Generator.invoke [as _invoke] (/home/chemotion-dev/node_modules/regenerator-runtime/runtime.js:294:22)
      at Generator.next (/home/chemotion-dev/node_modules/regenerator-runtime/runtime.js:119:21)
      at asyncGeneratorStep (/home/chemotion-dev/app/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js:29:103)
      at _next (/home/chemotion-dev/app/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js:31:194) {
    input: '/api/v1/comments?commentable_id=63b0d5f0-5085-11ee-acc4-e79dfa35b212&commentable_type=ResearchPlan',
    code: 'ERR_INVALID_URL'
  }
}
TypeError: Failed to parse URL from /api/v1/comments?commentable_id=63b19940-5085-11ee-acc4-e79dfa35b212&commentable_type=ResearchPlan
    at Object.fetch (node:internal/deps/undici/undici:11576:11) {
  [cause]: TypeError: Invalid URL
      at new NodeError (node:internal/errors:405:5)
      at new URL (node:internal/url:611:13)
      at new Request (node:internal/deps/undici/undici:7132:25)
      at fetch2 (node:internal/deps/undici/undici:10715:25)
      at Object.fetch (node:internal/deps/undici/undici:11574:18)
      at fetch (node:internal/process/pre_execution:229:25)
      at Function.fetchByCommentableId (/home/chemotion-dev/app/app/packs/src/fetchers/CommentFetcher.js:25:12)
      at /home/chemotion-dev/app/app/packs/src/stores/alt/actions/CommentActions.js:13:22
      at Object.fetchComments (/home/chemotion-dev/node_modules/alt/lib/actions/index.js:47:24)
      at ResearchPlanDetails.componentDidMount (/home/chemotion-dev/app/app/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js:57:20)
      at fn (/home/chemotion-dev/node_modules/enzyme/src/ShallowWrapper.js:429:22)
      at Object.batchedUpdates (/home/chemotion-dev/node_modules/@wojtekmaj/enzyme-adapter-react-17/src/ReactSeventeenAdapter.js:753:16)
      at new ShallowWrapper (/home/chemotion-dev/node_modules/enzyme/src/ShallowWrapper.js:428:26)
      at shallow (/home/chemotion-dev/node_modules/enzyme/src/shallow.js:10:10)
      at _callee5$ (/home/chemotion-dev/app/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js:96:25)
      at tryCatch (/home/chemotion-dev/node_modules/regenerator-runtime/runtime.js:63:40)
      at Generator.invoke [as _invoke] (/home/chemotion-dev/node_modules/regenerator-runtime/runtime.js:294:22)
      at Generator.next (/home/chemotion-dev/node_modules/regenerator-runtime/runtime.js:119:21)
      at asyncGeneratorStep (/home/chemotion-dev/app/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js:29:103)
      at _next (/home/chemotion-dev/app/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js:31:194) {
    input: '/api/v1/comments?commentable_id=63b19940-5085-11ee-acc4-e79dfa35b212&commentable_type=ResearchPlan',
    code: 'ERR_INVALID_URL'
  }
}
TypeError: Failed to parse URL from /api/v1/comments?commentable_id=63b2d1c0-5085-11ee-acc4-e79dfa35b212&commentable_type=ResearchPlan
    at Object.fetch (node:internal/deps/undici/undici:11576:11) {
  [cause]: TypeError: Invalid URL
      at new NodeError (node:internal/errors:405:5)
      at new URL (node:internal/url:611:13)
      at new Request (node:internal/deps/undici/undici:7132:25)
      at fetch2 (node:internal/deps/undici/undici:10715:25)
      at Object.fetch (node:internal/deps/undici/undici:11574:18)
      at fetch (node:internal/process/pre_execution:229:25)
      at Function.fetchByCommentableId (/home/chemotion-dev/app/app/packs/src/fetchers/CommentFetcher.js:25:12)
      at /home/chemotion-dev/app/app/packs/src/stores/alt/actions/CommentActions.js:13:22
      at Object.fetchComments (/home/chemotion-dev/node_modules/alt/lib/actions/index.js:47:24)
      at ResearchPlanDetails.componentDidMount (/home/chemotion-dev/app/app/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js:57:20)
      at fn (/home/chemotion-dev/node_modules/enzyme/src/ShallowWrapper.js:429:22)
      at Object.batchedUpdates (/home/chemotion-dev/node_modules/@wojtekmaj/enzyme-adapter-react-17/src/ReactSeventeenAdapter.js:753:16)
      at new ShallowWrapper (/home/chemotion-dev/node_modules/enzyme/src/ShallowWrapper.js:428:26)
      at shallow (/home/chemotion-dev/node_modules/enzyme/src/shallow.js:10:10)
      at _callee7$ (/home/chemotion-dev/app/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js:140:27)
      at tryCatch (/home/chemotion-dev/node_modules/regenerator-runtime/runtime.js:63:40)
      at Generator.invoke [as _invoke] (/home/chemotion-dev/node_modules/regenerator-runtime/runtime.js:294:22)
      at Generator.next (/home/chemotion-dev/node_modules/regenerator-runtime/runtime.js:119:21)
      at asyncGeneratorStep (/home/chemotion-dev/app/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js:29:103)
      at _next (/home/chemotion-dev/app/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js:31:194) {
    input: '/api/v1/comments?commentable_id=63b2d1c0-5085-11ee-acc4-e79dfa35b212&commentable_type=ResearchPlan',
    code: 'ERR_INVALID_URL'
  }
}
TypeError: Failed to parse URL from /api/v1/comments?commentable_id=63b36e01-5085-11ee-acc4-e79dfa35b212&commentable_type=ResearchPlan
    at Object.fetch (node:internal/deps/undici/undici:11576:11) {
  [cause]: TypeError: Invalid URL
      at new NodeError (node:internal/errors:405:5)
      at new URL (node:internal/url:611:13)
      at new Request (node:internal/deps/undici/undici:7132:25)
      at fetch2 (node:internal/deps/undici/undici:10715:25)
      at Object.fetch (node:internal/deps/undici/undici:11574:18)
      at fetch (node:internal/process/pre_execution:229:25)
      at Function.fetchByCommentableId (/home/chemotion-dev/app/app/packs/src/fetchers/CommentFetcher.js:25:12)
      at /home/chemotion-dev/app/app/packs/src/stores/alt/actions/CommentActions.js:13:22
      at Object.fetchComments (/home/chemotion-dev/node_modules/alt/lib/actions/index.js:47:24)
      at ResearchPlanDetails.componentDidMount (/home/chemotion-dev/app/app/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js:57:20)
      at fn (/home/chemotion-dev/node_modules/enzyme/src/ShallowWrapper.js:429:22)
      at Object.batchedUpdates (/home/chemotion-dev/node_modules/@wojtekmaj/enzyme-adapter-react-17/src/ReactSeventeenAdapter.js:753:16)
      at new ShallowWrapper (/home/chemotion-dev/node_modules/enzyme/src/ShallowWrapper.js:428:26)
      at shallow (/home/chemotion-dev/node_modules/enzyme/src/shallow.js:10:10)
      at _callee9$ (/home/chemotion-dev/app/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js:183:27)
      at tryCatch (/home/chemotion-dev/node_modules/regenerator-runtime/runtime.js:63:40)
      at Generator.invoke [as _invoke] (/home/chemotion-dev/node_modules/regenerator-runtime/runtime.js:294:22)
      at Generator.next (/home/chemotion-dev/node_modules/regenerator-runtime/runtime.js:119:21)
      at asyncGeneratorStep (/home/chemotion-dev/app/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js:29:103)
      at _next (/home/chemotion-dev/app/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js:31:194) {
    input: '/api/v1/comments?commentable_id=63b36e01-5085-11ee-acc4-e79dfa35b212&commentable_type=ResearchPlan',
    code: 'ERR_INVALID_URL'
  }
}
```
1c9886200014a649ab7b9d30ce8db3cff817e324 solves

```
Warning: Failed prop type: The prop `attachments` is marked as required in `ResearchPlanDetailsFieldImage`, but its value is `undefined`.
    at ResearchPlanDetailsFieldImage (/home/chemotion-dev/app/app/packs/src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsFieldImage.js:44:24)

```
