### PR TITLE
properties section now spans entire width when sample is decoupled

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/packs/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -726,7 +726,9 @@ export default class SampleForm extends React.Component {
             </td>
           </tr>
           <tr>
-            {this.additionalProperties(sample)}
+            <td colSpan="4">
+              {this.additionalProperties(sample)}
+            </td>
           </tr>
           <tr>
             <td colSpan="4">


### PR DESCRIPTION
Closes: https://github.com/ComPlat/chemotion/issues/62

Before:
![269576338-188e1b59-d1de-4b95-a884-6d6ce3b62e9a](https://github.com/ComPlat/chemotion_ELN/assets/67055123/6a8ebecf-9669-49c1-b9a3-49a7192499ee)

After:
![269588516-9feef540-e4a7-4347-baa4-e0b79667c481](https://github.com/ComPlat/chemotion_ELN/assets/67055123/08b34677-abcb-4fcd-88f0-6465fa1ef870)
