### PR TITLE
fix: dataset thumbnail image to match magnified preview when annotated

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/cellLines/analysesTab/EditModeHeader.js
+++ b/app/packs/src/apps/mydb/elements/details/cellLines/analysesTab/EditModeHeader.js
@@ -115,8 +115,10 @@ export default class EditModeHeader extends React.Component {
 
     return (
       <div className="preview">
+        
         <ImageModal
-          hasPop={false}
+          hasPop={true}
+          disableClick={false}
           previewObject={{
             src: previewImg
           }}

--- a/app/packs/src/apps/mydb/elements/list/AttachmentList.js
+++ b/app/packs/src/apps/mydb/elements/list/AttachmentList.js
@@ -48,6 +48,7 @@ export const attachmentThumbnail = (attachment) => (
         popObject={
         attachment.filename && attachment.filename.toLowerCase().match(/\.(png|jpg|bmp|tif|svg|jpeg|tiff)$/)
           ? {
+            fetchNeeded:true,
             src: `/api/v1/attachments/${attachment.id}/annotated_image`,
           }
           : {

--- a/app/packs/src/components/common/ImageModal.js
+++ b/app/packs/src/components/common/ImageModal.js
@@ -90,7 +90,7 @@ export default class ImageModal extends Component {
   }
 
   fetchImage() {
-    AttachmentFetcher.fetchImageAttachment({ id: this.props.popObject.fetchId }).then(
+    AttachmentFetcher.fetchImageAttachment({ id: this.props.popObject.fetchId, annotated: true }).then(
       (result) => {
         if (result.data != null) {
           this.setState({ fetchSrc: result.data, isPdf: result.type === 'application/pdf' });

--- a/app/packs/src/fetchers/AttachmentFetcher.js
+++ b/app/packs/src/fetchers/AttachmentFetcher.js
@@ -17,7 +17,11 @@ const fileFromAttachment = (attachment, containerId) => {
 
 export default class AttachmentFetcher {
   static fetchImageAttachment(params) {
-    return fetch(`/api/v1/attachments/image/${params.id}`, {
+    const url = params.annotated
+      ? `/api/v1/attachments/${params.id}/annotated_image`
+      : `/api/v1/attachments/image/${params.id}`;
+
+    return fetch(url, {
       credentials: 'same-origin',
       method: 'GET',
     })
@@ -515,9 +519,9 @@ export default class AttachmentFetcher {
       predict,
       keepPred,
       waveLength: waveLengthStr,
-      cyclicvolta: cyclicvolta,
-      curveIdx: curveIdx,
-      simulatenmr: simulatenmr,
+      cyclicvolta,
+      curveIdx,
+      simulatenmr,
       axesUnits: axesUnitsStr,
       detector
     };
@@ -536,16 +540,12 @@ export default class AttachmentFetcher {
         if (!isSaveCombined) {
           return json;
         }
-        const oldSpcInfos = [...previousSpcInfos].filter((spc) => {
-          return spc.idx !== attId;
-        });
+        const oldSpcInfos = [...previousSpcInfos].filter((spc) => spc.idx !== attId);
         let jcampIds = oldSpcInfos.map((spc) => (spc.idx));
         const fetchedFilesIdxs = json.files.map((file) => (file.id));
         jcampIds = [...jcampIds, ...fetchedFilesIdxs];
 
-        return AttachmentFetcher.combineSpectra(jcampIds, curveIdx).then((res) => {
-          return json;
-        }).catch((errMsg) => {
+        return AttachmentFetcher.combineSpectra(jcampIds, curveIdx).then((res) => json).catch((errMsg) => {
           console.log(errMsg); // eslint-disable-line
         });
       })
@@ -636,7 +636,7 @@ export default class AttachmentFetcher {
       },
       body: JSON.stringify({
         edited: jcampIds.edited,
-        molfile: molfile,
+        molfile,
       }),
     })
       .then((response) => response.json())
@@ -665,12 +665,8 @@ export default class AttachmentFetcher {
         }),
       },
     )
-      .then((response) => {
-        return response.json();
-      })
-      .then((json) => {
-        return json;
-      })
+      .then((response) => response.json())
+      .then((json) => json)
       .catch((errorMessage) => {
         console.log(errorMessage);
       });


### PR DESCRIPTION
This PR fixes the problem that in an container image preview the thumbnail image does not match the magnified image if the user clicks on it if there is an annotated version of the image (see #1927).

It also fixes that for cell lines the magnify function was not enabled.

As discussed with the reviewer the fix does not fully solve the problem. After annotating the image in the container the preview image is instantly updated but the magnified image still needs a reload of the element. It would need a relative big refactoring of the logic to achieve an instant updating. Since there is an issue that requires this modificationanyway, I would like to plead in favor of solving this remaining problem in issue https://github.com/ComPlat/chemotion_ELN/issues/1928