### PR TITLE
build(dev): fetch assets, or source code to build assets, of ketcher2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@
 !/public/ontologies/rxno.default.edited.json
 
 /public/data_type.json
+/public/default_editors
 
 /uploads/*
 !/public/attachments/.keep

--- a/.service-dependencies
+++ b/.service-dependencies
@@ -1,5 +1,5 @@
 #syntax=v1
-CONVERTER=ComPlat/chemotion-converter-app@v1.2.0
+CONVERTER=ComPlat/chemotion-converter-app@1.2.0
 KETCHER=ptrxyz/chemotion-ketchersvc@main
 SPECTRA=ComPlat/chem-spectra-app@1.2.2
 NMRIUMWRAPPER=NFDI4Chem/nmrium-react-wrapper@v0.4.0

--- a/bin/chem-get-git-src.sh
+++ b/bin/chem-get-git-src.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+
+# source utilities function located in the same directory
+source $(dirname $0)/chem-utils.sh
+
+
+# This script reads the version for a package as defined in the ../.service-dependencies file
+# @param $1: the package name
+# @return: the version of the package and the git repository as json or yml object 
+
+function get_git_src() {
+
+ # dependencies lock
+ local dep_filename=".service-dependencies"
+ local dependencies="${app_dir}${dep_filename}"
+ local ref=""
+ local version=""
+ local ref_type=""
+ local repo=""
+ local repo_url=""
+
+# check whether jq or yq are installed. need one of them (jq default) to output json or yml
+# if none installed, exit with error
+# if both installed, use jq as default
+# remember which one is used as $mode
+# local mode="json"
+
+  get_git_src_usage() {
+    echo "Usage: $0 --package-name <name>"
+    echo
+    echo "  -n, --package-name <name>        Specify the package name as defined in the .service-dependencies file - required"
+    echo "  -s, --package-src  <src@version> Set the src and version - optional default from .service-dependencies"
+    echo "  -p, --parse-only                 Do not try to get the assets urls from github"
+    exit 0
+  }
+
+# Initialize variables
+package_name=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+       -n|--package-name)
+            package_name="$2"
+            shift 2
+            ;;
+       -p|--parse-only)
+            parse_only=true
+	    shift
+	;;
+ -s|--package-src)
+            package_src="$2"
+	    shift 2
+	;;
+	-h|--help)
+	  get_git_src_usage
+	  ;;
+
+        *)
+  echo "hello $1"
+            echo "Invalid option: $1"
+  #          usage
+            ;;
+    esac
+done
+
+############################################################################################################
+# Local functions
+############################################################################################################
+
+# Function that extracts a line starting with the package name
+# or build the line if package_src is provided
+# @param $1: the package name
+# @return: the info after the "$package_name=" part if the line is valid
+get_package_src() {
+    local package_name="$1"
+    local line=$(grep -E "^${package_name}=" "$dependencies")	
+    if [[ -z $line ]]; then
+        vecho "No ${package_name} version specified/ in $dep_filename."
+        exit 1
+    fi
+    # package_src=$(echo "$line" | cut -d'=' -f2)
+    package_src=${line#*=}
+    vecho "Package source: $package_src"
+}
+
+# Function that validates the package info
+# @param $1: the package name src info
+validate_package_info() {
+    local info_src="$1"
+    if [[ ! $info_src =~ ^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+@[a-zA-Z0-9_.-]+$ ]]; then
+      # echo invalid version and exit
+      vecho "Invalid version format for $package_name in $dep_filename."
+      # return empty string
+      exit 1
+    fi
+    vecho "Valid version format: $info_src"
+    repo=${info_src%@*}  # part before '@' (user/repo)
+    repo_url="https://github.com/$repo"
+    version=${info_src#*@}  # part after '@' (version)
+    ref=${info_src#*@}   # part after '@' (branch/version/revision)
+    ref_type="tag"
+
+    # if ref is an hexademical string, it is a revision
+    # otherwise it is a branch or a tag
+    if [[ $ref =~ ^[0-9a-fA-F]+$ ]]; then
+	type="revision"
+    fi
+    # if ref is like a version number, it is a tag otherwise it is a branch
+    # A version number  is semantic, can start with v or a number, and can have dots
+    
+    if [[ $ref =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+	type="tag"
+    else
+	type="branch"
+    fi
+    vecho "Repo: $repo, Ref: $ref, Type: $type"
+ 
+}	
+
+
+# function to get the assets from the release by the tag
+# @param $1: the git repository
+# @param $2: the tag
+# @return: the url to the assets from the release tag
+get_assets_urls() {
+    # if mode is json, use jq to get the assets url
+    vecho "Getting assets urls from $repo_url/releases/tag/$ref"
+    if [[ $mode == "json" ]]; then
+      local assets_url=$(curl -L -H "Accept: application/vnd.github+json" -s "https://api.github.com/repos/${repo}/releases/tags/$ref" | jq -r '.assets_url')
+      assets_urls=$(curl -L -H "Accept: application/vnd.github+json" -s $assets_url | jq -r '[.[] | .browser_download_url]') jq -r ".$package_name.assets_urls = ( env.assets_urls | fromjson)" $dep_json > tmp/.tmp.json
+      mv tmp/.tmp.json $dep_json
+
+    elif [[ $mode == "yml" ]]; then
+      local assets_url=$(curl -L -H "Accept: application/vnd.github+json" -s "https://api.github.com/repos/${repo}/releases/tags/$ref" | yq -r '.assets_url')
+      local assets_urls=$(curl -L -H "Accept: application/vnd.github+json" -s $assets_url | yq -p=json '[.[] | .browser_download_url]')
+      assus="$assets_urls" yq  ".${package_name}.assets_urls = env(assus)" -i $dep_yml
+    fi
+}
+
+
+# Function that echoes a json object with the version and the git repository
+#  from the package info
+# @param $1: the package_info
+# @param $2: the git repository of the package
+# @return: the json or yml object
+get_service_info() {
+    # define the repo_url on github based on $repo
+   local result=""
+   local base_info="{\"$package_name\": {\"repo\": \"$repo\", \"repo_url\": \"$repo_url\", \"version\": \"$ref\", \"ref_type\": \"$ref_type\", \"assets_urls\": []}}"
+
+    if [[ $mode == "json" ]]; then
+      # build the json object from the base_info and the assets_urls
+      vecho "Building json object with base_info: $base_info"
+      echo $base_info | jq -r | tee $dep_json
+    elif [[ $mode == "yml" ]]; then
+       local cmd="yq -n '$base_info' > $dep_yml"
+       eval $cmd
+       cp $dep_yml $dep_yml.bak
+    fi
+}
+
+
+############################################################################################################
+# Main
+############################################################################################################
+
+# Check if the file exists in the current directory
+# if no package_name is provided, exit with error
+if [ -z "$package_name" ]; then
+  echo "Error: No package name provided"
+  get_git_src_usage
+fi
+# if no package_src is provided, and $dependencies does not exist, exit with error
+if [ -z "$package_src" ] && [ ! -f "$dependencies" ]; then
+  echo "Error: No package source provided and no dependencies file found"
+  get_git_src_usage
+fi
+
+
+if [ -z "$package_src" ]; then
+  get_package_src $package_name
+fi
+
+# if validate_package_info returns false, exit with error
+if ! validate_package_info $package_src; then
+  vecho "Error: Invalid package source provided"
+  get_git_src_usage
+fi
+
+get_service_info $package_src
+# get type of version from the package info
+# if the version is a tag, get the assets urls
+if [[ $ref_type == "tag" && -z $parse_only ]]; then
+	vecho "Getting assets urls for $package_name"
+  get_assets_urls
+fi
+
+}
+

--- a/bin/chem-ket2-install.sh
+++ b/bin/chem-ket2-install.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+
+# This script gets the src code (and build) or the compiled assets from a git repository
+# for Ketcher 2 
+# source and version should be defined in .service-dependencies file or passed as arguments
+# needs: jq or yq, unzip, git
+
+
+package_name="KETCHER2"
+package_type="standalone"
+usage() {
+    echo "Usage: $0 --package-src <user/repo:version> --artifact-type <type> --build-from-source"
+    echo
+    echo "  -s, --package-src <src>          Optional: specify the src and version for ${package_name} as defined in the .service-dependencies file. "
+    echo "                                             Default from .service-dependencies file"
+    echo "  -t, --package-type <standalone|remote> Optional: If multiple artifacts are present select the one to use - default 'standalone'"
+    echo "  -b, --build-from-src             Optional: Build from src - default false: get compiled artifacts from src repo "
+    echo "  --options <options>              Optional: Additional options to pass to the build script"
+    echo "  -h, --help                       Display this help message."
+    echo "  -v, --verbose                    verbose output  "
+    exit 0
+}
+
+# Initialize variables
+while [[ $# -gt 0 ]]; do
+    case $1 in
+       -s|--package-src)
+            package_src="$2"
+            shift 2
+            ;;
+        -t|--package-type)
+            package_type="$2"
+            shift 2
+            ;;
+	-b|--build-from-src)
+            build_from_source=true
+	    shift
+	;;
+	--options)
+	    options="$2"
+	    shift 2
+	    ;;
+	-h|--help)
+	    usage
+	    ;;
+	-v | --verbose)
+	    verbose=true
+	    shift
+	    ;;
+	*)
+	    echo "Unknown option: $1"
+	    usage
+	    ;;
+    esac
+done
+# source utilities script from the same directory
+source "$(dirname "$0")/chem-utils.sh"
+source "${script_dir}chem-get-git-src.sh"
+cd $app_dir
+
+package_name_lower=$(echo $package_name | tr '[:upper:]' '[:lower:]')
+log_file="${app_dir}log/install_${package_name_lower}.log"
+vecho "starting $(date) "
+editors_dir=public/editors/
+final_destination=${editors_dir}default
+relative_destination=${package_name_lower}/
+# if build_from_source add another subfolder
+if [ "$build_from_source" = true ]; then
+    relative_destination=${relative_destination}rebuilt/
+else
+    relative_destination=${relative_destination}built/
+fi
+
+#function to make links
+make_links(){
+    rm -f $final_destination
+    ln -s $relative_destination $final_destination
+    vecho "Created symlink $final_destination -> $relative_destination"
+
+    # create link for path from structure_editor.yml.example
+    example_path=$editors_dir$package_name_lower/$package_type
+
+    # check if the link exists
+    if [ -d $example_path ] && [ ! -L $example_path ]; then
+	vecho "Dir already exists: $example_path. Not symlinking"
+    else
+	rm -r $example_path
+        ln -s ../$relative_destination $example_path
+        vecho "symlinking $example_path to $relative_destination"
+    fi
+}
+
+# relative path in the package src to the tsconfig.json that should define the build directory
+tsconfig_path=example
+
+info_cmd="get_git_src -n ${package_name} "
+  
+# if current env=production, then defined other var for the build
+# will be added in the cloned directory .env file
+if [ "$RAILS_ENV" = "production" ]; then
+  echo "$package_name installation for Production environment: getting precompiled assets as defined in the .service-dependencies file"
+  build_from_source=''
+  package_src=''
+else
+
+  # multiple cases depending on args:
+  #  1 package_src and build_from_source
+  #  2 package_src and not build_from_source
+  #  3 not package_src and build_from_source
+  #  4 not package_src and not build_from_source
+    #  case 1
+  if [ -n "$package_src" ] && [ -n "$build_from_source" ]; then
+      vecho "Package source defined, want to build from source"
+      info_cmd="$info_cmd --package-src ${package_src} --parse-only"
+  fi
+  # case 2
+  if [ -n "$package_src" ] && [ -z "$build_from_source" ]; then
+      vecho "Package source defined, need to get asset links" 
+      info_cmd="$info_cmd -s ${package_src}"
+  fi
+  #  case 3
+  if [ -z "$package_src" ] && [ -n "$build_from_source" ]; then
+      vecho "Package source from .service-dependencies, want to build from source"
+      info_cmd="$info_cmd -p"
+  fi
+  # case 4
+  if [ -z "$package_src" ] && [ -z "$build_from_source" ]; then
+      vecho "Package source from .service-dependencies, need to get asset links" 
+  fi
+  
+
+  options="ENABLE_POLYMER_EDITOR=true GENERATE_SOURCEMAP=true $options"
+fi
+
+vecho "options: $options"
+
+vecho "running: $info_cmd"
+package_info=$(eval $info_cmd)
+vecho "Package info: $package_info"
+
+# make a subfolder in the destination name after the $package_name and version as given in package_info json
+version="$(get_attribute $package_name 'version')"
+vecho "Version: $version"
+relative_destination=${relative_destination}${version}/$package_type/
+destination=${editors_dir}$relative_destination
+mkdir -p $destination
+
+# if the destination is not empty, then echo message and exit
+if [ "$(ls -A $destination)" ]; then
+    echo "Destination directory $destination is not empty. Assets might already exist. Exiting"
+    vecho "Just re-creating the symlink"
+    make_links
+   exit 0
+else 
+  vecho "Destination: $destination"
+fi
+
+
+# if build_from_source then run the build script/ chem-node-package-install.sh
+if [ -n "$build_from_source" ]; then
+    vecho "Building from source"
+    build_cmd="${script_dir}/chem-node-package-install.sh -s ${repo}@${version} -a $package_type --destination ${destination} --package-name ${package_name} --env-options '${options}' --tsconfig-path ${tsconfig_path}" 
+    # add verbose flag if set
+    if [ "$verbose" = true ]; then
+	build_cmd="$build_cmd -v"
+    fi
+    vecho "running: $build_cmd"
+    eval $build_cmd || exit 1
+# else get assets from assets_url
+else
+    assets_url="$(get_attribute $package_name 'assets_urls' $package_type)"
+    vecho "Assets url: $assets_url"
+    # mk tmp dir, curl assets, and unzip them inside the tmp dir, then copy to destination, then remove tmp dir
+    tmpdir=$(sanitize_dir_path "$(mktemp -d)")
+    _cmd="curl -L  -o ${tmpdir}assets.zip ${assets_url}"
+    vecho "curl_cmd: $_cmd"
+    eval $_cmd || exit 1
+    _cmd="unzip -q ${tmpdir}assets.zip -d ${tmpdir}"
+    vecho "unzip_cmd: $_cmd"
+    eval $_cmd || exit 1
+    # remove zip file and copy to destination
+    rm ${tmpdir}assets.zip
+    cp -r ${tmpdir}${package_type}/* ${destination}
+    rm -rf ${tmpdir}
+fi
+
+# symlink the selected artifact to the final destination
+make_links
+

--- a/bin/chem-node-package-install.sh
+++ b/bin/chem-node-package-install.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+
+# This script build and installs a npm package from its source code
+# source and version should be defined in .service-dependencies
+# (nodejs and npm should be installed)
+usage() {
+    echo "Usage: $0 --destination <path> --package-name <name> --env-options <options>"
+    echo
+    echo "Options:"
+    echo "  --package-name <name>    Specify the package name as defined in the .service-dependencies file - required"
+    echo "  --destination <path>     Specify the relative destination directory for the build artifacts - default 'public/'"
+    echo "  --env-options <options>  Specify environment options to be added to the .env file in the package source - optional"
+    echo "  --tsconfig-path <path>   Specify the relative path in the package source to the tsconfig.json file - default '.'"
+    echo "  --artifact               Specify the artifact to be copied - optional"
+    echo "  --package-info           package info - optional default from .service-dependencies"
+    echo "  --help                   Display this help message and exit"
+    exit 0
+}
+
+# source utilities script from the same directory
+source "$(dirname "$0")/chem-utils.sh"
+
+# Initialize variables
+destination="./public/"
+package_name=""
+env_options=""
+tsconfig_dir="."
+artifact_path="."
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+       -n|--package-name)
+            package_name="$2"
+            shift 2
+            ;;
+        -d|--destination)
+            destination="$2"
+            shift 2
+            ;;
+	--tsconfig-path)
+	   tsconfig_dir="$2"
+	   shift 2
+	   ;;
+        -o|--env-options)
+            env_options="$2"
+            shift 2
+            ;;
+	-a|--artifact)
+            artifact_path="$2"
+	    shift 2
+	    ;;
+    -s|--package-src)
+	    package_info="$2"
+	    shift 2
+	    ;;
+    -v)
+	    verbose=true
+	    shift
+	    ;;
+	-h|--help)
+	    usage
+	    ;;
+	*)
+	    echo "Unknown option: $1"
+	    usage
+	    ;;
+    esac
+done
+
+
+# Set up trap to clean up on exit
+trap cleanup $tmpdir EXIT
+
+# Determine the destination directory for copying build artifacts
+destination=$(sanitize_dir_path "$destination")
+dest_dir=$(sanitize_dir_path "${app_dir}${destination}")
+# Filename where the version is stored
+filename="${app_dir}.service-dependencies"
+tsconfig_dir=$(sanitize_dir_path "$tsconfig_dir")
+artifact_path=$(sanitize_dir_path "$artifact_path")
+
+vecho "Installing $package_name - $(date)"
+vecho "Working from app dir: $app_dir"
+vecho "Destination directory: $destination"
+vecho "Destination directory: $dest_dir"
+vecho "Service file setting the version to install: $filename"
+vecho "relative path to tsconfig.json: $tsconfig_dir'"
+vecho "--env_options: $env_options"
+vecho "Log file: $log_file"
+
+
+
+# Check if the build artifacts already exist
+if [[ -d "$dest_dir" && "$(ls -A $dest_dir)" ]]; then
+    echo "Build artifacts already exist /in $dest_dir. Skipping clone, build, and copy steps."
+    exit 0
+fi
+
+# Create a temporary directory
+tmpdir=$(mktemp -d)
+tmpdir=$(sanitize_dir_path "$tmpdir")
+# Clone the specified repository and checkout the specified branch/version
+
+
+# Clone the repository
+# cloning single revision not implemented yet
+# exit if ref type is a revision. ref_type should be branch or tag
+ref_type=$(get_attribute $package_name "ref_type")
+if [[ "$ref_type" == "revision" ]]; then
+    vecho "Cloning single revision not implemented yet. Exiting."
+    exit 1
+fi
+
+repo_url=$(get_attribute $package_name "repo_url")
+branch=$(get_attribute $package_name "version")
+vecho "Cloning branch $branch $repo_url"
+if ! git clone --branch "$branch" --depth 1 --single-branch "$repo_url" "$tmpdir"; then
+    vecho "Failed to clone the repository."
+    exit 1
+fi
+
+vecho "Repository cloned into $tmpdir"
+
+# Navigate to the subdirectory
+cd "$tmpdir/" || exit
+
+# modify .env file located in the same directory as the tsconfig.json
+if [[ -n $env_options ]]; then
+    vecho "Adding environment options to .env file: $env_options"
+    env_options_formatted=$(echo "$env_options" | tr ' ,' '\n')
+ 
+    echo -e "\n${env_options_formatted}" >> "${tsconfig_dir}.env"
+fi
+
+# Run npm install and npm build
+if ! npm install --production=false || ! npm run build; then
+    vecho "npm install or npm build failed."
+    exit 1
+fi
+
+echo "npm install and npm build completed successfully."
+
+# Extract outDir from tsconfig.json
+# if mode json use jq to extract outDir else use yq
+if [[ $mode == "json" ]]; then
+   outDir=$(jq -r '.compilerOptions.outDir' ${tsconfig_dir}tsconfig.json)
+else
+   outDir=$(cat ${tsconfig_dir}tsconfig.json | yq -r  '.compilerOptions.outDir')
+fi
+vecho "outDir: $outDir"
+if [[ $outDir == "null" ]]; then
+    vecho "outDir not found in tsconfig.json."
+    exit 1
+fi
+
+vecho "outDir found in tsconfig.json: $outDir"
+outDir=$(sanitize_dir_path "$outDir")
+
+# Determine the absolute path to the build artifacts
+build_dir="${tmpdir}${tsconfig_dir}${outDir}${artifact_path}"
+echo "Build directory: $build_dir"
+
+# Create the destination directory if it doesn't exist
+mkdir -p "$dest_dir"
+
+# Copy the build artifacts to the destination directory
+if ! cp -r "$build_dir"* "$dest_dir"; then
+    vecho "Failed to copy build artifacts."
+    exit 1
+fi
+
+vecho "Build artifacts copied to $dest_dir successfully."
+

--- a/bin/chem-utils.sh
+++ b/bin/chem-utils.sh
@@ -1,0 +1,106 @@
+# shell utilities for chemotion dep installation
+
+# Sanitized directory paths 
+#  so that to not worryi about double slashes
+# @param $1: the directory path
+# @return: the directory path with removed trailing slash and
+#   with removed leading dot-slash
+function sanitize_dir_path {
+    local path="$1"
+    # Remove leading `./` if present
+    if [[ "$path" == "./" ]]; then
+        echo ""
+        return
+    fi
+    
+    path="${path#./}"
+    
+    # Ensure the path ends with `/` if it's not empty and doesn't already end with `/`
+    if [[ -n "$path" && "${path: -1}" != "/" ]]; then
+        path="$path/"
+    fi
+    
+
+    # remove '//' from  path
+    path=$(echo $path | sed 's/\/\//\//g')
+
+    echo "$path"
+}
+
+
+# Function to clean up temporary directory
+# @param $1: list of directory to clean up
+function cleanup {
+# rm tmp dir if defined
+    for dir in "$@"; do
+	if [[ -n $dir ]]; then
+	    rm -rf "$dir"
+	    vecho "Directory $dir removed."
+	fi
+    done
+}
+
+
+# function to echo message if verbose is set
+function vecho {
+    if [ "$verbose" = true ]; then
+	echo "$package_name install: $1"
+    fi
+    # log the message to the log file if defined
+    if [ -n "$log_file" ]; then
+	echo "$package_name install: $1" >> "$log_file"
+    fi
+}
+
+function log_only {
+  if [ -n "$log_file" ]; then
+    # Redirect all output to log file
+    exec > >(tee -a "$log_file") 2>&1
+  fi
+}
+
+
+
+# define sanitized directory paths 
+script_dir=$(dirname "$(realpath "$0")")
+script_dir=$(sanitize_dir_path "$script_dir")
+app_dir=$(realpath "${script_dir}..")
+app_dir=$(sanitize_dir_path "$app_dir")
+
+# define the parsed service info file
+dep_json="${app_dir}tmp/.service-dependencies.json"
+dep_yml="${app_dir}tmp/.service-dependencies.yml"
+
+
+
+# define whether jq or yq is installed
+if [ -x "$(command -v jq)" ]; then
+  mode="json"
+elif [ -x "$(command -v yq)" ]; then
+  mode="yml"
+else
+  echo "Error: jq or yq is required to run this script"
+  vecho "Error: jq or yq is required to run this script"
+  exit 1
+fi
+
+# WIP force yq mode
+# mode="yml"
+
+get_attribute() {
+    local package_name="$1"
+    local attribute="$2"
+    local package_type="${3:-standalone}"
+    local attribute_value=""
+    if [[ $mode == "json" ]]; then
+      local attribute_value=$(jq -r ".${package_name}.${attribute}" $dep_json)
+    elif [[ $mode == "yml" ]]; then
+      local attribute_value=$(yq ".${package_name}.${attribute}" $dep_yml)
+    fi
+    # if attribute is assets_urls, grep by package_type
+    if [[ $attribute == "assets_urls" ]]; then
+      local attribute_value=$(echo "$attribute_value" | grep -o -E "https://.*${package_type}-[^\"]*") > /dev/null
+    fi
+    echo "$attribute_value"
+}
+#


### PR DESCRIPTION
(requires jq or yq, unzip, git)

- default version locked in `.service-dependencies`
- move assets to public/editors/ketcher2/{pre}built/{version}/{standalone|remote}
- symlink to `public/editors/default` and `public/editors/ketcher2/standalone` (unless real dir present)

Examples:

- install the recommended version from provider artifacts

```sh
bin/chem-ket2-install.sh
```
- build and install the latest version from source

```sh
bin/chem-ket2-install.sh -b -s epam/ketcher@master
```

Usage:
```
 bin/chem-ket2-install.sh --package-src <user/repo:version> --artifact-type <type> --build-from-source

  -s, --package-src <src>          Optional: specify the src and version(tag, branch, or commit) for KETCHER2 as defined in the .service-dependencies file.
                                             Default from .service-dependencies file
  -t, --package-type <standalone|remote> Optional: If multiple artifacts are present select the one to use - default 'standalone'
  -b, --build-from-src             Optional: Build from src - default false: get compiled artifacts from src repo
  --options <options>              Optional: Additional options to pass to the build script
  -h, --help                       Display this help message.
  -v, --verbose                    verbose output
```

