### PR TITLE
fix: include reaction variations in `.docx` report

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -186,6 +186,7 @@ class Report < ApplicationRecord
       observation: true,
       analysis: true,
       literature: true,
+      variations: true,
     }
   end
 

--- a/app/packs/src/stores/alt/stores/ReportStore.js
+++ b/app/packs/src/stores/alt/stores/ReportStore.js
@@ -9,41 +9,49 @@ import UserStore from 'src/stores/alt/stores/UserStore';
 import { reOrderArr } from 'src/utilities/DndControl';
 import { UpdateSelectedObjs, OrderPreviewObjs } from 'src/utilities/ReportHelper';
 
+const splSettings = [
+  { checked: true, text: 'diagram' },
+  { checked: true, text: 'collection' },
+  { checked: true, text: 'analyses' },
+  { checked: true, text: 'reaction description' },
+  { checked: true, text: 'literature' },
+];
+
+const rxnSettings = [
+  { checked: true, text: 'diagram' },
+  { checked: true, text: 'material' },
+  { checked: true, text: 'description' },
+  { checked: true, text: 'purification' },
+  { checked: true, text: 'dangerous products' },
+  { checked: true, text: 'tlc' },
+  { checked: true, text: 'observation' },
+  { checked: true, text: 'analysis' },
+  { checked: true, text: 'literature' },
+  { checked: true, text: 'variations' },
+];
+
+const siRxnSettings = [
+  { checked: true, text: 'Name' },
+  { checked: true, text: 'CAS' },
+  { checked: true, text: 'Formula' },
+  { checked: true, text: 'Smiles' },
+  { checked: true, text: 'InChI' },
+  { checked: true, text: 'Molecular Mass' },
+  { checked: true, text: 'Exact Mass' },
+  { checked: true, text: 'EA' },
+];
+
+const configs = [
+  { checked: true, text: 'Page Break' },
+  { checked: true, text: 'Show all chemicals in schemes (unchecked to show products only)' },
+];
+
 class ReportStore {
   constructor() {
-    this.splSettings = [
-      { checked: true, text: 'diagram' },
-      { checked: true, text: 'collection' },
-      { checked: true, text: 'analyses' },
-      { checked: true, text: 'reaction description' },
-      { checked: true, text: 'literature' },
-    ];
-    this.rxnSettings = [
-      { checked: true, text: 'diagram' },
-      { checked: true, text: 'material' },
-      { checked: true, text: 'description' },
-      { checked: true, text: 'purification' },
-      { checked: true, text: 'dangerous products' },
-      { checked: true, text: 'tlc' },
-      { checked: true, text: 'observation' },
-      { checked: true, text: 'analysis' },
-      { checked: true, text: 'literature' },
-      { checked: true, text: 'variations' },
-    ];
-    this.siRxnSettings = [
-      { checked: true, text: 'Name' },
-      { checked: true, text: 'CAS' },
-      { checked: true, text: 'Formula' },
-      { checked: true, text: 'Smiles' },
-      { checked: true, text: 'InChI' },
-      { checked: true, text: 'Molecular Mass' },
-      { checked: true, text: 'Exact Mass' },
-      { checked: true, text: 'EA' },
-    ];
-    this.configs = [
-      { checked: true, text: 'Page Break' },
-      { checked: true, text: 'Show all chemicals in schemes (unchecked to show products only)' },
-    ];
+    this.splSettings = splSettings;
+    this.rxnSettings = rxnSettings;
+    this.siRxnSettings = siRxnSettings;
+    this.configs = configs;
     this.checkedAllSplSettings = true;
     this.checkedAllRxnSettings = true;
     this.checkedAllSiRxnSettings = true;
@@ -453,6 +461,7 @@ class ReportStore {
           { text: 'observation', checked: rs.observation },
           { text: 'analysis', checked: rs.analysis },
           { text: 'literature', checked: rs.literature },
+          { text: 'variations', checked: rs.variations },
         ],
       siRxnSettings:
         [
@@ -534,42 +543,10 @@ class ReportStore {
       checkedAllRxnSettings: true,
       checkedAllSiRxnSettings: true,
       checkedAllConfigs: true,
-      splSettings:
-        [
-          { text: 'diagram', checked: true },
-          { text: 'collection', checked: true },
-          { text: 'analyses', checked: true },
-          { text: 'reaction description', checked: true },
-          { text: 'literature', checked: true },
-        ],
-      rxnSettings:
-        [
-          { text: 'diagram', checked: true },
-          { text: 'material', checked: true },
-          { text: 'description', checked: true },
-          { text: 'purification', checked: true },
-          { text: 'dangerous products', checked: true },
-          { text: 'tlc', checked: true },
-          { text: 'observation', checked: true },
-          { text: 'analysis', checked: true },
-          { text: 'literature', checked: true },
-        ],
-      siRxnSettings:
-        [
-          { checked: true, text: 'Name' },
-          { checked: true, text: 'CAS' },
-          { checked: true, text: 'Formula' },
-          { checked: true, text: 'Smiles' },
-          { checked: true, text: 'InChI' },
-          { checked: true, text: 'Molecular Mass' },
-          { checked: true, text: 'Exact Mass' },
-          { checked: true, text: 'EA' },
-        ],
-      configs:
-        [
-          { text: 'Page Break', checked: true },
-          { text: 'Show all chemicals in schemes (unchecked to show products only)', checked: true },
-        ],
+      splSettings,
+      rxnSettings,
+      siRxnSettings,
+      configs,
       defaultObjTags: { sampleIds: [], reactionIds: [] },
       selectedObjTags: { sampleIds: [], reactionIds: [] },
       selectedObjs: [],

--- a/spec/factories/reports.rb
+++ b/spec/factories/reports.rb
@@ -31,7 +31,8 @@ FactoryBot.define do
         tlc: true,
         observation: true,
         analysis: true,
-        literature: true }
+        literature: true,
+        variations: true }
     end
     objects do
       [

--- a/spec/support/report_helpers.rb
+++ b/spec/support/report_helpers.rb
@@ -19,7 +19,8 @@ module ReportHelpers
       tlc: true,
       observation: true,
       analysis: true,
-      literature: true
+      literature: true,
+      variations: true,
     }
   end
 


### PR DESCRIPTION
Reaction variations weren't reliably included in the `.docx` report.
The reason for this is as follows. I originally added the `variations` attribute to the `constructor` of `ReportStore.js`:
https://github.com/ComPlat/chemotion_ELN/blob/e51e89d8d3f960aee5bcfdc989cb061198063af3/app/packs/src/stores/alt/stores/ReportStore.js#L31

However, I forgot to also add the `variations` attribute to the `ReportStore`'s [handleClone](https://github.com/ComPlat/chemotion_ELN/blob/e51e89d8d3f960aee5bcfdc989cb061198063af3/app/packs/src/stores/alt/stores/ReportStore.js#L414) and [hadnleReset](https://github.com/ComPlat/chemotion_ELN/blob/e51e89d8d3f960aee5bcfdc989cb061198063af3/app/packs/src/stores/alt/stores/ReportStore.js#L525) methods (I preserved the original `handle` -> `hadnle` typo).

The latter two methods re-define the report attributes, and therefore remove the `variations` attribute once called.
To fix this, I refactored `ReportStore.js` such that the attributes are configured in one place only (see top of the file), and are referenced by the `constructor`, as well as by `hadnleReset` (note that `handleClone` requires special treatment).