### PR TITLE
fix: handle sample xref properties for when xref is null

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/packs/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -312,6 +312,7 @@ export default class SampleForm extends React.Component {
       const object = { value: e, unit };
       sample.xref = { ...sample.xref, flash_point: object };
     } else if (/^xref_/.test(field)) {
+      sample.xref ||= {};
       const key = field.split('xref_')[1];
       sample.xref[key] = e;
     } else if (e && (e.value || e.value === 0)) {
@@ -343,13 +344,15 @@ export default class SampleForm extends React.Component {
 
   textInput(sample, field, label, disabled = false) {
     const condition = field !== 'external_label' && field !== 'xref_inventory_label' && field !== 'name';
+    const updateValue = (/^xref_/.test(field) && sample.xref
+      ? sample.xref[field.split('xref_')[1]] : sample[field]) || '';
     return (
       <FormGroup bsSize={condition ? 'small' : null}>
         <ControlLabel>{label}</ControlLabel>
         <FormControl
           id={`txinput_${field}`}
           type="text"
-          value={(/^xref_/.test(field) ? sample.xref[field.split('xref_')[1]] : sample[field]) || ''}
+          value={updateValue}
           onChange={(e) => { this.handleFieldChanged(field, e.target.value); }}
           disabled={disabled || !sample.can_update}
           readOnly={disabled || !sample.can_update}
@@ -359,8 +362,8 @@ export default class SampleForm extends React.Component {
   }
 
   inputWithUnit(sample, field, label) {
-    const value = sample.xref[field.split('xref_')[1]] ? sample.xref[field.split('xref_')[1]].value : '';
-    const unit = sample.xref[field.split('xref_')[1]] ? sample.xref[field.split('xref_')[1]].unit : '°C';
+    const value = sample.xref && sample.xref[field.split('xref_')[1]] ? sample.xref[field.split('xref_')[1]].value : '';
+    const unit = sample.xref && sample.xref[field.split('xref_')[1]] ? sample.xref[field.split('xref_')[1]].unit : '°C';
     return (
       <NumericInputUnit
         field="flash_point"


### PR DESCRIPTION

- [x] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
