### PR TITLE
chore: default ketcher2 configs in UI Feature

### DIFF
--- a/config/structure_editors.yml.example
+++ b/config/structure_editors.yml.example
@@ -12,6 +12,9 @@ development:
 
 production:
   :editors:
+    :ketcher2:
+      :label: 'Ketcher 2'
+      :extJs: '/editors/ketcher2/standalone/index.html'
     :chemdraw:
       :label: 'ChemDrawJS'
       :license: 'license file'

--- a/db/migrate/20240328150631_update_editor_feat.rb
+++ b/db/migrate/20240328150631_update_editor_feat.rb
@@ -1,0 +1,9 @@
+class UpdateEditorFeat < ActiveRecord::Migration[6.1]
+  def change
+    m = Matrice.find_by(name: 'ketcher2Editor')
+    # update the feature config unless it is already set
+    m && m.configs&.fetch('editor', nil).blank? && m.update_columns(configs: { editor: 'ketcher2' })
+  rescue StandardError => e
+    Rails.logger.error "Error updating editor feature: #{e.message}"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_19_162631) do
+ActiveRecord::Schema.define(version: 2024_03_28_150631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"


### PR DESCRIPTION
- The default editor id for ketcher2 config is missing. Although the ELN Admin can set it, this migration set the default value.
NB: a missing or wrong `editor` value will prevent the option to show up in the Structure Editor Modal

- Also updated the yml example file on pair with the doc (https://github.com/ComPlat/chemotion_saurus/pull/321)