### PR TITLE
fix: collection management right click on the add button to not drag things around

### DIFF
--- a/app/assets/stylesheets/collection_management.scss
+++ b/app/assets/stylesheets/collection_management.scss
@@ -92,9 +92,10 @@
       margin-left: 15px;
       float: left;
       padding-top: 4px;
+      padding-right: 0px;
       height: 26px;
       border-width: 0px;
-      width:80%;
+      width:94%;
       box-shadow: 0px 0px 0px rgb(104, 104, 104);
     }
 

--- a/app/assets/stylesheets/collection_management.scss
+++ b/app/assets/stylesheets/collection_management.scss
@@ -103,7 +103,11 @@
     }
 
     &.is-active {
-      background-color: #D3D3D3
+      background-color: #D3D3D3;
+
+      .root-label{
+        background-color: #D3D3D3 
+      }
     }
   }
 

--- a/app/assets/stylesheets/collection_management.scss
+++ b/app/assets/stylesheets/collection_management.scss
@@ -26,6 +26,7 @@
   position: relative;
   overflow: hidden;
   @extend .f-no-select;
+  margin-left: 5px;
 }
 
 .m-draggable {

--- a/app/assets/stylesheets/collection_management.scss
+++ b/app/assets/stylesheets/collection_management.scss
@@ -92,6 +92,9 @@
       float: left;
       padding-top: 4px;
       height: 26px;
+      border-width: 0px;
+      width:80%;
+      box-shadow: 0px 0px 0px rgb(104, 104, 104);
     }
 
     .form-group {

--- a/app/packs/src/apps/mydb/collections/CollectionTabs.js
+++ b/app/packs/src/apps/mydb/collections/CollectionTabs.js
@@ -128,8 +128,11 @@ export default class CollectionTabs extends React.Component {
   label(node) {
     if (node.label === 'My Collections') {
       return (
-        <div className="root-label">My Collections</div>
-      );
+        <FormControl 
+        value ="My Collections" 
+        type="text" 
+        className="root-label" 
+        disabled/>);
     }
     return (
       <FormControl className="collection-label" type="text" value={node.label || ''} disabled />

--- a/app/packs/src/apps/mydb/collections/MyCollections.js
+++ b/app/packs/src/apps/mydb/collections/MyCollections.js
@@ -30,7 +30,7 @@ export default class MyCollections extends React.Component {
         isChange: false
       }
     }
-
+    this.addSubcollection=this.addSubcollection.bind(this);
     this.onStoreChange = this.onStoreChange.bind(this);
   }
 
@@ -117,7 +117,12 @@ export default class MyCollections extends React.Component {
       const { isChange } = this.state;
       return (
         <div className="root-actions">
-          {isChange && <Button id="save-collections-button" bsSize="xsmall" bsStyle="warning" onClick={this.bulkUpdate.bind(this)}> Save </Button>}
+          {isChange && <Button 
+          id="save-collections-button" 
+          bsSize="xsmall" 
+          bsStyle="warning" 
+          onMouseDown={(e)=>{e.stopPropagation();}}
+          onClick={this.bulkUpdate.bind(this)}> Save </Button>}
           {this.addCollectionButton(node)}
         </div>
       )
@@ -204,7 +209,8 @@ export default class MyCollections extends React.Component {
         id="add-new-collection-button"
         bsSize="xsmall"
         bsStyle="success"
-        onClick={this.addSubcollection.bind(this, node)}
+        onClick={(e)=>{this.addSubcollection(node);}}
+        onMouseDown={(e)=>{e.stopPropagation();}}
       >
         <i className="fa fa-plus"></i>
       </Button>

--- a/app/packs/src/apps/mydb/collections/MyCollections.js
+++ b/app/packs/src/apps/mydb/collections/MyCollections.js
@@ -73,10 +73,11 @@ export default class MyCollections extends React.Component {
   label(node) {
     if (node.id == -1) {
       return (
-        <div className="root-label">
-          My Collections
-        </div>
-      )
+        <FormControl 
+        value ="My Collections" 
+        type="text" 
+        className="root-label" 
+        disabled/>);
     } else {
       return (
         <FormControl

--- a/app/packs/src/apps/mydb/collections/MySharedCollections.js
+++ b/app/packs/src/apps/mydb/collections/MySharedCollections.js
@@ -76,10 +76,11 @@ export default class MySharedCollections extends React.Component {
   label(node) {
     if (node.label == "My Shared Collections") {
       return (
-        <div className="root-label">
-          My Shared Collections
-        </div>
-      )
+        <FormControl 
+        value ="My Shared Collections" 
+        type="text" 
+        className="root-label" 
+        disabled/>);
     } else if (node.is_locked) {
       return (
         <FormControl className="collection-label" type="text"

--- a/app/packs/src/apps/mydb/collections/MySharedCollections.js
+++ b/app/packs/src/apps/mydb/collections/MySharedCollections.js
@@ -126,7 +126,9 @@ export default class MySharedCollections extends React.Component {
       return (
         <div className="root-actions">
           <Button bsSize="xsmall" bsStyle="warning"
-            onClick={this.bulkUpdate.bind(this)}>
+            onClick={this.bulkUpdate.bind(this)}
+            onMouseDown={(e)=>{e.stopPropagation();}}
+            >
             Update
           </Button>
         </div>

--- a/app/packs/src/apps/mydb/collections/SharedWithMeCollections.js
+++ b/app/packs/src/apps/mydb/collections/SharedWithMeCollections.js
@@ -59,10 +59,11 @@ export default class SharedWithMeCollections extends React.Component {
   label(node) {
     if(node.label == "Shared with me Collections") {
       return (
-        <div className="root-label">
-          Synchronized with me Collections
-        </div>
-      )
+        <FormControl 
+        value ="Synchronized with me Collections" 
+        type="text" 
+        className="root-label" 
+        disabled/>);
     } else {
       return (
         <FormControl

--- a/app/packs/src/apps/mydb/collections/SyncWithMeCollections.js
+++ b/app/packs/src/apps/mydb/collections/SyncWithMeCollections.js
@@ -58,10 +58,11 @@ export default class SyncWithMeCollections extends React.Component {
   label(node) {
     if (node.root) {
       return (
-        <div className="root-label">
-          Synchronized with me Collections
-        </div>
-      )
+        <FormControl 
+        value ="Synchronized with me Collections" 
+        type="text" 
+        className="root-label" 
+        disabled/>);
     }
     return (
       <FormControl


### PR DESCRIPTION
### This PR solves 2 different problems in the Collection management component:

- It makes the root collection undraggable to mitigate the bug in the used library mentioned in the linked issue
- It makes the buttons undraggable as mentioned in the issue

### Remaining problems

- There are still some draggable areas in the tree component. I tried to minimize them but they are still there. In my opinion instead of fixing these remaining issues we should look for another tree library which is not as old and undocumented than the current one.

Because it is mainly frontiest frontend stuff and css i skipped js-unit testing as i would only test trivial attributes.



















