### PR TITLE
fix: bug fix for broken cellline count

### DIFF
--- a/app/packs/src/apps/mydb/elements/list/ElementsList.js
+++ b/app/packs/src/apps/mydb/elements/list/ElementsList.js
@@ -270,7 +270,7 @@ export default class ElementsList extends React.Component {
             <i className={iconClass} />
           </OverlayTrigger>
           <span style={{ paddingLeft: 5 }}>
-            {elementState.totalElements && elementState.totalElements[`${value}s`]}
+            {elementState.totalElements && elementState.totalElements[`${value}s`] || 0}
             (
             {totalCheckedElements[value] || 0}
             )


### PR DESCRIPTION

Bug fix for broken cellLine count on ElementsList tab

![cellline_count_after](https://github.com/ComPlat/chemotion_ELN/assets/11820267/cafea29b-fb15-4b36-a6ef-091b8905b92a)
![cellline_count_before](https://github.com/ComPlat/chemotion_ELN/assets/11820267/249a7254-e6c3-420f-9b57-fa55cb0695fd)
