### PR TITLE
fix: add updating of annotations also in reaction container

### DIFF
--- a/app/packs/src/fetchers/ReactionsFetcher.js
+++ b/app/packs/src/fetchers/ReactionsFetcher.js
@@ -94,6 +94,7 @@ export default class ReactionsFetcher {
 
   static updateAnnotationsInReaction(reaction) {
     const tasks = [];
+    tasks.push(BaseFetcher.updateAnnotationsInContainer(reaction));
     reaction.products.forEach((e) => tasks.push(BaseFetcher.updateAnnotationsInContainer(e)));
     return Promise.all(tasks);
   }


### PR DESCRIPTION
Fixed the bug that an image in a dataset in a reaction could not be **annotated** correctly. The problem was a missing update of the **container of the reaction**, only the samples were updated.
