### PR TITLE
feat: admin can restore deleted user account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+# vscode settings
+.vscode/settings.json
+
 # Ignore bundler config.
 /.bundle
 

--- a/app/api/chemotion/admin_user_api.rb
+++ b/app/api/chemotion/admin_user_api.rb
@@ -90,6 +90,23 @@ module Chemotion
         end
       end
 
+      namespace :restoreAccount do
+        desc 'restore deleted user account'
+        params do
+          requires :name_abbreviation, type: String, desc: 'user name name_abbreviation'          
+        end
+        post do
+          user = User.only_deleted.find_by(name_abbreviation: params[:name_abbreviation])
+          error!('Record not found', 404) unless user
+          begin
+            user.update_columns(deleted_at: nil)
+            status 201
+          rescue ActiveRecord::RecordInvalid => e
+            { error: e.message }
+          end
+        end
+      end  
+
       namespace :updateAccount do
         desc 'update account'
         params do

--- a/app/api/chemotion/admin_user_api.rb
+++ b/app/api/chemotion/admin_user_api.rb
@@ -97,7 +97,6 @@ module Chemotion
         end
         post do
           existing_user = User.find_by(name_abbreviation: params[:name_abbreviation])
-          #user = User.only_deleted.find_by('email LIKE ?', "%#{params[:name_abbreviation]}@deleted")
           user = User.only_deleted.where('email LIKE ?', "%#{params[:name_abbreviation]}@deleted")
           error!('Deleted user not found', 404) if user.blank?
           $users_json = []
@@ -106,15 +105,13 @@ module Chemotion
               users = {  id: item.id, deleted_at: item.deleted_at }
               $users_json << users
             end
-            $msg = {status: 'error', warning: 'Warning:  More than one deleted account',  users: $users_json }
+            $msg = {status: 'error', warning: 'Error: More than one deleted account exists!', users: $users_json }
             error!($msg)                  
           elsif user.length == 1 && existing_user.present?
             user.first.update_columns(deleted_at: nil, account_active: false)
             error!(warning: 'Account Restored. Warning: Abbreviation already exists! Please update the Abbreviation and Email')
-            #msg = { :status => "ok", :message => "Success!" }
           else
             user.first.update_columns(deleted_at: nil, name_abbreviation: params[:name_abbreviation])
-            #render json: {status: 'Successfully restored'}
             status 205
           end                
         end

--- a/app/api/chemotion/admin_user_api.rb
+++ b/app/api/chemotion/admin_user_api.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 module Chemotion
   # Publish-Subscription MessageAPI
   class AdminUserAPI < Grape::API
@@ -98,31 +99,33 @@ module Chemotion
         end
         post do
           existing_user = User.find_by(name_abbreviation: params[:name_abbreviation])
-          user = User.only_deleted.where('email LIKE ?', "%#{params[:name_abbreviation]}@deleted")  
+          user = User.only_deleted.where('email LIKE ?', "%#{params[:name_abbreviation]}@deleted")
           user = user.where(id: params[:id]) if params[:id].present?
-            
-          error!({ status: 'error', message: 'Deleted user not found'}) if user.blank?
 
-          if user.length > 1 
+          error!({ status: 'error', message: 'Deleted user not found' }) if user.blank?
+
+          if user.length > 1
             users_json = []
             user.each do |item|
               users = { id: item.id, deleted_at: item.deleted_at }
               users_json << users
             end
-            error!( { status: 'error', 
-                      message: 'Error: More than one deleted account exists! Enter the ID of the account to be restored', 
-                      users: users_json })
+            error!({ status: 'error',
+                     message: 'Error: More than one deleted account exists! Enter the ID of the account to be restored',
+                     users: users_json })
 
+          # rubocop:disable Rails::SkipsModelValidations
           elsif existing_user.nil?
             user.first.update_columns(deleted_at: nil, name_abbreviation: params[:name_abbreviation])
-            { status: 'success', 
-              message: 'Account successfully restored'}
+            { status: 'success',
+              message: 'Account successfully restored' }
 
           elsif existing_user.present?
             user.first.update_columns(deleted_at: nil, account_active: false)
-            { status: 'warning', 
-              message: 'Account restored. Warning: Abbreviation already exists! Please update the Abbreviation and Email'}
-          end             
+            { status: 'warning',
+              message: 'Account restored. Warning: Abbreviation already exists! Please update the Abbr and Email' }
+          end
+          # rubocop:enable Rails::SkipsModelValidations
         end
       end
 
@@ -264,3 +267,4 @@ module Chemotion
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/api/chemotion/admin_user_api.rb
+++ b/app/api/chemotion/admin_user_api.rb
@@ -102,20 +102,20 @@ module Chemotion
           $users_json = []
           if user.length > 1
             user.each do |item|
-              users = {  id: item.id, deleted_at: item.deleted_at }
+              users = { id: item.id, deleted_at: item.deleted_at }
               $users_json << users
             end
-            $msg = {status: 'error', warning: 'Error: More than one deleted account exists!', users: $users_json }
-            error!($msg)                  
+            $msg = { status: 'error', warning: 'Error: More than one deleted account exists!', users: $users_json }
+            error!($msg)
           elsif user.length == 1 && existing_user.present?
             user.first.update_columns(deleted_at: nil, account_active: false)
             error!(warning: 'Account Restored. Warning: Abbreviation already exists! Please update the Abbreviation and Email')
           else
             user.first.update_columns(deleted_at: nil, name_abbreviation: params[:name_abbreviation])
             status 205
-          end                
+          end
         end
-      end  
+      end
 
       namespace :updateAccount do
         desc 'update account'

--- a/app/packs/src/apps/admin/UserManagement.js
+++ b/app/packs/src/apps/admin/UserManagement.js
@@ -441,7 +441,6 @@ export default class UserManagement extends React.Component {
         return false;
       }
       this.setState({ messageRestoreAccountModal: 'Successfully restored the account!', showSuccess: true });
-      // this.setState({ messageRestoreAccountModal: result.status ?? 'OK' , showSuccess: true });
       setTimeout(() => {
         this.nameAbbreviation.value = '';
         this.handleRestoreAccountClose();
@@ -983,9 +982,17 @@ export default class UserManagement extends React.Component {
                   />
                 </Col>
               </FormGroup>
-              <FormGroup controlId="formControlMessage" validationState={`${this.state.showError ? 'error' : this.state.showSuccess ? 'success' : null}`}>
+              <FormGroup
+                controlId="formControlMessage"
+                validationState={`${this.state.showError
+                  ? 'error'
+                  : this.state.showSuccess ? 'success' : null}`}>
                 <Col sm={12}>
-                  <FormControl type="text" readOnly name="messageRestoreAccountModal" value={this.state.messageRestoreAccountModal} />
+                  <FormControl
+                    type="text"
+                    readOnly
+                    name="messageRestoreAccountModal"
+                    value={this.state.messageRestoreAccountModal} />
                 </Col>
               </FormGroup>
               {this.state.deletedUsers.length > 0

--- a/app/packs/src/apps/admin/UserManagement.js
+++ b/app/packs/src/apps/admin/UserManagement.js
@@ -937,7 +937,7 @@ export default class UserManagement extends React.Component {
               </FormGroup>
               <FormGroup controlId="formControlAbbr">
                 <Col componentClass={ControlLabel} sm={3}>
-                  Abbr (3):
+                  Abbr:
                 </Col>
                 <Col sm={9}>
                   <FormControl

--- a/app/packs/src/apps/admin/UserManagement.js
+++ b/app/packs/src/apps/admin/UserManagement.js
@@ -185,7 +185,7 @@ export default class UserManagement extends React.Component {
   handleRestoreAccountShow() {
     this.setState({
       showRestoreAccountModal: true,
-      messageRestoreAccountModal: "",
+      messageRestoreAccountModal: '',
       showSuccess: false,
       showError: false,  
     });
@@ -943,7 +943,7 @@ export default class UserManagement extends React.Component {
             <Form horizontal>
               <FormGroup controlId="formControlAbbr">
                 <Col componentClass={ControlLabel} sm={3}>
-                  Abbr (3):
+                  Abbr:
                 </Col>
                 <Col sm={9}>
                   <FormControl

--- a/app/packs/src/apps/admin/UserManagement.js
+++ b/app/packs/src/apps/admin/UserManagement.js
@@ -974,7 +974,7 @@ export default class UserManagement extends React.Component {
             <Form horizontal>
               <FormGroup controlId="formControlAbbr">
                 <Col componentClass={ControlLabel} sm={3}>
-                  Abbr (3):
+                  Abbr:
                 </Col>
                 <Col sm={9}>
                   <FormControl

--- a/app/packs/src/apps/admin/UserManagement.js
+++ b/app/packs/src/apps/admin/UserManagement.js
@@ -134,6 +134,7 @@ export default class UserManagement extends React.Component {
       messageNewUserModal: '',
       messageEditUserModal: '',
       messageRestoreAccountModal: '',
+      messageRestoreAccountModal: '',
       processingSummaryUserFile: '',
       filterCriteria: {}
     };
@@ -1342,7 +1343,6 @@ export default class UserManagement extends React.Component {
         {this.renderMessageModal()}
         {this.renderNewUserModal()}
         {this.renderEditUserModal()}
-        {this.renderRestoreAccountModal()}
         {this.renderGenericAdminModal()}
       </div>
     );

--- a/app/packs/src/apps/admin/UserManagement.js
+++ b/app/packs/src/apps/admin/UserManagement.js
@@ -134,7 +134,6 @@ export default class UserManagement extends React.Component {
       messageNewUserModal: '',
       messageEditUserModal: '',
       messageRestoreAccountModal: '',
-      messageRestoreAccountModal: '',
       processingSummaryUserFile: '',
       filterCriteria: {}
     };
@@ -964,14 +963,13 @@ export default class UserManagement extends React.Component {
       </Modal>
     );
   }
-
   renderRestoreAccountModal() {
     return (
       <Modal show={this.state.showRestoreAccountModal} onHide={this.handleRestoreAccountClose}>
         <Modal.Header closeButton>
           <Modal.Title>Restore Account</Modal.Title>
         </Modal.Header>
-        <Modal.Body style={{ overflow: 'auto' }}>
+        <Modal.Body style={{ overflow: "auto" }}>
           <div className="col-md-9">
             <Form horizontal>
               <FormGroup controlId="formControlAbbr">
@@ -1343,6 +1341,7 @@ export default class UserManagement extends React.Component {
         {this.renderMessageModal()}
         {this.renderNewUserModal()}
         {this.renderEditUserModal()}
+        {this.renderRestoreAccountModal()}
         {this.renderGenericAdminModal()}
       </div>
     );

--- a/app/packs/src/apps/admin/UserManagement.js
+++ b/app/packs/src/apps/admin/UserManagement.js
@@ -963,13 +963,14 @@ export default class UserManagement extends React.Component {
       </Modal>
     );
   }
+
   renderRestoreAccountModal() {
     return (
       <Modal show={this.state.showRestoreAccountModal} onHide={this.handleRestoreAccountClose}>
         <Modal.Header closeButton>
           <Modal.Title>Restore Account</Modal.Title>
         </Modal.Header>
-        <Modal.Body style={{ overflow: "auto" }}>
+        <Modal.Body style={{ overflow: 'auto' }}>
           <div className="col-md-9">
             <Form horizontal>
               <FormGroup controlId="formControlAbbr">
@@ -1256,7 +1257,7 @@ export default class UserManagement extends React.Component {
             </Button>
           </OverlayTrigger>
           &nbsp;
-          <OverlayTrigger placement="bottom" overlay={<Tooltip id="generic_tooltip">Grant/Revoke Generic Designer</Tooltip>}>
+          <OverlayTrigger placement="bottom" overlay={<Tooltip id="generic_tooltip">Grant/Revoke Generic Designer</Tooltip>} >
             <Button
               bsSize="xsmall"
               bsStyle={(g.generic_admin?.elements || g.generic_admin?.segments || g.generic_admin?.datasets) ? 'success' : 'default'}

--- a/app/packs/src/apps/admin/UserManagement.js
+++ b/app/packs/src/apps/admin/UserManagement.js
@@ -974,7 +974,7 @@ export default class UserManagement extends React.Component {
             <Form horizontal>
               <FormGroup controlId="formControlAbbr">
                 <Col componentClass={ControlLabel} sm={3}>
-                  Abbr:
+                  Abbr (3):
                 </Col>
                 <Col sm={9}>
                   <FormControl

--- a/app/packs/src/apps/admin/UserManagement.js
+++ b/app/packs/src/apps/admin/UserManagement.js
@@ -425,24 +425,30 @@ export default class UserManagement extends React.Component {
   }
 
   handleRestoreAccount = () => {
+    this.setState({ deletedUsers: [] });
     if (this.nameAbbreviation.value.trim() === '') {
       this.setState({ messageRestoreAccountModal: 'Please enter the name abbreviation!', showError: true });
       return false;
     }
+
     AdminFetcher.restoreAccount({
       name_abbreviation: this.nameAbbreviation.value.trim(),
+      id: this.id.value === '' ? null : this.id.value,
+
     }).then((result) => {
       if (result?.users) {
-        this.setState({ messageRestoreAccountModal: result.warning, showError: true, deletedUsers: result.users });
+        this.setState({ messageRestoreAccountModal: result.message, showError: true, deletedUsers: result.users });
         return false;
       }
-      if (result?.error || result?.warning) {
-        this.setState({ messageRestoreAccountModal: result.error ?? result.warning, showError: true });
+
+      if (result.status === 'error' || result.status === 'warning') {
+        this.setState({ messageRestoreAccountModal: result.message, showError: true });
         return false;
       }
-      this.setState({ messageRestoreAccountModal: 'Successfully restored the account!', showSuccess: true });
+      this.setState({ messageRestoreAccountModal: result.message, showSuccess: true });
       setTimeout(() => {
         this.nameAbbreviation.value = '';
+        this.id.value = '';
         this.handleRestoreAccountClose();
       }, 3000);
       return true;
@@ -978,6 +984,23 @@ export default class UserManagement extends React.Component {
                     placeholder="Please enter the name abbreviation"
                     inputRef={(ref) => {
                       this.nameAbbreviation = ref;
+                    }}
+                  />
+                </Col>
+              </FormGroup>
+              <FormGroup controlId="formControlAbbr">
+                <Col componentClass={ControlLabel} sm={3}>
+                  ID:
+                </Col>
+                <Col sm={9}>
+                  <FormControl
+                    type="text"
+                    name="id"
+                    placeholder="Please enter the user ID"
+                    defaultValue=""
+                    onFocus={() => this.setState({ showError: false, showSuccess: false })}
+                    inputRef={(ref) => {
+                      this.id = ref;
                     }}
                   />
                 </Col>

--- a/app/packs/src/apps/admin/UserManagement.js
+++ b/app/packs/src/apps/admin/UserManagement.js
@@ -943,7 +943,7 @@ export default class UserManagement extends React.Component {
             <Form horizontal>
               <FormGroup controlId="formControlAbbr">
                 <Col componentClass={ControlLabel} sm={3}>
-                  Abbr:
+                  Abbr (3):
                 </Col>
                 <Col sm={9}>
                   <FormControl

--- a/app/packs/src/apps/admin/UserManagement.js
+++ b/app/packs/src/apps/admin/UserManagement.js
@@ -107,8 +107,10 @@ export default class UserManagement extends React.Component {
       showNewUserModal: false,
       showEditUserModal: false,
       showGenericAdminModal: false,
+      showRestoreAccountModal: false,
       messageNewUserModal: '',
       messageEditUserModal: '',
+      messageRestoreAccountModal:'',
       processingSummaryUserFile: '',
       filterCriteria: {}
     };
@@ -123,6 +125,9 @@ export default class UserManagement extends React.Component {
     this.handleEditUserShow = this.handleEditUserShow.bind(this);
     this.handleEditUserClose = this.handleEditUserClose.bind(this);
     this.handleUpdateUser = this.handleUpdateUser.bind(this);
+    this.handleRestoreAccountShow = this.handleRestoreAccountShow.bind(this);
+    this.handleRestoreAccountClose = this.handleRestoreAccountClose.bind(this);
+    this.handleRestoreAccount = this.handleRestoreAccount.bind(this);
     this.handleGenericAdminModal = this.handleGenericAdminModal.bind(this);
     this.handleGenericAdminModalCb = this.handleGenericAdminModalCb.bind(this);
   }
@@ -172,6 +177,20 @@ export default class UserManagement extends React.Component {
       showEditUserModal: false,
       messageEditUserModal: '',
       user: {}
+    });
+  }
+
+  handleRestoreAccountShow() {
+    this.setState({
+      showRestoreAccountModal: true,
+      messageRestoreAccountModal: '',   
+    });
+  }
+
+  handleRestoreAccountClose() {
+    this.setState({
+      showRestoreAccountModal: false,
+      messageRestoreAccountModal: '',
     });
   }
 
@@ -377,6 +396,10 @@ export default class UserManagement extends React.Component {
         return true;
       });
     return true;
+  }
+
+  handleRestoreAccount(user) {
+   console.log('Restore Account')
   }
 
   updateFilter = (key, value) => {
@@ -886,6 +909,73 @@ export default class UserManagement extends React.Component {
       </Modal>
     );
   }
+  renderRestoreAccountModal() {
+    //const { user } = this.state;
+    return (
+      <Modal
+        show={this.state.showRestoreAccountModal}
+        onHide={this.handleRestoreAccountClose}
+      >
+        <Modal.Header closeButton>
+          <Modal.Title>Restore Account</Modal.Title>
+        </Modal.Header>
+        <Modal.Body style={{ overflow: 'auto' }}>
+          <div className="col-md-9">
+            <Form horizontal>
+              <FormGroup controlId="formControlEmail">
+                <Col componentClass={ControlLabel} sm={3}>
+                  Email:
+                </Col>
+                <Col sm={9}>
+                  <FormControl
+                    type="email"
+                    name="u_email"
+                   // defaultValue={user.email}
+                    inputRef={(ref) => { this.u_email = ref; }}
+                  />
+                </Col>
+              </FormGroup>
+              <FormGroup controlId="formControlAbbr">
+                <Col componentClass={ControlLabel} sm={3}>
+                  Abbr (3):
+                </Col>
+                <Col sm={9}>
+                  <FormControl
+                    type="text"
+                    name="nameAbbrevation"
+                    //defaultValue={user.initials}
+                    inputRef={(ref) => { this.nameAbbrevation = ref; }}
+                  />
+                </Col>
+              </FormGroup>
+              <FormGroup controlId="formControlMessage">
+                <Col sm={12}>
+                  <FormControl
+                    type="text"
+                    readOnly
+                    name="messageRestoreAccountModal"
+                    value={this.state.messageRestoreAccountModal}
+                  />
+                </Col>
+              </FormGroup>
+              <FormGroup>
+                <Col smOffset={0} sm={10}>
+                  <Button bsStyle="primary" onClick={() => this.handleRestoreAccount()}>
+                    Restore&nbsp;
+                    <i className="fa fa-save" />
+                  </Button>
+                  &nbsp;
+                  <Button bsStyle="warning" onClick={() => this.handleRestoreAccountClose()}>
+                    Cancel&nbsp;
+                  </Button>
+                </Col>
+              </FormGroup>
+            </Form>
+          </div>
+        </Modal.Body>
+      </Modal>
+    );
+  }
 
   renderGenericAdminModal() {
     const { user, showGenericAdminModal } = this.state;
@@ -1171,6 +1261,11 @@ export default class UserManagement extends React.Component {
             New User&nbsp;
             <i className="fa fa-plus" />
           </Button>
+          &nbsp;
+          <Button bsStyle="primary" bsSize="small" onClick={() => this.handleRestoreAccountShow()} data-cy="restore-user">
+            Restore Account&nbsp;
+            <i className="fa fa-undo" />
+          </Button>
         </Panel>
         <Panel>
           <Table>
@@ -1183,6 +1278,7 @@ export default class UserManagement extends React.Component {
         {this.renderMessageModal()}
         {this.renderNewUserModal()}
         {this.renderEditUserModal()}
+        {this.renderRestoreAccountModal()}
         { this.renderGenericAdminModal() }
       </div>
     );

--- a/app/packs/src/fetchers/AdminFetcher.js
+++ b/app/packs/src/fetchers/AdminFetcher.js
@@ -213,23 +213,6 @@ export default class AdminFetcher {
       });
   }
 
-  static restoreAccount(params) {
-    return fetch("/api/v1/admin_user/restoreAccount/", {
-      credentials: "same-origin",
-      method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(params),
-    })
-      .then((response) => response.json())
-      .then((json) => json)
-      .catch((errorMessage) => {
-        console.log(errorMessage);
-      });
-  }
-
   static fetchUsers() {
     return fetch('/api/v1/admin_user/listUsers/all.json', {
       credentials: 'same-origin',

--- a/app/packs/src/fetchers/AdminFetcher.js
+++ b/app/packs/src/fetchers/AdminFetcher.js
@@ -213,6 +213,23 @@ export default class AdminFetcher {
       });
   }
 
+  static restoreAccount(params) {
+    return fetch("/api/v1/admin_user/restoreAccount/", {
+      credentials: "same-origin",
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(params),
+    })
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
+        console.log(errorMessage);
+      });
+  }
+
   static fetchUsers() {
     return fetch('/api/v1/admin_user/listUsers/all.json', {
       credentials: 'same-origin',


### PR DESCRIPTION
Restore deleted Account option in Admin UI:

- Restore deleted account if there is no existing name_abbreviation
- Restore and deactivate the account if name_abbreviation exists
- If multiple deleted users exist:
-  If user ID parameter is not provided :
       - Display the existing deleted accounts to the admin
-with ID: restore the deleted account
 
- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

