### PR TITLE
fix: add default value for citationMap

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/literature/LiteratureCommon.js
+++ b/app/packs/src/apps/mydb/elements/details/literature/LiteratureCommon.js
@@ -5,7 +5,7 @@ import {
 } from 'react-bootstrap';
 import uuid from 'uuid';
 import Literature from 'src/models/Literature';
-import { getKeysOfMap } from 'src/apps/mydb/elements/details/literature/CitationTools';
+import { getKeysOfMap,createCitationTypeMap } from 'src/apps/mydb/elements/details/literature/CitationTools';
 
 function RefByUserInfo({ info, litype }) {
   if (typeof (info) === 'undefined' || !info || info.length === 0) {
@@ -36,7 +36,7 @@ function LiteralType({
   val,
   handleInputChange,
   disabled = false,
-  citationMap
+  citationMap = createCitationTypeMap('')
 }) {
   return (
     <FormControl


### PR DESCRIPTION
This PR fixes an issue that there is a blank page when the reference manager is opened. The problem was a missing default value of the citationMap in the LiteralType component. The property is now optional and prefilled with the default values.