### PR TITLE
fix: ensure  wait_until is set for cron delayed jobs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@
 /config/compute_props.yml
 /config/converter.yml
 /config/ketcher_service.yml
+/config/structure_editors.yml
 !/config/data_collector_keys/.keep
 
 /config/database.yml

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'faraday'
 gem 'faraday-follow_redirects'
 gem 'faraday-multipart'
 gem 'font-awesome-rails'
+gem 'fugit'
 gem 'fun_sftp', git: 'https://github.com/fl9/fun_sftp.git', branch: 'allow-port-option'
 gem 'fx'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,7 +339,7 @@ GEM
     e2mmap (0.1.0)
     ed25519 (1.3.0)
     erubi (1.12.0)
-    et-orbi (1.2.7)
+    et-orbi (1.2.11)
       tzinfo
     execjs (2.9.1)
     factory_bot (6.2.1)
@@ -363,8 +363,8 @@ GEM
     flamegraph (0.9.5)
     font-awesome-rails (4.7.0.8)
       railties (>= 3.2, < 8.0)
-    fugit (1.7.1)
-      et-orbi (~> 1, >= 1.2.7)
+    fugit (1.11.0)
+      et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     fx (0.7.0)
       activerecord (>= 4.0.0)
@@ -904,6 +904,7 @@ DEPENDENCIES
   fast_stack
   flamegraph
   font-awesome-rails
+  fugit
   fun_sftp!
   fx
   grape
@@ -1001,4 +1002,4 @@ DEPENDENCIES
   yaml_db
 
 BUNDLED WITH
-   2.4.19
+   2.4.22

--- a/app/jobs/init_cron_jobs_job.rb
+++ b/app/jobs/init_cron_jobs_job.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+# desc:  Init cron jobs: validate schedule input into a cron schedule and create delayed job
+#     for each schedule, also ensure wait_until is set to the next scheduled time.
+#     Setting wait_until is not necessary if the application is running but otherwise
+#     can avoid immediate qeueing in some cases (perform_now on boot, etc)
+#
+class InitCronJobsJob < ApplicationJob
+  attr_reader :job
+
+  # desc: iterate through the arg jobs and queue each of the tasks if possible.
+  #
+  # @params jobs [Array] a list of tasks to queue. eg: [{job_class: 'JobClass', enabled: :datacollector}]
+  # Each iteration sets: @job, @cron_schedule, @next_run_time, @message
+  #  job = current task to queue
+  #  cron_schedule = validated cron schedule for the task
+  #  next_run_time = calculated next run time for the task
+  #  message = last message to log on completion
+  def perform(jobs)
+    # Create all enabled reccuring jobs
+    jobs.each do |job_entry|
+      @job = job_entry
+      next unless entry_valid? && entry_enabled? && next_run_time
+
+      # enqueue the job with the calculated cron schedule and next_run_time
+      # next_run_time ensure the job is enqueued at the right time and not immediately
+      active_job = job[:job_class].set(wait_until: next_run_time, cron: cron_schedule).perform_later
+      success_message(active_job)
+    rescue StandardError => e
+      Delayed::Worker.logger.error { "Error enqueuing job: #{job.inspect} - #{e.message}" }
+    ensure
+      Delayed::Worker.logger.info { @message }
+      reset_instance_variables
+    end
+  end
+
+  private
+
+  ################################################################################################
+  # utility methods
+  ################################################################################################
+
+  # desc: reset instance variables
+  def reset_instance_variables
+    @job = nil
+    @cron_schedule = nil
+    @next_run_time = nil
+    @message = nil
+  end
+
+  # desc: check if the job entry is valid
+  def entry_valid?
+    job.is_a?(Hash) && job.key?(:job_class) && job.key?(:enabled)
+  ensure
+    @message = "Not enqueuig invalid job#{job.inspect}"
+  end
+
+  def entry_enabled?
+    job[:enabled].present?
+  ensure
+    @message = "Not enqueuig disabled job#{job[:job_class]}" unless job[:enabled]
+  end
+
+  # desc: select scheduler for the job and set the cron schedule
+  def cron_schedule
+    @cron_schedule ||= case job[:enabled]
+                       when :datacollector
+                         cron_schedule_datacollector
+                       when :default
+                         cron_schedule_default
+                       end
+  end
+
+  # desc: convert a string to a cron schedule
+  def to_cron(reccurence)
+    Fugit.parse_cronish(reccurence)&.to_cron_s if reccurence.present?
+  rescue StandardError => e
+    Delayed::Worker.logger.info { "Error parsing reccurence: #{reccurence} - #{e.message}" }
+    nil
+  ensure
+    @message = "Not enqueuing #{job[:job_class]}: cannot cron schedule #{reccurence}"
+  end
+
+  # desc: calculate next run time with Fugit
+  def next_run_time
+    @next_run_time ||= Fugit.parse_cronish(cron_schedule)&.next_time&.to_t
+  rescue StandardError => e
+    @message = "Error parsing cron schedule: #{cron_schedule} - #{e.message}"
+    @next_run_time = nil
+  end
+
+  def success_message(active_job)
+    dj = Delayed::Job.find_by(id: active_job.provider_job_id)
+    @message = "Enqueuing #{job[:job_class]}:  cron schedule: #{cron_schedule} - "
+    @message += "#{dj.cron}, next run at: #{dj.run_at}"
+  end
+
+  ################################################################################################
+  # default schedules: job schedules can be set through env variables or get a weekly default
+  ################################################################################################
+
+  # desc: get a default weekly cron_schedule for the job unless cron env variable is defined
+  def cron_schedule_default
+    env_var = ENV.fetch(job[:cron_variable], nil)
+    return "#{rand(0..59)} #{rand(0..23)} * * #{rand(6..7)}" if env_var.blank?
+
+    return nil if env_var == 'disabled'
+
+    to_cron(env_var)
+  end
+
+  ################################################################################################
+  # datacollector schedules: set through the datacollector config config/datacollectors.yml
+  ################################################################################################
+
+  # desc: lookup hash to map a job class to a datacollector config service name
+  LOOKUP_JOB_SERVICE = {
+    CollectDataFromMailJob => 'mailcollector',
+    CollectDataFromLocalJob => 'folderwatcherlocal',
+    CollectDataFromSftpJob => 'folderwatchersftp',
+    CollectFileFromLocalJob => 'filewatcherlocal',
+    CollectFileFromSftpJob => 'filewatchersftp',
+  }.freeze
+
+  def datacollector_config
+    @datacollector_config ||= Rails.configuration.datacollectors&.dig(:services) || []
+  end
+
+  # desc: get the datacollector config for a datacollector job
+  def datacollector_config_for_job
+    service_name = LOOKUP_JOB_SERVICE[job[:job_class]]
+    return nil if service_name.blank?
+
+    datacollector_config.find { |service| service[:name] == service_name }
+                        .presence
+  ensure
+    @message = "Not enqueuing #{job[:job_class]}: no config found"
+  end
+
+  # desc: get the cron schedule for a datacollector job
+  def cron_schedule_datacollector
+    service_config = datacollector_config_for_job
+    # service disabled when no config
+    return nil if service_config.blank? || service_config[:enabled] == false
+
+    # NB: using fugit we could merge the 2 options into one in the configuration
+    #  -> would need documentation update
+    every_conf = service_config[:every]
+    cron_conf = service_config[:cron]
+    return nil if every_conf.blank? && cron_conf.blank?
+
+    # try to parse the config[:every] or config[:cron] to a cron schedule
+    every_to_cron(every_conf) || to_cron(cron_conf)
+  end
+
+  # desc format into every syntax for Fugit
+  def every_to_cron(reccurence)
+    return nil if reccurence.blank?
+
+    formated =    case reccurence.to_s.strip
+                  when /^\d+$/
+                    "every #{reccurence} minutes"
+                  else
+                    "every #{reccurence}"
+                  end
+    to_cron formated
+  end
+end

--- a/app/jobs/pubchem_cid_job.rb
+++ b/app/jobs/pubchem_cid_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Job to update molecule info for molecules with no CID
 # associated CID (molecule tag) and iupac names (molecule_names) are updated if
 # inchikey found in PC db
@@ -7,13 +9,13 @@ class PubchemCidJob < ApplicationJob
   # NB: PC has request restriction policy and timeout , hence the sleep_time and batch_size params
   # see http://pubchemdocs.ncbi.nlm.nih.gov/programmatic-access$_RequestVolumeLimitations
   def perform(sleep_time: 10, batch_size: 10)
-    t_limit = Time.now + 2.hours
+    t_limit = 2.hours.from_now
     Molecule.select(:id, :inchikey).joins(:samples)
             .joins("inner join element_tags et on et.taggable_id = molecules.id and et.taggable_type = 'Molecule'")
             .where(is_partial: false)
             .where("et.taggable_data->>'pubchem_cid' isnull")
             .distinct
-            .find_in_batches(batch_size: batch_size) do |batch|
+            .find_in_batches(batch_size: batch_size, order: :desc) do |batch|
       iks = batch.map(&:inchikey)
 
       ## This updates only cid
@@ -32,7 +34,7 @@ class PubchemCidJob < ApplicationJob
       pb_info = Chemotion::PubchemService.molecule_info_from_inchikeys(iks)
       pb_info.each do |obj|
         m = Molecule.find_by(inchikey: obj[:inchikey], is_partial: false)
-        m.update_columns(iupac_name: obj[:iupac_name]) unless m.iupac_name.present?
+        m.update_columns(iupac_name: obj[:iupac_name]) if m.iupac_name.blank?
         et = m.tag
         data = et.taggable_data || {}
         data['pubchem_cid'] = obj[:cid]
@@ -41,11 +43,12 @@ class PubchemCidJob < ApplicationJob
           MoleculeName.find_or_create_by(
             molecule_id: m.id,
             name: name,
-            description: 'iupac_name'
+            description: 'iupac_name',
           )
         end
       end
-      return if Time.now > t_limit
+      return if Time.zone.now > t_limit
+
       sleep sleep_time
     end
   end

--- a/app/jobs/pubchem_lcss_job.rb
+++ b/app/jobs/pubchem_lcss_job.rb
@@ -8,22 +8,21 @@ class PubchemLcssJob < ApplicationJob
   # NB: PC has request restriction policy and timeout , hence the sleep_time and batch_size params
   # see http://pubchemdocs.ncbi.nlm.nih.gov/programmatic-access$_RequestVolumeLimitations
   def perform(sleep_time: 10, batch_size: 50)
-    t_limit = Time.now + 2.hours
+    t_limit = 2.hours.from_now
 
-    Molecule.select(:id).joins(:samples)
+    Molecule.select(:id)
             .joins("inner join element_tags et on et.taggable_id = molecules.id and et.taggable_type = 'Molecule' ")
             .where("et.taggable_data->>'pubchem_cid' is not null")
             .where("et.taggable_data->>'pubchem_cid' ~ '^[0-9]+$'")
             .where("et.taggable_data->>'pubchem_lcss' is null")
             .distinct
-            .find_in_batches(batch_size: batch_size) do |batch|
-
+            .find_in_batches(batch_size: batch_size, order: :desc) do |batch|
       batch.each do |mol|
         mol.pubchem_lcss
         # request every 0.5 second
         sleep 0.5
       end
-      break if Time.now > t_limit
+      break if Time.zone.now > t_limit
 
       sleep sleep_time
     end

--- a/spec/config/initializers/delayed_job_spec.rb
+++ b/spec/config/initializers/delayed_job_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+def delayed_job_scope
+  Delayed::Job.where.not(cron: nil)
+end
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'queuing of a reccuring job through delayed_job initializer' do
+  # env variable name that can be used to define the cron schedules
+  let(:env_var_names) do
+    %w[
+      CRON_CONFIG_PC_CID
+      CRON_CONFIG_PC_LCSS
+      CRON_CONFIG_REFRESH_ELEMENT_TAG
+    ]
+  end
+  let(:days_from_now) { [2, 3, 4] }
+  # map to week day as integers
+  let(:wdays_from_now) { days_from_now.map { |num| Time.zone.now.next_day(num).wday } }
+  # map to weekly cron schedules starting in x days
+  let(:cron_schedules) { wdays_from_now.map { |wday| "5 5 * * #{wday}" } }
+  # set env variables
+  let(:env_vars) do
+    env_var_names.zip(cron_schedules).map do |var_name, schedule|
+      "#{var_name}='#{schedule}'"
+    end.join(' ')
+  end
+
+  let(:jobs_count_with_correct_run_at) do
+    days_from_now.zip(cron_schedules).map do |day, schedule|
+      delayed_job_scope.where(cron: schedule)
+                       .where('run_at > ?', Time.zone.now.next_day(day).beginning_of_day)
+                       .count
+    end
+  end
+  let(:expected_count) { [1, 1, 1] }
+
+  # rubocop:disable RSpec/BeforeAfterAll
+  before(:all) do
+    delayed_job_scope.delete_all
+  end
+
+  after(:all) do
+    delayed_job_scope.delete_all
+  end
+  # rubocop:enable RSpec/BeforeAfterAll
+
+  it 'queues the reccuring jobs with the defined cron schedules and correct run_at times' do
+    # set env variables and trigger the initializers for example with a rake command
+    `#{env_vars} bundle exec rake db:version`
+    expect(jobs_count_with_correct_run_at).to eq(expected_count)
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/jobs/init_cron_jobs_job_spec.rb
+++ b/spec/jobs/init_cron_jobs_job_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class DummyJob < ApplicationJob
+  queue_as :dummy
+
+  def perform(*args)
+    # Do something later
+    puts "DummyJob: #{args}"
+    logger.info "DummyJob: #{args}"
+  end
+end
+
+RSpec.describe InitCronJobsJob do
+  let(:cron_job_list) do
+    [{ job_class: DummyJob, enabled: :default, cron_variable: 'DUMMY_CRON' }]
+  end
+  let(:cron_schedule) { '5 5 * * 5' }
+
+  it 'initializes cron jobs' do
+    ENV['DUMMY_CRON'] = cron_schedule
+    Delayed::Job.where(queue: 'dummy').delete_all
+    described_class.perform_now(cron_job_list)
+    expect(Delayed::Job.where(queue: 'dummy').last&.cron).to eq(cron_schedule)
+  end
+
+  it 'has initialized a reccuring job running next weekend' do
+    Delayed::Job.where(queue: 'dummy').delete_all
+    described_class.perform_now(cron_job_list)
+    expect(
+      Delayed::Job.where(
+        'run_at > ? and run_at < ?', Time.zone.now.end_of_week(:friday), Time.zone.now.next_week(:monday)
+      ).where(queue: 'dummy').where.not(cron: nil).count,
+    ).to eq(1)
+  end
+end


### PR DESCRIPTION
- When the app is initializing and go through the delayed_job initializer

- so that job's run_at does not default to ~ created_at


Any action initializing the app (rake, bin/delayed_job, rails c...) will run the delayed job initializer and queue the recurring jobs.
Unfortunately at this stage the of the initialization, though the cron is set properly, the next run_at is not. Instead it defaults to ~Time.now every time. 

This PR:
- fix: the issue by calculating the next run_at and setting it

- refactor: move fetching, validation, and setting of the cron values for recurring jobs out of the delayed_job initializer
into an `init` job.  Use fugit to validate cron input
- test: unit test + testing on the initializer queueing

NB more cleaning needed but for another time:
- keep datacollector-config service key mapping to the  datacollector lib
- a more generic init job
- do not delete and requeue if the schedules match


