### PR TITLE
refactor: getting collection-element model for given model

### DIFF
--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
-
 # module API
 require 'grape-entity'
 require 'grape-swagger'
@@ -13,7 +11,7 @@ class API < Grape::API
 
   # TODO: needs to be tested,
   # source: http://funonrails.com/2014/03/api-authentication-using-devise-token/
-  helpers do
+  helpers do # rubocop:disable Metrics/BlockLength
     def present(*args)
       options = args.count > 1 ? args.extract_options! : {}
 
@@ -59,7 +57,7 @@ class API < Grape::API
       error!('401 Unauthorized', 401) unless current_user
     end
 
-    def is_public_request?
+    def public_request?
       request.path.start_with?(
         '/api/v1/public/',
         '/api/v1/chemscanner/',
@@ -85,8 +83,8 @@ class API < Grape::API
       ]
     end
 
-    def to_snake_case_key(k)
-      k.to_s.underscore.to_sym
+    def to_snake_case_key(key)
+      key.to_s.underscore.to_sym
     end
 
     def to_rails_snake_case(val)
@@ -100,8 +98,8 @@ class API < Grape::API
       end
     end
 
-    def to_camelcase_key(k)
-      k.to_s.camelcase(:lower).to_sym
+    def to_camelcase_key(key)
+      key.to_s.camelcase(:lower).to_sym
     end
 
     def to_json_camel_case(val)
@@ -117,7 +115,7 @@ class API < Grape::API
   end
 
   before do
-    authenticate! unless is_public_request?
+    authenticate! unless public_request?
   end
 
   # desc: whitelisted tables and columns for advanced_search
@@ -145,6 +143,15 @@ class API < Grape::API
 
   TEXT_TEMPLATE = %w[SampleTextTemplate ReactionTextTemplate WellplateTextTemplate ScreenTextTemplate
                      ResearchPlanTextTemplate ReactionDescriptionTextTemplate ElementTextTemplate].freeze
+
+  ELEMENT_CLASS = {
+    'research_plan' => ResearchPlan,
+    'screen' => Screen,
+    'wellplate' => Wellplate,
+    'reaction' => Reaction,
+    'sample' => Sample,
+    'cell_line' => CelllineSample,
+  }.freeze
 
   mount Chemotion::LiteratureAPI
   mount Chemotion::ContainerAPI
@@ -212,4 +219,3 @@ class API < Grape::API
                               })
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/api/chemotion/collection_api.rb
+++ b/app/api/chemotion/collection_api.rb
@@ -325,10 +325,10 @@ module Chemotion
 
             next unless ui_state[:checkedAll] || ui_state[:checkedIds].present?
 
-            classes = create_classes_of_element(element)
-            ids = classes[0].by_collection_id(from_collection.id).by_ui_state(ui_state).pluck(:id)
-            classes[1].move_to_collection(ids, from_collection.id, to_collection_id)
-            classes[1].remove_in_collection(
+            ids = element_class_ids(element, 'collections', from_collection.id, ui_state)
+            collections_element_class = join_element_class(element, 'collections')
+            collections_element_class.move_to_collection(ids, from_collection.id, to_collection_id)
+            collections_element_class.remove_in_collection(
               ids,
               Collection.get_all_collection_for_user(current_user.id)[:id]) if params[:is_sync_to_me]
           end
@@ -376,9 +376,8 @@ module Chemotion
             ui_state[:uncheckedIds] = ui_state[:uncheckedIds].presence || ui_state[:excluded_ids]
             next unless ui_state[:checkedAll] || ui_state[:checkedIds].present?
 
-            classes = create_classes_of_element(element)
-            ids = classes[0].by_collection_id(from_collection.id).by_ui_state(ui_state).pluck(:id)
-            classes[1].create_in_collection(ids, to_collection_id)
+            ids = element_class_ids(element, 'collections', from_collection.id, ui_state)
+            join_element_class(element, 'collections').create_in_collection(ids, to_collection_id)
           end
 
           klasses = Labimotion::ElementKlass.find_each do |klass|
@@ -422,9 +421,8 @@ module Chemotion
             ui_state[:collection_ids] = from_collection.id
             next unless ui_state[:checkedAll] || ui_state[:checkedIds].present?
 
-            classes = create_classes_of_element(element)
-            ids = classes[0].by_collection_id(from_collection.id).by_ui_state(ui_state).pluck(:id)
-            classes[1].remove_in_collection(ids, from_collection.id)
+            ids = element_class_ids(element, 'collections', from_collection.id, ui_state)
+            join_element_class(element, 'collections').remove_in_collection(ids, from_collection.id)
           end
 
           klasses = Labimotion::ElementKlass.find_each do |klass|

--- a/app/api/helpers/collection_helpers.rb
+++ b/app/api/helpers/collection_helpers.rb
@@ -68,7 +68,7 @@ module CollectionHelpers
         user_ids,
         pl,
       ).first
-    elsif
+    else
       c = Collection.where(id: c_id).where(
         'shared_by_id = ? OR (user_id in (?) AND (is_shared IS NOT TRUE OR permission_level >= ?))',
         current_user.id,
@@ -134,17 +134,6 @@ module CollectionHelpers
     @dl_rp = @dl[:researchplan_detail_level]
     @dl_e = @dl[:element_detail_level]
     @dl_cl = @dl[:celllinesample_detail_level]
-  end
-
-  def element_class_ids(element, join_table, from_collection_id, ui_state)
-    element_class = API::ELEMENT_CLASS[element]
-    element_class.reflections[join_table].options[:through]&.to_s&.classify&.constantize
-    element_class.by_collection_id(from_collection_id).by_ui_state(ui_state).pluck(:id)
-  end
-
-  def join_element_class(element, join_table)
-    element_class = API::ELEMENT_CLASS[element]
-    element_class.reflections[join_table].options[:through]&.to_s&.classify&.constantize
   end
 end
 # rubocop:enable Metrics/ModuleLength, Style/OptionalBooleanParameter, Naming/MethodParameterName, Layout/LineLength

--- a/app/api/helpers/collection_helpers.rb
+++ b/app/api/helpers/collection_helpers.rb
@@ -59,21 +59,21 @@ module CollectionHelpers
     c_id = prms[:collection_id]
     if !prms[:newCollection].blank?
       c = Collection.create(
-        user_id: current_user.id, label: prms[:newCollection]
+        user_id: current_user.id, label: prms[:newCollection],
       )
     elsif prms[:is_sync_to_me]
       c = Collection.joins(:sync_collections_users).where(
         'sync_collections_users.id = ? and sync_collections_users.user_id in (?) and (sync_collections_users.permission_level = 1 or sync_collections_users.permission_level >= ?)',
         c_id,
         user_ids,
-        pl
+        pl,
       ).first
     elsif
       c = Collection.where(id: c_id).where(
         'shared_by_id = ? OR (user_id in (?) AND (is_shared IS NOT TRUE OR permission_level >= ?))',
         current_user.id,
         user_ids,
-        pl
+        pl,
       ).first
     end
     c&.id
@@ -136,15 +136,15 @@ module CollectionHelpers
     @dl_cl = @dl[:celllinesample_detail_level]
   end
 
-  def create_classes_of_element(element)
-    if element == 'cell_line'
-      element_klass = CelllineSample
-      collections_element_klass = CollectionsCellline
-    else
-      collections_element_klass = "collections_#{element}".classify.constantize
-      element_klass = element.classify.constantize
-    end
-    [element_klass, collections_element_klass]
+  def element_class_ids(element, join_table, from_collection_id, ui_state)
+    element_class = API::ELEMENT_CLASS[element]
+    element_class.reflections[join_table].options[:through]&.to_s&.classify&.constantize
+    element_class.by_collection_id(from_collection_id).by_ui_state(ui_state).pluck(:id)
+  end
+
+  def join_element_class(element, join_table)
+    element_class = API::ELEMENT_CLASS[element]
+    element_class.reflections[join_table].options[:through]&.to_s&.classify&.constantize
   end
 end
 # rubocop:enable Metrics/ModuleLength, Style/OptionalBooleanParameter, Naming/MethodParameterName, Layout/LineLength

--- a/app/models/collections_cellline.rb
+++ b/app/models/collections_cellline.rb
@@ -24,56 +24,23 @@ class CollectionsCellline < ApplicationRecord
   include Collecting
 
   # Remove from collection and process associated elements (and update collection info tag)
-  def self.remove_in_collection(cellline_id, collection_id)
-    CollectionsCellline.find_by(
-      collection_id: collection_id,
-      cellline_sample_id: cellline_id,
-      deleted_at: nil,
-    )&.destroy
+  def self.remove_in_collection(element_ids, collection_ids)
+    # Remove from collections
+    delete_in_collection(element_ids, collection_ids)
+    # update sample tag with collection info
+    update_tag_by_element_ids(element_ids)
   end
 
-  def self.move_to_collection(cellline_ids, from_collection_id, to_colllection_id)
-    raise "could not find collection with #{to_colllection_id}" unless Collection.find_by(id: to_colllection_id)
-
-    Array(cellline_ids).each do |cell_line_id|
-      next if to_colllection_id == from_collection_id
-
-      CollectionsCellline.save_to_collection(cell_line_id, to_colllection_id)
-      CollectionsCellline.remove_in_collection(cell_line_id, from_collection_id)
-    end
-
-    CollectionsCellline.update_collection_tag(cellline_ids)
+  def self.move_to_collection(element_ids, from_collection_ids, to_colllection_ids)
+    # Delete in collection
+    delete_in_collection(element_ids, from_collection_ids)
+    # Upsert in target collection
+    insert_in_collection(element_ids, to_colllection_ids)
+    # Update element tag with collection info
+    update_tag_by_element_ids(element_ids)
   end
 
   def self.create_in_collection(cellline_ids, to_col_id)
-    raise "could not find collection with #{to_col_id}" unless Collection.find_by(id: to_col_id)
-
-    Array(cellline_ids).each do |cell_line_id|
-      CollectionsCellline.save_to_collection(cell_line_id, to_col_id) unless CollectionsCellline.find_by(
-        collection_id: to_col_id,
-        cellline_sample_id: cell_line_id,
-        deleted_at: nil,
-      )
-    end
-    CollectionsCellline.update_collection_tag(cellline_ids)
-  end
-
-  def self.save_to_collection(cell_line_id, to_col_id)
-    entry_already_there = CollectionsCellline.find_by(
-      cellline_sample_id: cell_line_id,
-      collection_id: to_col_id,
-    )
-
-    return if entry_already_there
-
-    CollectionsCellline.new(
-      cellline_sample_id: cell_line_id,
-      collection_id: to_col_id,
-    ).save
-  end
-
-  def self.update_collection_tag(element_ids)
-    CelllineSample.includes(:tag).where(id: element_ids).select(:id)
-                  .each { |el| el.update_tag!(collection_tag: true) }
+    static_create_in_collection(cellline_ids, to_col_id)
   end
 end

--- a/app/models/concerns/collecting.rb
+++ b/app/models/concerns/collecting.rb
@@ -1,44 +1,84 @@
+# frozen_string_literal: true
+
 # multiple upsert/delete for collections_elements and collection info tag update for associated element
 module Collecting
   extend ActiveSupport::Concern
 
+  # rubocop:disable Metrics/BlockLength
   included do
     class << self
-      def delete_in_collection(element_ids, collection_ids)
-        sql = sanitize_sql(["#{delete_sql} IN (?)", collection_ids, element_ids])
-        db_exec_query(sql)
+      # Foreign key for the associated element model
+      # @return [String, nil] the name of foreign key in the table for the associated element.
+      # @note This method expect the current AR model to represent a join table between
+      #   the Collection model and another element model:
+      #   The model should only have 2 reflections with one being with Collection.
+      # @example
+      #   "CollectionsSample.element_foreign_key"              #=> "sample_id"
+      #   "Labimotion::CollectionsElement.element_foreign_key" #=> "element_id"
+      #   "CollectionsCellline.element_foreign_key             #=> "cellline_sample_id"
+      def element_foreign_key
+        reflections.find { |key, _| key != 'collection' }&.last&.foreign_key
       end
 
+      # AR model for the associated element
+      # @return [Class<ActiveRecord>, nil] ActiveRecord model for the associated element.
+      # @example
+      #   "CollectionsSample.element_klass"              #=> "Sampl"
+      #   "Labimotion::CollectionsElement.element_klass" #=> "Labimotion::Element"
+      #   "CollectionsCellline.element_klass             #=> "CelllineSample"
+      # @note (see #element_foreign_key)
+      def element_klass
+        reflections.find { |key, _| key != 'collection' }&.last&.klass
+      end
+
+      # Build the list of paired foreign_key ids for a sql statement
+      # @param element_ids [Array<Integer>] list of element ids
+      # @param collection_ids [Array<Integer>] list of collection ids
+      # @return [String] SQL list of (element_id, collection_id) pairs
+      # @example
+      #  "value_list_sql([1, 2], [3, 4])" #=> "(1, 3), (1, 4), (2, 3), (2, 4)"
+      # @todo make private
+      def paired_id_list_sql(element_ids, collection_ids)
+        return '' if element_ids.empty? || collection_ids.empty?
+
+        element_ids.product(collection_ids).map { |pair| "(#{pair.join(',')})" }.join(',')
+      end
+
+      # upserts elements in collections
+      # @param element_ids [Array<Integer>, Integer] list of element ids
+      # @param collection_ids [Array<Integer>, Integer] list of collection ids
+      # @note only process ids of existing element and collection records where deleted_at is nil
       def insert_in_collection(element_ids, collection_ids)
-        eids = [element_ids].flatten.select(&:present?).map(&:to_i).uniq
-        cids = [collection_ids].flatten.select(&:present?).map(&:to_i).uniq
-        return unless eids.present? and cids.present?
-        values = eids.map { |eid|
-          cids.map { |cid|
-            "(#{eid},#{cid})"
-          }.join(',')
-        }.join(',')
-        sql = <<~SQL
-          INSERT INTO #{table_name} (#{table_name[12..-2]}_id, collection_id)
+        element_ids = element_klass.where(id: element_ids).pluck(:id)
+        collection_ids = Collection.where(id: collection_ids).pluck(:id)
+        return if (values = paired_id_list_sql(element_ids, collection_ids)).blank?
+
+        sql = <<~SQL.squish
+          INSERT INTO #{table_name} (#{element_foreign_key}, collection_id)
           VALUES #{values}
-          ON CONFLICT (#{table_name[12..-2]}_id, collection_id)
+          ON CONFLICT (#{element_foreign_key}, collection_id)
           DO UPDATE SET deleted_at = null
         SQL
         db_exec_query(sql)
       end
 
       def delete_sql
-        @delete_statement ||= <<~SQL
+        @delete_sql ||= <<~SQL.squish
           UPDATE #{table_name} SET deleted_at = Now()
-          WHERE #{table_name}.collection_id in (?) AND #{table_name}.deleted_at is null AND #{table_name}.#{table_name[12..-2]}_id
+          WHERE #{table_name}.collection_id in (?) AND #{table_name}.deleted_at is null AND #{table_name}.#{element_foreign_key}
         SQL
+      end
+
+      def delete_in_collection(element_ids, collection_ids)
+        sql = sanitize_sql(["#{delete_sql} IN (?)", collection_ids, element_ids])
+        db_exec_query(sql)
       end
 
       def db_exec_query(sql)
         ActiveRecord::Base.connection.exec_query(sql)
       end
 
-      # Static upsert without checking associated and element colleciton tag update
+      # Static upsert without checking associated and element collection tag update
       def static_create_in_collection(element_ids, collection_ids)
         # upsert in target collection
         insert_in_collection(element_ids, collection_ids)
@@ -47,14 +87,14 @@ module Collecting
       end
 
       def update_tag_by_element_ids(element_ids)
-        klass = Labimotion::Utils.klass_by_collection(name).constantize
-        klass.includes(:tag).where(id: element_ids).select(:id).each { |el| el.update_tag!(collection_tag: true) }
+        element_klass.includes(:tag).where(id: element_ids).select(:id)
+                     .each { |el| el.update_tag!(collection_tag: true) }
       end
 
       handle_asynchronously :update_tag_by_element_ids
 
       def queue_name
-        "collecting"
+        'collecting'
       end
 
       def delete_in_collection_by_ui_state(**args)
@@ -67,8 +107,7 @@ module Collecting
       end
 
       def update_tag_by_ui_state(**args)
-        element_klass = Labimotion::Utils.klass_by_collection(name).constantize
-        statement = "WHERE collection_id in (?) AND #{table_name}.#{table_name[12..-2]}_id"
+        statement = "WHERE collection_id in (?) AND #{table_name}.#{element_foreign_key}"
         if args[:checkedAll]
           statement += ' NOT IN (?)'
           ids = args[:uncheckedIds]
@@ -78,8 +117,9 @@ module Collecting
         end
         element_klass.join_collections_element.includes(:tag)
                      .where(statement, args[:collection_ids], ids)
-                     .each { |el| el.update_tag!(collection_tag: true) }
+                     .find_each { |el| el.update_tag!(collection_tag: true) }
       end
     end
+    # rubocop:enable Metrics/BlockLength
   end
 end

--- a/app/usecases/cell_lines/create.rb
+++ b/app/usecases/cell_lines/create.rb
@@ -13,13 +13,9 @@ module Usecases
         cell_line_material = find_cellline_material || create_cellline_material
         cell_line_sample = create_cellline_sample(cell_line_material)
 
-        CollectionsCellline.create(
-          collection: Collection.find(@params[:collection_id]),
-          cellline_sample_id: cell_line_sample.id,
-        )
-        CollectionsCellline.create(
-          collection: all_collection_of_current_user,
-          cellline_sample_id: cell_line_sample.id,
+        CollectionsCellline.create_in_collection(
+          cell_line_sample.id,
+          [@params[:collection_id], all_collection_of_current_user.id],
         )
 
         @current_user.increment_counter('celllines') # rubocop: disable Rails/SkipsModelValidations

--- a/spec/api/collection_api_spec.rb
+++ b/spec/api/collection_api_spec.rb
@@ -321,6 +321,9 @@ describe Chemotion::CollectionAPI do
             }
           end
 
+          before { Delayed::Worker.delay_jobs = false }
+          after  { Delayed::Worker.delay_jobs = true }
+
           context 'when try to move two of three cell line elements into empty collection' do
             let(:target_collection_id) { c_target.id }
             let(:cell_line_ids) { [cell_line_1.id, cell_line_2.id] }
@@ -403,6 +406,9 @@ describe Chemotion::CollectionAPI do
               },
             }
           end
+
+          before { Delayed::Worker.delay_jobs = false }
+          after  { Delayed::Worker.delay_jobs = true }
 
           context 'when assigning cellline to new collection' do
             before do

--- a/spec/models/collections_cellline_spec.rb
+++ b/spec/models/collections_cellline_spec.rb
@@ -19,11 +19,9 @@ RSpec.describe CollectionsCellline do
   let(:collection_target_id) { c2.id }
   let(:sample) { create(:cellline_sample, collections: [c1]) }
 
-  context 'when target collection is valid and has not yet the cell line' do
-    before do
-      execute
-    end
+  before { execute }
 
+  context 'when target collection is valid and has not yet the cell line' do
     it 'cell line is now connected to new collection' do
       expect(described_class.find_by(
                collection_id: collection_target_id,
@@ -40,22 +38,16 @@ RSpec.describe CollectionsCellline do
   end
 
   context 'when target collection is not available' do
-    let(:collection_target_id) { -1 }
+    let(:collection_target_id) { 1_234_567_890 }
 
-    it 'raise collection not found error' do
-      expect do
-        execute
-      end.to raise_error(RuntimeError)
+    it 'skips creating the record' do
+      expect(described_class.find_by(collection_id: collection_target_id)).to be_nil
     end
   end
 
   context 'when target collection is valid and but cell line is already in it' do
     let(:c2) { create(:collection) }
     let(:sample) { create(:cellline_sample, collections: [c1, c2]) }
-
-    before do
-      execute
-    end
 
     it 'cell line exists once in the target collection' do
       expect(described_class.where(


### PR DESCRIPTION
- API: clearer mapping of param keys <-> element Models

- Models: robust method to get the associated Collection{Element} model from given element model without relying on naming assumptions  (avoid string operation with table, column, reflections names)

- CollectionsCell-line: reuse available concern logic  

