### PR TITLE
fix: the container/dataset fetch API redundant requests being made for each click on deviceBox in the inbox

### DIFF
--- a/app/packs/src/apps/mydb/inbox/DeviceBox.js
+++ b/app/packs/src/apps/mydb/inbox/DeviceBox.js
@@ -66,8 +66,6 @@ export default class DeviceBox extends React.Component {
   handleDeviceBoxClick(deviceBox) {
     const { visible, currentDeviceBoxPage } = this.state;
 
-    InboxActions.setActiveDeviceBoxId(deviceBox.id);
-
     if (!visible) {
       if (Array.isArray(deviceBox.children) && !deviceBox.children.length) {
         LoadingActions.start();

--- a/app/packs/src/stores/alt/actions/InboxActions.js
+++ b/app/packs/src/stores/alt/actions/InboxActions.js
@@ -95,6 +95,7 @@ class InboxActions {
           dispatch({
             inbox: result.inbox,
             currentContainerPage,
+            containerId,
           });
         }).catch((errorMessage) => {
           console.log(errorMessage);

--- a/app/packs/src/stores/alt/stores/InboxStore.js
+++ b/app/packs/src/stores/alt/stores/InboxStore.js
@@ -153,6 +153,7 @@ class InboxStore {
         children: updatedChildren,
       },
       currentContainerPage: payload.currentContainerPage,
+      activeDeviceBoxId: payload.containerId
     }));
 
     this.sync();


### PR DESCRIPTION
Fixed issue where the container/dataset fetch API call was triggered multiple times for each click on deviceBox in the inbox