### PR TITLE
fix: camelcasing attributes for proper display of SVGs

### DIFF
--- a/app/models/molecule.rb
+++ b/app/models/molecule.rb
@@ -174,9 +174,14 @@ class Molecule < ApplicationRecord
                       "#{SecureRandom.hex(64)}.svg"
                     end
     Loofah::HTML5::SafeList::ALLOWED_ATTRIBUTES.add('overflow')
+    # NB: successiv gsub seems to be faster than a single gsub with a regexp with multiple matches
+    scrubbed_data = Loofah.scrub_fragment(svg_data.encode('UTF-8'), :strip).to_s
+                          .gsub('viewbox', 'viewBox')
+                          .gsub('lineargradient', 'linearGradient')
+                          .gsub('radialgradient', 'radialGradient')
     File.write(
       full_svg_path(svg_file_name),
-      Loofah.scrub_fragment(svg_data.encode('UTF-8'), :strip).to_s.gsub('viewbox', 'viewBox'),
+      scrubbed_data,
     )
 
     self.molecule_svg_file = svg_file_name

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -704,7 +704,11 @@ private
 
   def scrub(value)
     Loofah::HTML5::SafeList::ALLOWED_ATTRIBUTES.add('overflow')
-    Loofah.scrub_fragment(value, :strip).to_s.gsub('viewbox', 'viewBox')
+    # NB: successiv gsub seems to be faster than a single gsub with a regexp with multiple matches
+    Loofah.scrub_fragment(value, :strip).to_s
+          .gsub('viewbox', 'viewBox')
+          .gsub('lineargradient', 'linearGradient')
+          .gsub('radialgradient', 'radialGradient')
 #   value
   end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,7 +1499,7 @@
     reselect "^4.0.0"
     typescript "^5.0.4"
 
-"@complat/react-svg-file-zoom-pan@1.1.3":
+"@complat/react-svg-file-zoom-pan@1.1.3", "react-svg-file-zoom-pan-latest@npm:@complat/react-svg-file-zoom-pan@1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@complat/react-svg-file-zoom-pan/-/react-svg-file-zoom-pan-1.1.3.tgz#a3da916005b6d6ee18be2b1bce62745becf082be"
   integrity sha512-gtb41KBr/hQjKR9v6HOvwnyGEM61lSNsyMHTCk1rMX4SYJjx8iXw0J7z30Ff9tw2oK6sgEiejlPtM7tkdQi3GQ==
@@ -12426,15 +12426,6 @@ react-stickydiv@^3.4.19:
   integrity sha512-OpvOVuu3gXBYPP30q5EQfn5oApgeON1SAU73OweKHPuwlAUytz2shhqv7gqxlBUQq7onKlGE6ImLM9ELbRLbcw==
   dependencies:
     dom-find "^0.3.1"
-
-"react-svg-file-zoom-pan-latest@npm:@complat/react-svg-file-zoom-pan@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@complat/react-svg-file-zoom-pan/-/react-svg-file-zoom-pan-1.1.2.tgz#461897dcc501b2758383af1bd215e29153d8a642"
-  integrity sha512-D3aoTrzpUCUEkgY9SAYTfHuZ9nvOe4M+5Bn4iPKHNj00DfHg4lM9EywS5CkdX5/JSTXd7uYhVBITRCaQIsZRhg==
-  dependencies:
-    babel-plugin-transform-object-rest-spread "^6.26.0"
-    d3 "6.7.0"
-    regenerator-transform "^0.13.3"
 
 react-svg-file-zoom-pan@0.1.5:
   version "0.1.5"


### PR DESCRIPTION
due to the scrubber library lowercasing all attribute names some properties are not rendered in the browser.

In this case beads with a gradient  in molecule, sample and reaction were not displayed in browser and were also missing after conversion in png in doc report.

(successiv gsub benchmarked as faster than gsub with regex and a dict)


