### PR TITLE
refactor: extract` SpectraEditorButton` to dedicated component

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.js
@@ -4,7 +4,6 @@ import {
   PanelGroup,
   Panel,
   Button,
-  OverlayTrigger, SplitButton, ButtonGroup, MenuItem, Tooltip
 } from 'react-bootstrap';
 import Container from 'src/models/Container';
 import ContainerComponent from 'src/components/container/ContainerComponent';
@@ -22,8 +21,8 @@ import SpectraActions from 'src/stores/alt/actions/SpectraActions';
 import LoadingActions from 'src/stores/alt/actions/LoadingActions';
 import ViewSpectra from 'src/apps/mydb/elements/details/ViewSpectra';
 import NMRiumDisplayer from 'src/components/nmriumWrapper/NMRiumDisplayer';
-
 import TextTemplateActions from 'src/stores/alt/actions/TextTemplateActions';
+import SpectraEditorButton from 'src/components/common/SpectraEditorButton';
 
 const nmrMsg = (reaction, container) => {
   const ols = container.extended_metadata?.kind?.split('|')[0].trim();
@@ -39,99 +38,6 @@ const nmrMsg = (reaction, container) => {
     const msg = cNmrCount(nmrStr);
     return (<div style={{ display: 'inline', color: 'black' }}>&nbsp;(<sup>13</sup>C: {msg})</div>);
   }
-};
-
-const SpectraEditorBtn = ({
-  element, spcInfos, hasJcamp, hasChemSpectra,
-  toggleSpectraModal, confirmRegenerate,
-  toggleNMRDisplayerModal, hasNMRium,
-}) => (
-  <span>
-    <OverlayTrigger
-      placement="bottom"
-      delayShow={500}
-      overlay={<Tooltip id="spectra">Spectra Editor {spcInfos.length > 0 ? '' : ': Reprocess'}</Tooltip>}
-    >{spcInfos.length > 0 ? (
-      <ButtonGroup className="button-right">
-        <SplitButton
-          id="spectra-editor-split-button"
-          pullRight
-          bsStyle="info"
-          bsSize="xsmall"
-          title={<i className="fa fa-area-chart" />}
-          onToggle={(open, event) => { if (event) { event.stopPropagation(); } }}
-          onClick={toggleSpectraModal}
-          disabled={!(spcInfos.length > 0) || !hasChemSpectra}
-        >
-          <MenuItem
-            id="regenerate-spectra"
-            key="regenerate-spectra"
-            onSelect={(eventKey, event) => {
-              event.stopPropagation();
-              confirmRegenerate(event);
-            }}
-            disabled={!hasJcamp || !element.can_update}
-          >
-            <i className="fa fa-refresh" /> Reprocess
-          </MenuItem>
-        </SplitButton>
-      </ButtonGroup>
-      ) : (
-        <Button
-          bsStyle="warning"
-          bsSize="xsmall"
-          className="button-right"
-          onClick={confirmRegenerate}
-          disabled={!hasJcamp || !element.can_update || !hasChemSpectra}
-        >
-          <i className="fa fa-area-chart" /><i className="fa fa-refresh " />
-      </Button>
-    )}
-    </OverlayTrigger>
-    {
-      hasNMRium ? (
-        <OverlayTrigger
-          placement="top"
-          delayShow={500}
-          overlay={<Tooltip id="spectra_nmrium_wrapper">Process with NMRium</Tooltip>}
-        >
-          <ButtonGroup className="button-right">
-            <Button
-              id="spectra-editor-split-button"
-              pullRight
-              bsStyle="info"
-              bsSize="xsmall"
-              onToggle={(open, event) => { if (event) { event.stopPropagation(); } }}
-              onClick={toggleNMRDisplayerModal}
-              disabled={!hasJcamp || !element.can_update}
-            >
-              <i className="fa fa-bar-chart"/>
-            </Button>
-          </ButtonGroup>
-        </OverlayTrigger>
-      ) : null
-    }
-  </span>
-);
-
-SpectraEditorBtn.propTypes = {
-  element: PropTypes.object,
-  hasJcamp: PropTypes.bool,
-  spcInfos: PropTypes.array,
-  hasChemSpectra: PropTypes.bool,
-  toggleSpectraModal: PropTypes.func.isRequired,
-  confirmRegenerate: PropTypes.func.isRequired,
-  toggleNMRDisplayerModal: PropTypes.func.isRequired,
-  hasNMRium: PropTypes.bool,
-};
-
-SpectraEditorBtn.defaultProps = {
-  hasJcamp: false,
-  spcInfos: [],
-  element: {},
-  hasChemSpectra: false,
-  hasEditedJcamp: false,
-  hasNMRium: false,
 };
 
 export default class ReactionDetailsContainers extends Component {
@@ -252,7 +158,7 @@ export default class ReactionDetailsContainers extends Component {
           <i className="fa fa-trash" />
         </Button>
         <PrintCodeButton element={reaction} analyses={[container]} ident={container.id} />
-        <SpectraEditorBtn
+        <SpectraEditorButton
           element={reaction}
           hasJcamp={hasJcamp}
           spcInfos={spcInfos}

--- a/app/packs/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { PanelGroup, Panel, Tooltip, Button, OverlayTrigger, SplitButton, ButtonGroup, MenuItem } from 'react-bootstrap';
+import { PanelGroup, Panel, Button } from 'react-bootstrap';
 import Container from 'src/models/Container';
 import ContainerComponent from 'src/components/container/ContainerComponent';
 import QuillViewer from 'src/components/QuillViewer';
@@ -14,101 +14,8 @@ import SpectraActions from 'src/stores/alt/actions/SpectraActions';
 import LoadingActions from 'src/stores/alt/actions/LoadingActions';
 import ViewSpectra from 'src/apps/mydb/elements/details/ViewSpectra';
 import NMRiumDisplayer from 'src/components/nmriumWrapper/NMRiumDisplayer';
-
 import TextTemplateActions from 'src/stores/alt/actions/TextTemplateActions';
-
-const SpectraEditorBtn = ({
-  element, spcInfos, hasJcamp, hasChemSpectra,
-  toggleSpectraModal, confirmRegenerate,
-  toggleNMRDisplayerModal, hasNMRium,
-}) => (
-  <span>
-  <OverlayTrigger
-    placement="bottom"
-    delayShow={500}
-    overlay={<Tooltip id="spectra">Spectra Editor {spcInfos.length > 0 ? '' : ': Reprocess'}</Tooltip>}
-  >{spcInfos.length > 0 ? (
-    <ButtonGroup className="button-right">
-      <SplitButton
-        id="spectra-editor-split-button"
-        pullRight
-        bsStyle="info"
-        bsSize="xsmall"
-        title={<i className="fa fa-area-chart" />}
-        onToggle={(open, event) => { if (event) { event.stopPropagation(); } }}
-        onClick={toggleSpectraModal}
-        disabled={!(spcInfos.length > 0) || !hasChemSpectra}
-      >
-        <MenuItem
-            id="regenerate-spectra"
-            key="regenerate-spectra"
-            onSelect={(eventKey, event) => {
-              event.stopPropagation();
-              confirmRegenerate(event);
-            }}
-            disabled={!hasJcamp || !element.can_update}
-          >
-            <i className="fa fa-refresh" /> Reprocess
-          </MenuItem>
-        </SplitButton>
-      </ButtonGroup>
-      ) : (
-        <Button
-          bsStyle="warning"
-          bsSize="xsmall"
-          className="button-right"
-          onClick={confirmRegenerate}
-          disabled={!hasJcamp || !element.can_update || !hasChemSpectra}
-        >
-          <i className="fa fa-area-chart" /><i className="fa fa-refresh " />
-      </Button>
-    )}
-    </OverlayTrigger>
-    {
-      hasNMRium ? (
-        <OverlayTrigger
-          placement="top"
-          delayShow={500}
-          overlay={<Tooltip id="spectra_nmrium_wrapper">Process with NMRium</Tooltip>}
-        >
-          <ButtonGroup className="button-right">
-            <Button
-              id="spectra-editor-split-button"
-              pullRight
-              bsStyle="info"
-              bsSize="xsmall"
-              onToggle={(open, event) => { if (event) { event.stopPropagation(); } }}
-              onClick={toggleNMRDisplayerModal}
-              disabled={!hasJcamp}
-            >
-              <i className="fa fa-bar-chart"/>
-            </Button>
-          </ButtonGroup>
-        </OverlayTrigger>
-      ) : null
-    }
-  </span>
-);
-
-
-SpectraEditorBtn.propTypes = {
-  element: PropTypes.object,
-  hasJcamp: PropTypes.bool,
-  spcInfos: PropTypes.array,
-  hasChemSpectra: PropTypes.bool,
-  toggleSpectraModal: PropTypes.func.isRequired,
-  confirmRegenerate: PropTypes.func.isRequired,
-  toggleNMRDisplayerModal: PropTypes.func.isRequired,
-  hasNMRium: PropTypes.bool,
-};
-
-SpectraEditorBtn.defaultProps = {
-  hasJcamp: false,
-  spcInfos: PropTypes.array,
-  element: {},
-  hasChemSpectra: false,
-  hasNMRium: false,
-};
+import SpectraEditorButton from 'src/components/common/SpectraEditorButton';
 
 export default class ResearchPlanDetailsContainers extends Component {
   constructor(props) {
@@ -220,7 +127,7 @@ export default class ResearchPlanDetailsContainers extends Component {
         >
           <i className="fa fa-trash" />
         </Button>
-        <SpectraEditorBtn
+        <SpectraEditorButton
           element={researchPlan}
           hasJcamp={hasJcamp}
           spcInfos={spcInfos}

--- a/app/packs/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
+++ b/app/packs/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
@@ -1,9 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import {
-  Button, Checkbox, OverlayTrigger, Tooltip,
-  MenuItem, SplitButton, ButtonGroup
-} from 'react-bootstrap';
+import { Button, Checkbox } from 'react-bootstrap';
 import QuillViewer from 'src/components/QuillViewer';
 import PrintCodeButton from 'src/components/common/PrintCodeButton';
 import { stopBubble } from 'src/utilities/DomHelper';
@@ -17,6 +13,7 @@ import UIStore from 'src/stores/alt/stores/UIStore';
 import UserStore from 'src/stores/alt/stores/UserStore';
 import { chmoConversions } from 'src/components/OlsComponent';
 import { previewContainerImage } from 'src/utilities/imageHelper';
+import SpectraEditorButton from 'src/components/common/SpectraEditorButton';
 
 const qCheckPass = () => (
   <div style={{ display: 'inline', color: 'green' }}>
@@ -55,115 +52,6 @@ const qCheckMsg = (sample, container) => {
     return msg === '' ? qCheckPass() : qCheckFail(msg, 'MS', '');
   }
   return '';
-};
-
-const SpectraEditorBtn = ({
-  sample, spcInfos, hasJcamp, hasChemSpectra,
-  toggleSpectraModal, confirmRegenerate, confirmRegenerateEdited, hasEditedJcamp,
-  toggleNMRDisplayerModal, hasNMRium
-}) => (
-  <span>
-    <OverlayTrigger
-    placement="bottom"
-    delayShow={500}
-    overlay={<Tooltip id="spectra">Spectra Editor {spcInfos.length > 0 ? '' : ': Reprocess'}</Tooltip>}
-  >{spcInfos.length > 0 ? (
-    <ButtonGroup className="button-right">
-      <SplitButton
-        id="spectra-editor-split-button"
-        pullRight
-        bsStyle="info"
-        bsSize="xsmall"
-        title={<i className="fa fa-area-chart" />}
-        onToggle={(open, event) => { if (event) { event.stopPropagation(); } }}
-        onClick={toggleSpectraModal}
-        disabled={!(spcInfos.length > 0) || !hasChemSpectra}
-      >
-        <MenuItem
-          id="regenerate-spectra"
-          key="regenerate-spectra"
-          onSelect={(eventKey, event) => {
-            event.stopPropagation();
-            confirmRegenerate(event);
-          }}
-          disabled={!hasJcamp || !sample.can_update}
-        >
-          <i className="fa fa-refresh" /> Reprocess
-        </MenuItem>
-        {
-          hasEditedJcamp ? 
-            (<MenuItem
-              id="regenerate-edited-spectra"
-              key="regenerate-edited-spectra"
-              onSelect={(eventKey, event) => {
-                event.stopPropagation();
-                confirmRegenerateEdited(event);
-              }}
-            >
-              <i className="fa fa-refresh" /> Regenerate .edit.jdx files
-            </MenuItem>) : <span></span>
-        }
-      </SplitButton>
-    </ButtonGroup>
-  ) : (
-    <Button
-      bsStyle="warning"
-      bsSize="xsmall"
-      className="button-right"
-      onClick={confirmRegenerate}
-      disabled={!hasJcamp || !sample.can_update || !hasChemSpectra}
-    >
-      <i className="fa fa-area-chart" /><i className="fa fa-refresh " />
-    </Button>
-  )}
-  </OverlayTrigger>
-
-  {
-        hasNMRium ? (
-            <OverlayTrigger
-            placement="top"
-            delayShow={500}
-            overlay={<Tooltip id="spectra_nmrium_wrapper">Process with NMRium</Tooltip>}
-            >
-                <ButtonGroup className="button-right">
-                    <Button
-                    id="spectra-editor-split-button"
-                    pullRight
-                    bsStyle="info"
-                    bsSize="xsmall"
-                    onToggle={(open, event) => { if (event) { event.stopPropagation(); } }}
-                    onClick={toggleNMRDisplayerModal}
-                    disabled={!hasJcamp || !sample.can_update}
-                    >
-                    <i className="fa fa-bar-chart"/>
-                    </Button>
-                </ButtonGroup>
-            </OverlayTrigger>
-        ) : null
-    }
-  </span>
-);
-
-SpectraEditorBtn.propTypes = {
-  sample: PropTypes.object,
-  hasJcamp: PropTypes.bool,
-  spcInfos: PropTypes.array,
-  hasChemSpectra: PropTypes.bool,
-  toggleSpectraModal: PropTypes.func.isRequired,
-  confirmRegenerate: PropTypes.func.isRequired,
-  confirmRegenerateEdited: PropTypes.func.isRequired,
-  hasEditedJcamp: PropTypes.bool,
-  toggleNMRDisplayerModal: PropTypes.func.isRequired,
-  hasNMRium: PropTypes.bool,
-};
-
-SpectraEditorBtn.defaultProps = {
-  hasJcamp: false,
-  spcInfos: [],
-  sample: {},
-  hasChemSpectra: false,
-  hasEditedJcamp: false,
-  hasNMRium: false,
 };
 
 const editModeBtn = (toggleMode, isDisabled) => (
@@ -318,7 +206,7 @@ const headerBtnGroup = (
         analyses={[container]}
         ident={container.id}
       />
-      <SpectraEditorBtn
+      <SpectraEditorButton
         sample={sample}
         hasJcamp={hasJcamp}
         spcInfos={spcInfos}

--- a/app/packs/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
+++ b/app/packs/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
@@ -207,7 +207,7 @@ const headerBtnGroup = (
         ident={container.id}
       />
       <SpectraEditorButton
-        sample={sample}
+        element={sample}
         hasJcamp={hasJcamp}
         spcInfos={spcInfos}
         hasChemSpectra={hasChemSpectra}

--- a/app/packs/src/components/common/SpectraEditorButton.js
+++ b/app/packs/src/components/common/SpectraEditorButton.js
@@ -1,0 +1,129 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Tooltip, Button, OverlayTrigger, SplitButton, ButtonGroup, MenuItem
+} from 'react-bootstrap';
+
+export default function SpectraEditorButton({
+  element, spcInfos, hasJcamp, hasChemSpectra,
+  toggleSpectraModal, confirmRegenerate, confirmRegenerateEdited,
+  hasEditedJcamp, toggleNMRDisplayerModal, hasNMRium
+}) {
+  return (
+    <span>
+      <OverlayTrigger
+        placement="bottom"
+        delayShow={500}
+        overlay={(
+          <Tooltip id="spectra">
+            Spectra Editor
+            {spcInfos.length > 0 ? '' : ': Reprocess'}
+          </Tooltip>
+)}
+      >
+        {spcInfos.length > 0 ? (
+          <ButtonGroup className="button-right">
+            <SplitButton
+              id="spectra-editor-split-button"
+              pullRight
+              bsStyle="info"
+              bsSize="xsmall"
+              title={<i className="fa fa-area-chart" />}
+              onToggle={(_, event) => { if (event) { event.stopPropagation(); } }}
+              onClick={toggleSpectraModal}
+              disabled={!(spcInfos.length > 0) || !hasChemSpectra}
+            >
+              <MenuItem
+                id="regenerate-spectra"
+                key="regenerate-spectra"
+                onSelect={(_, event) => {
+                  event.stopPropagation();
+                  confirmRegenerate(event);
+                }}
+                disabled={!hasJcamp || !element.can_update}
+              >
+                <i className="fa fa-refresh" />
+                {' '}
+                Reprocess
+              </MenuItem>
+              {
+            hasEditedJcamp
+              ? (
+                <MenuItem
+                  id="regenerate-edited-spectra"
+                  key="regenerate-edited-spectra"
+                  onSelect={(_, event) => {
+                    event.stopPropagation();
+                    confirmRegenerateEdited(event);
+                  }}
+                >
+                  <i className="fa fa-refresh" />
+                  {' '}
+                  Regenerate .edit.jdx files
+                </MenuItem>
+              ) : <span />
+          }
+            </SplitButton>
+          </ButtonGroup>
+        ) : (
+          <Button
+            bsStyle="warning"
+            bsSize="xsmall"
+            className="button-right"
+            onClick={confirmRegenerate}
+            disabled={!hasJcamp || !element.can_update || !hasChemSpectra}
+          >
+            <i className="fa fa-area-chart" />
+            <i className="fa fa-refresh " />
+          </Button>
+        )}
+      </OverlayTrigger>
+
+      {
+          hasNMRium ? (
+            <OverlayTrigger
+              placement="top"
+              delayShow={500}
+              overlay={<Tooltip id="spectra_nmrium_wrapper">Process with NMRium</Tooltip>}
+            >
+              <ButtonGroup className="button-right">
+                <Button
+                  id="spectra-editor-split-button"
+                  pullRight
+                  bsStyle="info"
+                  bsSize="xsmall"
+                  onToggle={(_, event) => { if (event) { event.stopPropagation(); } }}
+                  onClick={toggleNMRDisplayerModal}
+                  disabled={!hasJcamp || !element.can_update}
+                >
+                  <i className="fa fa-bar-chart" />
+                </Button>
+              </ButtonGroup>
+            </OverlayTrigger>
+          ) : null
+      }
+    </span>
+  );
+}
+
+SpectraEditorButton.propTypes = {
+  element: PropTypes.object,
+  hasJcamp: PropTypes.bool,
+  spcInfos: PropTypes.array,
+  hasChemSpectra: PropTypes.bool,
+  toggleSpectraModal: PropTypes.func.isRequired,
+  confirmRegenerate: PropTypes.func.isRequired,
+  confirmRegenerateEdited: PropTypes.func.isRequired,
+  hasEditedJcamp: PropTypes.bool,
+  toggleNMRDisplayerModal: PropTypes.func.isRequired,
+  hasNMRium: PropTypes.bool,
+};
+
+SpectraEditorButton.defaultProps = {
+  hasJcamp: false,
+  spcInfos: [],
+  element: {},
+  hasChemSpectra: false,
+  hasEditedJcamp: false,
+  hasNMRium: false,
+};


### PR DESCRIPTION
I moved the `SpectraEditorButton` component to a dedicated file.
Before, the component was (re-)defined in three other component files (presumably copy-pasted):
`ReactionDetailsContainer`, `ResearchPlanDetailsContainer`, and `SampleDetailsContainer`.

FYI, the button looks like this (in the `Analyses` tab):
![screenshot](https://github.com/ComPlat/chemotion_ELN/assets/30125107/2d863d4c-a685-422b-a14b-741beda9b9e1)




