### PR TITLE
feat: enable nmrium in read only collection

### DIFF
--- a/app/packs/src/components/common/SpectraEditorButton.js
+++ b/app/packs/src/components/common/SpectraEditorButton.js
@@ -94,7 +94,7 @@ export default function SpectraEditorButton({
                   bsSize="xsmall"
                   onToggle={(_, event) => { if (event) { event.stopPropagation(); } }}
                   onClick={toggleNMRDisplayerModal}
-                  disabled={!hasJcamp || !element.can_update}
+                  disabled={!hasJcamp}
                 >
                   <i className="fa fa-bar-chart" />
                 </Button>

--- a/app/packs/src/components/nmriumWrapper/NMRiumDisplayer.js
+++ b/app/packs/src/components/nmriumWrapper/NMRiumDisplayer.js
@@ -427,6 +427,7 @@ export default class NMRiumDisplayer extends React.Component {
 
   renderModalTitle() {
     const { nmriumData } = this.state;
+    const { sample } = this.props;
     let hasSpectra = false;
     if (nmriumData) {
       const { version } = nmriumData;
@@ -454,7 +455,7 @@ export default class NMRiumDisplayer extends React.Component {
           </span>
         </Button>
         {
-          hasSpectra ?
+          hasSpectra && sample.can_update ? 
           (
             <Button
               bsStyle="success"


### PR DESCRIPTION
In read-only collections, NMRium and chemspectra are enabled while the 'close with save' buttons are hidden.
Closes https://github.com/ComPlat/chemotion/issues/114

[nmrium_enabled.webm](https://github.com/ComPlat/chemotion_ELN/assets/112618970/08990f97-d386-4ee0-995e-f93aeb24e532)