### PR TITLE
Add new API to upload files via API without collector.

### DIFF
--- a/app/api/chemotion/attachment_api.rb
+++ b/app/api/chemotion/attachment_api.rb
@@ -38,6 +38,17 @@ module Chemotion
         { ok: false, statusText: 'File key is not valid' }
       end
 
+
+      def upload_raw_error_message
+        { ok: false, statusText: 'File is not valid' }
+      end
+
+      def upload_device
+        return current_user if current_user.is_a?(Device)
+        return @device ||= Device.find_by(id: params[:device_id]) if params.has_key? :device_id
+        nil
+      end
+
       def remove_duplicated(att)
         old_att = Attachment.find_by(filename: att.filename, attachable_id: att.attachable_id)
         return unless old_att.id != att.id
@@ -125,6 +136,33 @@ module Chemotion
                 with: Entities::AttachmentEntity,
                 root: :attachment
       end
+
+      desc 'Upload raw data completed'
+      params do
+        requires :filename, type: String
+        requires :key, type: String
+        requires :checksum, type: String
+        optional :device_id, type: Integer, desc: 'Id of device only needed if current user is not a device'
+      end # frozen_string_literal: true
+
+      post 'upload_raw_chunk_complete' do
+        break upload_chunk_error_message unless AttachmentPolicy.can_upload_chunk?(params[:key])
+
+        complete_file = Usecases::Attachments::UploadRawComplete.execute!(current_user, params)
+        begin
+          current_collector = DataReceiverFile.new(params[:filename], complete_file[:file_path])
+          break upload_raw_error_message if upload_device.nil?
+          break { ok: false } unless (att = current_collector.collect_from(upload_device))
+          break { ok: true, path: att.backup_file }
+        rescue
+          break { ok: false }
+        ensure
+          FileUtils.rm_f(complete_file[:file_path])
+        end
+
+      end
+
+
 
       # TODO: Remove this endpoint. It is not used by the FE
       desc 'Upload attachments'

--- a/app/usecases/attachments/upload_raw_complete.rb
+++ b/app/usecases/attachments/upload_raw_complete.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Usecases
+  module Attachments
+    class UploadRawComplete
+      attr_reader :user, :params
+
+      def initialize(user, params)
+        @user = user
+        @params = params
+      end
+
+      def self.execute!(user, params)
+        new(user, params).execute!
+      end
+
+      def execute! # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+        file_name = ActiveStorage::Filename.new(params[:filename]).sanitized
+        FileUtils.mkdir_p(Rails.root.join('tmp/uploads/full'))
+        entries = Dir["#{Rails.root.join('tmp/uploads/chunks', params[:key])}*"].sort_by do |s|
+          s.scan(/\d+/).last.to_i
+        end
+        file_path = Rails.root.join('tmp/uploads/full', params[:key])
+        file_path = "#{file_path}#{File.extname(file_name)}"
+        file_checksum = Digest::MD5.new
+        File.open(file_path, 'wb') do |outfile|
+          entries.each do |file|
+            buff = File.binread(file)
+            file_checksum.update(buff)
+            outfile.write(buff)
+          end
+        end
+
+        return {ok: true, file_name: file_name, file_path: file_path} if file_checksum == params[:checksum]
+
+        { ok: false, statusText: ['File upload has error. Please try again!'] }
+      ensure
+        entries.each do |file|
+          FileUtils.rm_f(file)
+        end
+      end
+    end
+  end
+end

--- a/lib/datacollector/data_receiver_file.rb
+++ b/lib/datacollector/data_receiver_file.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# A class as a file data collector
+class DataReceiverFile < DatacollectorFile
+
+  def initialize(filename, temp_file_path)
+    super filename, false
+    @path = temp_file_path
+  end
+
+end


### PR DESCRIPTION
This code was lying around for a long time so I thoud I can finally finish it and push it.

[Issue](https://github.com/ComPlat/chemotion_ELN/issues/1553)

- New AttachmentRawCompleted entrypoint
- it uses usecase UploadRawCompleted (Extracted code snippets from UploadChunkComplete) 
- With UploadRawCompleted no new Attachment entry is created, this is done by DataReceiverFile (Reuse as much code as possible).



- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
