### PR TITLE
fix: collection tree not to collapse on select

### DIFF
--- a/app/packs/src/apps/mydb/collections/CollectionSubtree.js
+++ b/app/packs/src/apps/mydb/collections/CollectionSubtree.js
@@ -46,7 +46,7 @@ export default class CollectionSubtree extends React.Component {
       const visible = this.isVisible(this.state.root, state)
       const { root } = this.state;
 
-      const selectedCol = state.currentCollection.id == root.id
+      const selectedCol = state.currentCollection.id === root.id
 
       if (selectedCol) {
         this.setState({
@@ -56,7 +56,6 @@ export default class CollectionSubtree extends React.Component {
       } else {
         this.setState({
           selected: false,
-          visible
         });
       }
     }


### PR DESCRIPTION
fix to resolve bug where collection sub tree collapses when a different sub tree is selected.
