### PR TITLE
1815 user feedback advanced search for temperature or time

### DIFF
--- a/app/usecases/search/conditions_for_advanced_search.rb
+++ b/app/usecases/search/conditions_for_advanced_search.rb
@@ -190,14 +190,13 @@ module Usecases
           @conditions[:additional_condition] = "AND (#{@table}.temperature ->> 'valueUnit')::TEXT = '#{filter['unit']}'"
           @conditions[:condition_table] = ''
         when 'duration'
-          time_divisor= duration_interval_by_unit(filter['unit'])
-          is_data_valid = "reactions.duration similar to ('\\d+%')"
+          time_divisor = duration_interval_by_unit(filter['unit'])
+          is_data_valid = "#{@table}.duration similar to ('\\d+%')"
           time_from_duration_column = "EXTRACT(epoch FROM #{@table}.duration::interval)/#{time_divisor}::INT"
 
           @conditions[:field] =
             "CASE WHEN #{is_data_valid} THEN #{time_from_duration_column} ELSE 0 END"
 
-          @conditions[:first_condition] = "#{@table}.duration IS NOT NULL AND #{@table}.duration != '' AND "
           @conditions[:condition_table] = ''
         when 'target_amount_value'
           @conditions[:additional_condition] = "AND #{@table}.target_amount_unit = '#{filter['unit']}'"

--- a/app/usecases/search/conditions_for_advanced_search.rb
+++ b/app/usecases/search/conditions_for_advanced_search.rb
@@ -189,7 +189,8 @@ module Usecases
 
           @conditions[:field] =
             "CASE WHEN #{is_data_valid} THEN (#{@table}.temperature ->> 'userText')::FLOAT ELSE -30000 END "
-          @conditions[:first_condition] += " AND (#{@table}.temperature ->> 'valueUnit')::TEXT != '' AND "
+
+          @conditions[:first_condition] += " (#{@table}.temperature ->> 'valueUnit')::TEXT != '' AND "
           @conditions[:additional_condition] = "AND (#{@table}.temperature ->> 'valueUnit')::TEXT = '#{filter['unit']}'"
           @conditions[:condition_table] = ''
         when 'duration'

--- a/app/usecases/search/conditions_for_advanced_search.rb
+++ b/app/usecases/search/conditions_for_advanced_search.rb
@@ -191,10 +191,11 @@ module Usecases
           @conditions[:condition_table] = ''
         when 'duration'
           time_divisor= duration_interval_by_unit(filter['unit'])
-          is_data_valid = "reactions.duration similar to ('%[0-9]%')"
+          is_data_valid = "reactions.duration similar to ('\\d+%')"
+          time_from_duration_column = "EXTRACT(epoch FROM #{@table}.duration::interval)/#{time_divisor}::INT"
 
           @conditions[:field] =
-            "CASE WHEN #{is_data_valid} THEN EXTRACT(epoch FROM #{@table}.duration::interval)/#{time_divisor}::INT ELSE 0 END"
+            "CASE WHEN #{is_data_valid} THEN #{time_from_duration_column} ELSE 0 END"
 
           @conditions[:first_condition] = "#{@table}.duration IS NOT NULL AND #{@table}.duration != '' AND "
           @conditions[:condition_table] = ''

--- a/app/usecases/search/conditions_for_advanced_search.rb
+++ b/app/usecases/search/conditions_for_advanced_search.rb
@@ -190,8 +190,12 @@ module Usecases
           @conditions[:additional_condition] = "AND (#{@table}.temperature ->> 'valueUnit')::TEXT = '#{filter['unit']}'"
           @conditions[:condition_table] = ''
         when 'duration'
+          time_divisor= duration_interval_by_unit(filter['unit'])
+          is_data_valid = "reactions.duration similar to ('%[0-9]%')"
+
           @conditions[:field] =
-            "(EXTRACT(epoch FROM #{@table}.duration::interval)/#{duration_interval_by_unit(filter['unit'])})::INT"
+            "CASE WHEN #{is_data_valid} THEN EXTRACT(epoch FROM #{@table}.duration::interval)/#{time_divisor}::INT ELSE 0 END"
+
           @conditions[:first_condition] = "#{@table}.duration IS NOT NULL AND #{@table}.duration != '' AND "
           @conditions[:condition_table] = ''
         when 'target_amount_value'

--- a/app/usecases/search/conditions_for_advanced_search.rb
+++ b/app/usecases/search/conditions_for_advanced_search.rb
@@ -184,8 +184,11 @@ module Usecases
             AND private_notes.noteable_id = #{@table}.id"
           @conditions[:condition_table] = 'private_notes.'
         when 'temperature'
-          @conditions[:field] = "(#{@table}.temperature ->> 'userText')::FLOAT"
-          @conditions[:first_condition] = "(#{@table}.temperature ->> 'userText')::TEXT != ''"
+          regex_number = "'^-{0,1}\\d+(\\.\\d+){0,1}\\Z'"
+          is_data_valid = "(#{@table}.temperature ->> 'userText' ~ #{regex_number})"
+
+          @conditions[:field] =
+            "CASE WHEN #{is_data_valid} THEN (#{@table}.temperature ->> 'userText')::FLOAT ELSE -30000 END "
           @conditions[:first_condition] += " AND (#{@table}.temperature ->> 'valueUnit')::TEXT != '' AND "
           @conditions[:additional_condition] = "AND (#{@table}.temperature ->> 'valueUnit')::TEXT = '#{filter['unit']}'"
           @conditions[:condition_table] = ''

--- a/spec/api/chemotion/search_api_spec.rb
+++ b/spec/api/chemotion/search_api_spec.rb
@@ -20,6 +20,23 @@ describe Chemotion::SearchAPI do
   let(:invalid_reaction_with_duration) do
     create(:reaction, name: 'invalid Reaction', creator: user, duration: 'Day(s)')
   end
+  let(:reaction_with_temperature) do
+    create(:reaction, name: 'reaction with temperature',
+                      creator: user,
+                      temperature: { data: [], userText: '21.24', valueUnit: '°C' })
+  end
+  let(:reaction_with_negative_temperature) do
+    create(:reaction, name: 'reaction with temperature',
+                      creator: user,
+                      temperature: { data: [], userText: '-21', valueUnit: '°C' })
+  end
+
+  let(:invalid_reaction_with_temperature) do
+    create(:reaction, name: 'invalid reaction with temperature',
+                      creator: user,
+                      temperature: { data: [], userText: '-4 to rt', valueUnit: '°C' })
+  end
+
   let(:reaction_with_duration) { create(:reaction, name: 'invalid Reaction', creator: user, duration: '1.33 Day(s)') }
   let(:other_reaction) { create(:reaction, name: 'Other Reaction', samples: [sample_c, sample_d], creator: other_user) }
   let(:screen) { create(:screen, name: 'Screen') }
@@ -30,6 +47,10 @@ describe Chemotion::SearchAPI do
     CollectionsReaction.create!(reaction: reaction, collection: collection)
     CollectionsReaction.create!(reaction: invalid_reaction_with_duration, collection: collection)
     CollectionsReaction.create!(reaction: reaction_with_duration, collection: collection)
+
+    CollectionsReaction.create!(reaction: reaction_with_temperature, collection: collection)
+    CollectionsReaction.create!(reaction: reaction_with_negative_temperature, collection: collection)
+    CollectionsReaction.create!(reaction: invalid_reaction_with_temperature, collection: collection)
     CollectionsSample.create!(sample: sample_a, collection: collection)
     CollectionsScreen.create!(screen: screen, collection: collection)
     CollectionsWellplate.create!(wellplate: wellplate, collection: collection)
@@ -40,6 +61,7 @@ describe Chemotion::SearchAPI do
     CollectionsScreen.create!(screen: other_screen, collection: other_collection)
     CollectionsWellplate.create!(wellplate: other_wellplate, collection: other_collection)
     ScreensWellplate.create!(wellplate: other_wellplate, screen: other_screen)
+    ActiveRecord::Base.logger = Logger.new($stdout)
 
     post url, params: params
   end
@@ -222,6 +244,35 @@ describe Chemotion::SearchAPI do
       it 'returns one reaction' do
         result = JSON.parse(response.body)
         expect(result.dig('reactions', 'totalElements')).to eq 1
+      end
+    end
+
+    context 'when searching a temperature in reactions in correct collection' do
+      let(:advanced_params) do
+        [
+          {
+            link: '',
+            match: '>=',
+            table: 'reactions',
+            element_id: 0,
+            field: {
+              column: 'temperature',
+              label: 'Temperature',
+              type: 'system-defined',
+              option_layers: 'temperature',
+              info: 'Only numbers are allowed',
+              advanced: true,
+            },
+            value: -22,
+            sub_values: [],
+            unit: '°C',
+          },
+        ]
+      end
+
+      it 'returns one reaction' do
+        result = JSON.parse(response.body)
+        expect(result.dig('reactions', 'totalElements')).to eq 2
       end
     end
   end

--- a/spec/api/chemotion/search_api_spec.rb
+++ b/spec/api/chemotion/search_api_spec.rb
@@ -61,7 +61,6 @@ describe Chemotion::SearchAPI do
     CollectionsScreen.create!(screen: other_screen, collection: other_collection)
     CollectionsWellplate.create!(wellplate: other_wellplate, collection: other_collection)
     ScreensWellplate.create!(wellplate: other_wellplate, screen: other_screen)
-    ActiveRecord::Base.logger = Logger.new($stdout)
 
     post url, params: params
   end

--- a/spec/api/chemotion/search_api_spec.rb
+++ b/spec/api/chemotion/search_api_spec.rb
@@ -17,6 +17,10 @@ describe Chemotion::SearchAPI do
   let(:wellplate) { create(:wellplate, name: 'Wellplate', wells: [build(:well, sample: sample_a)]) }
   let(:other_wellplate) { create(:wellplate, name: 'Other Wellplate', wells: [build(:well, sample: sample_b)]) }
   let(:reaction) { create(:reaction, name: 'Reaction', samples: [sample_a, sample_b], creator: user) }
+  let(:invalid_reaction_with_duration) do
+    create(:reaction, name: 'invalid Reaction', creator: user, duration: 'Day(s)')
+  end
+  let(:reaction_with_duration) { create(:reaction, name: 'invalid Reaction', creator: user, duration: '1 Day(s)') }
   let(:other_reaction) { create(:reaction, name: 'Other Reaction', samples: [sample_c, sample_d], creator: other_user) }
   let(:screen) { create(:screen, name: 'Screen') }
   let(:other_screen) { create(:screen, name: 'Other Screen') }
@@ -24,6 +28,8 @@ describe Chemotion::SearchAPI do
 
   before do
     CollectionsReaction.create!(reaction: reaction, collection: collection)
+    CollectionsReaction.create!(reaction: invalid_reaction_with_duration, collection: collection)
+    CollectionsReaction.create!(reaction: reaction_with_duration, collection: collection)
     CollectionsSample.create!(sample: sample_a, collection: collection)
     CollectionsScreen.create!(screen: screen, collection: collection)
     CollectionsWellplate.create!(wellplate: wellplate, collection: collection)
@@ -187,6 +193,35 @@ describe Chemotion::SearchAPI do
         expect(result.dig('screens', 'ids')).to eq [screen.id]
         expect(result.dig('wellplates', 'totalElements')).to eq 1
         expect(result.dig('wellplates', 'ids')).to eq [wellplate.id]
+      end
+    end
+
+    context 'when searching a duration in reactions in correct collection' do
+      let(:advanced_params) do
+        [
+          {
+            link: '',
+            match: '>=',
+            table: 'reactions',
+            element_id: 0,
+            field: {
+              column: 'duration',
+              label: 'Duration',
+              type: 'system-defined',
+              option_layers: 'duration',
+              info: 'Only numbers are allowed',
+              advanced: true,
+            },
+            value: 12,
+            sub_values: [],
+            unit: 'Hour(s)',
+          },
+        ]
+      end
+
+      it 'returns one reaction' do
+        result = JSON.parse(response.body)
+        expect(result.dig('reactions', 'totalElements')).to eq 1
       end
     end
   end

--- a/spec/api/chemotion/search_api_spec.rb
+++ b/spec/api/chemotion/search_api_spec.rb
@@ -20,7 +20,7 @@ describe Chemotion::SearchAPI do
   let(:invalid_reaction_with_duration) do
     create(:reaction, name: 'invalid Reaction', creator: user, duration: 'Day(s)')
   end
-  let(:reaction_with_duration) { create(:reaction, name: 'invalid Reaction', creator: user, duration: '1 Day(s)') }
+  let(:reaction_with_duration) { create(:reaction, name: 'invalid Reaction', creator: user, duration: '1.33 Day(s)') }
   let(:other_reaction) { create(:reaction, name: 'Other Reaction', samples: [sample_c, sample_d], creator: other_user) }
   let(:screen) { create(:screen, name: 'Screen') }
   let(:other_screen) { create(:screen, name: 'Other Screen') }


### PR DESCRIPTION
This PR solves the problem with the **advanced search** for **durations** and **temperature** search for reactions.

### Part 1: duration

In the DB in the table reactions in the column duration the duration is encoded as as string like "1 Day(s)" or  "4.5 Hour(s)" or other ways. In the search method the postgres sql function" [extract( )]( https://www.postgresql.org/docs/14/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT) is used which requires a certain string content like above.

If the value of the column violates that containt this leads to a crash. 
To avoid this the sql part for generating that query is augmented with an CASE clause which checks if the content is valid and only then executes the extract function.

### Part 2: temperature
In the DB in the table reactions in the column temperature the information about different temperatures are saved in a JSON format. The user can entry a uncontraint string in the UI and the string will than be saved in the json field "userTExt". For the advanced search this json entry is cast to a float value and crashed if the user entered e.g. "-4 to rt" . To avoid this i augmented the sql query again with an CASE statement which first checks if the string has the form of a correct number and only then applys the cast operator.

The regEx might look not very elegant, but to several layers of different contexts (String, Regex, rails orm) some char were not usable and i substitued those chars by:

$ -> \Z
? -> {0,1}

Values without a valid string format are ignored by the search.
