### PR TITLE
1558 no attachments after research plan save

### DIFF
--- a/app/api/chemotion/attachable_api.rb
+++ b/app/api/chemotion/attachable_api.rb
@@ -45,8 +45,6 @@ module Chemotion
               tempfile.unlink
             end
           end
-
-          TransferThumbnailToPublicJob.set(queue: "transfer_thumbnail_to_public_#{current_user.id}").perform_later(rp_attach_ary) if rp_attach_ary.any?
         end
         Attachment.where('id IN (?) AND attachable_type = (?)', params[:del_files].map!(&:to_i), attachable_type).update_all(attachable_id: nil) if params[:del_files].any?
         true

--- a/app/api/chemotion/attachable_api.rb
+++ b/app/api/chemotion/attachable_api.rb
@@ -7,6 +7,7 @@ module Chemotion
         optional :files, type: Array[File], desc: 'files', default: []
         optional :attachable_type, type: String, desc: 'attachable_type'
         optional :attachable_id, type: Integer, desc: 'attachable id'
+        optional :attfilesIdentifier, type: Array[String], desc: 'file identifier'
         optional :del_files, type: Array[Integer], desc: 'del file id', default: []
       end
       after_validation do
@@ -20,13 +21,15 @@ module Chemotion
       post 'update_attachments_attachable' do
         attachable_type = params[:attachable_type]
         attachable_id = params[:attachable_id]
+       
         if params.fetch(:files, []).any?
           attach_ary = []
           rp_attach_ary = []
-          params[:files].each do |file|
+          index=0;
+          params[:files].each do |file,index|
             next unless (tempfile = file[:tempfile])
-
             a = Attachment.new(
+              identifier: params[:attfilesIdentifier][index],
               bucket: file[:container_id],
               filename: file[:filename],
               file_path: file[:tempfile],
@@ -36,6 +39,7 @@ module Chemotion
               attachable_type: attachable_type,
               attachable_id: attachable_id
             )
+            index=index +1
             begin
               a.save!
               attach_ary.push(a.id)

--- a/app/api/chemotion/attachable_api.rb
+++ b/app/api/chemotion/attachable_api.rb
@@ -26,7 +26,7 @@ module Chemotion
           attach_ary = []
           rp_attach_ary = []
           index=0;
-          params[:files].each do |file,index|
+          params[:files].each do |file|
             next unless (tempfile = file[:tempfile])
             a = Attachment.new(
               identifier: params[:attfilesIdentifier][index],

--- a/app/api/chemotion/attachable_api.rb
+++ b/app/api/chemotion/attachable_api.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Rails/SkipsModelValidations
+
 module Chemotion
   class AttachableAPI < Grape::API
     resource :attachable do
@@ -13,7 +15,10 @@ module Chemotion
       after_validation do
         case params[:attachable_type]
         when 'ResearchPlan'
-          error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, ResearchPlan.find_by(id: params[:attachable_id])).update?
+          error!('401 Unauthorized', 401) unless ElementPolicy.new(
+            current_user,
+            ResearchPlan.find_by(id: params[:attachable_id]),
+          ).update?
         end
       end
 
@@ -21,13 +26,13 @@ module Chemotion
       post 'update_attachments_attachable' do
         attachable_type = params[:attachable_type]
         attachable_id = params[:attachable_id]
-       
+
         if params.fetch(:files, []).any?
           attach_ary = []
           rp_attach_ary = []
-          index=0;
-          params[:files].each do |file|
+          params[:files].each_with_index do |file, index|
             next unless (tempfile = file[:tempfile])
+
             a = Attachment.new(
               identifier: params[:attfilesIdentifier][index],
               bucket: file[:container_id],
@@ -37,9 +42,9 @@ module Chemotion
               created_for: current_user.id,
               content_type: file[:type],
               attachable_type: attachable_type,
-              attachable_id: attachable_id
+              attachable_id: attachable_id,
             )
-            index=index +1
+
             begin
               a.save!
               attach_ary.push(a.id)
@@ -50,9 +55,13 @@ module Chemotion
             end
           end
         end
-        Attachment.where('id IN (?) AND attachable_type = (?)', params[:del_files].map!(&:to_i), attachable_type).update_all(attachable_id: nil) if params[:del_files].any?
+        if params[:del_files].any?
+          Attachment.where('id IN (?) AND attachable_type = (?)', params[:del_files].map!(&:to_i),
+                           attachable_type).update_all(attachable_id: nil)
+        end
         true
       end
     end
   end
 end
+# rubocop:enable Rails/SkipsModelValidations

--- a/app/packs/src/fetchers/AttachmentFetcher.js
+++ b/app/packs/src/fetchers/AttachmentFetcher.js
@@ -156,10 +156,12 @@ export default class AttachmentFetcher {
   static updateAttachables(files, attachableType, attachableId, dels) {
     const data = new FormData();
     files.forEach(file => {
+      data.append('attfilesIdentifier[]', file.id);
       data.append('files[]', file.file, file.name);
     });
     data.append('attachable_type', attachableType);
     data.append('attachable_id', attachableId);
+    
     dels.forEach(f => {
       data.append('del_files[]', f.id);
     });

--- a/app/packs/src/fetchers/GenericElsFetcher.js
+++ b/app/packs/src/fetchers/GenericElsFetcher.js
@@ -89,8 +89,8 @@ export default class GenericElsFetcher extends GenericBaseFetcher {
       data.append('elInfo', JSON.stringify(elMap));
     }
 
-    if (GenericElsFetcher.shouldUploadAttachments(hasAttach,element)){
-      GenericElsFetcher.prepareAttachmentParam(element,data);
+    if (GenericElsFetcher.shouldUploadAttachments(hasAttach, element)) {
+      GenericElsFetcher.prepareAttachmentParam(element, data);
     }
 
     (element.segments || []).forEach((segment) => {
@@ -205,9 +205,7 @@ export default class GenericElsFetcher extends GenericBaseFetcher {
     return this.execData(params, 'create_repo_klass');
   }
 
- 
-
-  static prepareAttachmentParam(element,data){
+  static prepareAttachmentParam(element, data) {
     const newFiles = (element.attachments || []).filter(
       (a) => a.is_new && !a.is_deleted
     );
@@ -223,10 +221,10 @@ export default class GenericElsFetcher extends GenericBaseFetcher {
     });
   }
 
-  static shouldUploadAttachments(hasAttach,element){
+  static shouldUploadAttachments(hasAttach, element) {
     return hasAttach === true
     && element.attachments
     && element.attachments.length > 0
-    && element.type !== "research_plan"
+    && element.type !== 'research_plan';
   }
 }

--- a/app/packs/src/fetchers/GenericElsFetcher.js
+++ b/app/packs/src/fetchers/GenericElsFetcher.js
@@ -88,25 +88,11 @@ export default class GenericElsFetcher extends GenericBaseFetcher {
       });
       data.append('elInfo', JSON.stringify(elMap));
     }
-    if (
-      hasAttach === true
-      && element.attachments
-      && element.attachments.length > 0
-    ) {
-      const newFiles = (element.attachments || []).filter(
-        (a) => a.is_new && !a.is_deleted
-      );
-      const delFiles = (element.attachments || []).filter(
-        (a) => !a.is_new && a.is_deleted
-      );
-      (newFiles || []).forEach((file) => {
-        data.append('attfiles[]', file.file, file.name);
-        data.append('attfilesIdentifier[]', file.id);
-      });
-      (delFiles || []).forEach((f) => {
-        data.append('delfiles[]', f.id);
-      });
+
+    if (GenericElsFetcher.shouldUploadAttachments(hasAttach,element)){
+      GenericElsFetcher.prepareAttachmentParam(element,data);
     }
+
     (element.segments || []).forEach((segment) => {
       segMap[segment.segment_klass_id] = {
         type: 'SegmentProps',
@@ -217,5 +203,30 @@ export default class GenericElsFetcher extends GenericBaseFetcher {
 
   static createRepo(params) {
     return this.execData(params, 'create_repo_klass');
+  }
+
+ 
+
+  static prepareAttachmentParam(element,data){
+    const newFiles = (element.attachments || []).filter(
+      (a) => a.is_new && !a.is_deleted
+    );
+    const delFiles = (element.attachments || []).filter(
+      (a) => !a.is_new && a.is_deleted
+    );
+    (newFiles || []).forEach((file) => {
+      data.append('attfiles[]', file.file, file.name);
+      data.append('attfilesIdentifier[]', file.id);
+    });
+    (delFiles || []).forEach((f) => {
+      data.append('delfiles[]', f.id);
+    });
+  }
+
+  static shouldUploadAttachments(hasAttach,element){
+    return hasAttach === true
+    && element.attachments
+    && element.attachments.length > 0
+    && element.type !== "research_plan"
   }
 }

--- a/app/packs/src/fetchers/ResearchPlansFetcher.js
+++ b/app/packs/src/fetchers/ResearchPlansFetcher.js
@@ -42,18 +42,21 @@ export default class ResearchPlansFetcher {
       },
       body: JSON.stringify(researchPlan.serialize())
     })
-    .then((response) => response.json())
-    .then((json) => {AttachmentFetcher.updateAttachables(
-      researchPlan.getNewAttachments(),
-       'ResearchPlan',
-        json.research_plan.id,
-        researchPlan.getMarkedAsDeletedAttachments())();
-        return json;})
-    .then((json) => GenericElsFetcher.uploadGenericFiles(researchPlan, json.research_plan.id, 'ResearchPlan', true)
-    .then(() => this.fetchById(json.research_plan.id)))
-    .catch((errorMessage) => {
-      console.log(errorMessage);
-    });
+      .then((response) => response.json())
+      .then((json) => {
+        AttachmentFetcher.updateAttachables(
+          researchPlan.getNewAttachments(),
+          'ResearchPlan',
+          json.research_plan.id,
+          researchPlan.getMarkedAsDeletedAttachments()
+        )();
+        return json;
+      })
+      .then((json) => GenericElsFetcher.uploadGenericFiles(researchPlan, json.research_plan.id, 'ResearchPlan', true)
+        .then(() => this.fetchById(json.research_plan.id)))
+      .catch((errorMessage) => {
+        console.log(errorMessage);
+      });
     return promise;
   }
 
@@ -69,23 +72,21 @@ export default class ResearchPlansFetcher {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify(researchPlan.serialize())
-    }).then( response => response.json())
-      .then((json) => { 
-          AttachmentFetcher.updateAttachables(
-            researchPlan.getNewAttachments(),
-            'ResearchPlan',
-            json.research_plan.id,
-            researchPlan.getMarkedAsDeletedAttachments()
-          )()
-          .then((json)=> {return json});
-          return json;
+    }).then((response) => response.json())
+      .then((json) => {
+        AttachmentFetcher.updateAttachables(
+          researchPlan.getNewAttachments(),
+          'ResearchPlan',
+          json.research_plan.id,
+          researchPlan.getMarkedAsDeletedAttachments()
+        )()
+          .then((json) => json);
+        return json;
       })
-      .then((json) =>{ return GenericElsFetcher.uploadGenericFiles(researchPlan, json.research_plan.id, 'ResearchPlan', true)})
-      .then(() => {
-         return ResearchPlansFetcher.updateAnnotations(researchPlan) })
-      .then(() =>{
-        return this.fetchById(researchPlan.id)} )
-      .catch((errorMessage) => {console.log(errorMessage);});
+      .then((json) => GenericElsFetcher.uploadGenericFiles(researchPlan, json.research_plan.id, 'ResearchPlan', true))
+      .then(() => ResearchPlansFetcher.updateAnnotations(researchPlan))
+      .then(() => this.fetchById(researchPlan.id))
+      .catch((errorMessage) => { console.log(errorMessage); });
 
     if (containerFiles.length > 0) {
       const tasks = [];
@@ -278,28 +279,28 @@ export default class ResearchPlansFetcher {
   static updateAnnotations(researchPlan) {
     return Promise.all(
       [
-      ResearchPlansFetcher.updateAnnotationsOfAttachments(researchPlan),
-      BaseFetcher.updateAnnotationsInContainer(researchPlan,[])
-    ]);        
-  } 
+        ResearchPlansFetcher.updateAnnotationsOfAttachments(researchPlan),
+        BaseFetcher.updateAnnotationsInContainer(researchPlan, [])
+      ]
+    );
+  }
 
-  static updateAnnotationsOfAttachments(researchPlan){
-
-    const updateTasks=[];
+  static updateAnnotationsOfAttachments(researchPlan) {
+    const updateTasks = [];
     researchPlan.attachments
-      .filter((attach => attach.hasOwnProperty('updatedAnnotation')))
-      .forEach(attach => {
-        let data = new FormData();
+      .filter(((attach) => attach.hasOwnProperty('updatedAnnotation')))
+      .forEach((attach) => {
+        const data = new FormData();
         data.append('updated_svg_string', attach.updatedAnnotation);
-        updateTasks.push(fetch('/api/v1/attachments/' + attach.id + '/annotation', {
+        updateTasks.push(fetch(`/api/v1/attachments/${attach.id}/annotation`, {
           credentials: 'same-origin',
           method: 'post',
           body: data
         })
-        .catch((errorMessage) => {
-          console.log(errorMessage);
-        }));
-    })
+          .catch((errorMessage) => {
+            console.log(errorMessage);
+          }));
+      });
 
     return Promise.all(updateTasks);
   }

--- a/app/packs/src/fetchers/ResearchPlansFetcher.js
+++ b/app/packs/src/fetchers/ResearchPlansFetcher.js
@@ -32,6 +32,7 @@ export default class ResearchPlansFetcher {
 
   static create(researchPlan) {
     researchPlan.convertTemporaryImageFieldsInBody();
+
     const promise = fetch('/api/v1/research_plans/', {
       credentials: 'same-origin',
       method: 'post',
@@ -40,8 +41,16 @@ export default class ResearchPlansFetcher {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify(researchPlan.serialize())
-    }).then((response) => response.json()).then((json) => GenericElsFetcher.uploadGenericFiles(researchPlan, json.research_plan.id, 'ResearchPlan', true)
-      .then(() => this.fetchById(json.research_plan.id))).catch((errorMessage) => {
+    })
+    .then((response) => response.json())
+    .then((json) => AttachmentFetcher.updateAttachables(
+      researchPlan.getNewAttachments(),
+       'ResearchPlan',
+        json.research_plan.id,
+        researchPlan.getMarkedAsDeletedAttachments())())
+    .then(() => GenericElsFetcher.uploadGenericFiles(researchPlan, json.research_plan.id, 'ResearchPlan', true)
+    .then(() => this.fetchById(json.research_plan.id)))
+    .catch((errorMessage) => {
       console.log(errorMessage);
     });
     return promise;

--- a/app/packs/src/fetchers/ResearchPlansFetcher.js
+++ b/app/packs/src/fetchers/ResearchPlansFetcher.js
@@ -43,17 +43,13 @@ export default class ResearchPlansFetcher {
       body: JSON.stringify(researchPlan.serialize())
     })
       .then((response) => response.json())
-      .then((json) => {
-        AttachmentFetcher.updateAttachables(
-          researchPlan.getNewAttachments(),
-          'ResearchPlan',
-          json.research_plan.id,
-          researchPlan.getMarkedAsDeletedAttachments()
-        )();
-        return json;
-      })
-      .then((json) => GenericElsFetcher.uploadGenericFiles(researchPlan, json.research_plan.id, 'ResearchPlan', true)
-        .then(() => this.fetchById(json.research_plan.id)))
+      .then((json) => AttachmentFetcher.updateAttachables(
+        researchPlan.getNewAttachments(),
+        'ResearchPlan',
+        json.research_plan.id,
+        researchPlan.getMarkedAsDeletedAttachments()
+      )().then(() => GenericElsFetcher.uploadGenericFiles(researchPlan, json.research_plan.id, 'ResearchPlan', true)
+        .then(() => this.fetchById(json.research_plan.id))))
       .catch((errorMessage) => {
         console.log(errorMessage);
       });

--- a/app/packs/src/fetchers/ResearchPlansFetcher.js
+++ b/app/packs/src/fetchers/ResearchPlansFetcher.js
@@ -70,12 +70,15 @@ export default class ResearchPlansFetcher {
       },
       body: JSON.stringify(researchPlan.serialize())
     }).then( response => response.json())
-      .then((json) => { AttachmentFetcher.updateAttachables(
-      researchPlan.getNewAttachments(),
-       'ResearchPlan',
-        json.research_plan.id,
-        researchPlan.getMarkedAsDeletedAttachments())();
-        return json;
+      .then((json) => { 
+          AttachmentFetcher.updateAttachables(
+            researchPlan.getNewAttachments(),
+            'ResearchPlan',
+            json.research_plan.id,
+            researchPlan.getMarkedAsDeletedAttachments()
+          )()
+          .then((json)=> {return json});
+          return json;
       })
       .then((json) =>{ return GenericElsFetcher.uploadGenericFiles(researchPlan, json.research_plan.id, 'ResearchPlan', true)})
       .then(() => {

--- a/app/packs/src/fetchers/ResearchPlansFetcher.js
+++ b/app/packs/src/fetchers/ResearchPlansFetcher.js
@@ -69,19 +69,14 @@ export default class ResearchPlansFetcher {
       },
       body: JSON.stringify(researchPlan.serialize())
     }).then((response) => response.json())
-      .then((json) => {
-        return AttachmentFetcher.updateAttachables(
-          researchPlan.getNewAttachments(),
-          'ResearchPlan',
-          json.research_plan.id,
-          researchPlan.getMarkedAsDeletedAttachments()
-        )().then(()=>{
-          return GenericElsFetcher.uploadGenericFiles(researchPlan, json.research_plan.id, 'ResearchPlan', true)
-          .then(() => ResearchPlansFetcher.updateAnnotations(researchPlan))
-          .then(() => this.fetchById(researchPlan.id))
-        }
-        )
-      })
+      .then((json) => AttachmentFetcher.updateAttachables(
+        researchPlan.getNewAttachments(),
+        'ResearchPlan',
+        json.research_plan.id,
+        researchPlan.getMarkedAsDeletedAttachments()
+      )().then(() => GenericElsFetcher.uploadGenericFiles(researchPlan, json.research_plan.id, 'ResearchPlan', true)
+        .then(() => ResearchPlansFetcher.updateAnnotations(researchPlan))
+        .then(() => this.fetchById(researchPlan.id))))
       .catch((errorMessage) => { console.log(errorMessage); });
 
     if (containerFiles.length > 0) {

--- a/app/packs/src/fetchers/ResearchPlansFetcher.js
+++ b/app/packs/src/fetchers/ResearchPlansFetcher.js
@@ -43,12 +43,13 @@ export default class ResearchPlansFetcher {
       body: JSON.stringify(researchPlan.serialize())
     })
     .then((response) => response.json())
-    .then((json) => AttachmentFetcher.updateAttachables(
+    .then((json) => {AttachmentFetcher.updateAttachables(
       researchPlan.getNewAttachments(),
        'ResearchPlan',
         json.research_plan.id,
-        researchPlan.getMarkedAsDeletedAttachments())())
-    .then(() => GenericElsFetcher.uploadGenericFiles(researchPlan, json.research_plan.id, 'ResearchPlan', true)
+        researchPlan.getMarkedAsDeletedAttachments())();
+        return json;})
+    .then((json) => GenericElsFetcher.uploadGenericFiles(researchPlan, json.research_plan.id, 'ResearchPlan', true)
     .then(() => this.fetchById(json.research_plan.id)))
     .catch((errorMessage) => {
       console.log(errorMessage);

--- a/app/packs/src/fetchers/ResearchPlansFetcher.js
+++ b/app/packs/src/fetchers/ResearchPlansFetcher.js
@@ -74,18 +74,18 @@ export default class ResearchPlansFetcher {
       body: JSON.stringify(researchPlan.serialize())
     }).then((response) => response.json())
       .then((json) => {
-        AttachmentFetcher.updateAttachables(
+        return AttachmentFetcher.updateAttachables(
           researchPlan.getNewAttachments(),
           'ResearchPlan',
           json.research_plan.id,
           researchPlan.getMarkedAsDeletedAttachments()
-        )()
-          .then((json) => json);
-        return json;
+        )().then(()=>{
+          return GenericElsFetcher.uploadGenericFiles(researchPlan, json.research_plan.id, 'ResearchPlan', true)
+          .then(() => ResearchPlansFetcher.updateAnnotations(researchPlan))
+          .then(() => this.fetchById(researchPlan.id))
+        }
+        )
       })
-      .then((json) => GenericElsFetcher.uploadGenericFiles(researchPlan, json.research_plan.id, 'ResearchPlan', true))
-      .then(() => ResearchPlansFetcher.updateAnnotations(researchPlan))
-      .then(() => this.fetchById(researchPlan.id))
       .catch((errorMessage) => { console.log(errorMessage); });
 
     if (containerFiles.length > 0) {

--- a/app/packs/src/fetchers/ResearchPlansFetcher.js
+++ b/app/packs/src/fetchers/ResearchPlansFetcher.js
@@ -69,6 +69,13 @@ export default class ResearchPlansFetcher {
       },
       body: JSON.stringify(researchPlan.serialize())
     }).then( response => response.json())
+      .then((json) => { AttachmentFetcher.updateAttachables(
+      researchPlan.getNewAttachments(),
+       'ResearchPlan',
+        json.research_plan.id,
+        researchPlan.getMarkedAsDeletedAttachments())();
+        return json;
+      })
       .then((json) =>{ return GenericElsFetcher.uploadGenericFiles(researchPlan, json.research_plan.id, 'ResearchPlan', true)})
       .then(() => {
          return ResearchPlansFetcher.updateAnnotations(researchPlan) })

--- a/app/packs/src/fetchers/WellplatesFetcher.js
+++ b/app/packs/src/fetchers/WellplatesFetcher.js
@@ -88,7 +88,9 @@ export default class WellplatesFetcher {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify(wellplate.serialize())
-    }).then((response) => response.json()).then((json) => {
+    })
+    .then((response) => response.json())
+    .then((json) => {
       if (files.length <= 0) {
         return new Wellplate(json.wellplate);
       }

--- a/app/packs/src/models/ResearchPlan.js
+++ b/app/packs/src/models/ResearchPlan.js
@@ -260,11 +260,11 @@ export default class ResearchPlan extends Element {
 
   getNewAttachments() {
     return this.attachments
-      .filter((attachment) => attachment.is_new === true);
+      .filter((attachment) => attachment.is_new === true && !attachment.is_deleted);
   }
 
   getMarkedAsDeletedAttachments() {
     return this.attachments
-      .filter((attachment) => attachment.is_deleted === true);
+      .filter((attachment) => attachment.is_deleted === true && !attachment.is_new);
   }
 }

--- a/app/packs/src/models/ResearchPlan.js
+++ b/app/packs/src/models/ResearchPlan.js
@@ -252,8 +252,19 @@ export default class ResearchPlan extends Element {
         delete value.old_value;
       });
   }
+
   getAttachmentByIdentifier(identifier){
      return this.attachments
      .filter((attachment)=>attachment.identifier===identifier)[0];
+  }
+
+  getNewAttachments(){
+    return this.attachments
+      .filter((attachment)=>attachment.is_new===true);
+  }
+
+  getMarkedAsDeletedAttachments(){
+    return this.attachments
+    .filter((attachment)=>attachment.is_deleted===true);
   }
 }

--- a/app/packs/src/models/ResearchPlan.js
+++ b/app/packs/src/models/ResearchPlan.js
@@ -198,7 +198,7 @@ export default class ResearchPlan extends Element {
     return this._wellplates || [];
   }
 
-  upsertAttachments(attachmentsToAdd=[]) {
+  upsertAttachments(attachmentsToAdd = []) {
     const idsOfAttachmentsInResearchPlan = this.attachments.map(
       (attachmentInResearchPlan) => attachmentInResearchPlan.identifier
     );
@@ -253,18 +253,18 @@ export default class ResearchPlan extends Element {
       });
   }
 
-  getAttachmentByIdentifier(identifier){
-     return this.attachments
-     .filter((attachment)=>attachment.identifier===identifier)[0];
+  getAttachmentByIdentifier(identifier) {
+    return this.attachments
+      .filter((attachment) => attachment.identifier === identifier)[0];
   }
 
-  getNewAttachments(){
+  getNewAttachments() {
     return this.attachments
-      .filter((attachment)=>attachment.is_new===true);
+      .filter((attachment) => attachment.is_new === true);
   }
 
-  getMarkedAsDeletedAttachments(){
+  getMarkedAsDeletedAttachments() {
     return this.attachments
-    .filter((attachment)=>attachment.is_deleted===true);
+      .filter((attachment) => attachment.is_deleted === true);
   }
 }

--- a/spec/javascripts/packs/src/models/ResearchPlan.spec.js
+++ b/spec/javascripts/packs/src/models/ResearchPlan.spec.js
@@ -1,6 +1,9 @@
 import Attachment from 'src/models/Attachment';
 import ResearchPlan from 'src/models/ResearchPlan';
 import expect from 'expect';
+import {
+  describe, it
+} from 'mocha';
 
 describe('ResearchPlan', () => {
   const researchPlan = ResearchPlan.buildEmpty();
@@ -178,6 +181,48 @@ describe('ResearchPlan', () => {
       researchPlan.convertTemporaryImageFieldsInBody();
 
       expect(researchPlan.body).toEqual([permanentBodyField, expected]);
+    });
+  });
+
+  describe('.getNewAttachments', () => {
+    describe('.with two new attachments but one is already deleted, one was already there', () => {
+      const attachmentNewAndDeleted = new Attachment();
+      const attachmentNew = new Attachment();
+      const attachmentPresent = new Attachment();
+      researchPlan.attachments = [attachmentNewAndDeleted, attachmentNew, attachmentPresent];
+      attachmentNewAndDeleted.is_new = true;
+      attachmentNewAndDeleted.is_deleted = true;
+
+      attachmentNew.is_new = true;
+      attachmentPresent.is_deleted = false;
+
+      attachmentPresent.is_new = false;
+      attachmentPresent.is_deleted = false;
+
+      it('one attachment was found', () => {
+        expect(researchPlan.getNewAttachments().length).toEqual(1);
+      });
+    });
+  });
+
+  describe('.getMarkedAsDeletedAttachments', () => {
+    describe('.with two new attachments but one is already deleted, one was already there', () => {
+      const attachmentNewAndDeleted = new Attachment();
+      const attachmentNew = new Attachment();
+      const attachmentPresent = new Attachment();
+      researchPlan.attachments = [attachmentNewAndDeleted, attachmentNew, attachmentPresent];
+      attachmentNewAndDeleted.is_new = true;
+      attachmentNewAndDeleted.is_deleted = true;
+
+      attachmentNew.is_new = true;
+      attachmentPresent.is_deleted = false;
+
+      attachmentPresent.is_new = false;
+      attachmentPresent.is_deleted = false;
+
+      it('one attachment was found', () => {
+        expect(researchPlan.getNewAttachments().length).toEqual(1);
+      });
     });
   });
 });


### PR DESCRIPTION
This PR fixes https://github.com/ComPlat/chemotion_ELN/issues/1558 which came from https://github.com/ComPlat/chemotion/discussions/70 and https://github.com/ComPlat/chemotion_ELN/issues/1549 .

The problem was a wrong tablename in the ` attachable_type` column in table **attachments**. Instead of 'ResearchPlan ' the entry was 'Labimotion::ResearchPlan' . By that rails could not resolve the polymorphic association and could not fetch the saved attachments of a researchplan. 

The wrong entry was set in the method `element_helper.rb:162` inside the new rails gem of labimotion.

The current solution is:
 - Do not use the labimotion endpoint for uploading attachments `/api/v1/generic_elements/upload_generics_files`
 - Use instead the already used (in wellplates) endpoint  ` /api/v1/attachable/update_attachments_attachable`


