### PR TITLE
refactor: generalise initializers:  ketcher_service structure_editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Latest
 
-
+* Bug fixes
+  * fix YAML key in structure_editors.yml.example file ([#1929](https://github.com/ComPlat/chemotion_ELN/issues/1929))
 
 ## [v1.9.3]
 > (2024-05-13)

--- a/app/models/molecule.rb
+++ b/app/models/molecule.rb
@@ -253,7 +253,7 @@ class Molecule < ApplicationRecord
   end
 
   def self.svg_reprocess(svg, molfile)
-    return svg unless Rails.configuration.ketcher_service.url.present?
+    return svg if Rails.configuration.ketcher_service.disabled?
     return svg if svg.present? && !svg&.include?('Open Babel')
 
     svg = KetcherService::RenderSvg.svg(molfile)

--- a/app/models/molecule.rb
+++ b/app/models/molecule.rb
@@ -253,7 +253,7 @@ class Molecule < ApplicationRecord
   end
 
   def self.svg_reprocess(svg, molfile)
-    return svg unless Rails.configuration.try(:ketcher_service).try(:url).present?
+    return svg unless Rails.configuration.ketcher_service.url.present?
     return svg if svg.present? && !svg&.include?('Open Babel')
 
     svg = KetcherService::RenderSvg.svg(molfile)

--- a/config/default_missing.yml
+++ b/config/default_missing.yml
@@ -1,0 +1,6 @@
+shared:
+  :desc: 'configuration missing - service disabled'
+  :disabled: true
+  :disabled?: true
+  :enabled: false
+  :enabled?: false

--- a/config/default_missing.yml
+++ b/config/default_missing.yml
@@ -1,5 +1,5 @@
 shared:
-  :desc: 'configuration missing - service disabled'
+  :desc: 'configuration missing or invalid - service disabled'
   :disabled: true
   :disabled?: true
   :enabled: false

--- a/config/initializers/ketcher_service.rb
+++ b/config/initializers/ketcher_service.rb
@@ -1,13 +1,21 @@
 # frozen_string_literal: true
 
-if File.exist? Rails.root.join('config', 'ketcher_service.yml')
-  ketcher_svc_config = Rails.application.config_for(:ketcher_service)
-  url = ketcher_svc_config[:url]
+# This load the optional configuration for the backend ketcher rendering service
 
-  Rails.application.configure do
-    config.ketcher_service = ActiveSupport::OrderedOptions.new
-    config.ketcher_service.url = url
+ref = "Initializing #{File.basename(__FILE__, '.rb')}:"
+
+Rails.application.configure do
+  config.ketcher_service = nil                           # Create service config
+  config.ketcher_service = config_for :ketcher_service   # Load config/.yml
+rescue RuntimeError                                      # Rescue: RuntimeError is raised if the file is not found
+  Rails.logger.info "#{ref} yml configuration not found"
+ensure
+  # Load default missing configuration if ketcher_service.yml not found or no config is defined for the environment
+  config.ketcher_service ||= config_for :default_missing
+
+  if (info = config.ketcher_service.url || config.ketcher_service.desc)
+    Rails.logger.info "#{ref} Ketcher-render service: #{info}"
+  else
+    Rails.logger.warn "#{ref} Ketcher render service: configuration found but no url defined"
   end
-
-  Rails.logger.info("Render service configured at: #{Rails.configuration.try(:ketcher_service).try(:url)}")
 end

--- a/config/initializers/ketcher_service.rb
+++ b/config/initializers/ketcher_service.rb
@@ -14,14 +14,12 @@ end
 
 # Generic initialization
 service = File.basename(__FILE__, '.rb').to_sym # Service name
-service_setter = "#{service}=".to_sym # Service setter
+service_setter = :"#{service}=" # Service setter
 ref = "Initializing #{service}:" # Message prefix
 
 Rails.application.configure do
   config.send(service_setter, config_for(service)) # Load config/.yml
-
   validations.call(config, service) # Validate configuration
-
 # Rescue:
 # - RuntimeError is raised if the file is not found
 # - NoMethodError is raised if the yml file cannot be parsed

--- a/config/initializers/structure_editors.rb
+++ b/config/initializers/structure_editors.rb
@@ -1,16 +1,36 @@
 # frozen_string_literal: true
 
-# This initializer loads the optional configuration for additional structure editors.
-ref = "Initializing #{File.basename(__FILE__, '.rb')}:"
+# This initializer loads the optional configuration for:
+#   the additional structure editors
+
+# Specific
+validations = lambda do |config, service|
+  editor_count = config.send(service).editors.size
+  raise ArgumentError, 'No Editor config' unless editor_count.positive?
+
+  # set description
+  config.send(service).desc = "#{editor_count} optional editors"
+end
+
+# Generic initialization
+service = File.basename(__FILE__, '.rb').to_sym # Service name
+service_setter = "#{service}=".to_sym # Service setter
+ref = "Initializing #{service}:" # Message prefix
 
 Rails.application.configure do
-  config.structure_editors = config_for :structure_editors  # Load config/.yml
-rescue RuntimeError                                         # Rescue if the yml file is not found
-  config.structure_editors = nil                            # Create service key or clear config
+  config.send(service_setter, config_for(service)) # Load config/.yml
+
+  validations.call(config, service) # Validate and set description
+
+# Rescue:
+# - RuntimeError is raised if the file is not found
+# - NoMethodError is raised if the yml file cannot be parsed
+rescue RuntimeError, NoMethodError, ArgumentError, URI::InvalidURIError => e
+  Rails.logger.warn "#{ref} Error while loading configuration #{e.message}"
+  # Create service key or clear config
+  config.send(service_setter, nil)
 ensure
   # Load default missing configuration if the yml file not found or no config is defined for the environment
-  config.structure_editors ||= config_for :default_missing
-
-  info = config.structure_editors.editors&.size || config.structure_editors.desc
-  Rails.logger.info "#{ref} optional editors: #{info}"
+  config.send(service_setter, config_for(:default_missing)) unless config.send(service)
+  Rails.logger.info "#{ref} #{config.send(service).desc}"
 end

--- a/config/initializers/structure_editors.rb
+++ b/config/initializers/structure_editors.rb
@@ -1,16 +1,14 @@
 # frozen_string_literal: true
 
-# This load the optional configuration for additional structure editors.
-
+# This initializer loads the optional configuration for additional structure editors.
 ref = "Initializing #{File.basename(__FILE__, '.rb')}:"
 
 Rails.application.configure do
-  config.structure_editors = nil                            # Create service
   config.structure_editors = config_for :structure_editors  # Load config/.yml
 rescue RuntimeError                                         # Rescue if the yml file is not found
-  Rails.logger.info "#{ref} yml configuration not found"
+  config.structure_editors = nil                            # Create service key or clear config
 ensure
-  # Load default missing configuration if ketcher_service.yml not found or no config is defined for the environment
+  # Load default missing configuration if the yml file not found or no config is defined for the environment
   config.structure_editors ||= config_for :default_missing
 
   info = config.structure_editors.editors&.size || config.structure_editors.desc

--- a/config/initializers/structure_editors.rb
+++ b/config/initializers/structure_editors.rb
@@ -1,11 +1,18 @@
 # frozen_string_literal: true
-structure_editors_config = {}
 
-if File.exist? Rails.root.join('config', 'structure_editors.yml')
-  structure_editors_config = Rails.application.config_for :structure_editors
-end
+# This load the optional configuration for additional structure editors.
+
+ref = "Initializing #{File.basename(__FILE__, '.rb')}:"
 
 Rails.application.configure do
-  config.structure_editors = ActiveSupport::OrderedOptions.new
-  config.structure_editors.editors = structure_editors_config[:editors]
+  config.structure_editors = nil                            # Create service
+  config.structure_editors = config_for :structure_editors  # Load config/.yml
+rescue RuntimeError                                         # Rescue if the yml file is not found
+  Rails.logger.info "#{ref} yml configuration not found"
+ensure
+  # Load default missing configuration if ketcher_service.yml not found or no config is defined for the environment
+  config.structure_editors ||= config_for :default_missing
+
+  info = config.structure_editors.editors&.size || config.structure_editors.desc
+  Rails.logger.info "#{ref} optional editors: #{info}"
 end

--- a/config/initializers/structure_editors.rb
+++ b/config/initializers/structure_editors.rb
@@ -14,14 +14,12 @@ end
 
 # Generic initialization
 service = File.basename(__FILE__, '.rb').to_sym # Service name
-service_setter = "#{service}=".to_sym # Service setter
+service_setter = :"#{service}=" # Service setter
 ref = "Initializing #{service}:" # Message prefix
 
 Rails.application.configure do
   config.send(service_setter, config_for(service)) # Load config/.yml
-
   validations.call(config, service) # Validate and set description
-
 # Rescue:
 # - RuntimeError is raised if the file is not found
 # - NoMethodError is raised if the yml file cannot be parsed

--- a/config/structure_editors.yml.example
+++ b/config/structure_editors.yml.example
@@ -1,16 +1,4 @@
-development:
-  :editors:
-    :chemdraw:
-      :label: 'ChemDrawJS'
-      :license: 'license file'
-      :extJs: ['external javascript files to be included']
-    :marvinjs:
-      :label: 'MarvinJS'
-      :license: 'license file'
-      :extJs: ['external javascript files to be included']
-      :extSrc: 'external file'
-
-production:
+shared:
   :editors:
     :ketcher2:
       :label: 'Ketcher 2'
@@ -24,3 +12,4 @@ production:
       :license: 'license file'
       :extJs: ['external javascript files to be included']
       :extSrc: 'external file'
+

--- a/config/structure_editors.yml.example
+++ b/config/structure_editors.yml.example
@@ -14,7 +14,7 @@ production:
   :editors:
     :ketcher2:
       :label: 'Ketcher 2'
-      :extJs: '/editors/ketcher2/standalone/index.html'
+      :extSrc: '/editors/ketcher2/standalone/index.html'
     :chemdraw:
       :label: 'ChemDrawJS'
       :license: 'license file'


### PR DESCRIPTION
## Generalised initializers that load config from a yaml file

Only the validation section is config dependentant.

ensure  Rails.application.{structure_editors,ketcher_service} is defined and an instance
    of ActiveSupport::OrderedOptions, when config/{structure_editors,ketcher_service}.yml:
        -- is missing or
        -- is present but nothing defined for the current environment

- add minor validation when loading the config yml

- also resolve #1929: proper key in the yml example file
