### PR TITLE
fix: attachment permission validation to allow access on shared items

### DIFF
--- a/app/api/chemotion/attachment_api.rb
+++ b/app/api/chemotion/attachment_api.rb
@@ -103,11 +103,19 @@ module Chemotion
                           ElementPermissionProxy.new(current_user, element, user_ids).read_dataset?
             end
           elsif @attachment
+           
             can_dwnld = @attachment.container_id.nil? && @attachment.created_for == current_user.id
-            if !can_dwnld && (element = @attachment.attachable)
+
+            if !can_dwnld && (element = @attachment.container&.root&.containable || @attachment.attachable)
+              if(!element.is_a?(Container)) then
               can_dwnld = (element.is_a?(User) && (element == current_user)) ||
-                          (ElementPolicy.new(current_user, element).read? &&
-                          ElementPermissionProxy.new(current_user, element, user_ids).read_dataset?)
+                          ( 
+                            ElementPolicy.new(current_user, element).read? &&
+                          ElementPermissionProxy.new(current_user, element, user_ids).read_dataset?
+                        )
+                      else
+                        can_dwnld=false
+                      end 
             end
           end
           error!('401 Unauthorized', 401) unless can_dwnld

--- a/app/api/chemotion/attachment_api.rb
+++ b/app/api/chemotion/attachment_api.rb
@@ -51,7 +51,6 @@ module Chemotion
       error!(message, 404)
     end
 
-
     resource :export_ds do
       before do
         @container = Container.find_by(id: params[:container_id])
@@ -61,7 +60,7 @@ module Chemotion
                     ElementPermissionProxy.new(current_user, element, user_ids).read_dataset?
         error!('401 Unauthorized', 401) unless can_dwnld
       end
-      desc "Download the dataset attachment file"
+      desc 'Download the dataset attachment file'
       get 'dataset/:container_id' do
         env['api.format'] = :binary
         export = Labimotion::ExportDataset.new
@@ -103,19 +102,19 @@ module Chemotion
                           ElementPermissionProxy.new(current_user, element, user_ids).read_dataset?
             end
           elsif @attachment
-           
+
             can_dwnld = @attachment.container_id.nil? && @attachment.created_for == current_user.id
 
             if !can_dwnld && (element = @attachment.container&.root&.containable || @attachment.attachable)
-              if(!element.is_a?(Container)) then
-              can_dwnld = (element.is_a?(User) && (element == current_user)) ||
-                          ( 
-                            ElementPolicy.new(current_user, element).read? &&
-                          ElementPermissionProxy.new(current_user, element, user_ids).read_dataset?
-                        )
-                      else
-                        can_dwnld=false
-                      end 
+              can_dwnld = if element.is_a?(Container)
+                            false
+                          else
+                            (element.is_a?(User) && (element == current_user)) ||
+                              (
+                                ElementPolicy.new(current_user, element).read? &&
+                              ElementPermissionProxy.new(current_user, element, user_ids).read_dataset?
+                              )
+                          end
             end
           end
           error!('401 Unauthorized', 401) unless can_dwnld

--- a/app/api/chemotion/attachment_api.rb
+++ b/app/api/chemotion/attachment_api.rb
@@ -104,7 +104,7 @@ module Chemotion
             end
           elsif @attachment
             can_dwnld = @attachment.container_id.nil? && @attachment.created_for == current_user.id
-            if !can_dwnld && (element = @attachment.container&.root&.containable)
+            if !can_dwnld && (element = @attachment.attachable)
               can_dwnld = (element.is_a?(User) && (element == current_user)) ||
                           (ElementPolicy.new(current_user, element).read? &&
                           ElementPermissionProxy.new(current_user, element, user_ids).read_dataset?)
@@ -214,6 +214,7 @@ module Chemotion
         content_type 'application/octet-stream'
 
         env['api.format'] = :binary
+
         store = @attachment.attachment.storage.directory
         file_location = store.join(
           @attachment.attachment_data['derivatives']['annotation']['annotated_file_location'] || 'not available',

--- a/spec/api/chemotion/attachment_api_spec.rb
+++ b/spec/api/chemotion/attachment_api_spec.rb
@@ -312,18 +312,18 @@ describe Chemotion::AttachmentAPI do
         expect(response).to have_http_status :ok
       end
 
-      it 'expecting attachment as binary stream' do
-        pending
+      xit 'expecting attachment as binary stream' do
+        pending 'not yet implemented'
       end
     end
 
     context 'when attachment is nested in a analysis container' do
-      it 'expecting return code 200' do
-        pending
+      xit 'expecting return code 200' do
+        pending 'not yet implemented'
       end
 
-      it 'expecting attachment as binary stream' do
-        pending
+      xit 'expecting attachment as binary stream' do
+        pending 'not yet implemented'
       end
     end
   end

--- a/spec/api/chemotion/attachment_api_spec.rb
+++ b/spec/api/chemotion/attachment_api_spec.rb
@@ -281,7 +281,51 @@ describe Chemotion::AttachmentAPI do
   end
 
   describe 'GET /api/v1/attachments/{attachment_id}' do
-    pending 'not yet implemented'
+    let(:owner_user) { create(:person) }
+    let(:receiving_user) { logged_in_user }
+    let(:shared_collection) do
+      create(:collection,
+             user_id: receiving_user.id,
+             is_shared: true,
+             shared_by_id: owner_user.id,
+             is_locked: true,
+             permission_level: 0,
+             label: 'shared by owner_user')
+    end
+
+    let(:attachment) { create(:attachment) }
+
+    context 'when attachment is directly linked to the research plan' do
+      let(:research_plan) do
+        create(:research_plan,
+               creator: owner_user,
+               attachments: [attachment],
+               collections: [shared_collection])
+      end
+
+      before do
+        research_plan
+        get "/api/v1/attachments/#{attachment.id}"
+      end
+
+      it 'expecting return code 200' do
+        expect(response).to have_http_status :ok
+      end
+
+      it 'expecting attachment as binary stream' do
+        pending
+      end
+    end
+
+    context 'when attachment is nested in a analysis container' do
+      it 'expecting return code 200' do
+        pending
+      end
+
+      it 'expecting attachment as binary stream' do
+        pending
+      end
+    end
   end
 
   describe 'GET /api/v1/attachments/zip/{container_id}' do
@@ -423,7 +467,7 @@ describe Chemotion::AttachmentAPI do
   end
 
   describe 'POST /api/v1/attachments/thumbnails' do
-    pending 'not yet implemented'
+    pending
   end
 
   describe 'POST /api/v1/attachments/files' do

--- a/spec/api/chemotion/attachment_api_spec.rb
+++ b/spec/api/chemotion/attachment_api_spec.rb
@@ -313,17 +313,29 @@ describe Chemotion::AttachmentAPI do
       end
 
       it 'expecting attachment as binary stream of correct size' do
-        expect(response.body.size).to be 318425
+        expect(response.body.size).to be 318_425
       end
     end
 
     context 'when attachment is nested in a analysis container' do
-      xit 'expecting return code 200' do
-        pending 'not yet implemented'
+      let(:research_plan) do
+        create(:research_plan,
+               creator: owner_user,
+               collections: [shared_collection],
+               container: create(:container, :with_jpg_in_dataset))
+      end
+      let(:attachment) { research_plan.container.children.first.children.first.children.first.attachments.first }
+
+      before do
+        get "/api/v1/attachments/#{attachment.id}"
       end
 
-      xit 'expecting attachment as binary stream' do
-        pending 'not yet implemented'
+      it 'expecting return code 200' do
+        expect(response).to have_http_status :ok
+      end
+
+      it 'expecting attachment as binary stream of correct size' do
+        expect(response.body.size).to be 163_233
       end
     end
   end

--- a/spec/api/chemotion/attachment_api_spec.rb
+++ b/spec/api/chemotion/attachment_api_spec.rb
@@ -293,7 +293,7 @@ describe Chemotion::AttachmentAPI do
              label: 'shared by owner_user')
     end
 
-    let(:attachment) { create(:attachment) }
+    let(:attachment) { create(:attachment, :with_png_image) }
 
     context 'when attachment is directly linked to the research plan' do
       let(:research_plan) do
@@ -312,8 +312,8 @@ describe Chemotion::AttachmentAPI do
         expect(response).to have_http_status :ok
       end
 
-      xit 'expecting attachment as binary stream' do
-        pending 'not yet implemented'
+      it 'expecting attachment as binary stream of correct size' do
+        expect(response.body.size).to be 318425
       end
     end
 


### PR DESCRIPTION
This PR will fix a problem if the user tries to **download** an **attachment** from e.g. a research plan if the plan is in a **synchronized** or shared **collection**.