### PR TITLE
test: fix flaky tests in chemical_api_spec (webmock)

### DIFF
--- a/spec/api/chemotion/chemical_api_spec.rb
+++ b/spec/api/chemotion/chemical_api_spec.rb
@@ -120,15 +120,16 @@ describe Chemotion::ChemicalAPI do
 
       before do
         stub_request(:get, 'https://www.alfa.com/en/search/?q=')
-          .with(headers: { 'Access-Control-Request-Method' => 'GET', 'Accept' => '*/*', 'User-Agent': 'Google Chrome' })
+          .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate, br',
+                           'Access-Control-Request-Method' => 'GET' })
           .to_return(status: 200, body: '', headers: {})
         stub_request(:get, 'https://www.sigmaaldrich.com/US/en/search')
-          .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate, br',
                            'Access-Control-Request-Method' => 'GET',
                            'User-Agent' => 'Google Chrome' })
           .to_return(status: 200, body: '', headers: {})
         get "/api/v1/chemicals/fetch_safetysheet/#{chemical.sample_id}?data[vendor]=#{params[:vendor]}&data[option]=
-            #{params[:option]}&data[language]=#{params[:language]}", params: params
+          #{params[:option]}&data[language]=#{params[:language]}", params: params
       end
 
       it 'fetches the response from merck/thermofischer api' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -148,10 +148,11 @@ RSpec.configure do |config|
       .with(headers: { 'Accept' => '*/*', 'Access-Control-Request-Method' => 'GET', 'User-Agent' => 'Google Chrome' })
       .to_return(status: 200, body: '', headers: {})
     stub_request(:get, 'https://www.alfa.com/en/search/?q=')
-      .with(headers: { 'Access-Control-Request-Method' => 'GET', 'Accept' => '*/*', 'User-Agent': 'Google Chrome' })
+      .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate, br',
+                       'Access-Control-Request-Method' => 'GET' })
       .to_return(status: 200, body: '', headers: {})
     stub_request(:get, 'https://www.sigmaaldrich.com/US/en/search')
-      .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+      .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate, br',
                        'Access-Control-Request-Method' => 'GET',
                        'User-Agent' => 'Google Chrome' })
       .to_return(status: 200, body: '', headers: {})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -144,18 +144,6 @@ RSpec.configure do |config|
         body: File.read(Rails.root + 'spec/fixtures/body_643785_LCSS.json'),
         headers: { 'Content-Type' => 'application/json' }
       )
-    stub_request(:get, 'https://www.alfa.com/en/catalog/A14672')
-      .with(headers: { 'Accept' => '*/*', 'Access-Control-Request-Method' => 'GET', 'User-Agent' => 'Google Chrome' })
-      .to_return(status: 200, body: '', headers: {})
-    stub_request(:get, 'https://www.alfa.com/en/search/?q=')
-      .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate, br',
-                       'Access-Control-Request-Method' => 'GET' })
-      .to_return(status: 200, body: '', headers: {})
-    stub_request(:get, 'https://www.sigmaaldrich.com/US/en/search')
-      .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate, br',
-                       'Access-Control-Request-Method' => 'GET',
-                       'User-Agent' => 'Google Chrome' })
-      .to_return(status: 200, body: '', headers: {})
   end
 
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION

- [ ] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [x] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
