### PR TITLE
fix: add cell lines to structure search result

### DIFF
--- a/app/usecases/search/structure_search.rb
+++ b/app/usecases/search/structure_search.rb
@@ -33,6 +33,10 @@ module Usecases
         scope = basic_scope
         elements_by_scope(scope)
         @shared_methods.serialization_by_elements_and_page(@elements, '')
+
+        results = @shared_methods.serialization_by_elements_and_page(@elements, '')
+        results['cell_lines'] = { elements: [], ids: [], page: 1, perPage: params["per_page"], pages: 0, totalElements: 0, error: '' }
+        results
       end
 
       private


### PR DESCRIPTION
This PR patches a crash that occurs if the user searches with the **structure search** and has in its **profile** the **cell line element** visible. The process requires in a search result an result part associated to all visible elements.
Cell lines were missing, so i put an empty result set to a result. 
