### PR TITLE
fix: Show save-status of reaction variations table

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -101,6 +101,7 @@ export default class ReactionDetails extends Component {
 
   shouldComponentUpdate(nextProps, nextState) {
     const reactionFromNextProps = nextProps.reaction;
+    const reactionFromNextState = nextState.reaction;
     const nextActiveTab = nextState.activeTab;
     const nextActiveAnalysisTab = nextState.activeAnalysisTab;
     const nextVisible = nextState.visible;
@@ -114,6 +115,7 @@ export default class ReactionDetails extends Component {
       !!reactionFromNextProps.changed || !!reactionFromNextProps.editedSample ||
       nextActiveTab !== activeTab || nextVisible !== visible ||
       nextActiveAnalysisTab !== activeAnalysisTab
+      || reactionFromNextState !== reactionFromCurrentState
     );
   }
 

--- a/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -100,18 +100,18 @@ export default class ReactionDetails extends Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    const nextReaction = nextProps.reaction;
+    const reactionFromNextProps = nextProps.reaction;
     const nextActiveTab = nextState.activeTab;
     const nextActiveAnalysisTab = nextState.activeAnalysisTab;
     const nextVisible = nextState.visible;
     const {
-      reaction, activeTab, visible, activeAnalysisTab
+      reaction: reactionFromCurrentState, activeTab, visible, activeAnalysisTab
     } = this.state;
     return (
-      nextReaction.id !== reaction.id ||
-      nextReaction.updated_at !== reaction.updated_at ||
-      nextReaction.reaction_svg_file !== reaction.reaction_svg_file ||
-      !!nextReaction.changed || !!nextReaction.editedSample ||
+      reactionFromNextProps.id !== reactionFromCurrentState.id ||
+      reactionFromNextProps.updated_at !== reactionFromCurrentState.updated_at ||
+      reactionFromNextProps.reaction_svg_file !== reactionFromCurrentState.reaction_svg_file ||
+      !!reactionFromNextProps.changed || !!reactionFromNextProps.editedSample ||
       nextActiveTab !== activeTab || nextVisible !== visible ||
       nextActiveAnalysisTab !== activeAnalysisTab
     );

--- a/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -17,8 +17,9 @@ import {
   AnalysesCellRenderer, AnalysesCellEditor, getReactionAnalyses, updateAnalyses, getAnalysesOverlay, AnalysisOverlay
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses';
 import {
-  getMaterialColumnGroupChild, updateColumnDefinitionsMaterials, getReactionMaterials,
-  removeObsoleteMaterialsFromVariations, addMissingMaterialsToVariations,
+  getMaterialColumnGroupChild, updateColumnDefinitionsMaterials,
+  getReactionMaterials, getReactionMaterialsIDs,
+  removeObsoleteMaterialsFromVariations, addMissingMaterialsToVariations
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
 import {
   PropertyFormatter, PropertyParser,
@@ -290,7 +291,12 @@ export default function ReactionVariations({ reaction, onReactionChange }) {
   }, [reactionVariations]);
 
   const updatedReactionMaterials = getReactionMaterials(reaction);
-  if (!isEqual(reactionMaterials, updatedReactionMaterials)) {
+  if (
+    !isEqual(
+      getReactionMaterialsIDs(reactionMaterials),
+      getReactionMaterialsIDs(updatedReactionMaterials)
+    )
+  ) {
     /*
     Keep set of materials up-to-date.
     Materials could have been added or removed in the "Scheme" tab.

--- a/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -171,7 +171,7 @@ MenuHeader.propTypes = {
 
 export default function ReactionVariations({ reaction, onReactionChange }) {
   const gridRef = useRef(null);
-  const [reactionVariations, setReactionVariations] = useState(reaction.variations);
+  const [reactionVariations, _setReactionVariations] = useState(reaction.variations);
   const [allReactionAnalyses, setAllReactionAnalyses] = useState(getReactionAnalyses(reaction));
   const [reactionMaterials, setReactionMaterials] = useState(getReactionMaterials(reaction));
   const [columnDefinitions, setColumnDefinitions] = useState([
@@ -281,14 +281,12 @@ export default function ReactionVariations({ reaction, onReactionChange }) {
     autoHeaderHeight: true,
   }), []);
 
-  useEffect(() => {
-    /*
-    Push changes to parent component. Treat parent component as external system,
-    since it's not obvious when and how state is mutated in the parent component.
-    */
-    reaction.variations = reactionVariations;
+  const setReactionVariations = (updatedReactionVariations) => {
+    // Set updated state here and in parent component.
+    _setReactionVariations(updatedReactionVariations);
+    reaction.variations = updatedReactionVariations;
     onReactionChange(reaction);
-  }, [reactionVariations]);
+  };
 
   const updatedReactionMaterials = getReactionMaterials(reaction);
   if (

--- a/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -289,14 +289,13 @@ export default function ReactionVariations({ reaction, onReactionChange }) {
     onReactionChange(reaction);
   }, [reactionVariations]);
 
-  if (!isEqual(reactionMaterials, getReactionMaterials(reaction))) {
+  const updatedReactionMaterials = getReactionMaterials(reaction);
+  if (!isEqual(reactionMaterials, updatedReactionMaterials)) {
     /*
     Keep set of materials up-to-date.
     Materials could have been added or removed in the "Scheme" tab.
     These changes need to be reflected in the variations.
     */
-    const updatedReactionMaterials = getReactionMaterials(reaction);
-
     const updatedColumnDefinitions = updateColumnDefinitionsMaterials(
       columnDefinitions,
       updatedReactionMaterials,

--- a/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.js
@@ -56,6 +56,13 @@ function getReactionMaterials(reaction) {
   }, {});
 }
 
+function getReactionMaterialsIDs(reactionMaterials) {
+  return Object.entries(reactionMaterials).reduce((checksumsByMaterialType, [materialType, materials]) => {
+    checksumsByMaterialType[materialType] = materials.map((material) => material.id);
+    return checksumsByMaterialType;
+  }, {});
+}
+
 function updateYields(variationsRow, reactionHasPolymers) {
   const updatedVariationsRow = cloneDeep(variationsRow);
   const referenceMaterial = getReferenceMaterial(updatedVariationsRow);
@@ -310,6 +317,7 @@ export {
   MaterialOverlay,
   getMaterialColumnGroupChild,
   getReactionMaterials,
+  getReactionMaterialsIDs,
   getMaterialData,
   updateColumnDefinitionsMaterials,
   updateNonReferenceMaterialOnMassChange,


### PR DESCRIPTION
Addresses issue #2000.

TLDR of the issue: a UI element shows the save-status of the reaction variations table by turning from dark-blue to light-blue when there are unsaved changes. Prior to this PR, the UI element was always light-blue, even when all changes in the reaction variations table had been changed.

Commits 3cc75ffb6c32401479a6e647724ab5f972308aad and 5731839b1af8908740316c2767d3b7cd0b5845ab fix the issue.
The remaining commits are related refactorings.