### PR TITLE
fix: coefficient display value defaults to 1

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
@@ -515,7 +515,7 @@ class Material extends Component {
             <div>
               <NumeralInputWithUnitsCompo
                 key={material.id}
-                value={material.coefficient}
+                value={material.coefficient ?? 1}
                 onChange={this.handleCoefficientChange}
                 name="coefficient"
               />


### PR DESCRIPTION
- [X] rather 1-story 1-commit than sub-atomic commits

**Before**:
![coefficient_before](https://github.com/ComPlat/chemotion_ELN/assets/11820267/9de1ba3c-d936-4c08-b8f2-34a4026f58ec)



**After**:
![coeffiient_after](https://github.com/ComPlat/chemotion_ELN/assets/11820267/07709d4b-e604-4cba-8ca4-f3ba021edda0)
