### PR TITLE
feat: admin can delete single user account

### DIFF
--- a/app/api/chemotion/admin_api.rb
+++ b/app/api/chemotion/admin_api.rb
@@ -11,7 +11,7 @@ module Chemotion
     helpers AdminHelpers
     resource :admin do
       before do
-        error(401) unless current_user.is_a?(Admin)
+        error!(401) unless current_user.is_a?(Admin)
       end
 
       desc 'Check disk space'

--- a/app/api/chemotion/admin_user_api.rb
+++ b/app/api/chemotion/admin_user_api.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
+# rubocop:disable Metrics/ClassLength, Rails/HelperInstanceVariable
 module Chemotion
-  # Publish-Subscription MessageAPI
+  # desc: AdminUserApi class to manage the users and their roles
   class AdminUserAPI < Grape::API
-    resource :admin_user do
-      namespace :listUsers do
+    resource :admin do
+      before { error!('401 Unauthorized', 401) unless current_user.is_a?(Admin) }
+
+      # users resource for admin - CRUD + specific actions
+      namespace :users do
         desc 'Find all users'
-        get 'all' do
+        get do
           present User.all.order('type desc, id'), with: Entities::UserEntity, root: 'users'
         end
 
@@ -26,78 +29,13 @@ module Chemotion
                        .limit(params[:limit])
           present users, with: Entities::UserSimpleEntity, root: 'users'
         end
-      end
 
-      namespace :resetPassword do
-        desc 'reset user password'
-        params do
-          requires :user_id, type: Integer, desc: 'user id'
-          requires :random, type: Boolean, desc: 'random password?'
-          optional :password, type: String, desc: 'user pwd', values: ->(v) { v.length > 7 }
-        end
-        post do
-          u = User.find(params[:user_id])
-          pwd = nil
-          rp = if params[:password] || !Rails.env.production? || params[:random]
-                 pwd = params[:password].presence || Devise.friendly_token.first(8)
-                 u.reset_password(pwd, pwd)
-               else
-                 u.respond_to?(:send_reset_password_instructions) && u.send_reset_password_instructions
-               end
-          status(400) unless rp
-          { pwd: pwd, rp: rp, email: u.email }
-        end
-      end
-
-      namespace :newUser do
-        desc 'crate new user account'
-        params do
-          requires :email, type: String, desc: 'user email'
-          requires :password, type: String, desc: 'user password'
-          requires :first_name, type: String, desc: 'user first_name'
-          requires :last_name, type: String, desc: 'user last_name'
-          requires :type, type: String, desc: 'user type'
-          requires :name_abbreviation, type: String, desc: 'user name abbr'
-        end
-        post do
-          attributes = declared(params, include_missing: false)
-          User.create!(attributes)
-          status 201
-        rescue ActiveRecord::RecordInvalid => e
-          { error: e.message }
-        end
-      end
-
-      namespace :updateUser do
-        desc 'update user account'
-        params do
-          requires :id, type: Integer, desc: 'user ID'
-          requires :email, type: String, desc: 'user email'
-          requires :first_name, type: String, desc: 'user first_name'
-          requires :last_name, type: String, desc: 'user last_name'
-          requires :name_abbreviation, type: String, desc: 'user name name_abbreviation'
-          requires :type, type: String, desc: 'user type'
-        end
-        post do
-          attributes = declared(params, include_missing: false)
-          user = User.find_by(id: params[:id])
-          error!('401 Not found', 404) unless user
-          begin
-            user.update!(attributes) unless attributes.empty?
-            status 201
-          rescue ActiveRecord::RecordInvalid => e
-            { error: e.message }
-          end
-        end
-      end
-
-      namespace :restoreAccount do
         desc 'restore deleted user account'
         params do
           requires :name_abbreviation, type: String, desc: 'user name name_abbreviation'
           optional :id, type: Integer, desc: 'user ID'
         end
-        post do
+        post :restoreAccount do
           existing_user = User.find_by(name_abbreviation: params[:name_abbreviation])
           user = User.only_deleted.where('email LIKE ?', "%#{params[:name_abbreviation]}@deleted")
           user = user.where(id: params[:id]) if params[:id].present?
@@ -127,144 +65,189 @@ module Chemotion
           end
           # rubocop:enable Rails::SkipsModelValidations
         end
-      end
 
-      namespace :updateAccount do
-        desc 'update account'
+        desc 'create new user account'
         params do
-          requires :user_id, type: Integer, desc: 'user id'
-          optional :enable, type: Boolean, desc: 'enable or disable account'
-          optional :is_templates_moderator, type: Boolean, desc: 'enable or disable ketcherails template moderation'
-          optional :confirm_user, type: Boolean, desc: 'confirm account'
-          optional :reconfirm_user, type: Boolean, desc: 'reconfirm account'
-          optional :molecule_editor, type: Boolean, desc: 'enable or disable molecule moderation'
-          optional :converter_admin, type: Boolean, desc: 'converter profile'
-          optional :account_active, type: Boolean, desc: 'active or inactive this user'
-          optional :auth_generic_admin, type: Hash do
-            optional :elements, type: Boolean, desc: 'un-authorize the user as generic elements admin'
-            optional :segments, type: Boolean, desc: 'un-authorize the user as generic segments admin'
-            optional :datasets, type: Boolean, desc: 'un-authorize the user as generic datasets admin'
-          end
+          requires :email, type: String, desc: 'user email'
+          requires :password, type: String, desc: 'user password'
+          requires :first_name, type: String, desc: 'user first_name'
+          requires :last_name, type: String, desc: 'user last_name'
+          requires :type, type: String, desc: 'user type'
+          requires :name_abbreviation, type: String, desc: 'user name abbr'
+        end
+        post do
+          attributes = declared(params, include_missing: false)
+          User.create!(attributes)
+          status 201
+        rescue ActiveRecord::RecordInvalid => e
+          { error: e.message }
         end
 
-        post do
-          user = User.find_by(id: params[:user_id])
-          unless params[:enable].nil?
-            case params[:enable]
+        route_param :user_id, type: Integer, desc: 'user ID' do
+          after_validation do
+            @user = User.find(params.delete(:user_id))
+          end
+
+          rescue_from ActiveRecord::RecordNotFound do
+            error!('404 user with given id not found', 404)
+          end
+
+          desc 'Find user by ID'
+          get do
+            present @user, with: Entities::UserEntity
+          end
+
+          desc 'update user account'
+          params do
+            optional :email, type: String, desc: 'user email'
+            optional :first_name, type: String, desc: 'user first_name'
+            optional :last_name, type: String, desc: 'user last_name'
+            optional :name_abbreviation, type: String, desc: 'user name name_abbreviation'
+            optional :type, type: String, desc: 'user type'
+            optional :account_active, type: Boolean, desc: '(in)activate or activate user account'
+            # special params
+            optional :enable, type: Boolean, desc: '(un)lock user account'
+            optional :confirm_user, type: Boolean, desc: 'confirm account'
+            optional :reconfirm_user, type: Boolean, desc: 'reconfirm account (email changed)'
+          end
+          put do
+            # (un)lock user - does nothing when params[:enable] is nil
+            case params.delete(:enable)
             when true
-              user.unlock_access!
+              @user.unlock_access!
             when false
-              user.lock_access!(send_instructions: false)
+              @user.lock_access!(send_instructions: false)
             end
-          end
 
-          if params[:reconfirm_user].present? && (params[:reconfirm_user] == true)
-            user.update_columns(email: user.unconfirmed_email,
-                                unconfirmed_email: nil)
-          end
+            # confirm user new email - does nothing when params[:reconfirm_user] is nil
+            if params.delete(:reconfirm_user) == true
+              # rubocop:disable Rails::SkipsModelValidations
+              @user.update_columns(email: @user.unconfirmed_email, unconfirmed_email: nil)
+              # rubocop:enable Rails::SkipsModelValidations
+            end
 
-          unless params[:confirm_user].nil?
-            case params[:confirm_user]
+            # confirm user - does nothing when params[:confirm_user] is nil
+            case params.delete(:confirm_user)
             when true
-              user.update!(confirmed_at: DateTime.now)
+              @user.update!(confirmed_at: DateTime.now)
             when false
-              user.update!(confirmed_at: nil)
+              @user.update!(confirmed_at: nil)
+            end
+
+            attributes = declared(params, include_missing: false)
+            begin
+              @user.update!(attributes) unless attributes.empty?
+              present @user, with: Entities::UserEntity
+            rescue ActiveRecord::RecordInvalid => e
+              { error: e.message }
             end
           end
 
-          unless params[:is_templates_moderator].nil?
-            case params[:is_templates_moderator]
-            when true, false
-              profile = user.profile
+          desc 'delete user account'
+          delete do
+            @user.destroy!
+            status 204
+          end
+
+          desc 'reset user password'
+          params do
+            requires :random, type: Boolean, desc: 'random password?'
+            optional :password, type: String, desc: 'user pwd', values: ->(v) { v.length > 7 }
+          end
+          put :resetPassword do
+            pwd = nil
+            rp = if params[:password] || params[:random]
+                   pwd = params[:password].presence || Devise.friendly_token.first(10)
+                   @user.reset_password(pwd, pwd)
+                 else
+                   @user.respond_to?(:send_reset_password_instructions) && @user.send_reset_password_instructions
+                 end
+            status(400) unless rp
+            { pwd: pwd, rp: rp, email: @user.email }
+          end
+
+          # desc: manage user roles saved in user profile
+          namespace :profile do
+            desc 'get user profile'
+            get do
+              @user.profile
+            end
+
+            desc 'update user profile'
+            params do
+              optional :is_templates_moderator, type: Boolean,
+                                                desc: 'enable or disable ketcherails template moderation'
+              optional :molecule_editor, type: Boolean, desc: 'enable or disable molecule moderation'
+              optional :converter_admin, type: Boolean, desc: 'converter profile'
+              optional :auth_generic_admin, type: Hash do
+                optional :elements, type: Boolean, desc: 'un-authorize the user as generic elements admin'
+                optional :segments, type: Boolean, desc: 'un-authorize the user as generic segments admin'
+                optional :datasets, type: Boolean, desc: 'un-authorize the user as generic datasets admin'
+              end
+            end
+
+            put do
+              profile = @user.profile
               pdata = profile.data || {}
-              data = pdata.merge('is_templates_moderator' => params[:is_templates_moderator])
-              profile.update!(data: data)
+              case params[:is_templates_moderator]
+              when true, false
+                pdata = pdata.merge('is_templates_moderator' => params[:is_templates_moderator])
+              end
+
+              case params[:converter_admin]
+              when true, false
+                pdata = pdata.merge('converter_admin' => params[:converter_admin])
+              end
+
+              case params[:molecule_editor]
+              when true, false
+                pdata = pdata.merge('molecule_editor' => params[:molecule_editor])
+              end
+
+              if params[:auth_generic_admin].present?
+                pdata = pdata.deep_merge('generic_admin' => params[:auth_generic_admin])
+              end
+
+              profile.update!(data: pdata)
+              present @user, with: Entities::UserEntity
             end
           end
-
-          unless params[:converter_admin].nil?
-            case params[:converter_admin]
-            when true, false
-              profile = user.profile
-              pdata = profile.data || {}
-              data = pdata.merge('converter_admin' => params[:converter_admin])
-              profile.update!(data: data)
-            end
-          end
-
-          unless params[:molecule_editor].nil?
-            case params[:molecule_editor]
-            when true, false
-              profile = user.profile
-              pdata = profile.data || {}
-              data = pdata.merge('molecule_editor' => params[:molecule_editor])
-              profile.update!(data: data)
-            end
-          end
-
-          user.update!(account_active: params[:account_active]) unless params[:account_active].nil?
-          if params[:auth_generic_admin].present?
-            profile = user.profile
-            pdata = profile.data || {}
-            data = pdata.deep_merge('generic_admin' => params[:auth_generic_admin])
-            profile.update!(data: data)
-          end
-
-          present user, with: Entities::UserEntity
         end
       end
-    end
-
-    resource :matrix do
-      namespace :list do
+      resource :matrix do
         desc 'Find all matrices'
         get do
           present Matrice.all.order('id'), with: Entities::MatriceEntity, root: 'matrices'
         end
-      end
 
-      namespace :update do
         desc 'update matrice'
         params do
           requires :id, type: Integer, desc: 'Matrice ID'
-          requires :label, type: String, desc: 'Matrice label'
-          requires :enabled, type: Boolean, desc: 'globally enabled'
+          optional :label, type: String, desc: 'Matrice label'
+          optional :enabled, type: Boolean, desc: 'globally enabled'
           optional :include_ids, type: Array, desc: 'include_ids'
           optional :exclude_ids, type: Array, desc: 'exclude_ids'
+          optional :configs, type: Hash, desc: 'configs'
         end
-        post do
+        put do
           attributes = declared(params, include_missing: false)
-          matrice = Matrice.find_by(id: params[:id])
-          error!('401 Not found', 404) unless matrice
+          matrice = Matrice.find(params.delete(:id))
           begin
             matrice.update!(attributes) unless attributes.empty?
+            load Rails.root.join('config/initializers/devise.rb') if params[:configs].present?
             status 201
           rescue ActiveRecord::RecordInvalid => e
+            if params[:configs].present?
+              Rails.logger.error ['update_json', e.message,
+                                  *e.backtrace].join($INPUT_RECORD_SEPARATOR)
+            end
             { error: e.message }
           end
-        end
-      end
-
-      namespace :update_json do
-        desc 'update matrice configs'
-        params do
-          requires :id, type: Integer, desc: 'Matrice ID'
-          requires :configs, type: Hash, desc: 'Matrice configs'
-        end
-        post do
-          matrice = Matrice.find_by(id: params[:id])
-          error!('401 Not found', 401) unless matrice
-          begin
-            matrice.update!(configs: params[:configs])
-            load Rails.root.join('config/initializers/devise.rb')
-            status 201
-          rescue ActiveRecord::RecordInvalid => e
-            Rails.logger.error ['update_json', e.message, *e.backtrace].join($INPUT_RECORD_SEPARATOR)
-            { error: e.message }
-          end
+        rescue ActiveRecord::RecordNotFound
+          error!('404 Not found', 404) unless matrice
         end
       end
     end
   end
 end
-# rubocop:enable Metrics/ClassLength
+# rubocop:enable Metrics/ClassLength, Rails/HelperInstanceVariable

--- a/app/packs/src/apps/admin/MatrixManagement.js
+++ b/app/packs/src/apps/admin/MatrixManagement.js
@@ -137,7 +137,7 @@ export default class MatrixManagement extends React.Component {
 
 
   handleJsonSave(matrice) {
-    AdminFetcher.updateMatriceJson({ id: matrice.id, configs: matrice.configs })
+    AdminFetcher.updateMatrice({ id: matrice.id, configs: matrice.configs })
       .then((result) => {
         if (result.error) {
           Notification({ title: `Function [${matrice.name}]`, lvl: 'error', msg: result.error });

--- a/app/packs/src/apps/admin/UserManagement.js
+++ b/app/packs/src/apps/admin/UserManagement.js
@@ -1,14 +1,36 @@
 /* eslint-disable react/destructuring-assignment */
 import React from 'react';
 import {
-  Panel, Table, Button, Modal, FormGroup, ControlLabel, Form, Col, FormControl, Tooltip, OverlayTrigger, Tabs, Tab
+  Panel, Table, Button, Modal, FormGroup, ControlLabel, Form, Col, FormControl, Tooltip, OverlayTrigger, Tabs, Tab,
+  Nav, NavItem, Alert
 } from 'react-bootstrap';
 import Select from 'react-select';
 import { CSVReader } from 'react-papaparse';
+import propType from 'prop-types';
 import AdminFetcher from 'src/fetchers/AdminFetcher';
 import MessagesFetcher from 'src/fetchers/MessagesFetcher';
 import { selectUserOptionFormater } from 'src/utilities/selectHelper';
 import GenericAdminModal from 'src/apps/admin/generic/GenericAdminModal';
+
+function MessageAlert({ message, onHide }) {
+  return (
+    message?.length > 0 ? (
+      <Alert bsStyle="info" onDismiss={onHide}>
+        <p>
+          {message}
+        </p>
+      </Alert>
+    ) : null
+  );
+}
+
+MessageAlert.propTypes = {
+  message: propType.string,
+  onHide: propType.func.isRequired,
+};
+MessageAlert.defaultProps = {
+  message: '',
+};
 
 const loadUserByName = (input) => {
   if (!input) {
@@ -22,21 +44,21 @@ const loadUserByName = (input) => {
     });
 };
 
-const handleResetPassword = (id, random) => {
+const handleResetPassword = (id, random, handleShowAlert) => {
   AdminFetcher.resetUserPassword({ user_id: id, random })
     .then((result) => {
       if (result.rp) {
         let message = '';
         if (random) {
-          message = result.pwd ? `Password reset! New password: \n ${result.pwd}`
+          message = result.pwd ? `Password reset for user ${id}! New password: \n ${result.pwd}`
             : 'Password reset!';
         } else {
           message = result.email ? `Password reset! instructions sent to : \n ${result.email}`
             : 'Password instruction sent!';
         }
-        alert(message);
+        handleShowAlert(message);
       } else {
-        alert(`Password reset fail: \n ${result.pwd}`);
+        handleShowAlert(`Password reset fail: \n ${result.pwd}`);
       }
     });
 };
@@ -87,12 +109,12 @@ const moleculeModeratorDisableTooltip = (
 );
 const accountActiveTooltip = (
   <Tooltip id="assign_button">
-    This user account is deactivated, press button to [activate]
+    This user account is deactivated, click to [activate]
   </Tooltip>
 );
 const accountInActiveTooltip = (
   <Tooltip id="assign_button">
-    This user account is activated, press button to [deactivate]
+    This user account is activated, click to [deactivate]
   </Tooltip>
 );
 
@@ -135,6 +157,7 @@ export default class UserManagement extends React.Component {
       messageEditUserModal: '',
       messageRestoreAccountModal: '',
       processingSummaryUserFile: '',
+      alertMessage: null,
       filterCriteria: {}
     };
     this.handleFetchUsers = this.handleFetchUsers.bind(this);
@@ -153,10 +176,21 @@ export default class UserManagement extends React.Component {
     this.handleRestoreAccount = this.handleRestoreAccount.bind(this);
     this.handleGenericAdminModal = this.handleGenericAdminModal.bind(this);
     this.handleGenericAdminModalCb = this.handleGenericAdminModalCb.bind(this);
+    this.handleDismissAlert = this.handleDismissAlert.bind(this);
+    this.handleShowAlert = this.handleShowAlert.bind(this);
+    this.tableBodyRef = React.createRef();
   }
 
   componentDidMount() {
     this.handleFetchUsers();
+    // update maxHeight for user table body
+    if (this.tableBodyRef?.current) {
+      // Get the available space
+      const availableSpace = window.innerHeight - this.tableBodyRef.current.getBoundingClientRect().top;
+
+      // Set the max-height dynamically
+      this.tableBodyRef.current.style.maxHeight = `${availableSpace}px`;
+    }
     return true;
   }
 
@@ -220,15 +254,22 @@ export default class UserManagement extends React.Component {
     this.handleFetchUsers();
   }
 
+  handleDismissAlert() {
+    this.setState({ alertMessage: null });
+  }
+
+  handleShowAlert(message) {
+    this.setState({ alertMessage: message });
+  }
+
   handleGenericAdminModalCb(user) {
-    AdminFetcher.fetchUsers()
-      .then((result) => {
-        let updated = result.users.find((u) => u.id === user.id);
-        updated = updated || user;
-        this.setState({
-          users: result.users, user: updated
-        });
-      });
+    const { users } = this.state;
+    const { id, error } = user;
+    if (error) { this.setState({ alertMessage: error }); }
+    this.setState({
+      users: users.map((u) => (u.id === id ? user : u)),
+      user,
+    });
   }
 
   handleGenericAdminModal(show, user = {}) {
@@ -245,52 +286,30 @@ export default class UserManagement extends React.Component {
   }
 
   handleEnableDisableAccount(id, lockedAt) {
-    AdminFetcher.updateAccount({ user_id: id, enable: lockedAt !== null })
-      .then(() => {
-        this.handleFetchUsers();
-        const message = lockedAt !== null ? 'Account unlocked!' : 'Account locked!'; //
-        alert(message);
-      });
+    const message = lockedAt !== null ? 'Account unlocked!' : 'Account locked! User can unlock it under condition'; //
+    this.updateUser({ id, enable: lockedAt !== null }, message);
   }
 
   handleConverterAdmin(id, isConverterAdmin) {
-    AdminFetcher.updateAccount({ user_id: id, converter_admin: !isConverterAdmin })
-      .then(() => {
-        this.handleFetchUsers();
-        const message = isConverterAdmin === true
-          ? 'Disable Converter profiles editing for this user' : 'Enable Converter profiles editing for this user';
-        alert(message);
-      });
+    const message = `Converter-profiles editing has been ${isConverterAdmin === true ? 'dis' : 'en'}abled for user ${id}`;
+    this.updateProfile({ user_id: id, converter_admin: !isConverterAdmin }, message);
   }
 
   handleTemplatesModerator(id, isTemplatesModerator) {
-    AdminFetcher.updateAccount({ user_id: id, is_templates_moderator: !isTemplatesModerator })
-      .then(() => {
-        this.handleFetchUsers();
-        const message = isTemplatesModerator === true
-          ? 'Disable Ketcher template editing for this user' : 'Enable Ketcher template editing for this user';
-        alert(message);
-      });
+    const message = `Ketcher-template editing has been ${isTemplatesModerator === true ? 'en' : 'dis'}abled for user ${id}`;
+    this.updateProfile({ user_id: id, is_templates_moderator: !isTemplatesModerator }, message);
   }
 
   handleMoleculesModerator(id, isMoleculesEditor) {
-    AdminFetcher.updateAccount({ user_id: id, molecule_editor: !isMoleculesEditor })
-      .then(() => {
-        this.handleFetchUsers();
-        const message = isMoleculesEditor === true
-          ? 'Disable editing the representation of the global molecules for this user'
-          : 'Enable editing the representation of the global molecules for this user';
-        alert(message);
-      });
+    const message = isMoleculesEditor === true
+      ? 'Disable editing the representation of the global molecules for this user'
+      : 'Enable editing the representation of the global molecules for this user';
+    this.updateProfile({ user_id: id, molecule_editor: !isMoleculesEditor }, message);
   }
 
   handleActiveInActiveAccount(id, isActive) {
-    AdminFetcher.updateAccount({ user_id: id, account_active: !isActive })
-      .then(() => {
-        this.handleFetchUsers();
-        const message = isActive === true ? 'User is In-Active!' : 'User is Active now!';
-        alert(message);
-      });
+    const message = `User ${id} account has been ${isActive === true ? 'de-' : ''}activated!`;
+    this.updateUser({ id, account_active: !isActive }, message);
   }
 
   handleSelectUser(val) {
@@ -300,23 +319,11 @@ export default class UserManagement extends React.Component {
   }
 
   handleConfirmUserAccount(id) {
-    AdminFetcher.updateAccount({ user_id: id, confirm_user: true })
-      .then((result) => {
-        if (result !== null) {
-          this.handleFetchUsers();
-          alert('User Account has been confirmed!');
-        }
-      });
+    this.updateUser({ id, confirm_user: true }, `User ${id} account has been confirmed!`);
   }
 
   handleReConfirmUserAccount(id) {
-    AdminFetcher.updateAccount({ user_id: id, reconfirm_user: true })
-      .then((result) => {
-        if (result !== null) {
-          this.handleFetchUsers();
-          alert('User New Email has been confirmed!');
-        }
-      });
+    this.updateUser({ id, reconfirm_user: true }, `User ${id} new Email has been confirmed!`);
   }
 
   handleCreateNewUser() {
@@ -413,15 +420,44 @@ export default class UserManagement extends React.Component {
           this.setState({ messageEditUserModal: result.error });
           return false;
         }
-        this.setState({ showEditUserModal: false, messageEditUserModal: '' });
+        // update this.state.users with result
+        const { users } = this.state;
+        const index = users.findIndex((u) => u.id === user.id);
+        users[index] = result;
+
+        this.setState({
+          users, showEditUserModal: false, messageEditUserModal: '', alertMessage: `User ${user.id} account has been updated.`
+        });
         this.u_email.value = '';
         this.u_firstname.value = '';
         this.u_lastname.value = '';
         this.u_abbr.value = '';
-        this.handleFetchUsers();
         return true;
       });
     return true;
+  }
+
+  handleDeleteUser(user) {
+    AdminFetcher.deleteUser({ id: user.id }).then(
+      (result) => {
+        if (result.error) {
+          this.setState({ showEditUserModal: false, alertMessage: result.error });
+          return false;
+        }
+        // remove deleted user from this.state.users
+        const { users } = this.state;
+        const index = users.findIndex((u) => u.id === user.id);
+        if (index > -1) {
+          users.splice(index, 1);
+        }
+        this.setState({
+          showEditUserModal: false,
+          alertMessage: `User with name abbreviation ${user.initials} has been deleted!`,
+          users,
+        });
+        return true;
+      }
+    );
   }
 
   handleRestoreAccount = () => {
@@ -464,6 +500,40 @@ export default class UserManagement extends React.Component {
       }
     }));
   };
+
+  updateUser(params, message = null) {
+    const { users } = this.state;
+    AdminFetcher.updateUser(params)
+      .then((result) => {
+        if (result.error) {
+          this.handleShowAlert(result.error);
+          return false;
+        }
+        this.setState({
+          users: users.map((user) => (user.id === params.id ? result : user)),
+          user: result,
+          alertMessage: message
+        });
+        return true;
+      });
+  }
+
+  updateProfile(params, message = null) {
+    const { users } = this.state;
+    AdminFetcher.updateAccount(params)
+      .then((result) => {
+        if (result.error) {
+          this.handleShowAlert(result.error);
+          return false;
+        }
+        this.setState({
+          users: users.map((user) => (user.id === result.id ? result : user)),
+          user: result,
+          alertMessage: message
+        });
+        return true;
+      });
+  }
 
   updateDropdownFilter(field, value) {
     this.setState((prevState) => ({
@@ -609,9 +679,9 @@ export default class UserManagement extends React.Component {
   messageSend() {
     const { selectedUsers } = this.state;
     if (this.myMessage.value === '') {
-      alert('Please input the message!');
+      this.handleShowAlert('Please input the message!');
     } else if (!selectedUsers) {
-      alert('Please select user(s)!');
+      this.handleShowAlert('Please select user(s)!');
     } else {
       const userIds = [];
       selectedUsers.map((g) => {
@@ -856,111 +926,214 @@ export default class UserManagement extends React.Component {
   renderEditUserModal() {
     const { user } = this.state;
     return (
-      <Modal
-        show={this.state.showEditUserModal}
-        onHide={this.handleEditUserClose}
-      >
-        <Modal.Header closeButton>
-          <Modal.Title>Edit User</Modal.Title>
-        </Modal.Header>
-        <Modal.Body style={{ overflow: 'auto' }}>
-          <div className="col-md-9">
-            <Form horizontal>
-              <FormGroup controlId="formControlEmail">
-                <Col componentClass={ControlLabel} sm={3}>
-                  Email:
-                </Col>
-                <Col sm={9}>
-                  <FormControl
-                    type="email"
-                    name="u_email"
-                    defaultValue={user.email}
-                    inputRef={(ref) => { this.u_email = ref; }}
-                  />
-                </Col>
-              </FormGroup>
-              <FormGroup controlId="formControlFirstName">
-                <Col componentClass={ControlLabel} sm={3}>
-                  First name:
-                </Col>
-                <Col sm={9}>
-                  <FormControl
-                    type="text"
-                    name="u_firstname"
-                    defaultValue={user.first_name}
-                    inputRef={(ref) => { this.u_firstname = ref; }}
-                  />
-                </Col>
-              </FormGroup>
-              <FormGroup controlId="formControlLastName">
-                <Col componentClass={ControlLabel} sm={3}>
-                  Last name:
-                </Col>
-                <Col sm={9}>
-                  <FormControl
-                    type="text"
-                    name="u_lastname"
-                    defaultValue={user.last_name}
-                    inputRef={(ref) => { this.u_lastname = ref; }}
-                  />
-                </Col>
-              </FormGroup>
-              <FormGroup controlId="formControlAbbr">
-                <Col componentClass={ControlLabel} sm={3}>
-                  Abbr (3):
-                </Col>
-                <Col sm={9}>
-                  <FormControl
-                    type="text"
-                    name="u_abbr"
-                    defaultValue={user.initials}
-                    inputRef={(ref) => { this.u_abbr = ref; }}
-                  />
-                </Col>
-              </FormGroup>
-              <FormGroup controlId="formControlsType">
-                <Col componentClass={ControlLabel} sm={3}>
-                  Type:
-                </Col>
-                <Col sm={9}>
-                  <FormControl
-                    componentClass="select"
-                    defaultValue={user.type}
-                    inputRef={(ref) => { this.u_type = ref; }}
-                  >
-                    <option value="Person">Person</option>
-                    <option value="Group">Group</option>
-                    <option value="Device">Device</option>
-                    <option value="Admin">Admin</option>
-                  </FormControl>
-                </Col>
-              </FormGroup>
-              <FormGroup controlId="formControlMessage">
-                <Col sm={12}>
-                  <FormControl
-                    type="text"
-                    readOnly
-                    name="messageEditUserModal"
-                    value={this.state.messageEditUserModal}
-                  />
-                </Col>
-              </FormGroup>
-              <FormGroup>
-                <Col smOffset={0} sm={10}>
-                  <Button bsStyle="primary" onClick={() => this.handleUpdateUser(user)}>
-                    Update&nbsp;
-                    <i className="fa fa-save" />
-                  </Button>
-                  &nbsp;
-                  <Button bsStyle="warning" onClick={() => this.handleEditUserClose()}>
-                    Cancel&nbsp;
-                  </Button>
-                </Col>
-              </FormGroup>
-            </Form>
-          </div>
-        </Modal.Body>
-      </Modal>
+      <Tab.Container id="tabs-with-dropdown" defaultActiveKey="first">
+        <Modal
+          show={this.state.showEditUserModal}
+          onHide={this.handleEditUserClose}
+        >
+          <Modal.Header closeButton>
+            <Modal.Title>
+              <Nav bsStyle="tabs">
+                <NavItem eventKey="first">
+                  Edit user account
+                </NavItem>
+                <NavItem eventKey="second">Delete User</NavItem>
+              </Nav>
+            </Modal.Title>
+          </Modal.Header>
+          <Modal.Body style={{ overflow: 'auto' }}>
+            <Tab.Content animation>
+              <Tab.Pane eventKey="first">
+                <div className="col-md-10 col-md-offset-1">
+                  <Form horizontal>
+                    <FormGroup controlId="formControlEmail">
+                      <Col componentClass={ControlLabel} sm={3}>
+                        Email:
+                      </Col>
+                      <Col sm={9}>
+                        <FormControl
+                          type="email"
+                          name="u_email"
+                          defaultValue={user.email}
+                          inputRef={(ref) => { this.u_email = ref; }}
+                        />
+                      </Col>
+                    </FormGroup>
+                    <FormGroup controlId="formControlFirstName">
+                      <Col componentClass={ControlLabel} sm={3}>
+                        First name:
+                      </Col>
+                      <Col sm={9}>
+                        <FormControl
+                          type="text"
+                          name="u_firstname"
+                          defaultValue={user.first_name}
+                          inputRef={(ref) => { this.u_firstname = ref; }}
+                        />
+                      </Col>
+                    </FormGroup>
+                    <FormGroup controlId="formControlLastName">
+                      <Col componentClass={ControlLabel} sm={3}>
+                        Last name:
+                      </Col>
+                      <Col sm={9}>
+                        <FormControl
+                          type="text"
+                          name="u_lastname"
+                          defaultValue={user.last_name}
+                          inputRef={(ref) => { this.u_lastname = ref; }}
+                        />
+                      </Col>
+                    </FormGroup>
+                    <FormGroup controlId="formControlAbbr">
+                      <Col componentClass={ControlLabel} sm={3}>
+                        Abbr (3):
+                      </Col>
+                      <Col sm={9}>
+                        <FormControl
+                          type="text"
+                          name="u_abbr"
+                          defaultValue={user.initials}
+                          inputRef={(ref) => { this.u_abbr = ref; }}
+                        />
+                      </Col>
+                    </FormGroup>
+                    <FormGroup controlId="formControlsType">
+                      <Col componentClass={ControlLabel} sm={3}>
+                        Type:
+                      </Col>
+                      <Col sm={9}>
+                        <FormControl
+                          componentClass="select"
+                          defaultValue={user.type}
+                          inputRef={(ref) => { this.u_type = ref; }}
+                        >
+                          <option value="Person">Person</option>
+                          <option value="Group">Group</option>
+                          <option value="Device">Device</option>
+                          <option value="Admin">Admin</option>
+                        </FormControl>
+                      </Col>
+                    </FormGroup>
+                    <FormGroup controlId="formControlMessage">
+                      <Col sm={12}>
+                        <FormControl
+                          type="text"
+                          readOnly
+                          name="messageEditUserModal"
+                          value={this.state.messageEditUserModal}
+                        />
+                      </Col>
+                    </FormGroup>
+                    <FormGroup>
+                      <Button className="col-sm-5" onClick={() => this.handleEditUserClose()}>
+                        Cancel&nbsp;
+                      </Button>
+                      <Col sm={2}>&nbsp;</Col>
+                      <Button bsStyle="primary" className="col-sm-5" onClick={() => this.handleUpdateUser(user)}>
+                        Update&nbsp;
+                        <i className="fa fa-save" />
+                      </Button>
+                    </FormGroup>
+                  </Form>
+                </div>
+              </Tab.Pane>
+              <Tab.Pane eventKey="second">
+                <div className="col-md-10 col-md-offset-1">
+
+                  <Form horizontal>
+                    <FormGroup controlId="formControlEmail">
+                      <Col componentClass={ControlLabel} sm={3}>
+                        Email:
+                      </Col>
+                      <Col sm={9}>
+                        <FormControl
+                          type="email"
+                          name="u_email"
+                          defaultValue={user.email}
+                          disabled
+                        />
+                      </Col>
+                    </FormGroup>
+                    <FormGroup controlId="formControlFirstName">
+                      <Col componentClass={ControlLabel} sm={3}>
+                        First name:
+                      </Col>
+                      <Col sm={9}>
+                        <FormControl
+                          type="text"
+                          name="u_firstname"
+                          defaultValue={user.first_name}
+                          disabled
+                        />
+                      </Col>
+                    </FormGroup>
+                    <FormGroup controlId="formControlLastName">
+                      <Col componentClass={ControlLabel} sm={3}>
+                        Last name:
+                      </Col>
+                      <Col sm={9}>
+                        <FormControl
+                          type="text"
+                          name="u_lastname"
+                          defaultValue={user.last_name}
+                          disabled
+                        />
+                      </Col>
+                    </FormGroup>
+                    <FormGroup controlId="formControlAbbr">
+                      <Col componentClass={ControlLabel} sm={3}>
+                        Abbr (3):
+                      </Col>
+                      <Col sm={9}>
+                        <FormControl
+                          type="text"
+                          name="u_abbr"
+                          defaultValue={user.initials}
+                          disabled
+                        />
+                      </Col>
+                    </FormGroup>
+                    <FormGroup controlId="formControlsType">
+                      <Col componentClass={ControlLabel} sm={3}>
+                        Type:
+                      </Col>
+                      <Col sm={9}>
+                        <FormControl
+                          disabled
+                          defaultValue={user.type}
+                        />
+                      </Col>
+                    </FormGroup>
+                    <FormGroup controlId="formControlMessage">
+                      <Col sm={12}>
+                        <FormControl
+                          type="text"
+                          readOnly
+                          name="messageEditUserModal"
+                          value="Delete User Account. Are you sure ?"
+                          bsClass="form-control alert-danger text-center"
+                        />
+                      </Col>
+                    </FormGroup>
+
+                    <FormGroup>
+                      <Button className="col-sm-5" onClick={() => this.handleEditUserClose()}>
+                        Cancel
+                      </Button>
+                      <Col sm={2}>&nbsp;</Col>
+                      <Button bsStyle="danger" className="col-sm-5" onClick={() => this.handleDeleteUser(user)}>
+                        Delete &nbsp;
+                        <i className="fa fa-trash" />
+                      </Button>
+                    </FormGroup>
+                  </Form>
+                </div>
+              </Tab.Pane>
+            </Tab.Content>
+          </Modal.Body>
+        </Modal>
+      </Tab.Container>
     );
   }
 
@@ -1009,13 +1182,15 @@ export default class UserManagement extends React.Component {
                 controlId="formControlMessage"
                 validationState={`${this.state.showError
                   ? 'error'
-                  : this.state.showSuccess ? 'success' : null}`}>
+                  : this.state.showSuccess ? 'success' : null}`}
+              >
                 <Col sm={12}>
                   <FormControl
                     type="text"
                     readOnly
                     name="messageRestoreAccountModal"
-                    value={this.state.messageRestoreAccountModal} />
+                    value={this.state.messageRestoreAccountModal}
+                  />
                 </Col>
               </FormGroup>
               {this.state.deletedUsers.length > 0
@@ -1102,7 +1277,10 @@ export default class UserManagement extends React.Component {
     }));
 
     const tcolumn = (
-      <thead>
+      <thead style={{
+        position: 'sticky', top: '0px', zIndex: '1', backgroundColor: '#eee'
+      }}
+      >
         <tr style={{ height: '26px', verticalAlign: 'middle' }}>
           <th width="1%">#</th>
           <th width="17%">Actions</th>
@@ -1188,7 +1366,7 @@ export default class UserManagement extends React.Component {
             <Button
               bsSize="xsmall"
               bsStyle="success"
-              onClick={() => handleResetPassword(g.id, true)}
+              onClick={() => handleResetPassword(g.id, true, this.handleShowAlert)}
             >
               <i className="fa fa-key" />
             </Button>
@@ -1198,7 +1376,7 @@ export default class UserManagement extends React.Component {
             <Button
               bsSize="xsmall"
               bsStyle="primary"
-              onClick={() => handleResetPassword(g.id, false)}
+              onClick={() => handleResetPassword(g.id, false, this.handleShowAlert)}
             >
               <i className="fa fa-key" />
             </Button>
@@ -1257,17 +1435,24 @@ export default class UserManagement extends React.Component {
             </Button>
           </OverlayTrigger>
           &nbsp;
-          <OverlayTrigger placement="bottom" overlay={<Tooltip id="generic_tooltip">Grant/Revoke Generic Designer</Tooltip>} >
+          <OverlayTrigger
+            placement="bottom"
+            overlay={<Tooltip id="generic_tooltip">Grant/Revoke Generic Designer</Tooltip>}
+          >
             <Button
               bsSize="xsmall"
-              bsStyle={(g.generic_admin?.elements || g.generic_admin?.segments || g.generic_admin?.datasets) ? 'success' : 'default'}
+              bsStyle={(g.generic_admin?.elements
+               || g.generic_admin?.segments || g.generic_admin?.datasets) ? 'success' : 'default'}
               onClick={() => this.handleGenericAdminModal(true, g)}
             >
               <i className="fa fa-empire" aria-hidden="true" />
             </Button>
           </OverlayTrigger>
           &nbsp;
-          <OverlayTrigger placement="bottom" overlay={!g.account_active ? accountActiveTooltip : accountInActiveTooltip}>
+          <OverlayTrigger
+            placement="bottom"
+            overlay={!g.account_active ? accountActiveTooltip : accountInActiveTooltip}
+          >
             <Button
               bsSize="xsmall"
               bsStyle={g.account_active === true ? 'default' : 'danger'}
@@ -1315,6 +1500,7 @@ export default class UserManagement extends React.Component {
 
     return (
       <div>
+        <MessageAlert message={this.state.alertMessage} onHide={this.handleDismissAlert} />
         <Panel>
           <Button bsStyle="warning" bsSize="small" onClick={() => this.handleMsgShow()}>
             Send Message&nbsp;
@@ -1326,18 +1512,25 @@ export default class UserManagement extends React.Component {
             <i className="fa fa-plus" />
           </Button>
           &nbsp;
-          <Button bsStyle="primary" bsSize="small" onClick={() => this.handleRestoreAccountShow()} data-cy="restore-user">
+          <Button
+            bsStyle="primary"
+            bsSize="small"
+            onClick={() => this.handleRestoreAccountShow()}
+            data-cy="restore-user"
+          >
             Restore Account&nbsp;
             <i className="fa fa-undo" />
           </Button>
         </Panel>
         <Panel>
-          <Table>
-            {tcolumn}
-            <tbody>
-              {tbody}
-            </tbody>
-          </Table>
+          <div style={{ maxHeight: '399px', overflowY: 'auto' }} ref={this.tableBodyRef}>
+            <Table>
+              {tcolumn}
+              <tbody>
+                {tbody}
+              </tbody>
+            </Table>
+          </div>
         </Panel>
         {this.renderMessageModal()}
         {this.renderNewUserModal()}

--- a/app/packs/src/apps/admin/UserManagement.js
+++ b/app/packs/src/apps/admin/UserManagement.js
@@ -462,13 +462,15 @@ export default class UserManagement extends React.Component {
 
   handleRestoreAccount = () => {
     this.setState({ deletedUsers: [] });
-    if (this.nameAbbreviation.value.trim() === '') {
-      this.setState({ messageRestoreAccountModal: 'Please enter the name abbreviation!', showError: true });
+    // trim the params
+    this.id.value = this.id.value.trim();
+    this.nameAbbreviation.value = this.nameAbbreviation.value.trim();
+    if (this.nameAbbreviation.value.trim() === '' && this.id.value.trim() === '') {
+      this.setState({ messageRestoreAccountModal: 'Please enter the name abbreviation or an id!', showError: true });
       return false;
     }
-
     AdminFetcher.restoreAccount({
-      name_abbreviation: this.nameAbbreviation.value.trim(),
+      name_abbreviation: this.nameAbbreviation.value === '' ? null : this.nameAbbreviation.value,
       id: this.id.value === '' ? null : this.id.value,
 
     }).then((result) => {
@@ -478,15 +480,15 @@ export default class UserManagement extends React.Component {
       }
 
       if (result.status === 'error' || result.status === 'warning') {
-        this.setState({ messageRestoreAccountModal: result.message, showError: true });
+        this.setState({ messageRestoreAccountModal: result.message, alertMessage: result.message, showError: true });
         return false;
       }
-      this.setState({ messageRestoreAccountModal: result.message, showSuccess: true });
+      this.setState({ messageRestoreAccountModal: result.message, alertMessage: result.message, showSuccess: true });
       setTimeout(() => {
         this.nameAbbreviation.value = '';
         this.id.value = '';
         this.handleRestoreAccountClose();
-      }, 3000);
+      }, 2000);
       return true;
     });
     return true;
@@ -1154,7 +1156,7 @@ export default class UserManagement extends React.Component {
                   <FormControl
                     type="text"
                     name="nameAbbreviation"
-                    placeholder="Please enter the name abbreviation"
+                    placeholder="Please enter the name abbreviation .."
                     inputRef={(ref) => {
                       this.nameAbbreviation = ref;
                     }}
@@ -1169,7 +1171,7 @@ export default class UserManagement extends React.Component {
                   <FormControl
                     type="text"
                     name="id"
-                    placeholder="Please enter the user ID"
+                    placeholder=".. or enter the user ID"
                     defaultValue=""
                     onFocus={() => this.setState({ showError: false, showSuccess: false })}
                     inputRef={(ref) => {

--- a/app/packs/src/apps/admin/generic/GenericAdminModal.js
+++ b/app/packs/src/apps/admin/generic/GenericAdminModal.js
@@ -45,7 +45,7 @@ export default class GenericAdminModal extends Component {
       auth_generic_admin: {},
     };
     params.auth_generic_admin[type] = !value;
-    AdminFetcher.updateAccount(params).then(() => fnCb(user));
+    AdminFetcher.updateAccount(params).then((updatedUser) => fnCb(updatedUser));
   }
 
   render() {

--- a/app/packs/src/fetchers/AdminFetcher.js
+++ b/app/packs/src/fetchers/AdminFetcher.js
@@ -6,9 +6,9 @@ export default class AdminFetcher {
     return fetch('/api/v1/admin/listLocalCollector/all.json', {
       credentials: 'same-origin',
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
@@ -17,9 +17,9 @@ export default class AdminFetcher {
     return fetch('/api/v1/admin/disk.json', {
       credentials: 'same-origin',
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
@@ -28,9 +28,9 @@ export default class AdminFetcher {
     return fetch('/api/v1/admin/listDevices/all.json', {
       credentials: 'same-origin',
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
@@ -39,9 +39,9 @@ export default class AdminFetcher {
     return fetch(`/api/v1/admin/device/${deviceId}`, {
       credentials: 'same-origin',
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
@@ -50,9 +50,9 @@ export default class AdminFetcher {
     return fetch(`/api/v1/admin/deviceMetadata/${deviceId}`, {
       credentials: 'same-origin',
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
@@ -67,9 +67,9 @@ export default class AdminFetcher {
       },
       body: JSON.stringify(params),
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
@@ -87,9 +87,9 @@ export default class AdminFetcher {
         body: JSON.stringify(params),
       }
     )
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
@@ -104,9 +104,9 @@ export default class AdminFetcher {
       },
       body: JSON.stringify(params),
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
@@ -121,9 +121,9 @@ export default class AdminFetcher {
       },
       body: JSON.stringify(params),
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
@@ -138,9 +138,9 @@ export default class AdminFetcher {
       },
       body: JSON.stringify(params),
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
@@ -154,7 +154,7 @@ export default class AdminFetcher {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(params),
-    }).then(response => {
+    }).then((response) => {
       if (response.status === 204) {
         return '';
       }
@@ -163,63 +163,30 @@ export default class AdminFetcher {
   }
 
   static resetUserPassword(params) {
-    return fetch('/api/v1/admin_user/resetPassword/', {
+    const { user_id, ...otherParams } = params;
+    return fetch(`/api/v1/admin/users/${user_id}/resetPassword/`, {
       credentials: 'same-origin',
-      method: 'POST',
+      method: 'PUT',
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(params),
+      body: JSON.stringify(otherParams),
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
 
   static createUserAccount(params) {
-    return fetch('/api/v1/admin_user/newUser/', {
+    return fetch('/api/v1/admin/users', {
       credentials: 'same-origin',
       method: 'POST',
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(params),
-    })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
-        console.log(errorMessage);
-      });
-  }
-
-  static updateUser(params) {
-    return fetch('/api/v1/admin_user/updateUser/', {
-      credentials: 'same-origin',
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(params),
-    })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
-        console.log(errorMessage);
-      });
-  }
-
-  static restoreAccount(params) {
-    return fetch("/api/v1/admin_user/restoreAccount/", {
-      credentials: "same-origin",
-      method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
       },
       body: JSON.stringify(params),
     })
@@ -230,20 +197,67 @@ export default class AdminFetcher {
       });
   }
 
-  static fetchUsers() {
-    return fetch('/api/v1/admin_user/listUsers/all.json', {
+  static updateUser(params) {
+    const { id, ...otherParams } = params;
+    return fetch(`/api/v1/admin/users/${id}`, {
+      credentials: 'same-origin',
+      method: 'PUT',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(otherParams),
+    })
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
+        console.log(errorMessage);
+      });
+  }
+
+  static deleteUser({ id }) {
+    return fetch(`/api/v1/admin/users/${id}`, {
+      credentials: 'same-origin',
+      method: 'DELETE',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  static restoreAccount(params) {
+    return fetch('/api/v1/admin/users/restoreAccount/', {
+      credentials: 'same-origin',
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(params),
+    })
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
+        console.log(errorMessage);
+      });
+  }
+
+  static fetchUsers(id = null) {
+    const url = id ? `/api/v1/admin/users/${id}` : '/api/v1/admin/users';
+    return fetch(url, {
       credentials: 'same-origin',
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
 
   static fetchUsersByNameType(name, type, limit = 5) {
     return fetch(
-      `/api/v1/admin_user/listUsers/byname.json?${new URLSearchParams({
+      `/api/v1/admin/users/byname.json?${new URLSearchParams({
         name,
         type,
         limit,
@@ -253,26 +267,27 @@ export default class AdminFetcher {
         method: 'GET',
       }
     )
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
 
   static updateAccount(params) {
-    return fetch('/api/v1/admin_user/updateAccount/', {
+    const { user_id, ...otherParams } = params;
+    return fetch(`/api/v1/admin/users/${user_id}/profile/`, {
       credentials: 'same-origin',
-      method: 'POST',
+      method: 'PUT',
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(params),
+      body: JSON.stringify(otherParams),
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
@@ -286,7 +301,7 @@ export default class AdminFetcher {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(params),
-    }).then(response => {
+    }).then((response) => {
       if (response.status === 204) {
         return true;
       }
@@ -302,9 +317,9 @@ export default class AdminFetcher {
       method: 'POST',
       body: data,
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
@@ -313,9 +328,9 @@ export default class AdminFetcher {
     return fetch(`/api/v1/admin/group_device/list?type=${type}`, {
       credentials: 'same-origin',
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
@@ -330,9 +345,9 @@ export default class AdminFetcher {
       },
       body: JSON.stringify(params),
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
@@ -347,54 +362,37 @@ export default class AdminFetcher {
       },
       body: JSON.stringify(params),
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
 
   static fetchMatrices() {
-    return fetch('/api/v1/matrix/list.json', {
+    return fetch('/api/v1/admin/matrix', {
       credentials: 'same-origin',
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
 
   static updateMatrice(params) {
-    return fetch('/api/v1/matrix/update/', {
+    return fetch('/api/v1/admin/matrix', {
       credentials: 'same-origin',
-      method: 'POST',
+      method: 'PUT',
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(params),
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
-        console.log(errorMessage);
-      });
-  }
-
-  static updateMatriceJson(params) {
-    return fetch('/api/v1/matrix/update_json/', {
-      credentials: 'same-origin',
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(params),
-    })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.log(errorMessage);
       });
   }
@@ -404,9 +402,9 @@ export default class AdminFetcher {
       credentials: 'same-origin',
       method: 'GET',
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.error(errorMessage);
       });
   }
@@ -421,9 +419,9 @@ export default class AdminFetcher {
       },
       body: JSON.stringify(id),
     })
-      .then(response => response.json())
-      .then(json => json)
-      .catch(errorMessage => {
+      .then((response) => response.json())
+      .then((json) => json)
+      .catch((errorMessage) => {
         console.error(errorMessage);
       });
   }

--- a/spec/api/chemotion/admin_api_spec.rb
+++ b/spec/api/chemotion/admin_api_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Chemotion::AdminAPI do
     end
   end
 
-  describe 'GET /api/v1/admin_user/listUsers/byname' do
+  describe 'GET /api/v1/admin/users/byname' do
     let(:person) { create(:person) }
     let(:group) { create(:group) }
     let(:person_obj) { JSON.parse(Entities::UserSimpleEntity.new(person).to_json) }
@@ -52,7 +52,7 @@ RSpec.describe Chemotion::AdminAPI do
 
     describe 'with group type' do
       before do
-        get "/api/v1/admin_user/listUsers/byname?name=#{group.last_name[0..3]}&type=Group"
+        get "/api/v1/admin/users/byname?name=#{group.last_name[0..3]}&type=Group"
       end
 
       it 'returns the right http status' do
@@ -66,7 +66,7 @@ RSpec.describe Chemotion::AdminAPI do
 
     describe 'with person type' do
       before do
-        get "/api/v1/admin_user/listUsers/byname?name=#{person.last_name[0..3]}&type=Person"
+        get "/api/v1/admin/users/byname?name=#{person.last_name[0..3]}&type=Person"
       end
 
       it 'returns the right http status' do
@@ -80,7 +80,7 @@ RSpec.describe Chemotion::AdminAPI do
 
     describe 'with person and group type' do
       before do
-        get "/api/v1/admin_user/listUsers/byname?name=#{person.last_name[0..3]}&type=Person,Group"
+        get "/api/v1/admin/users/byname?name=#{person.last_name[0..3]}&type=Person,Group"
       end
 
       it 'returns the right http status' do
@@ -94,7 +94,7 @@ RSpec.describe Chemotion::AdminAPI do
 
     describe 'with no type' do
       before do
-        get "/api/v1/admin_user/listUsers/byname?name=#{person.last_name[0..3]}"
+        get "/api/v1/admin/users/byname?name=#{person.last_name[0..3]}"
       end
 
       it 'returns the right http status' do


### PR DESCRIPTION
![image](https://github.com/ComPlat/chemotion_ELN/assets/15799181/54c99fec-df4d-42bc-b77f-095a1c95c1c2)

refactor!: user managment
- better notification (no alert)
![image](https://github.com/ComPlat/chemotion_ELN/assets/15799181/d93e51a0-6146-4a2b-b5fd-098be8149f43)

 - clean api endpoints:
 ```
                                Find all users     GET  /api/v1/admin/users 
 Find top (5) matched user by name and by type     GET  /api/v1/admin/users/byname 
                  restore deleted user account    POST  /api/v1/admin/users/restoreAccount 
                       create new user account    POST  /api/v1/admin/users 
                               Find user by ID     GET  /api/v1/admin/users/:user_id 
                           update user account     PUT  /api/v1/admin/users/:user_id 
                           delete user account  DELETE  /api/v1/admin/users/:user_id 
                           reset user password     PUT  /api/v1/admin/users/:user_id/resetPassword
                              get user profile     GET  /api/v1/admin/users/:user_id/profile
 ```
   
  
  





