### PR TITLE
fix: skip empty well initialization on existing wellplate

### DIFF
--- a/app/packs/src/models/Wellplate.js
+++ b/app/packs/src/models/Wellplate.js
@@ -130,6 +130,8 @@ export default class Wellplate extends Element {
   }
 
   #initEmptyWells() {
+    if (!this.isNew) return
+    
     this.wells = Array(this.size).fill({});
     this.wells = this.wells.map((well, i) => this.#initWellWithPositionByIndex(well, i));
     this._checksum = this.checksum();

--- a/spec/javascripts/fixture/wellplates/wellplate_2_2_from_server.js
+++ b/spec/javascripts/fixture/wellplates/wellplate_2_2_from_server.js
@@ -1,0 +1,140 @@
+const wellplate2x2fromServer = {
+        "id": 46,
+        "is_restricted": false,
+        "height": 2,
+        "width": 2,
+        "type": "wellplate",
+        "wells": [{
+                "id": 3517,
+                "is_restricted": false,
+                "position": {
+                    "x": 1,
+                    "y": 1
+                },
+                "sample": null,
+                "type": "well",
+                "readouts": [],
+                "additive": null,
+                "color_code": null,
+                "label": "Molecular structure"
+            }, {
+                "id": 3518,
+                "is_restricted": false,
+                "position": {
+                    "x": 2,
+                    "y": 1
+                },
+                "sample": null,
+                "type": "well",
+                "readouts": [],
+                "additive": null,
+                "color_code": null,
+                "label": "Molecular structure"
+            }, {
+                "id": 3519,
+                "is_restricted": false,
+                "position": {
+                    "x": 1,
+                    "y": 2
+                },
+                "sample": null,
+                "type": "well",
+                "readouts": [],
+                "additive": null,
+                "color_code": null,
+                "label": "Molecular structure"
+            }, {
+                "id": 3520,
+                "is_restricted": false,
+                "position": {
+                    "x": 2,
+                    "y": 2
+                },
+                "sample": null,
+                "type": "well",
+                "readouts": [],
+                "additive": null,
+                "color_code": null,
+                "label": "Molecular structure"
+            }
+        ],
+        "comment_count": 0,
+        "code_log": {
+            "id": "c4d49d20-e702-4d8f-b24e-ab2b2e8f3f0f",
+            "value": "0261632641052955689708431930374409371407",
+            "source": "wellplate",
+            "source_id": 46,
+            "root_code": {},
+            "value_sm": "2616326410"
+        },
+        "container": {
+            "id": 36157,
+            "name": null,
+            "container_type": null,
+            "description": "",
+            "extended_metadata": {
+                "report": false,
+                "status": null,
+                "kind": null,
+                "index": null,
+                "instrument": null
+            },
+            "attachments": [],
+            "code_log": null,
+            "children": [{
+                    "id": 36158,
+                    "name": "new",
+                    "container_type": "analyses",
+                    "description": "",
+                    "extended_metadata": {
+                        "report": true,
+                        "status": null,
+                        "kind": null,
+                        "index": null,
+                        "instrument": null
+                    },
+                    "attachments": [],
+                    "code_log": null,
+                    "children": [],
+                    "dataset": null
+                }
+            ],
+            "dataset": null
+        },
+        "description": {
+            "ops": [{
+                    "insert": "\n"
+                }
+            ]
+        },
+        "name": "New Wellplate",
+        "readout_titles": [],
+        "segments": [],
+        "short_label": "FMA-WP19",
+        "tag": {
+            "taggable_data": {
+                "collection_labels": [{
+                        "id": 778,
+                        "name": "synced-coll-with-HAN",
+                        "user_id": 14,
+                        "is_shared": false,
+                        "shared_by_id": null,
+                        "is_synchronized": false
+                    }, {
+                        "id": 23,
+                        "name": "synced-coll-with-HAN",
+                        "user_id": 26,
+                        "is_shared": false,
+                        "shared_by_id": 14,
+                        "is_synchronized": true
+                    }
+                ]
+            },
+            "taggable_id": 46,
+            "taggable_type": "Wellplate",
+            "created_at": "12.07.2024, 12:00:57 +0000",
+            "updated_at": "12.07.2024, 12:00:57 +0000"
+        },
+        "created_at": "12.07.2024, 12:00:57 +0000",
+        "updated_at": "12.07.2024, 12:00:57 +0000"
+}

--- a/spec/javascripts/fixture/wellplates/wellplate_2_3_empty.js
+++ b/spec/javascripts/fixture/wellplates/wellplate_2_3_empty.js
@@ -6,7 +6,8 @@ const wellplate2x3EmptyJson = {
   type: 'wellplate',
   description: 'A test description for 2x3 plate',
   name: 'Testwellplate 2x3',
-  wells: []
+  wells: [],
+  is_new: true
 };
 
 export default wellplate2x3EmptyJson;

--- a/spec/javascripts/fixture/wellplates/wellplate_8_12_empty.js
+++ b/spec/javascripts/fixture/wellplates/wellplate_8_12_empty.js
@@ -7,7 +7,8 @@ const wellplate8x12EmptyJson = {
   width: 12,
   type: 'wellplate',
   description: 'A test description for 8x12 plate',
-  wells: []
+  wells: [],
+  is_new: true
 };
 
 export default wellplate8x12EmptyJson;

--- a/spec/javascripts/packs/src/models/Wellplate.spec.js
+++ b/spec/javascripts/packs/src/models/Wellplate.spec.js
@@ -6,12 +6,24 @@ import {
 import Wellplate from '../../../../../app/packs/src/models/Wellplate';
 import wellplate2x3EmptyJson from '../../../fixture/wellplates/wellplate_2_3_empty';
 import wellplate8x12EmptyJson from '../../../fixture/wellplates/wellplate_8_12_empty';
+import wellplate2x2fromServer from '../../../fixture/wellplates/wellplate_2_2_from_server';
 
 describe('Wellplate', async () => {
   const sampleMock = {};
   sampleMock.buildChild = () => ({ wasCopied: 'yes' });
 
   describe('constructor()', async () => {
+    context('when file was fetched from server', async () => {
+      const wellplate = new Wellplate(wellplate2x2fromServer);
+
+      it('created a wellplate of size 2 x 3', async () => {
+        expect(wellplate.size).toEqual(4);
+        expect(wellplate.height).toEqual(2);
+        expect(wellplate.width).toEqual(2);
+        expect(wellplate.wells.length).toEqual(4);
+      });
+    });
+
     context('when input is valid and has dimension 2x3 and has no samples in wells', async () => {
       const wellplate = new Wellplate(wellplate2x3EmptyJson);
 

--- a/spec/javascripts/packs/src/models/Wellplate.spec.js
+++ b/spec/javascripts/packs/src/models/Wellplate.spec.js
@@ -12,7 +12,7 @@ describe('Wellplate', async () => {
   sampleMock.buildChild = () => ({ wasCopied: 'yes' });
 
   describe('constructor()', async () => {
-    context('when input is valid and has dimesion 2x3 and has no samples in wells', async () => {
+    context('when input is valid and has dimension 2x3 and has no samples in wells', async () => {
       const wellplate = new Wellplate(wellplate2x3EmptyJson);
 
       it('created a wellplate of size 2 x 3', async () => {
@@ -176,7 +176,7 @@ describe('Wellplate', async () => {
       const wellplateSerialized = wellplate.serialize();
       it('properties of wellplate correct serialized', async () => {
         expect(wellplateSerialized.id).toEqual(1);
-        expect(wellplateSerialized.is_new).toEqual(false);
+        expect(wellplateSerialized.is_new).toEqual(true);
         expect(wellplateSerialized.name).toEqual('Testwellplate 2x3');
         expect(wellplateSerialized.size).toEqual(6);
         expect(wellplateSerialized.description).toEqual('A test description for 2x3 plate');


### PR DESCRIPTION

Fixed a bug : if wellplate was fetched from server its wells were initialised empty.