### PR TITLE
refactor: dry schmooze tools

### DIFF
--- a/lib/chemotion/meta_schmooze/meta_schmooze.rb
+++ b/lib/chemotion/meta_schmooze/meta_schmooze.rb
@@ -64,5 +64,20 @@ module Chemotion
         schmooze_klass.send(:method, method_name, script[var])
       end
     end
+
+    def parse_input(delta_ops)
+      return '[]' if delta_ops.blank? || delta_ops == "{\"ops\":[{\"insert\":\"\"}]}"
+
+      delta_ops = JSON.parse delta_ops if delta_ops.is_a?(String)
+      delta_ops = case delta_ops.class.name
+                  when 'Array'
+                    delta_ops.to_json
+                  when 'Hash', 'ActiveSupport::HashWithIndifferentAccess'
+                    delta_ops.fetch('ops', []).to_json
+                  else
+                    '[]'
+                  end
+      (delta_ops == "[{\"insert\":\"\"}]" && '[]') || delta_ops
+    end
   end
 end

--- a/lib/chemotion/quill_to_html.rb
+++ b/lib/chemotion/quill_to_html.rb
@@ -12,16 +12,7 @@ module Chemotion
       @schmooze_dependencies = schmooze_dependencies.merge(delta: 'quill-delta-to-html')
       @schmooze_methods = schmooze_methods.merge(
         convert: lambda { |delta_ops = []|
-          delta_ops = JSON.parse delta_ops if delta_ops.is_a?(String)
-          delta_ops = case delta_ops.class.name
-                      when 'Array'
-                        delta_ops.to_json
-                      when 'Hash', 'ActiveSupport::HashWithIndifferentAccess'
-                        delta_ops.fetch('ops', []).to_json
-                      else
-                        '[]'
-                      end
-          return "function(){  var converter = new delta(#{delta_ops}, {});  return converter.convert(); } "
+          return "function(){  var converter = new delta(#{parse_input(delta_ops)}, {});  return converter.convert(); } "
         },
       )
       compose_schmooze_class

--- a/lib/chemotion/quill_to_plain_text.rb
+++ b/lib/chemotion/quill_to_plain_text.rb
@@ -12,16 +12,7 @@ module Chemotion
       @schmooze_dependencies = schmooze_dependencies.merge(delta: 'quill-delta-to-plaintext')
       @schmooze_methods = schmooze_methods.merge(
         convert: lambda { |delta_ops = []|
-          delta_ops = JSON.parse delta_ops if delta_ops.is_a?(String)
-          delta_ops = case delta_ops.class.name
-                      when 'Array'
-                        delta_ops.to_json
-                      when 'Hash', 'ActiveSupport::HashWithIndifferentAccess'
-                        delta_ops.fetch('ops', []).to_json
-                      else
-                        '[]'
-                      end
-          "function(){   return delta(#{delta_ops}); } "
+          "function(){   return delta(#{parse_input(delta_ops)}); } "
         },
       )
       compose_schmooze_class

--- a/spec/lib/chemotion/quill_to_plain_text_spec.rb
+++ b/spec/lib/chemotion/quill_to_plain_text_spec.rb
@@ -16,12 +16,46 @@ RSpec.describe 'QuillToPlainText' do
       "Hello\nThis is colorful"
     end
 
-    it 'converts a quill delta ops as ruby array to html' do
+    it 'converts a quill delta ops as ruby array to plain text' do
       expect(lib.convert(delta_ops)).to match(plain_text)
     end
 
-    it 'converts a quill delta ops as ruby json string to html' do
+    it 'converts a quill delta ops as ruby json string to plain text' do
       expect(lib.convert(delta_ops.to_json)).to match(plain_text)
+    end
+  end
+
+  describe 'convert empty array' do
+    let(:delta_ops) do
+      []
+    end
+    let(:plain_text) do
+      ''
+    end
+
+    it 'converts a quill delta ops as ruby array to plain text' do
+      expect(lib.convert(delta_ops)).to match(plain_text)
+    end
+
+    it 'converts a quill delta ops as ruby json string to plain text' do
+      expect(lib.convert(delta_ops.to_json)).to match(plain_text)
+    end
+  end
+
+  describe 'convert empty delta' do
+    let(:delta_ops) do
+      "{\"ops\":[{\"insert\":\"\"}]}"
+    end
+    let(:plain_text) do
+      ''
+    end
+
+    it 'converts a quill delta ops as ruby array to plain text' do
+      expect(lib.convert(delta_ops)).to match(plain_text)
+    end
+
+    it 'converts a quill delta ops as ruby json string to plain text' do
+      expect(lib.convert(JSON.parse(delta_ops))).to match(plain_text)
     end
   end
 end


### PR DESCRIPTION
common input parser for quill-to-html and quill-to-plain-text 

now handle empty delta to prevent (db/migration) errors
```
     Schmooze::JavaScript::TypeError:
       only `insert` operations can be transformed!
```