### PR TITLE
Fix show example label for reaction

### DIFF
--- a/app/views/pages/settings.haml
+++ b/app/views/pages/settings.haml
@@ -18,7 +18,7 @@
                                 maxlength: 3,
                                 class: 'form-control',
                                 id: 'reaction-name-prefix',
-                                oninput: 'showExampleLabel();'
+                                oninput: 'showExampleLabel()'
           .form-group
             = f.label 'Counter starts at', class: 'col-sm-2 col-sm-offset-2 control-label'
             .col-sm-2
@@ -27,7 +27,7 @@
                                   min: 0,
                                   class: 'form-control',
                                   id: 'reactions-count',
-                                  oninput: 'showExampleLabel();'
+                                  oninput: 'showExampleLabel()'
           = hidden_field_tag :name_abbreviation, current_user.name_abbreviation
           %div
             .col-sm-4.col-sm-offset-2
@@ -85,3 +85,4 @@
 
   = link_to "Back", root_path
 
+  %script{:src => asset_path('pages.js')}


### PR DESCRIPTION

- [ ] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [x] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
