### PR TITLE
chore(CI): unpin `rubocop` gem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,7 @@ jobs:
           ruby-version: '3.3.0'
 
       - name: install linting dependencies
-        # IMPORTANT: install rubocop first for pinning to take effect (`gem` doesn't resolve dependencies but simply installs gems in order)
-        run: gem install rubocop:1.37.1 pronto pronto-rubocop rubocop-rspec rubocop-rails rubocop-performance    # TODO: unpin rubocop once it's not breaking pronto anymore (as does rubocop:1.38.0)
+        run: gem install rubocop pronto pronto-rubocop rubocop-rspec rubocop-rails rubocop-performance
 
       - name: run Pronto
         run: pronto run -f github_status github_pr_review -c origin/${{ github.base_ref }}


### PR DESCRIPTION
A `rubocop` error breaks the linting job in our CI since version 1.63.
An upcoming release is (hopefully) fixing the error: https://github.com/rubocop/rubocop/issues/12823.

This PR doesn't directly address the error. I just noticed and removed the (ineffective and obsolete) pinning of `rubocop` while I was investigating the CI failure.

Note that the removed comment refers to another, unrelated `rubocop` problem (with version 1.38).