### PR TITLE
Fix: sample entry alignment and spacing

### DIFF
--- a/app/packs/src/apps/mydb/elements/list/ElementsTableSampleEntries.js
+++ b/app/packs/src/apps/mydb/elements/list/ElementsTableSampleEntries.js
@@ -364,18 +364,20 @@ export default class ElementsTableSampleEntries extends Component {
             onClick={showDetails.bind(this, sample.id)}
           >
             {sample.title(selected)}
-            <div style={{ float: 'right', display: 'flex', alignItems: 'center' }}>
-              <CommentIcon commentCount={sample.comment_count} />
-              {showDecoupledIcon(sample)}
-              <ShowUserLabels element={sample} />
-              <XvialIcon label={sample.external_label} />
-              <ElementReactionLabels element={sample} key={`${sample.id}_reactions`} />
+
+            <div style={{
+              float: 'right', display: 'flex', alignItems: 'center', gap: '5px'
+            }}
+            >
+              <div style={{ marginTop: '1px' }}><CommentIcon commentCount={sample.comment_count} /></div>
+              <div style={{ marginTop: '3px' }}><ShowUserLabels element={sample} /></div>
+              <div style={{ marginTop: '3px' }}><XvialIcon label={sample.external_label} /></div>
+              <div style={{ marginTop: '1px' }}><ElementReactionLabels element={sample} key={`${sample.id}_reactions`} /></div>
               <ElementWellplateLabels element={sample} key={`${sample.id}_wellplate`} />
               <GenericElementLabels element={sample} key={`${sample.id}_element`} />
-              <div style={{ marginLeft: '5px', marginTop: '-1px' }}>
-                <ElementCollectionLabels element={sample} key={`${sample.id}`} />
-              </div>
+              <ElementCollectionLabels element={sample} key={`${sample.id}`} />
               <ElementAnalysesLabels element={sample} key={`${sample.id}_analyses`} />
+              {showDecoupledIcon(sample)}
               <TopSecretIcon element={sample} />
             </div>
           </td>


### PR DESCRIPTION
Fixes: https://github.com/ComPlat/chemotion_ELN/issues/1847

I showed all the buttons and symbols that I saw for the aligment (see picture)

Some quick and dirty techniques were used because most of the components use css classes that are not universal and serve specific needs. Changing css would break other things

Before: 
![Screenshot from 2024-04-08 10-17-03](https://github.com/ComPlat/chemotion_ELN/assets/59936007/93d8f7e5-16a8-4349-9d92-49e418d58b7c)

After:
![Screenshot from 2024-04-08 10-13-48](https://github.com/ComPlat/chemotion_ELN/assets/59936007/0d06eb6e-bd03-474b-a62a-b47590275455)
