### PR TITLE
refactor: rb quill delta converter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -511,7 +511,7 @@ GEM
       net-protocol
     net-ssh (6.1.0)
     nio4r (2.7.0)
-    nokogiri (1.16.2-x86_64-linux)
+    nokogiri (1.15.5-x86_64-linux)
       racc (~> 1.4)
     numerizer (0.1.1)
     oauth2 (2.0.9)

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -73,9 +73,11 @@ class Container < ApplicationRecord
   def content_to_plain_text
     return unless extended_metadata_changed?
     return if extended_metadata.blank? || (extended_metadata.present? && extended_metadata['content'].blank?)
-    return if extended_metadata['content'] == "{\"ops\":[{\"insert\":\"\"}]}"
 
-    self.plain_text_content = Chemotion::QuillToPlainText.new.convert(extended_metadata['content'])
+    plain_text = Chemotion::QuillToPlainText.convert(extended_metadata['content'])
+    return if plain_text.blank?
+
+    self.plain_text_content = plain_text
   end
   # rubocop:enable Style/StringLiterals
 end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -295,13 +295,13 @@ class Reaction < ApplicationRecord
   def description_to_plain_text
     return unless description_changed?
 
-    self.plain_text_description = Chemotion::QuillToPlainText.new.convert(description)
+    self.plain_text_description = Chemotion::QuillToPlainText.convert(description)
   end
 
   def observation_to_plain_text
     return unless observation_changed?
 
-    self.plain_text_observation = Chemotion::QuillToPlainText.new.convert(observation)
+    self.plain_text_observation = Chemotion::QuillToPlainText.convert(observation)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/screen.rb
+++ b/app/models/screen.rb
@@ -71,6 +71,6 @@ class Screen < ApplicationRecord
   def description_to_plain_text
     return unless description_changed?
 
-    self.plain_text_description = Chemotion::QuillToPlainText.new.convert(description)
+    self.plain_text_description = Chemotion::QuillToPlainText.convert(description)
   end
 end

--- a/app/models/wellplate.rb
+++ b/app/models/wellplate.rb
@@ -161,6 +161,6 @@ class Wellplate < ApplicationRecord
   def description_to_plain_text
     return unless description_changed?
 
-    self.plain_text_description = Chemotion::QuillToPlainText.new.convert(description)
+    self.plain_text_description = Chemotion::QuillToPlainText.convert(description)
   end
 end

--- a/db/migrate/20230630140647_fill_new_plain_text_description_fields.rb
+++ b/db/migrate/20230630140647_fill_new_plain_text_description_fields.rb
@@ -1,26 +1,40 @@
+# frozen_string_literal: true
+
 class FillNewPlainTextDescriptionFields < ActiveRecord::Migration[6.1]
   def up
-    Reaction.where.not(description: nil).or(Reaction.where.not(observation: nil)).each do | reaction |
-      description = Chemotion::QuillToPlainText.new.convert(reaction.description)
-      observation = Chemotion::QuillToPlainText.new.convert(reaction.observation)
-      reaction.update_columns(plain_text_description: description, plain_text_observation: observation)
+    Reaction.where.not(description: nil).or(Reaction.where.not(observation: nil)).find_each do |reaction|
+      description = Chemotion::QuillToPlainText.convert(reaction.description)
+      observation = Chemotion::QuillToPlainText.convert(reaction.observation)
+      if description.present? || observation.present?
+        reaction.update_columns(plain_text_observation: observation, plain_text_description: description)
+      end
+      # force gc of node processes
+      ObjectSpace.garbage_collect
     end
-    Screen.where.not(description: nil).each do | screen |
-      screen.update_columns(plain_text_description: Chemotion::QuillToPlainText.new.convert(screen.description))
+    Screen.where.not(description: nil).find_each do |screen|
+      description = Chemotion::QuillToPlainText.convert(screen.description)
+      next if description.blank?
+
+      screen.update_columns(plain_text_description: description)
+      ObjectSpace.garbage_collect
     end
-    Wellplate.where.not(description: nil).each do | wellplate |
-      wellplate.update_columns(plain_text_description: Chemotion::QuillToPlainText.new.convert(wellplate.description))
+    Wellplate.where.not(description: nil).find_each do |wellplate|
+      description = Chemotion::QuillToPlainText.convert(wellplate.description)
+      next if description.blank?
+
+      wellplate.update_columns(plain_text_description: description)
+      ObjectSpace.garbage_collect
     end
   end
 
   def down
-    Reaction.where.not(description: nil).or(Reaction.where.not(observation: nil)).each do | reaction |
+    Reaction.where.not(description: nil).or(Reaction.where.not(observation: nil)).find_each do |reaction|
       reaction.update_columns(plain_text_description: nil, plain_text_observation: nil)
     end
-    Screen.where.not(description: nil).each do | screen |
+    Screen.where.not(description: nil).find_each do |screen|
       screen.update_columns(plain_text_description: nil)
     end
-    Wellplate.where.not(description: nil).each do | wellplate |
+    Wellplate.where.not(description: nil).find_each do |wellplate|
       wellplate.update_columns(plain_text_description: nil)
     end
   end

--- a/db/migrate/20230814121455_fill_new_plain_text_content_field_at_containers.rb
+++ b/db/migrate/20230814121455_fill_new_plain_text_content_field_at_containers.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 class FillNewPlainTextContentFieldAtContainers < ActiveRecord::Migration[6.1]
   def up
-    Container.where(container_type: 'analysis').where('extended_metadata::TEXT LIKE ?', '%content%').each do | container |
+    Container.where(container_type: 'analysis').where('extended_metadata::TEXT LIKE ?',
+                                                      '%content%').find_each do |container|
       content = Chemotion::QuillToPlainText.convert(container.extended_metadata['content'])
       # force gc of node processes
       ObjectSpace.garbage_collect
@@ -11,7 +14,8 @@ class FillNewPlainTextContentFieldAtContainers < ActiveRecord::Migration[6.1]
   end
 
   def down
-    Container.where(container_type: 'analysis').where('extended_metadata::TEXT LIKE ?', '%content%').each do | container |
+    Container.where(container_type: 'analysis').where('extended_metadata::TEXT LIKE ?',
+                                                      '%content%').find_each do |container|
       container.update_columns(plain_text_content: nil)
     end
   end

--- a/db/migrate/20230814121455_fill_new_plain_text_content_field_at_containers.rb
+++ b/db/migrate/20230814121455_fill_new_plain_text_content_field_at_containers.rb
@@ -1,7 +1,11 @@
 class FillNewPlainTextContentFieldAtContainers < ActiveRecord::Migration[6.1]
   def up
     Container.where(container_type: 'analysis').where('extended_metadata::TEXT LIKE ?', '%content%').each do | container |
-      content = Chemotion::QuillToPlainText.new.convert(container.extended_metadata['content'])
+      content = Chemotion::QuillToPlainText.convert(container.extended_metadata['content'])
+      # force gc of node processes
+      ObjectSpace.garbage_collect
+      next if content.blank?
+
       container.update_columns(plain_text_content: content)
     end
   end

--- a/lib/chemotion/meta_schmooze/meta_schmooze.rb
+++ b/lib/chemotion/meta_schmooze/meta_schmooze.rb
@@ -64,20 +64,5 @@ module Chemotion
         schmooze_klass.send(:method, method_name, script[var])
       end
     end
-
-    def parse_input(delta_ops)
-      return '[]' if delta_ops.blank? || delta_ops == "{\"ops\":[{\"insert\":\"\"}]}"
-
-      delta_ops = JSON.parse delta_ops if delta_ops.is_a?(String)
-      delta_ops = case delta_ops.class.name
-                  when 'Array'
-                    delta_ops.to_json
-                  when 'Hash', 'ActiveSupport::HashWithIndifferentAccess'
-                    delta_ops.fetch('ops', []).to_json
-                  else
-                    '[]'
-                  end
-      (delta_ops == "[{\"insert\":\"\"}]" && '[]') || delta_ops
-    end
   end
 end

--- a/lib/chemotion/quill_to_html.rb
+++ b/lib/chemotion/quill_to_html.rb
@@ -5,14 +5,29 @@ require 'meta_schmooze'
 
 module Chemotion
   class QuillToHtml < MetaSchmooze
+    extend QuillUtils
     def initialize(schmooze_methods: {}, schmooze_dependencies: {}, root: Rails.root.to_s, env: {}, var: {})
       super
       @root = root
       @env = env
       @schmooze_dependencies = schmooze_dependencies.merge(delta: 'quill-delta-to-html')
       @schmooze_methods = schmooze_methods.merge(
-        convert: lambda { |delta_ops = []|
-          return "function(){  var converter = new delta(#{parse_input(delta_ops)}, {});  return converter.convert(); } "
+        convert: lambda { |delta_ops = '[]'|
+          <<~FUNCTION
+            function(){
+              var converter = new delta(#{delta_ops.presence || '[]'}, {});
+              return converter.convert();
+            }
+          FUNCTION
+        },
+        convert_from_file: lambda { |file_path|
+          <<~FUNCTION
+            function(){
+              var input = JSON.parse(fs.readFileSync('#{file_path}', 'utf8'));
+              var converter = new delta(input, {});
+              return converter.convert();
+            }
+          FUNCTION
         },
       )
       compose_schmooze_class

--- a/lib/chemotion/quill_to_plain_text.rb
+++ b/lib/chemotion/quill_to_plain_text.rb
@@ -5,14 +5,22 @@ require 'meta_schmooze'
 
 module Chemotion
   class QuillToPlainText < MetaSchmooze
+    extend QuillUtils
     def initialize(schmooze_methods: {}, schmooze_dependencies: {}, root: Rails.root.to_s, env: {}, var: {})
       super
       @root = root
       @env = env
-      @schmooze_dependencies = schmooze_dependencies.merge(delta: 'quill-delta-to-plaintext')
+      @schmooze_dependencies = schmooze_dependencies.merge(delta: 'quill-delta-to-plaintext', fs: 'fs')
       @schmooze_methods = schmooze_methods.merge(
-        convert: lambda { |delta_ops = []|
-          "function(){   return delta(#{parse_input(delta_ops)}); } "
+        convert: lambda { |delta_ops = '[]'|
+          "function(){   return delta(#{delta_ops}); } "
+        },
+        convert_from_file: lambda { |file_path|
+          <<~FUNCTION
+            function(){
+              return delta(JSON.parse(fs.readFileSync('#{file_path}', 'utf8')));
+            }
+          FUNCTION
         },
       )
       compose_schmooze_class

--- a/lib/export/export_research_plan.rb
+++ b/lib/export/export_research_plan.rb
@@ -16,7 +16,7 @@ module Export
         when 'richtext'
           @fields << {
             type: field['type'],
-            text: Chemotion::QuillToHtml.new.convert(field['value']),
+            text: Chemotion::QuillToHtml.convert(field['value']),
           }
         when 'table'
           @fields << {

--- a/lib/export/export_table.rb
+++ b/lib/export/export_table.rb
@@ -142,7 +142,7 @@ module Export
     end
 
     def quill_to_html_to_string(delta)
-      html_content = Chemotion::QuillToHtml.new.convert(delta)
+      html_content = Chemotion::QuillToHtml.convert(delta)
       Nokogiri::HTML( html_content).text
     end
   end

--- a/lib/quill_utils.rb
+++ b/lib/quill_utils.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module QuillUtils
+  # desc: convert quill delta ops to html or plain text
+  # without_image: remove image inserts from quill ops string.
+  #   Images are anyway discarded for plain text output
+  def convert(content, without_image: false)
+    # avoid spwaning a nodejs process if the content is empty
+    return '' if blank_ops?(content)
+
+    input = parse_input(content)
+    input = filter_image(input) if without_image
+
+    # prepare and convert input as file if input too large (`ulimit -s` is usually 8192)
+    file = nil
+    if input.to_s.size > 4000
+      file = input_as_file(input)
+      return new.convert_from_file(file.path)
+    end
+
+    new.convert(input)
+  ensure
+    file&.close!
+  end
+
+  private
+
+  # desc: check for empty quill delta ops
+  def blank_ops?(content)
+    return true if content.blank?
+    return true if [{ "ops" => [{ "insert"=>"" }] }, { "ops" => [{ "insert"=>"\n" }] }].include?(content)
+    return true if ["{\"ops\":[{\"insert\":\"\"}]}", "{\"ops\":[{\"insert\":\"\\n\"}]}"].include?(content)
+  end
+
+  # desc: return the quill delta as string
+  def parse_input(delta_ops)
+    delta_ops = JSON.parse delta_ops if delta_ops.is_a?(String)
+    delta_ops = case delta_ops.class.name
+                when 'Array'
+                  delta_ops.to_json
+                when 'Hash', 'ActiveSupport::HashWithIndifferentAccess', 'Hashie::Mash'
+                  delta_ops.fetch('ops', []).to_json
+                else
+                  '[]'
+                end
+    # remove blank inserts that can break the conversion
+    delta_ops.gsub(/\{"insert":""\},/, '').gsub(/\{"insert":""\}\]/, ']')
+  end
+
+  # remove image inserts from quill ops string
+  def filter_image(delta_string)
+    delta_string.gsub(/\{"insert":\{"image":.*"\}\},/, '').gsub(/\{"insert":\{"image":.*"\}\}\]/, ']')
+  end
+
+  def input_as_file(input)
+    temp = Tempfile.new('input', encoding: 'UTF-8')
+    temp.write(input)
+    temp.rewind
+    temp
+  end
+end

--- a/lib/quill_utils.rb
+++ b/lib/quill_utils.rb
@@ -25,12 +25,17 @@ module QuillUtils
 
   private
 
+  # rubocop:disable Style/StringLiterals
+
   # desc: check for empty quill delta ops
   def blank_ops?(content)
     return true if content.blank?
-    return true if [{ "ops" => [{ "insert"=>"" }] }, { "ops" => [{ "insert"=>"\n" }] }].include?(content)
-    return true if ["{\"ops\":[{\"insert\":\"\"}]}", "{\"ops\":[{\"insert\":\"\\n\"}]}"].include?(content)
+    return true if [{ "ops" => [{ "insert" => "" }] }, { "ops" => [{ "insert" => "\n" }] }].include?(content)
+
+    ["{\"ops\":[{\"insert\":\"\"}]}", "{\"ops\":[{\"insert\":\"\\n\"}]}"].include?(content)
   end
+
+  # rubocop:enable Style/StringLiterals
 
   # desc: return the quill delta as string
   def parse_input(delta_ops)
@@ -44,7 +49,7 @@ module QuillUtils
                   '[]'
                 end
     # remove blank inserts that can break the conversion
-    delta_ops.gsub(/\{"insert":""\},/, '').gsub(/\{"insert":""\}\]/, ']')
+    delta_ops.gsub('{"insert":""},', '').gsub('{"insert":""}]', ']')
   end
 
   # remove image inserts from quill ops string

--- a/spec/lib/chemotion/quill_to_html_spec.rb
+++ b/spec/lib/chemotion/quill_to_html_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'QuillToHtml' do
-  subject(:quill_to_html) { Chemotion::QuillToHtml.new }
+  subject(:quill_to_html) { Chemotion::QuillToHtml }
 
   describe 'convert' do
     let(:delta_ops) do

--- a/spec/lib/chemotion/quill_to_plain_text_spec.rb
+++ b/spec/lib/chemotion/quill_to_plain_text_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'QuillToPlainText' do
-  subject(:lib) { Chemotion::QuillToPlainText.new }
+  subject(:lib) { Chemotion::QuillToPlainText }
 
   describe 'convert' do
     let(:delta_ops) do
@@ -46,6 +46,9 @@ RSpec.describe 'QuillToPlainText' do
     let(:delta_ops) do
       "{\"ops\":[{\"insert\":\"\"}]}"
     end
+    let(:delta_ops_multi) do
+      "{\"ops\":[{\"insert\":\"\"},{\"insert\":\"\"}]}"
+    end
     let(:plain_text) do
       ''
     end
@@ -56,6 +59,23 @@ RSpec.describe 'QuillToPlainText' do
 
     it 'converts a quill delta ops as ruby json string to plain text' do
       expect(lib.convert(JSON.parse(delta_ops))).to match(plain_text)
+    end
+
+    it 'converts a quill delata with multiple empty inserts' do
+      expect(lib.convert(JSON.parse(delta_ops_multi))).to match(plain_text)
+    end
+  end
+
+  describe 'convert long delta' do
+    let(:delta_ops) do
+      "{\"ops\":[{\"insert\":\"#{'a' * 10_000}\"}]}"
+    end
+    let(:plain_text) do
+      'a' * 10_000
+    end
+
+    it 'converts a long quill delta ops to plain text' do
+      expect(lib.convert(delta_ops)).to match(plain_text)
     end
   end
 end


### PR DESCRIPTION
- prevent spawning node process if quill ops is blank

- filter empty insert to prevent the node conversion to throw error

- add option to filter image insert from ops before conversion

- pass input as file if input too large (also prevent `Errno::E2BIG (Argument list too long - node)`)

- quill convert as class method

- modularize common quill utilities

chore: revert noko upd


