### PR TITLE
3PA: apply UI refresh to all areas

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
@@ -247,7 +247,7 @@ class ResearchPlanDetailsAttachments extends Component {
     
     let combinedAttachments = filteredAttachments;
     if(this.context.attachmentNotificationStore ){
-      combinedAttachments =  this.context.attachmentNotificationStore.getCombinedAttachments(filteredAttachments,researchPlan,"ResearchPlan");
+      combinedAttachments =  this.context.attachmentNotificationStore.getCombinedAttachments(filteredAttachments,"ResearchPlan",researchPlan);
     }
 
     const { onUndoDelete, attachments } = this.props;

--- a/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
@@ -58,7 +58,6 @@ class ResearchPlanDetailsAttachments extends Component {
     this.confirmAttachmentImport = this.confirmAttachmentImport.bind(this);
     this.showImportConfirm = this.showImportConfirm.bind(this);
     this.hideImportConfirm = this.hideImportConfirm.bind(this);
-    this.addUniqueAttachments = this.addUniqueAttachments.bind(this);
   }
 
   componentDidMount() {
@@ -218,21 +217,6 @@ class ResearchPlanDetailsAttachments extends Component {
     this.hideImportConfirm(attachment.id);
   }
 
-  addUniqueAttachments(attachmentsFromMessages, researchPlan) {
-    const { filteredAttachments } = this.state;
-    attachmentsFromMessages.forEach((attachment) => {
-      const existingMessage = filteredAttachments.find((a) => a.id === attachment.id);
-      const forCurrentElement = researchPlan.id === attachment.attachable_id
-        && attachment.attachable_type === 'ResearchPlan';
-      if (!existingMessage && forCurrentElement) {
-        const copiedAttachment = { ...attachment };
-        copiedAttachment.is_deleted = false;
-        filteredAttachments.push(copiedAttachment);
-        researchPlan.attachments.push(copiedAttachment);
-      }
-    });
-  }
-
   renderImageEditModal() {
     const { chosenAttachment, imageEditModalShown } = this.state;
     const { onEdit } = this.props;
@@ -260,17 +244,15 @@ class ResearchPlanDetailsAttachments extends Component {
     const { researchPlan } = this.props;
 
     //Ugly temporary hack to avoid tests failling because the context is not accessable in tests with the enzyme framework
-    let attachmentsFromMessages = [] ;
-    if(this.context.attachmentNotificationStore ){
-      attachmentsFromMessages = this.context.attachmentNotificationStore.getAttachmentsOfMessages();
-    }
     
-
-    this.addUniqueAttachments(attachmentsFromMessages, researchPlan);
+    let combinedAttachments = filteredAttachments;
+    if(this.context.attachmentNotificationStore ){
+      combinedAttachments =  this.context.attachmentNotificationStore.getCombinedAttachments(filteredAttachments,researchPlan,"ResearchPlan");
+    }
 
     const { onUndoDelete, attachments } = this.props;
     const thirdPartyApps = this.thirdPartyApps;
-
+    
     return (
       <div className="attachment-main-container">
         {this.renderImageEditModal()}
@@ -289,12 +271,12 @@ class ResearchPlanDetailsAttachments extends Component {
         )}
           </div>
         </div>
-        {filteredAttachments.length === 0 ? (
+        {combinedAttachments.length === 0 ? (
           <div className="no-attachments-text">
             There are currently no attachments.
           </div>
         ) : (
-          filteredAttachments.map((attachment) => (
+          combinedAttachments.map((attachment) => (
             <div className="attachment-row" key={attachment.id}>
               {attachmentThumbnail(attachment)}
               <div className="attachment-row-text" title={attachment.filename}>

--- a/app/packs/src/apps/mydb/elements/details/wellplates/attachmentsTab/WellplateDetailsAttachments.js
+++ b/app/packs/src/apps/mydb/elements/details/wellplates/attachmentsTab/WellplateDetailsAttachments.js
@@ -25,6 +25,8 @@ import {
   thirdPartyAppButton,
 } from 'src/apps/mydb/elements/list/AttachmentList';
 import { formatDate, parseDate } from 'src/utilities/timezoneHelper';
+import { StoreContext } from 'src/stores/mobx/RootStore';
+import { observer } from 'mobx-react';
 
 const templateInfo = (
   <Popover id="popver-template-info" title="Template info">
@@ -42,7 +44,9 @@ const templateInfo = (
   </Popover>
 );
 
-export default class WellplateDetailsAttachments extends Component {
+export class WellplateDetailsAttachments extends Component {
+  static contextType = StoreContext;
+
   constructor(props) {
     super(props);
     this.importButtonRefs = [];
@@ -271,7 +275,12 @@ export default class WellplateDetailsAttachments extends Component {
     const {
       filteredAttachments, sortDirection, attachmentEditor, extension
     } = this.state;
-    const { onUndoDelete, attachments } = this.props;
+    const { onUndoDelete, attachments,wellplate } = this.props;
+
+    let combinedAttachments = filteredAttachments;
+    if(this.context.attachmentNotificationStore ){
+      combinedAttachments =  this.context.attachmentNotificationStore.getCombinedAttachments(filteredAttachments,"Wellplate",wellplate);
+    }
 
     return (
       <div className="attachment-main-container">
@@ -292,12 +301,12 @@ export default class WellplateDetailsAttachments extends Component {
         )}
           </div>
         </div>
-        {filteredAttachments.length === 0 ? (
+        {combinedAttachments.length === 0 ? (
           <div className="no-attachments-text">
             There are currently no attachments.
           </div>
         ) : (
-          filteredAttachments.map((attachment) => (
+          combinedAttachments.map((attachment) => (
             <div className="attachment-row" key={attachment.id}>
               {attachmentThumbnail(attachment)}
 
@@ -430,3 +439,5 @@ WellplateDetailsAttachments.propTypes = {
 WellplateDetailsAttachments.defaultProps = {
   attachments: [],
 };
+
+export default observer(WellplateDetailsAttachments);

--- a/app/packs/src/components/container/ContainerDatasetModalContent.js
+++ b/app/packs/src/components/container/ContainerDatasetModalContent.js
@@ -38,8 +38,11 @@ import {
 } from 'src/apps/mydb/elements/list/AttachmentList';
 import { formatDate } from 'src/utilities/timezoneHelper';
 import UIStore from 'src/stores/alt/stores/UIStore';
+import { StoreContext } from 'src/stores/mobx/RootStore';
+import { observer } from 'mobx-react';
 
-export default class ContainerDatasetModalContent extends Component {
+export class ContainerDatasetModalContent extends Component {
+  static contextType = StoreContext;
   constructor(props) {
     super(props);
     const datasetContainer = { ...props.datasetContainer };
@@ -549,6 +552,12 @@ export default class ContainerDatasetModalContent extends Component {
     } = this.state;
     const { datasetContainer } = this.props;
 
+    let combinedAttachments = filteredAttachments;
+    if (this.context.attachmentNotificationStore) {
+      // eslint-disable-next-line max-len
+      combinedAttachments = this.context.attachmentNotificationStore.getCombinedAttachments(filteredAttachments, 'Container', datasetContainer);
+    }
+
     const renderGroup = (attachments, title, key) => (
       <div key={key} style={{ marginTop: '10px' }}>
         <div style={{
@@ -561,7 +570,7 @@ export default class ContainerDatasetModalContent extends Component {
         >
           {title}
         </div>
-        {attachments.map((attachment) => this.renderAttachmentRow(attachment))}
+        {combinedAttachments.map((attachment) => this.renderAttachmentRow(attachment))}
       </div>
     );
 
@@ -587,7 +596,7 @@ export default class ContainerDatasetModalContent extends Component {
               )}
           </div>
         </div>
-        {filteredAttachments.length === 0 ? (
+        {combinedAttachments.length === 0 ? (
           <div className="no-attachments-text">
             There are currently no attachments.
           </div>
@@ -746,3 +755,5 @@ ContainerDatasetModalContent.defaultProps = {
   kind: null,
   onInstrumentChange: () => {},
 };
+
+export default observer(ContainerDatasetModalContent);

--- a/app/packs/src/stores/mobx/AttachmentNotificationStore.jsx
+++ b/app/packs/src/stores/mobx/AttachmentNotificationStore.jsx
@@ -56,7 +56,7 @@ export const AttachmentNotificationStore = types
     getAttachmentsOfMessages() {
       return self.messages.map((element) => element.content.attachment || []).flat();
     },
-    getCombinedAttachments(attachmentsFromElement, element, elementContext) {
+    getCombinedAttachments(attachmentsFromElement, elementContext,element=undefined) {
       self.getAttachmentsOfMessages().forEach((attachment) => {
         const attachmentAlreadyInElement = attachmentsFromElement.find((a) => a.id === attachment.id);
         const forCurrentElement = element.id === attachment.attachable_id
@@ -65,7 +65,9 @@ export const AttachmentNotificationStore = types
           const copiedAttachment = { ...attachment };
           copiedAttachment.is_deleted = false;
           attachmentsFromElement.push(copiedAttachment);
-          element.attachments.push(copiedAttachment);
+          if(element){
+            element.attachments.push(copiedAttachment);
+          }
         }
       });
       return attachmentsFromElement;

--- a/app/packs/src/stores/mobx/AttachmentNotificationStore.jsx
+++ b/app/packs/src/stores/mobx/AttachmentNotificationStore.jsx
@@ -1,5 +1,21 @@
 import { types } from 'mobx-state-tree';
 
+const messageAttachment = types.model({
+  id: types.union(types.string, types.integer),
+  filename: types.string,
+  identifier: types.union(types.string, types.integer),
+  content_type: types.string,
+  thumb: types.boolean,
+  filesize: types.integer,
+  created_at: types.string,
+  updated_at: types.string,
+  preview: types.maybeNull(types.string)
+});
+
+const messageContent = types.model({
+  attachment: types.frozen(messageAttachment)
+});
+
 const messageModel = types.model({
   id: types.integer,
   message_id: types.integer,
@@ -11,20 +27,7 @@ const messageModel = types.model({
   is_ack: types.integer,
   created_at: types.string,
   updated_at: types.string,
-  content: types.frozen(messageAttachment)
-});
-
-const messageAttachment=types.model({
-  id: types.integer,
-  filename: types.string,
-  identifier: types.string,
-  content_type: types.string,
-  thumb: types.boolean,
-  aasm_state: types.string,
-  filesize: types.integer,
-  created_at: types.string,
-  updated_at: types.string,
-  preview: types.string
+  content: types.frozen(messageContent)
 });
 
 // eslint-disable-next-line import/prefer-default-export
@@ -37,12 +40,11 @@ export const AttachmentNotificationStore = types
   }))
   .actions((self) => ({
     addMessage(newMessage) {
-      
       const existingMessage = self.messages.find((message) => message.id === newMessage.id);
-     
+
       const channelTypeCorrect = newMessage.channel_type === 8
         && newMessage.subject === 'Send TPA attachment arrival notification';
-     
+
       if (!existingMessage && channelTypeCorrect) {
         self.messages.push(newMessage);
       }
@@ -52,8 +54,20 @@ export const AttachmentNotificationStore = types
     }
   })).views((self) => ({
     getAttachmentsOfMessages() {
-      return self.messages.map((element) => {
-        return element.content.attachment || [];
-      }).flat();
-    }
+      return self.messages.map((element) => element.content.attachment || []).flat();
+    },
+    getCombinedAttachments(attachmentsFromElement, element, elementContext) {
+      self.getAttachmentsOfMessages().forEach((attachment) => {
+        const attachmentAlreadyInElement = attachmentsFromElement.find((a) => a.id === attachment.id);
+        const forCurrentElement = element.id === attachment.attachable_id
+          && attachment.attachable_type === elementContext;
+        if (!attachmentAlreadyInElement && forCurrentElement) {
+          const copiedAttachment = { ...attachment };
+          copiedAttachment.is_deleted = false;
+          attachmentsFromElement.push(copiedAttachment);
+          element.attachments.push(copiedAttachment);
+        }
+      });
+      return attachmentsFromElement;
+    },
   }));

--- a/app/packs/src/stores/mobx/AttachmentNotificationStore.jsx
+++ b/app/packs/src/stores/mobx/AttachmentNotificationStore.jsx
@@ -56,7 +56,7 @@ export const AttachmentNotificationStore = types
     getAttachmentsOfMessages() {
       return self.messages.map((element) => element.content.attachment || []).flat();
     },
-    getCombinedAttachments(attachmentsFromElement, elementContext,element=undefined) {
+    getCombinedAttachments(attachmentsFromElement, elementContext,element) {
       self.getAttachmentsOfMessages().forEach((attachment) => {
         const attachmentAlreadyInElement = attachmentsFromElement.find((a) => a.id === attachment.id);
         const forCurrentElement = element.id === attachment.attachable_id
@@ -65,7 +65,7 @@ export const AttachmentNotificationStore = types
           const copiedAttachment = { ...attachment };
           copiedAttachment.is_deleted = false;
           attachmentsFromElement.push(copiedAttachment);
-          if(element){
+          if(element.attachments){
             element.attachments.push(copiedAttachment);
           }
         }

--- a/spec/javascripts/factories/AttachmentFactory.js
+++ b/spec/javascripts/factories/AttachmentFactory.js
@@ -17,7 +17,7 @@ export default class AttachmentFactory {
     this.factory = factory;
 
     this.factory.define('AttachmentFactory.new', Attachment, {
-      id: parseInt(Element.buildID(), 10),
+      id: factory.sequence('AttachmentFactory.id', (n) => n),
       is_new: true,
       updated_at: new Date(),
       filename: 'test.png',
@@ -31,15 +31,15 @@ export default class AttachmentFactory {
     });
 
     this.factory.define('AttachmentFactory.notificationAttachment', Attachment, {
-      id: parseInt(Element.buildID(), 10),
+      id: factory.sequence('AttachmentFactory.id', (n) => n),
       filename: 'MyAttachment',
       identifier: 'myIdentifier',
       content_type: 'image/png',
       thumb: true,
-      aasm_state: 'non_jcamp',
       filesize: 1485,
       created_at: '08.07.2024, 14:01:25 +0000',
-      updated_at: '08.07.2024, 14:01:25 +0000'
+      updated_at: '08.07.2024, 14:01:25 +0000',
+      preview: 'myPreview'
     });
   }
 }

--- a/spec/javascripts/factories/AttachmentNotificationFactory.js
+++ b/spec/javascripts/factories/AttachmentNotificationFactory.js
@@ -32,14 +32,15 @@ export default class AttachmentNotificationFactory {
         receiver_id: 2,
         is_ack: 0,
         created_at: '2023-07-01T12:00:00Z',
-        updated_at: '2023-07-01T12:00:00Z'
+        updated_at: '2023-07-01T12:00:00Z',
+        content:{}
+
       };
 
       const attachment = await AttachmentFactory.build('AttachmentFactory.notificationAttachment');
-      attachment.preview='MyPreview';
       delete attachment._checksum;
       // I deconstruct the class object here because the store needs a plain js object
-      model.content = { ...attachment };
+      model.content.attachment = { ...attachment };
       return model;
     });
   }


### PR DESCRIPTION

This PR extends the refresh of Third party app attachments to wellplates and container datasets.

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

