### PR TITLE
Fix jcamp spec for CI runner

### DIFF
--- a/spec/lib/chemotion/jcamp_spec.rb
+++ b/spec/lib/chemotion/jcamp_spec.rb
@@ -8,7 +8,7 @@ require 'webmock/rspec'
 RSpec.describe Chemotion::Jcamp do
   WebMock.allow_net_connect!
 
-  Rails.configuration.spectra.chemspectra.url = 'http://example.com'
+  Rails.configuration.spectra.chemspectra.url = 'http://localhost'
   headers = { 'Content-Type' => /multipart\/form-data/ } # rubocop:disable Style/RegexpLiteral
 
   match_multipart_body = ->(request) do # rubocop:disable Style/Lambda
@@ -17,15 +17,17 @@ RSpec.describe Chemotion::Jcamp do
   end
 
   describe Chemotion::Jcamp::CreateImg do
-    url = 'http://example.com/zip_image'
     file_path = 'spec/fixtures/upload.txt'
 
-    it 'stubs peak in image request' do
-      stub_request(:post, url)
+    before do
+      stub_request(:post, 'localhost/zip_image')
         .with(
           headers: headers, &match_multipart_body
         )
         .to_return(status: 200, body: '')
+    end
+
+    it 'stubs peak in image request' do
 
       response = described_class.stub_peak_in_image(file_path)
 
@@ -45,15 +47,17 @@ RSpec.describe Chemotion::Jcamp do
   end
 
   describe Chemotion::Jcamp::CombineImg do
-    url = 'http://example.com/combine_images'
     file_path = 'spec/fixtures/upload.txt'
 
-    it 'stubs combine image request' do
-      stub_request(:post, url)
+    before do
+      stub_request(:post, 'localhost/combine_images')
         .with(
           headers: headers, &match_multipart_body
         )
         .to_return(status: 200, body: '')
+    end
+
+    it 'stubs combine image request' do
 
       response = described_class.stub_request([file_path, file_path], 1, ['file_1', 'file_2'])
 


### PR DESCRIPTION

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
