### PR TITLE
Improve Dev Setup by autorecognizing the installed tool versions

### DIFF
--- a/Dockerfile.chemotion-dev
+++ b/Dockerfile.chemotion-dev
@@ -6,14 +6,11 @@
 FROM --platform=linux/amd64 ubuntu:jammy
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG VRUBY=2.7.7
-ARG VNODE=18.18.2
-ARG ASDF_BRANCH=v0.11.3
 
 RUN set -xe  && apt-get update -yqqq --fix-missing && apt-get upgrade -y
 RUN apt update && apt-get install -yqq --fix-missing bash ca-certificates wget apt-transport-https git gpg\
       imagemagick libmagic-dev libmagickcore-dev libmagickwand-dev curl gnupg2 \
-      build-essential nodejs sudo postgresql-client libappindicator1 swig \
+      build-essential sudo postgresql-client libappindicator1 swig \
       gconf-service libasound2 libgconf-2-4 cmake \
       libnspr4 libnss3 libpango1.0-0 libxss1 xdg-utils tzdata libpq-dev \
       gtk2-engines-pixbuf \
@@ -49,18 +46,9 @@ RUN mkdir /home/chemotion-dev/node_modules
 
 SHELL ["/bin/bash", "-c"]
 
-RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch $ASDF_BRANCH
-
+# Even if asdf and the related tools are only installed by running run-ruby-dev.sh, we set the PATH variables here, so when we enter the container via docker exec, we have the path set correctly
 ENV ASDF_DIR=/home/chemotion-dev/.asdf
 ENV PATH=/home/chemotion-dev/.asdf/shims:/home/chemotion-dev/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-
-RUN asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
-RUN asdf install nodejs $VNODE
-RUN asdf global nodejs $VNODE
-
-RUN asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git
-RUN asdf install ruby $VRUBY
-RUN asdf global ruby $VRUBY
 
 RUN echo 'network-timeout 600000' > /home/chemotion-dev/.yarnrc
 # use node modules from outside the application directory

--- a/run-js-dev.sh
+++ b/run-js-dev.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
-if [ ! -x yarn ]
-then
-  npm install -g yarn
+if command -v yarn; then
+    echo '>>> yarn is installed -> continue'
+else
+    echo '>>> Missing yarn. Installing...'
+    npm install -g yarn
 fi
-asdf global nodejs 18.18.2
+
+echo '>>> Installing JS packages...'
 yarn install
 
+echo "=========================================================================================================="
 echo "THIS WILL FAIL UNTIL THE RUBY GEMS ARE INSTALLED BY run-ruby-dev.sh. JUST TRY AGAIN AFTER INSTALLING THEM."
+echo "=========================================================================================================="
 ./bin/webpack-dev-server

--- a/run-ruby-dev.sh
+++ b/run-ruby-dev.sh
@@ -1,6 +1,40 @@
 #!/bin/bash
+export ASDF_BRANCH=v0.13.1
 
-gem install bundler -v 2.1.4 && bundle install
+# if asdf is not installed -> install
+if command -v asdf ; then
+    echo '>>> asdf is already installed -> continue'
+else
+    echo '>>> Missing asdf. Installing...'
+    git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch $ASDF_BRANCH
+fi
+
+# if asdf plugins are not installed -> install
+if asdf plugin list | grep -Fxq 'ruby'; then
+    echo '>>> Ruby plugin for asdf is installed -> continue'
+else
+    echo '>>> Missing ruby plugin for asdf. Installing...'
+    asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git
+fi
+
+if asdf plugin list | grep -Fxq 'nodejs'; then
+    echo '>>> Nodejs plugin for asdf is installed -> continue'
+else
+    echo '>>> Missing nodejs plugin for asdf. Installing...'
+    asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
+fi
+
+# install all tools as defined by .tool-versions
+echo '>>> Installing tool versions'
+asdf install
+
+# install bundler if not present and then install all gems as defined by GEMFILE
+echo '>>> checking bundler installation'
+BUNDLER_VERSION=$(sed -n '/BUNDLED WITH/{n;p;}' "Gemfile.lock" | tr -d '[:space:]')
+gem install bundler -v $BUNDLER_VERSION
+
+echo '>>> Installing gems'
+bundle install
 
 rm -f tmp/pids/server.pid
 
@@ -15,6 +49,5 @@ else
     echo "================================================"
     bundle exec rake db:setup
 fi
-
 
 bundle exec rails s -p 3000 -b 0.0.0.0


### PR DESCRIPTION
We regularly face the situation that other developers update tool versions (nodejs for example) and forget to update the Docker files (especially if they don't use them anyway). 

I updated the Dockerfile.chemotion-dev, to no longer install a hardcoded Ruby and NodeJS version. Instead, the run-ruby-dev.sh script checks if ASDF is installed and then installs the tools to the versions defined in .tool-versions.

This way, developers using the Docker dev environment, don't have to rebuild their docker container all the time, when a new nodejs version is used.