### PR TITLE
fix: show `Tooltip` on "+" button in "Variations" tab

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -326,7 +326,8 @@ export default function ReactionVariations({ reaction, onEditVariations }) {
             </Tooltip>
           )}
         >
-          <AddButton onClick={() => addRow()} />
+          {/* Wrapping button in span necessary in order for OverlayTrigger to work */}
+          <span><AddButton onClick={() => addRow()} /></span>
         </OverlayTrigger>
         {' '}
         <FormGroup>


### PR DESCRIPTION
The `Tooltip` of the "+" button in the "Variations" tab did not appear anymore on hover over.
That was fixed by wrapping the button in a `<span>`.

@PiTrem, could you have a quick look (I feel like we won't need another reviewer for this)?
