### PR TITLE
refactor: quill to plain text call-backs 

### DIFF
--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -28,7 +28,8 @@ class Container < ApplicationRecord
   belongs_to :containable, polymorphic: true, optional: true
   has_many :attachments, as: :attachable
 
-  before_save :content_to_plain_text
+  around_save :content_to_plain_text,
+              if: -> { extended_metadata_changed? && extended_metadata && extended_metadata['content'].present? }
   # TODO: dependent destroy for attachments should be implemented when attachment get paranoidized instead of this DJ
   before_destroy :delete_attachment
   before_destroy :destroy_datasetable
@@ -71,13 +72,22 @@ class Container < ApplicationRecord
   # rubocop:disable Style/StringLiterals
 
   def content_to_plain_text
-    return unless extended_metadata_changed?
-    return if extended_metadata.blank? || (extended_metadata.present? && extended_metadata['content'].blank?)
+    yield
+    update_content_to_plain_text
+  end
 
+  # rubocop:disable Rails/SkipsModelValidations
+  def update_content_to_plain_text
     plain_text = Chemotion::QuillToPlainText.convert(extended_metadata['content'])
     return if plain_text.blank?
 
-    self.plain_text_content = plain_text
+    update_columns(plain_text_content: plain_text)
+  # we dont want to raise any error if the plain text content is not updated
+  rescue StandardError => e
+    Rails.logger.error("Error while converting content to plain text: #{e.message}")
   end
+  # rubocop:enable Rails/SkipsModelValidations
+
+  handle_asynchronously :update_content_to_plain_text, queue: 'plain_text_container_content'
   # rubocop:enable Style/StringLiterals
 end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -148,8 +148,7 @@ class Reaction < ApplicationRecord
   before_save :cleanup_array_fields
   before_save :scrub
   before_save :auto_format_temperature!
-  before_save :description_to_plain_text
-  before_save :observation_to_plain_text
+  around_save :update_fields_to_plain_text, if: -> { description_changed? || observation_changed? }
   before_create :auto_set_short_label
 
   after_create :update_counter
@@ -291,16 +290,27 @@ class Reaction < ApplicationRecord
     Chemotion::Sanitizer.scrub_xml(value)
   end
 
-  def description_to_plain_text
-    return unless description_changed?
-
-    self.plain_text_description = Chemotion::QuillToPlainText.convert(description)
+  def update_fields_to_plain_text
+    description_changed = description_changed?
+    observation_changed = observation_changed?
+    yield
+    update_to_plain_text(description_changed, observation_changed)
   end
 
-  def observation_to_plain_text
-    return unless observation_changed?
-
-    self.plain_text_observation = Chemotion::QuillToPlainText.convert(observation)
+  # rubocop:disable Rails/SkipsModelValidations
+  def update_to_plain_text(description_changed, observation_changed)
+    update_columns(
+      {
+        plain_text_observation: observation_changed.presence && Chemotion::QuillToPlainText.convert(observation),
+        plain_text_description: description_changed.presence && Chemotion::QuillToPlainText.convert(description),
+      }.compact,
+    )
+  # NB: we don't want to raise an error if the conversion fails
+  rescue StandardError => e
+    Rails.logger.error("Error converting quill to plain text: #{e}")
   end
+  # rubocop:enable Rails/SkipsModelValidations
+
+  handle_asynchronously :update_to_plain_text, queue: 'plain_text_reaction'
 end
 # rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
convert quill to plain text in background job to speed up saving containers or reactions