### PR TITLE
feat: Allow comma and period as decimal separators in reaction variations table

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -9,6 +9,7 @@ import {
 import { cloneDeep, isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import Reaction from 'src/models/Reaction';
+import { parseNumericString } from 'src/utilities/MathUtils';
 import {
   createVariationsRow, copyVariationsRow, updateVariationsRow,
   temperatureUnits, durationUnits, convertUnit, materialTypes, getVariationsRowName
@@ -176,7 +177,7 @@ function ValueUnitParser({
   const standardUnit = cellData.unit;
   const columnGroup = field.split('.')[0];
   const column = field.split('.').splice(1).join('.');
-  let value = Number(newValue);
+  let value = parseNumericString(newValue);
   if (column !== 'temperature' && value < 0) {
     value = 0;
   }

--- a/app/packs/src/utilities/MathUtils.js
+++ b/app/packs/src/utilities/MathUtils.js
@@ -60,8 +60,6 @@ function parseNumericString(numberString) {
   if (typeof numberString !== 'string') {
     return NaN;
   }
-
-  const numberIsNegative = numberString.startsWith('-');
   let sanitizedNumberString = numberString;
 
   // Remove all characters that aren't digits, commas, or periods.
@@ -81,7 +79,7 @@ function parseNumericString(numberString) {
       sanitizedNumberString.slice(finalPeriodIndex + 1)}`;
   }
 
-  if (numberIsNegative) {
+  if (numberString.startsWith('-')) {
     sanitizedNumberString = `-${sanitizedNumberString}`;
   }
 

--- a/app/packs/src/utilities/MathUtils.js
+++ b/app/packs/src/utilities/MathUtils.js
@@ -56,6 +56,17 @@ const formatBytes = (bytes, decimals = 2) => {
   return `${parseFloat((bytes / (k ** i)).toFixed(dm))} ${sizes[i]}`;
 };
 
+/**
+ * Parse a string into a number.
+ *
+ * All characters other than digits, commas, and periods are ignored,
+ * with the exception of an optional leading dash to indicate a negative number.
+ * The string may contain a decimal separator, which can be either a comma or a period.
+ * All other periods or commas (such as thousands separators) are ignored.
+ *
+ * @param {string} numberString - The string to parse.
+ * @returns {number|NaN} - The parsed number or NaN if parsing fails.
+ */
 function parseNumericString(numberString) {
   if (typeof numberString !== 'string') {
     return NaN;

--- a/app/packs/src/utilities/MathUtils.js
+++ b/app/packs/src/utilities/MathUtils.js
@@ -56,9 +56,42 @@ const formatBytes = (bytes, decimals = 2) => {
   return `${parseFloat((bytes / (k ** i)).toFixed(dm))} ${sizes[i]}`;
 };
 
+function parseNumericString(numberString) {
+  if (typeof numberString !== 'string') {
+    return NaN;
+  }
+
+  const numberIsNegative = numberString.startsWith('-');
+  let sanitizedNumberString = numberString;
+
+  // Remove all characters that aren't digits, commas, or periods.
+  sanitizedNumberString = sanitizedNumberString.replace(/[^0-9,.]/g, '');
+  if (sanitizedNumberString === '') {
+    return NaN;
+  }
+
+  // Decimal separator can be comma or period. Convert to period.
+  sanitizedNumberString = sanitizedNumberString.replaceAll(',', '.');
+  // Keep only final (non-terminal) period under the assumption that it's meant as the decimal separator.
+  // Assume that preceding periods were meant as thousands separators.
+  const finalPeriodIndex = sanitizedNumberString.lastIndexOf('.');
+  if (finalPeriodIndex !== -1) {
+    sanitizedNumberString = `${sanitizedNumberString.slice(0, finalPeriodIndex).replaceAll('.', '')
+    }.${
+      sanitizedNumberString.slice(finalPeriodIndex + 1)}`;
+  }
+
+  if (numberIsNegative) {
+    sanitizedNumberString = `-${sanitizedNumberString}`;
+  }
+
+  return Number(sanitizedNumberString);
+}
+
 export {
   fixDigit,
   validDigit,
   correctPrefix,
   formatBytes,
+  parseNumericString,
 };

--- a/spec/javascripts/utils/MathUtils.spec.js
+++ b/spec/javascripts/utils/MathUtils.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 
 import {
-  fixDigit, validDigit, correctPrefix,
+  fixDigit, validDigit, correctPrefix, parseNumericString,
 } from '../../../app/packs/src/utilities/MathUtils';
 
 describe('fixDigit', () => {
@@ -168,5 +168,33 @@ describe('correctPrefix', () => {
     const result = correctPrefix(num, 3).toString();
     const expected = `${11.1} \u03BC`;
     expect(result).toEqual(expected);
+  });
+});
+
+describe('number formatting', () => {
+  it('converts decimal separator', () => {
+    expect(parseNumericString('1.23')).toEqual(1.23);
+    expect(parseNumericString('1,23')).toEqual(1.23);
+  });
+  it('removes thousands separator', () => {
+    expect(parseNumericString('12.345,8')).toEqual(12345.8);
+    expect(parseNumericString('12,345.8')).toEqual(12345.8);
+  });
+  it('accepts negative numbers', () => {
+    expect(parseNumericString('-1,23')).toEqual(-1.23);
+  });
+  it('handles malformatted numbers', () => {
+    expect(parseNumericString('--1,-23-')).toEqual(-1.23);
+    expect(parseNumericString('..,1,2.3,')).toEqual(123);
+    expect(parseNumericString('-foo1.2bar,3.baz---)')).toEqual(-123);
+    expect(parseNumericString('12.3.4,567')).toEqual(1234.567);
+  });
+  it('handles invalid input', () => {
+    expect(parseNumericString('foo')).toEqual(NaN);
+    expect(parseNumericString('.')).toEqual(NaN);
+    expect(parseNumericString(',')).toEqual(NaN);
+    expect(parseNumericString('-')).toEqual(NaN);
+    expect(parseNumericString('')).toEqual(NaN);
+    expect(parseNumericString(1)).toEqual(NaN);
   });
 });


### PR DESCRIPTION
This PR addresses #1948.

The reaction variations table accepts only a period (i.e., ".") as decimal separator for numeric entries. The goal is to allow a comma and period as decimal separators. In the current codebase, there are at least two ways to achieve this.

## 1. Using the JavaScript package `numeral`

The package is used in the `NumeralInput` component (which in turn is used in "Elemental composition" section of `SampleDetails` component via `ElementalCompositionCustom` and `ElementalCompositionGroup`components). I decided not to use `numeral`:

- The package is dead (last commit 7 years ago: https://github.com/adamwdraper/Numeral-js).
- We're limited to an outdated version (of the dead package).

## 2. Custom logic in the `handleInputValueChange` method of the `NumeralInputWithUnitsCompo` component

I decided against using the custom logic:
- It's not re-usable outside of the component and its not trivial to extract since it's tightly coupled to the component.
- It's not applicable to my needs since it parses characters as they are entered rather than the entire string on submission.
- It breaks when using multiple commas or periods (e.g., as thousands separator).
		
Since the JavaScript standard library doesn't offer locale-specific number parsing / parsing different decimal separators (see https://stackoverflow.com/a/42000120 and https://stackoverflow.com/questions/55364947/is-there-any-javascript-standard-api-to-parse-to-number-according-to-locale), I'm adding a dependency-free solution that could ideally be re-used to replace solutions 1. and 2. (in a separate PR).