### PR TITLE
fix: amount change of a reaction product from the sample properties tab

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/packs/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -701,7 +701,7 @@ export default class SampleForm extends React.Component {
     const { enableSampleDecoupled } = this.props;
     const minPadding = { padding: '4px 4px 4px 4px' };
 
-    if (sample.belongTo !== undefined) {
+    if (sample.belongTo !== undefined && sample.belongTo !== null) {
       // assign amount type for product samples of reaction to real
       this.assignAmountType(sample.belongTo, sample);
     }

--- a/app/packs/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/packs/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -679,6 +679,18 @@ export default class SampleForm extends React.Component {
     );
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  assignAmountType(reaction, sample) {
+    // eslint-disable-next-line no-underscore-dangle
+    reaction._products.map((s) => {
+      if (s.id === sample.id) {
+        // eslint-disable-next-line no-param-reassign
+        sample.amountType = 'real';
+      }
+      return sample;
+    });
+  }
+
   render() {
     const sample = this.props.sample || {};
     const isPolymer = (sample.molfile || '').indexOf(' R# ') !== -1;
@@ -688,6 +700,11 @@ export default class SampleForm extends React.Component {
     const densityBlocked = isDisabled ? true : !molarityBlocked;
     const { enableSampleDecoupled } = this.props;
     const minPadding = { padding: '4px 4px 4px 4px' };
+
+    if (sample.belongTo !== undefined) {
+      // assign amount type for product samples of reaction to real
+      this.assignAmountType(sample.belongTo, sample);
+    }
 
     return (
       <Table responsive className="sample-form">


### PR DESCRIPTION
…roperties tab, does not render the change in the reaction scheme after saving sample change



- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
