### PR TITLE
fix: reaction sort column default to created_at

### DIFF
--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -19,7 +19,8 @@ module Chemotion
         optional :to_date, type: Integer, desc: 'created_date to in ms'
         optional :filter_created_at, type: Boolean, desc: 'filter by created at or updated at'
         optional :sort_column, type: String, desc: 'sort by created_at, updated_at, rinchi_short_key, or rxno',
-                               values: %w[created_at updated_at rinchi_short_key rxno]
+                               values: %w[created_at updated_at rinchi_short_key rxno],
+                               default: 'created_at'
       end
       paginate per_page: 7, offset: 0
 

--- a/app/packs/src/fetchers/BaseFetcher.js
+++ b/app/packs/src/fetchers/BaseFetcher.js
@@ -74,6 +74,10 @@ export default class BaseFetcher {
         addQuery = group === 'none'
           ? '&sort_column=created_at'
           : `&sort_column=${sort && group ? group : 'updated_at'}`;
+        // if the user has not updated its profile yet, we set the default sort to created_at
+        if (!filters.reaction) {
+          addQuery = '&sort_column=created_at';
+        }
         break;
       case 'generic_elements':
         userState = UserStore.getState();


### PR DESCRIPTION
prevent unexpected sorting in case when the user profile.data.filter is missing and incorrect params sort_column is sent by the client (update_at instead of created_at)

more thorough resolution should come with #1461


