### PR TITLE
fix: assets precompilation css issue

### DIFF
--- a/package_postinstall.sh
+++ b/package_postinstall.sh
@@ -4,11 +4,24 @@
 
 set -euo pipefail
 
+## ag-grid css
+src5=$(node -e 'console.log(require.resolve("ag-grid-community/styles/ag-grid.css"))')
+src6=$(node -e 'console.log(require.resolve("ag-grid-community/styles/ag-grid-no-native-widgets.css"))')
+
+
 YEL='\033[0;33m'
 NOC='\033[0m'
 yellow() {
   printf "${YEL}${1:-}${NOC}\n"
 }
+
+
+
+yellow "$src5"
+sed -i "s~height: min~height: Min~" $src5
+sed -i "s~height: min~height: Min~" $src6
+yellow "Done fixing css."
+
 
 
 


### PR DESCRIPTION
SassC::SyntaxError: Error: "var(--ag-internal-calculated-line-height)" is not a number for `min'
        on line 2381:11 of stdin, in function `min`
        from line 2381:11 of stdin
>>   height: min(var(--ag-internal-calculated-line-height), var(--ag-internal-p



