### PR TITLE
fix: disabled create button for synced collection

### DIFF
--- a/app/packs/src/components/contextActions/ContextActions.js
+++ b/app/packs/src/components/contextActions/ContextActions.js
@@ -38,7 +38,7 @@ export default class ContextActions extends React.Component {
   isCreateDisabled() {
     const { currentCollection } = this.state.uiState;
     return currentCollection && ((currentCollection.label == 'All' && currentCollection.is_locked)
-      || (currentCollection.is_shared && currentCollection.is_synchronized == false) || (currentCollection.is_sync_to_me && currentCollection.permission_level != PermissionConst.Write));
+      || (currentCollection.is_shared && currentCollection.is_synchronized == false) || (currentCollection.is_sync_to_me && currentCollection.permission_level < PermissionConst.Write));
   }
 
   isDisabled() {

--- a/app/packs/src/components/contextActions/CreateButton.js
+++ b/app/packs/src/components/contextActions/CreateButton.js
@@ -265,9 +265,11 @@ export default class CreateButton extends React.Component {
     const { layout } = this.state;
     const type = UserStore.getState().currentType;
     const { elements, genericEls, itemTables } = elementList();
-    
-    elements.concat(genericEls).forEach((el) => {
-      itemTables.push(<MenuItem id={`create-${el.name}-button`} key={el.name} onSelect={() => this.createElementOfType(`${el.name}`)}>Create {el.label}</MenuItem>);
+    const sortedLayout = filter(Object.entries(layout), (o) => o[1] && o[1] > 0).sort((a, b) => a[1] - b[1]);
+
+    sortedLayout?.forEach(([sl]) => {
+      const el = elements.concat(genericEls).find((ael) => ael.name === sl);
+      if (el) itemTables.push(<MenuItem id={`create-${el.name}-button`} key={el.name} onSelect={() => this.createElementOfType(`${el.name}`)}>Create {el.label}</MenuItem>);
     });
 
     return (


### PR DESCRIPTION
Issues fixed: 
- Synchronized collections:
Even if I give the other person all rights, he/she is not able to import elements (neither samples nor reactions) into the collection.

- [1793](https://github.com/ComPlat/chemotion_ELN/issues/1793) 
