### PR TITLE
fix(UI): Display molecule SVG in sample SDF-import table

### DIFF
--- a/app/packs/src/components/contextActions/ModalImportConfirm.js
+++ b/app/packs/src/components/contextActions/ModalImportConfirm.js
@@ -194,7 +194,7 @@ export default class ModalImportConfirm extends React.Component {
     let columns={
           columnDefs: [
             {headerName: '#', field: 'index', width: 60, pinned: 'left'},
-            {headerName: 'Structure', field: 'svg', cellRenderer: SvgCellRenderer, pinned: 'left' },
+            {headerName: 'Structure', field: 'svg', cellRenderer: SvgCellRenderer, pinned: 'left', autoHeight: true },
             {headerName: 'name', field: 'name', editable:true},
             {headerName: 'Select', field: 'checked', cellRenderer: SelectCellRenderer,
               cellRendererParams:{onSelectChange: this.onSelectChange}, width: 30,


### PR DESCRIPTION
Prior to this PR, the SVGs of SDF-imported samples weren't properly displayed by the `SvgCellRenderer` in the `ModalImportConfirm` component:

![before](https://github.com/ComPlat/chemotion_ELN/assets/30125107/75da2858-fe42-41cc-8c1e-1859be9cf9a0)

924ea834a2b5ce93308c8f4d688dc028ec66fa88 fixed this by adjusting the row height to the SVG:

![after](https://github.com/ComPlat/chemotion_ELN/assets/30125107/ce4fe413-e086-49ce-8d27-5b22a2cb2d93)
