### PR TITLE
fix: avoid multiple API calls to load the inbox when datasets/attachments are deleted

### DIFF
--- a/app/api/chemotion/attachment_api.rb
+++ b/app/api/chemotion/attachment_api.rb
@@ -77,6 +77,8 @@ module Chemotion
 
     resource :attachments do
       before do
+        next if request.path.end_with?('bulk_delete') && request.request_method == 'DELETE'
+
         @attachment = Attachment.find_by(id: params[:attachment_id])
 
         @attachment = Attachment.find_by(identifier: params[:identifier]) if @attachment.nil? && params[:identifier]
@@ -110,6 +112,25 @@ module Chemotion
           end
           error!('401 Unauthorized', 401) unless can_dwnld
         end
+      end
+
+      desc 'Bulk Delete Attachments'
+      delete 'bulk_delete' do
+        ids = params[:ids]
+        attachments = Attachment.where(id: ids)
+
+        unpermitted_attachments = attachments.reject { |attachment| writable?(attachment) }
+
+        if unpermitted_attachments.any?
+          error!('401 Unauthorized', 401)
+        else
+          deleted_attachments = attachments.destroy_all
+        end
+
+        render json: { deleted_attachments: deleted_attachments }, status: :ok
+      rescue StandardError => e
+        render json: { error: e.message }, status: :unprocessable_entity
+        Rails.logger.error("Error deleting attachments: #{e.message}")
       end
 
       desc 'Delete Attachment'

--- a/app/packs/src/apps/mydb/inbox/DeviceBox.js
+++ b/app/packs/src/apps/mydb/inbox/DeviceBox.js
@@ -188,6 +188,8 @@ export default class DeviceBox extends React.Component {
     const currentItemsCount = device_box.children.length;
     const itemsDeleted = checkedDeviceIds.length;
 
+    const attachmentIdsToDelete = [];
+
     checkedDeviceIds.forEach((checkedDeviceId) => {
       const datasetToDelete = device_box.children.find((dataset) => dataset.id === checkedDeviceId);
       if (datasetToDelete) {
@@ -199,10 +201,14 @@ export default class DeviceBox extends React.Component {
       device_box.children.forEach((dataset) => {
         const attachmentToDelete = dataset.attachments.find((attachment) => attachment.id === checkedId);
         if (attachmentToDelete) {
-          InboxActions.deleteAttachment(attachmentToDelete, false);
+          attachmentIdsToDelete.push(checkedId);
         }
       });
     });
+
+    if (attachmentIdsToDelete.length > 0) {
+      InboxActions.bulkDeleteAttachments(attachmentIdsToDelete, false);
+    }
 
     const params = {
       checkedDeviceIds: [],

--- a/app/packs/src/fetchers/AttachmentFetcher.js
+++ b/app/packs/src/fetchers/AttachmentFetcher.js
@@ -343,6 +343,25 @@ export default class AttachmentFetcher {
     return promise;
   }
 
+  static bulkDeleteAttachments(attachmentIdsToDelete) {
+    const promise = fetch('/api/v1/attachments/bulk_delete', {
+      credentials: 'same-origin',
+      method: 'DELETE',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ ids: attachmentIdsToDelete }),
+    })
+      .then((response) => response.json())
+      .then((json) => new Attachment(json.attachment))
+      .catch((errorMessage) => {
+        console.log(errorMessage);
+      });
+
+    return promise;
+  }
+
   static deleteContainerLink(params) {
     const promise = fetch(`/api/v1/attachments/link/${params.id}`, {
       credentials: 'same-origin',
@@ -523,7 +542,7 @@ export default class AttachmentFetcher {
         let jcampIds = oldSpcInfos.map((spc) => (spc.idx));
         const fetchedFilesIdxs = json.files.map((file) => (file.id));
         jcampIds = [...jcampIds, ...fetchedFilesIdxs];
-  
+
         return AttachmentFetcher.combineSpectra(jcampIds, curveIdx).then((res) => {
           return json;
         }).catch((errMsg) => {

--- a/app/packs/src/stores/alt/actions/InboxActions.js
+++ b/app/packs/src/stores/alt/actions/InboxActions.js
@@ -151,6 +151,20 @@ class InboxActions {
     };
   }
 
+  bulkDeleteAttachments(attachmentIdsToDelete, fromUnsorted = false) {
+    return (dispatch) => {
+      AttachmentFetcher.bulkDeleteAttachments(attachmentIdsToDelete)
+        .then((result) => {
+          dispatch({
+            result,
+            fromUnsorted,
+          });
+        }).catch((errorMessage) => {
+          console.log(errorMessage);
+        });
+    };
+  }
+
   deleteContainerLink(params) {
     return (dispatch) => {
       AttachmentFetcher.deleteContainerLink(params)


### PR DESCRIPTION
fix: avoid multiple API calls to load the inbox when datasets/attachments are deleted
add the bulk delete API endpoint for attachments

Closes https://github.com/ComPlat/chemotion/issues/140