### PR TITLE
fix: temperature conversion

### DIFF
--- a/app/packs/src/models/Reaction.js
+++ b/app/packs/src/models/Reaction.js
@@ -29,6 +29,9 @@ const TemperatureDefault = {
 };
 
 export const convertTemperature = (temperature, fromUnit, toUnit) => {
+  if (fromUnit === toUnit) {
+    return temperature;
+  }
   const conversionTable = {
     'K': {
       '°C': (t) => parseFloat(t) - 273.15,


### PR DESCRIPTION
Prior to this bug fix, if  `fromUnit` and `toUnit` are identical, `convertTemperature` throws:

```
TypeError
conversionTable[fromUnit][toUnit] is not a function
```