### PR TITLE
Changed Mail collector rules

### DIFF
--- a/bin/run_mail_collector
+++ b/bin/run_mail_collector
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+CollectDataFromMailJob.perform_now
+

--- a/lib/datacollector/collector_helper.rb
+++ b/lib/datacollector/collector_helper.rb
@@ -2,7 +2,7 @@ class CollectorHelper
   attr_reader :sender, :sender_container, :recipient
 
   def initialize(from, cc = nil)
-    if from.is_a?(Device) && cc.is_a?(User)
+    if (from.is_a?(Device) && cc.is_a?(User)) || (from.is_a?(User) && from == cc)
       @sender = from
       @recipient = cc
       prepare_containers

--- a/lib/datacollector/collector_helper.rb
+++ b/lib/datacollector/collector_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CollectorHelper
   attr_reader :sender, :sender_container, :recipient
 
@@ -8,13 +10,13 @@ class CollectorHelper
       prepare_containers
     elsif cc
       @sender = Device.find_by email: from
-      @sender = Device.find_by email: from.downcase unless @sender
+      @sender ||= Device.find_by email: from.downcase
       @recipient = User.find_by email: cc
-      @recipient = User.find_by email: cc.downcase unless @recipient
+      @recipient ||= User.find_by email: cc.downcase
       prepare_containers if @sender && @recipient
     else
       @sender = User.find_by email: from
-      @sender = User.find_by email: from.downcase unless @sender
+      @sender ||= User.find_by email: from.downcase
       @recipient = @sender
       prepare_containers if @sender
     end
@@ -26,19 +28,21 @@ class CollectorHelper
 
   def prepare_new_dataset(subject)
     return nil unless sender_recipient_known?
+
     Container.create(
       name: subject,
       container_type: 'dataset',
-      parent: @sender_container
+      parent: @sender_container,
     )
   end
 
   def prepare_dataset(subject)
     return nil unless sender_recipient_known?
+
     Container.where(
       name: subject,
       container_type: 'dataset',
-      parent: @sender_container
+      parent: @sender_container,
     ).first_or_create
   end
 
@@ -65,14 +69,14 @@ class CollectorHelper
     unless @recipient.container
       @recipient.container = Container.create(
         name: 'inbox',
-        container_type: 'root'
+        container_type: 'root',
       )
     end
-    sender_box_id = 'sender_box_' + @sender.id.to_s
+    sender_box_id = "sender_box_#{@sender.id}"
     @sender_container = Container.where(
       name: @sender.first_name,
       container_type: sender_box_id,
-      parent_id: @recipient.container.id
+      parent_id: @recipient.container.id,
     ).first_or_create
   end
 end

--- a/lib/datacollector/collector_helper_set.rb
+++ b/lib/datacollector/collector_helper_set.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 class CollectorHelperSet
   attr_reader :helper_set
 
   def initialize(from, cc_list)
     @helper_set = []
-    for cc in cc_list do
+    cc_list.each do |cc|
       h = CollectorHelper.new(from, cc)
       @helper_set.push(h) if h.sender_recipient_known?
     end

--- a/lib/datacollector/collector_helper_set.rb
+++ b/lib/datacollector/collector_helper_set.rb
@@ -1,0 +1,15 @@
+class CollectorHelperSet
+  attr_reader :helper_set
+
+  def initialize(from, cc_list)
+    @helper_set = []
+    for cc in cc_list do
+      h = CollectorHelper.new(from, cc)
+      @helper_set.push(h) if h.sender_recipient_known?
+    end
+  end
+
+  def sender_recipient_known?
+    @helper_set.length.positive?
+  end
+end

--- a/lib/datacollector/datacollector_file.rb
+++ b/lib/datacollector/datacollector_file.rb
@@ -19,7 +19,7 @@ class DatacollectorFile < DatacollectorObject
   def attach(device)
     att = Attachment.new(
       filename: @name,
-      file_data: IO.binread(@path),
+      file_data: File.binread(@path),
       content_type: MimeMagic.by_path(@name)&.type,
       created_by: device.id,
       created_for: recipient.id,
@@ -52,7 +52,7 @@ class DatacollectorFile < DatacollectorObject
 
   def add_attach_to_container(device, attach, _ = false)
     helper = CollectorHelper.new(device, recipient)
-    dataset = helper.prepare_dataset(Time.now.strftime('%Y-%m-%d'))
+    dataset = helper.prepare_dataset(Time.zone.now.strftime('%Y-%m-%d'))
     attach.update!(attachable: dataset)
 
     # add notifications

--- a/lib/datacollector/datacollector_folder.rb
+++ b/lib/datacollector/datacollector_folder.rb
@@ -47,7 +47,7 @@ class DatacollectorFolder < DatacollectorObject
 
   def register_new_data(device, tmpzip)
     att = Attachment.new(
-      filename: @name + '.zip',
+      filename: "#{@name}.zip",
       created_by: device.id,
       created_for: recipient.id,
       content_type: 'application/zip',

--- a/lib/datacollector/dc_logger.rb
+++ b/lib/datacollector/dc_logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DCLogger
   def self.log
     @@fw_logger ||= Logger.new("#{Rails.root}/log/datacollector.log")

--- a/lib/datacollector/fcollector.rb
+++ b/lib/datacollector/fcollector.rb
@@ -63,7 +63,7 @@ class Fcollector
           inspect_folder(device)
           @sftp = nil
         end
-      rescue => e
+      rescue StandardError => e
         log_error("#{e.message} >>> #{device.info}\n#{e.backtrace.join('\n')}")
       end
     end
@@ -77,7 +77,7 @@ class Fcollector
   private
 
   def devices(use_sftp)
-    sql = <<~SQL
+    sql = <<~SQL.squish
       profiles."data"->>'method' = '#{self.class::FCOLL}watcher#{use_sftp ? 'sftp' : 'local'}'
     SQL
     Device.joins(:profile).where(sql).includes(:profile)

--- a/lib/datacollector/filecollector.rb
+++ b/lib/datacollector/filecollector.rb
@@ -7,7 +7,6 @@ class Filecollector < Fcollector
   private
 
   # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/MethodLength
 
   def inspect_folder(device)
     directory = device.profile.data['method_params']['dir']
@@ -15,7 +14,7 @@ class Filecollector < Fcollector
       @current_collector = DatacollectorFile.new(new_file_p, @sftp)
       error = CollectorError.find_by error_code: CollectorHelper.hash(
         @current_collector.path,
-        @sftp
+        @sftp,
       )
       begin
         stored = false
@@ -31,10 +30,10 @@ class Filecollector < Fcollector
           @current_collector.delete
           log_info("Recipient unknown. File deleted! >>> #{device.info}")
         end
-      rescue => e
+      rescue StandardError => e
         if stored
           CollectorHelper.write_error(
-            CollectorHelper.hash(@current_collector.path, @sftp)
+            CollectorHelper.hash(@current_collector.path, @sftp),
           )
         end
         log_error("#{e.message} >>> #{device.info}\n#{e.backtrace.join('\n')}")
@@ -53,15 +52,13 @@ class Filecollector < Fcollector
         File.join(monitored_folder_p, f.name)
       end
     else
-      new_files_p = Dir.glob(File.join(monitored_folder_p, '*')).reject { |e|
+      new_files_p = Dir.glob(File.join(monitored_folder_p, '*')).reject do |e|
         File.directory?(e)
-      }
+      end
     end
     new_files_p.delete_if do |f|
       f.end_with?('.filepart', '.part')
     end
     new_files_p
   end
-
-  # rubocop:enable Metrics/MethodLength
 end

--- a/lib/datacollector/mailcollector.rb
+++ b/lib/datacollector/mailcollector.rb
@@ -22,7 +22,12 @@ class Mailcollector
       log_info('Login...')
       imap.select('INBOX')
       imap.search(['NOT', 'SEEN']).each do |message_id|
-        handle_new_mail(message_id, imap)
+        begin
+          handle_new_mail(message_id, imap)
+        rescue => e
+          log_error e.message
+        end
+
       end
       imap.close
     else
@@ -44,28 +49,30 @@ class Mailcollector
     envelope = imap.fetch(message_id, 'ENVELOPE')[0].attr['ENVELOPE']
     raw_message = imap.fetch(message_id, 'RFC822').first.attr['RFC822']
     message = Mail.read_from_string raw_message
-    helper = create_helper(envelope)
+    helper_set = create_helper_set(envelope)
     log_info 'Mail from ' + message.from.to_s
-    unless helper
+    unless helper_set
       log_info message.from.to_s + ' Email format incorrect or sender unknown!'
       return nil
     end
-    unless helper.sender
-      log_info message.from.to_s + ' Sender unknown!'
-      return nil
+    for helper in helper_set.helper_set do
+      unless helper.sender
+        log_info message.from.to_s + ' Sender unknown!'
+        return nil
+      end
+      unless helper.recipient
+        log_info message.from.to_s + ' Recipient unknown!'
+        return nil
+      end
+      if message.attachments
+        handle_new_message(message, helper)
+        log_info message.from.to_s + ' Data stored!'
+      else
+        log_info message.from.to_s + ' No data!'
+      end
+      imap.store(message_id, '+FLAGS', [:Deleted])
+      log_info message.from.to_s + ' Email processed!'
     end
-    unless helper.recipient
-      log_info message.from.to_s + ' Recipient unknown!'
-      return nil
-    end
-    if message.attachments
-      handle_new_message(message, helper)
-      log_info message.from.to_s + ' Data stored!'
-    else
-      log_info message.from.to_s + ' No data!'
-    end
-    imap.store(message_id, '+FLAGS', [:Deleted])
-    log_info message.from.to_s + ' Email processed!'
   rescue => e
     log_error 'Error on mailcollector handle_new_mail'
     log_error e.backtrace.join('\n')
@@ -85,7 +92,7 @@ class Mailcollector
           created_by: helper.sender.id,
           created_for: helper.recipient.id,
           file_path: tempfile.path,
-          )
+        )
 
         att.save!
         tempfile.close
@@ -99,45 +106,42 @@ class Mailcollector
     end
   end
 
-  def create_helper(envelope)
+  def is_email_eln_email?(mail_to)
+    begin
+      return mail_to.casecmp(@mail_address).zero? ||
+        (@aliases.any? { |s| s.casecmp(mail_to).zero? })
+    end
+  end
+
+  def get_user(mail)
+    user = User.find_by email: mail
+    user = User.find_by email: mail.downcase unless user
+    user
+  end
+
+  def create_helper_set(envelope)
     helper = nil
     begin
-      if (envelope.cc && envelope.cc.length == 1) && (envelope.to && envelope.to.length == 1)
-        log_info 'Using CC method...'
-        mail_to = envelope.to[0].mailbox.to_s + '@' + envelope.to[0].host.to_s
-        if mail_to.casecmp(@mail_address).zero? ||
-           (@aliases.any? { |s| s.casecmp(mail_to).zero? })
-          helper = CollectorHelper.new(
-            envelope.from[0].mailbox.to_s + '@' + envelope.from[0].host.to_s,
-            envelope.cc[0].mailbox.to_s + '@' + envelope.cc[0].host.to_s
-          )
-        end
-      elsif !envelope.cc && envelope.to && envelope.to.length == 2
-        log_info 'Using To method...'
-        mail_to_first = envelope.to[0].mailbox.to_s + '@' + envelope.to[0].host.to_s
-        mail_to_second = envelope.to[1].mailbox.to_s + '@' + envelope.to[1].host.to_s
-        if  mail_to_first.casecmp(@mail_address).zero? ||
-            (@aliases.any? { |s| s.casecmp(mail_to_first).zero? })
-          helper = CollectorHelper.new(
-            envelope.from[0].mailbox.to_s + '@' + envelope.from[0].host.to_s,
-            mail_to_second
-          )
-        elsif mail_to_second.casecmp(@mail_address).zero? ||
-              (@aliases.any? { |s| s.casecmp(mail_to_second).zero? })
-          helper = CollectorHelper.new(
-            envelope.from[0].mailbox.to_s + '@' + envelope.from[0].host.to_s,
-            mail_to_first
-          )
-        end
-      elsif !envelope.cc && envelope.to && envelope.to.length == 1
-        log_info 'Using Sender = Recipient method...'
-        mail_to = envelope.to[0].mailbox.to_s + '@' + envelope.to[0].host.to_s
-        if mail_to.casecmp(@mail_address).zero? || (@aliases.any? { |s| s.casecmp(mail_to).zero? })
-          helper = CollectorHelper.new(
-            envelope.from[0].mailbox.to_s + '@' + envelope.from[0].host.to_s
-          )
-        end
+
+      # Check if from is User or Device
+      from = envelope.from[0].mailbox.to_s + '@' + envelope.from[0].host.to_s
+      from_user = get_user from
+      raise from + ' not registered' if from_user.nil?
+      receiver = []
+      if from_user.is_a?(User) && (!from_user.is_a?(Device) && !from_user.is_a?(Admin))
+        receiver.push(from_user)
+      else # Concatenate all receiver (cc & to)
+        receiver.concat(envelope.cc) if envelope.cc
+        receiver.concat(envelope.to) if envelope.to
+        receiver = receiver.map { |m| m.mailbox.to_s + '@' + m.host.to_s }
+        receiver = receiver.select { |m| !is_email_eln_email?(m) }
+        receiver = receiver.map { |m| get_user m }.select { |user| !user.nil? && !user.is_a?(Device) && !user.is_a?(Admin) }
       end
+      helper = CollectorHelperSet.new(
+        from_user,
+        receiver
+      ) unless receiver.length == 0
+
     rescue => e
       log_error 'Error on mailcollector create_helper:'
       log_error e.backtrace.join('\n')


### PR DESCRIPTION
Changed Mail collector rules:
Attachment e-mails...

 1) ... can be sent to multiple chemotion instances
 2) ... can be sent to chemotion user in 'cc' or 'to'. The e-mail addresses in to and cc are treated equally
 3) ... can be sent to different e-mails. All emails in "cc" or "to" belonging to a registered user will trigger the creation of an attachment. All non-registered e-mails are ignored.

Additionally, if an e-mail throws an error the collector keeps running. -> see mailcollector line 25

[Issue](https://github.com/ComPlat/chemotion_ELN/issues/1560)



- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
