### PR TITLE
fix: devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -53,11 +53,11 @@
   ],
   "postCreateCommand": [
     "/bin/bash",
-    ".devcontainer/post_create.sh"
+    "prepare-ruby-dev.sh"
   ],
   "remoteUser": "chemotion-dev", // see https: //aka.ms/vscode-remote/containers/non-root
   "shutdownAction": "stopCompose", // stop compose when quitting
-  "overrideCommand": true, // override the commands in the compose file
+  "overrideCommand": true, // The 'app' container (which vscode is using as the devontainer) dies, as soon as we are killing the rails server that is started in the 'app' container command. To prevent this we override the 'app' container command from the the compose file.
   "containerEnv": {
     "RAILS_ENV": "development"
   },

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# install dependencies
-bundle update --bundler # update the bundler version in Gemfile.lock to the installed version
-yarn install
-
-# set up database
-bundle exec rake db:setup

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,6 +27,10 @@ services:
       dockerfile: 'Dockerfile.chemotion-dev'
     depends_on:
       - 'postgres'
+    healthcheck:
+      test: ["CMD", "bundle", "check"] # exit 0 if all gems from Gemfile are installed, otherwise exit 1
+      interval: 30s
+      timeout: 10s
     environment:
       - 'WEBPACKER_DEV_SERVER_HOST=webpacker'
       - 'WEBPACKER_DEV_SERVER_PORT=3035'
@@ -45,8 +49,8 @@ services:
       context: '.'
       dockerfile: 'Dockerfile.chemotion-dev'
     depends_on:
-      - 'app'
-    restart: on-failure:5
+      app:
+        condition: service_healthy
     environment:
       - 'WEBPACKER_DEV_SERVER_HOST=webpacker'
       - 'WEBPACKER_DEV_SERVER_PORT=3035'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,8 +6,6 @@
 #     docker-compose -f docker-compose.dev.yml up postgres app webpacker
 # - Open a bash shell in the app container:
 #     docker exec -it NAME_OF_APP_CONTAINER_FROM_DOCKER_PS /bin/bash
-# - Setup the database environment inside the bash shell:
-#     bundle exec rake db:setup
 # - Run tests:
 #     bundle exec rspec
 #

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -46,6 +46,9 @@ services:
     build:
       context: '.'
       dockerfile: 'Dockerfile.chemotion-dev'
+    depends_on:
+      - 'app'
+    restart: on-failure:5
     environment:
       - 'WEBPACKER_DEV_SERVER_HOST=webpacker'
       - 'WEBPACKER_DEV_SERVER_PORT=3035'

--- a/prepare-ruby-dev.sh
+++ b/prepare-ruby-dev.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+export ASDF_BRANCH=v0.13.1
+
+# if asdf is not installed -> install
+if command -v asdf ; then
+    echo '>>> asdf is already installed -> continue'
+else
+    echo '>>> Missing asdf. Installing...'
+    git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch $ASDF_BRANCH
+fi
+
+# if asdf plugins are not installed -> install
+if asdf plugin list | grep -Fxq 'ruby'; then
+    echo '>>> Ruby plugin for asdf is installed -> continue'
+else
+    echo '>>> Missing ruby plugin for asdf. Installing...'
+    asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git
+fi
+
+if asdf plugin list | grep -Fxq 'nodejs'; then
+    echo '>>> Nodejs plugin for asdf is installed -> continue'
+else
+    echo '>>> Missing nodejs plugin for asdf. Installing...'
+    asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
+fi
+
+# install all tools as defined by .tool-versions
+echo '>>> Installing tool versions'
+asdf install
+
+# install bundler if not present and then install all gems as defined by GEMFILE
+echo '>>> checking bundler installation'
+BUNDLER_VERSION=$(sed -n '/BUNDLED WITH/{n;p;}' "Gemfile.lock" | tr -d '[:space:]')
+gem install bundler -v $BUNDLER_VERSION
+
+echo '>>> Installing gems'
+bundle install
+
+rm -f tmp/pids/server.pid
+
+if [ "$( psql -h postgres -U postgres -XtAc "SELECT 1 FROM pg_database WHERE datname='chemotion_dev'" )" = '1' ]
+then
+    echo "================================================"
+    echo "Database already exists, skipping Database setup"
+    echo "================================================"
+else
+    echo "================================================"
+    echo "Database does not exist, running 'rake db:setup'"
+    echo "================================================"
+    bundle exec rake db:setup
+fi

--- a/run-ruby-dev.sh
+++ b/run-ruby-dev.sh
@@ -1,53 +1,5 @@
 #!/bin/bash
-export ASDF_BRANCH=v0.13.1
 
-# if asdf is not installed -> install
-if command -v asdf ; then
-    echo '>>> asdf is already installed -> continue'
-else
-    echo '>>> Missing asdf. Installing...'
-    git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch $ASDF_BRANCH
-fi
-
-# if asdf plugins are not installed -> install
-if asdf plugin list | grep -Fxq 'ruby'; then
-    echo '>>> Ruby plugin for asdf is installed -> continue'
-else
-    echo '>>> Missing ruby plugin for asdf. Installing...'
-    asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git
-fi
-
-if asdf plugin list | grep -Fxq 'nodejs'; then
-    echo '>>> Nodejs plugin for asdf is installed -> continue'
-else
-    echo '>>> Missing nodejs plugin for asdf. Installing...'
-    asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
-fi
-
-# install all tools as defined by .tool-versions
-echo '>>> Installing tool versions'
-asdf install
-
-# install bundler if not present and then install all gems as defined by GEMFILE
-echo '>>> checking bundler installation'
-BUNDLER_VERSION=$(sed -n '/BUNDLED WITH/{n;p;}' "Gemfile.lock" | tr -d '[:space:]')
-gem install bundler -v $BUNDLER_VERSION
-
-echo '>>> Installing gems'
-bundle install
-
-rm -f tmp/pids/server.pid
-
-if [ "$( psql -h postgres -U postgres -XtAc "SELECT 1 FROM pg_database WHERE datname='chemotion_dev'" )" = '1' ]
-then
-    echo "================================================"
-    echo "Database already exists, skipping Database setup"
-    echo "================================================"
-else
-    echo "================================================"
-    echo "Database does not exist, running 'rake db:setup'"
-    echo "================================================"
-    bundle exec rake db:setup
-fi
+./prepare-ruby-dev.sh
 
 bundle exec rails s -p 3000 -b 0.0.0.0


### PR DESCRIPTION
With https://github.com/ComPlat/chemotion_ELN/pull/1665 the node installation is moved from `Dockerfile.chemotion-dev` to `run-ruby-dev.sh`, which is not executed by the devcontainer. That's why the devcontainer would not start. Running `run-ruby-dev.sh` as part of the devcontainer startup would introduce a lifetime depdendency from the rails server (running in the `app` container) to the devcontainer. This is why we extracted the installation of node into a new script, which is now called from `prepare-ruby-dev.sh` as well as `postCreateCommand` command in devcontainer.