### PR TITLE
fix: advanced search not working - cell-line

### DIFF
--- a/app/api/chemotion/search_api.rb
+++ b/app/api/chemotion/search_api.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/MethodLength, Metrics/BlockLength, Metrics/AbcSize, Metrics/ClassLength
+# rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/ClassLength
 
 # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Lint/SafeNavigationChain, Style/RedundantParentheses
 
@@ -551,10 +551,9 @@ module Chemotion
             user: current_user,
             conditions: conditions,
           ).perform!
-          
-          results["cell_lines"]={:elements=>[], :ids=>[], :page=>1, :perPage=>15, :pages=>0, :totalElements=>0, :error=>""}
+
+          results['cell_lines'] = { elements: [], ids: [], page: 1, perPage: 15, pages: 0, totalElements: 0, error: '' }
           results
-          
         end
       end
 
@@ -701,4 +700,4 @@ end
 
 # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Lint/SafeNavigationChain, Style/RedundantParentheses
 
-# rubocop:enable Metrics/MethodLength, Metrics/BlockLength, Metrics/AbcSize, Metrics/ClassLength
+# rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/ClassLength

--- a/app/api/chemotion/search_api.rb
+++ b/app/api/chemotion/search_api.rb
@@ -545,12 +545,16 @@ module Chemotion
               params: params[:selection][:advanced_params],
             ).filter!
 
-          Usecases::Search::AdvancedSearch.new(
+          results = Usecases::Search::AdvancedSearch.new(
             collection_id: @c_id,
             params: params,
             user: current_user,
             conditions: conditions,
           ).perform!
+          
+          results["cell_lines"]={:elements=>[], :ids=>[], :page=>1, :perPage=>15, :pages=>0, :totalElements=>0, :error=>""}
+          results
+          
         end
       end
 

--- a/app/packs/src/components/searchModal/forms/TextSearch.js
+++ b/app/packs/src/components/searchModal/forms/TextSearch.js
@@ -10,7 +10,7 @@ import { observer } from 'mobx-react';
 import { StoreContext } from 'src/stores/mobx/RootStore';
 
 const TextSearch = () => {
-  const elnElements = ['samples', 'reactions', 'wellplates', 'screens', 'research_plans'];
+  const elnElements = ['cell_line','samples', 'reactions', 'wellplates', 'screens', 'research_plans'];
   const genericElements = UserStore.getState().genericEls || [];
   const searchStore = useContext(StoreContext).search;
   const panelVars = panelVariables(searchStore);
@@ -54,7 +54,7 @@ const TextSearch = () => {
   const SelectSearchTable = () => {
     const layout = UserStore.getState().profile.data.layout;
 
-    const elnElements = ['sample', 'reaction', 'screen', 'wellplate', 'research_plan'];
+    const elnElements = ['cell_line','sample', 'reaction', 'screen', 'wellplate', 'research_plan'];
 
     const buttons = Object.entries(layout).filter((value) => {
       return value[1] > 0


### PR DESCRIPTION

To avoid the crash at the advanced search, i added an empty search result for the cell line block at the advanced search endpoint.
In another feature we had to include the search for the cell lines into the advanced search analogue to other elements.

Also fixed the missing icons in the search frontend.
