### PR TITLE
Add root container to seeded reactions

### DIFF
--- a/db/seeds/development/users.seed.rb
+++ b/db/seeds/development/users.seed.rb
@@ -162,6 +162,7 @@ Person.find_each do |u|
     }
 
     reaction = Reaction.new(attributes)
+    reaction.container = Container.create_root_container
     reaction.collections = [collection, ca]
     reaction.save!
   end


### PR DESCRIPTION
This PR addresses #1943.

How to test this PR?

1. Check out `main`.
2. Run `bundle exec rails db:setup`.
3. Open the app and click ![image](https://github.com/ComPlat/chemotion_ELN/assets/30125107/b43eb066-5468-4af6-a3f7-4f581c157dce) in one of the reactions detail modals.
The app should throw (in the browser's dev console):
```
TypeError: Cannot read properties of null (reading 'attachments')
    at Function.getAttachments (BaseFetcher.js:127:1)
    at Function.updateAnnotationsInContainer (BaseFetcher.js:137:1)
    at Function.updateAnnotationsInReaction (ReactionsFetcher.js:97:1)
    at ReactionsFetcher.js:81:1
ElementActions.js:620 TypeError: Cannot read properties of undefined (reading 'type')
    at Store.handleUpdateElement (ElementStore.js:1327:1)
    at Store.handleUpdateLinkedElement (ElementStore.js:718:1)
    at AltStore.js:88:1
    at Array.every (<anonymous>)
    at AltStore.js:87:1
    at handleDispatch (AltStore.js:54:1)
    at Object.ID_4 (AltStore.js:86:1)
    at Dispatcher._invokeCallback (Dispatcher.js:198:1)
    at Dispatcher.dispatch (Dispatcher.js:174:1)
    at index.js:83:1
```

Now, check out this PR (branch `reaction-development-seeds`) and run steps 2. and 3. again.
The app should no longer throw the error above.