### PR TITLE
Reaction variations UI updates

### DIFF
--- a/app/assets/stylesheets/CustomHeader.scss
+++ b/app/assets/stylesheets/CustomHeader.scss
@@ -1,6 +1,14 @@
+$highlightColor: #337ab7;
+
 div[role=columnheader] {
   display: grid;
 
+}
+
+.header-title {
+    &:hover {
+        color: $highlightColor;
+    }
 }
 
 .customHeaderLabel {
@@ -29,5 +37,5 @@ div[role=columnheader] {
 }
 
 .sort_active {
-  color:#5bc0de;
+  color: $highlightColor;
 }

--- a/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -25,7 +25,7 @@ import {
   PropertyFormatter, PropertyParser,
   MaterialFormatter, MaterialParser,
   EquivalentFormatter, EquivalentParser,
-  RowToolsCellRenderer
+  RowToolsCellRenderer, NoteCellEditor
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsCellComponents';
 
 function MenuHeader({
@@ -196,11 +196,8 @@ export default function ReactionVariations({ reaction, onReactionChange }) {
       field: 'notes',
       sortable: false,
       cellDataType: 'text',
-      cellEditor: 'agLargeTextCellEditor',
+      cellEditor: NoteCellEditor,
       cellEditorPopup: true,
-      cellEditorParams: {
-        maxLength: 1000
-      }
     },
     {
       headerName: 'Analyses',

--- a/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -42,11 +42,11 @@ function MenuHeader({
   const [unit, setUnit] = useState(units[0]);
 
   const onSortChanged = () => {
-    setAscendingSort(column.isSortAscending() ? 'active' : 'inactive');
-    setDescendingSort(column.isSortDescending() ? 'active' : 'inactive');
+    setAscendingSort(column.isSortAscending() ? 'sort_active' : 'inactive');
+    setDescendingSort(column.isSortDescending() ? 'sort_active' : 'inactive');
     setNoSort(
       !column.isSortAscending() && !column.isSortDescending()
-        ? 'active'
+        ? 'sort_active'
         : 'inactive'
     );
   };
@@ -123,7 +123,7 @@ function MenuHeader({
   );
 
   const sortMenu = (
-    <div style={{ display: 'flex', alignItems: 'center', opacity: 0.5 }}>
+    <div className="sortHeader" style={{ display: 'flex', alignItems: 'center', opacity: 0.5 }}>
       <div
         onClick={(event) => onSortRequested('asc', event)}
         onTouchEnd={(event) => onSortRequested('asc', event)}
@@ -150,7 +150,12 @@ function MenuHeader({
 
   return (
     <div style={{ display: 'grid' }}>
-      <b onClick={() => setName(names[(names.indexOf(name) + 1) % names.length])}>{name}</b>
+      <span
+        className="header-title"
+        onClick={() => setName(names[(names.indexOf(name) + 1) % names.length])}
+      >
+        {name}
+      </span>
       <div>
         {entrySelection}
         {' '}

--- a/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -394,6 +394,11 @@ export default function ReactionVariations({ reaction, onReactionChange }) {
     );
   }
 
+  const fitColumnToContent = (event) => {
+    const { column } = event;
+    gridRef.current.api.autoSizeColumns([column], false);
+  };
+
   return (
     <div>
       <OverlayTrigger
@@ -447,8 +452,9 @@ export default function ReactionVariations({ reaction, onReactionChange }) {
           */
           readOnlyEdit
           onCellEditRequest={updateRow}
-          onVirtualColumnsChanged={() => gridRef.current.api.autoSizeAllColumns(false)}
-          onColumnHeaderClicked={() => gridRef.current.api.autoSizeAllColumns(false)}
+          onFirstDataRendered={() => gridRef.current.api.autoSizeAllColumns()}
+          onCellValueChanged={(event) => fitColumnToContent(event)}
+          onColumnHeaderClicked={(event) => fitColumnToContent(event)}
         />
       </div>
     </div>

--- a/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -176,6 +176,7 @@ export default function ReactionVariations({ reaction, onReactionChange }) {
   const [reactionMaterials, setReactionMaterials] = useState(getReactionMaterials(reaction));
   const [columnDefinitions, setColumnDefinitions] = useState([
     {
+      headerName: 'Tools',
       field: null,
       cellRenderer: RowToolsCellRenderer,
       lockPosition: 'left',

--- a/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsCellComponents.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsCellComponents.js
@@ -1,8 +1,8 @@
 /* eslint-disable react/display-name */
-import React from 'react';
+import React, { useState } from 'react';
 import { AgGridReact } from 'ag-grid-react';
 import {
-  Button, ButtonGroup, Badge
+  Button, ButtonGroup, Badge, Modal, FormControl
 } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import {
@@ -129,6 +129,55 @@ function MaterialParser({
   );
 }
 
+function NoteCellEditor({
+  data: variationsRow,
+  value,
+  onValueChange,
+  stopEditing,
+  context
+}) {
+  const [note, setNote] = useState(value);
+  const { reactionShortLabel } = context;
+
+  const onClose = () => {
+    stopEditing();
+  };
+
+  const onSave = () => {
+    onValueChange(note);
+    stopEditing();
+  };
+
+  const cellContent = (
+    <Modal show onHide={onClose}>
+      <Modal.Header closeButton>
+        {`Edit note for ${getVariationsRowName(reactionShortLabel, variationsRow.id)}`}
+      </Modal.Header>
+      <Modal.Body>
+        <FormControl
+          componentClass="textarea"
+          placeholder="Start typing your note..."
+          value={note}
+          onChange={(event) => setNote(event.target.value)}
+        />
+      </Modal.Body>
+      <Modal.Footer>
+        <Button onClick={onSave}>Save</Button>
+      </Modal.Footer>
+    </Modal>
+  );
+
+  return cellContent;
+}
+
+NoteCellEditor.propTypes = {
+  data: PropTypes.instanceOf(AgGridReact.data).isRequired,
+  value: PropTypes.instanceOf(AgGridReact.value).isRequired,
+  onValueChange: PropTypes.func.isRequired,
+  stopEditing: PropTypes.instanceOf(AgGridReact.value).isRequired,
+  context: PropTypes.instanceOf(AgGridReact.context).isRequired,
+};
+
 export {
   RowToolsCellRenderer,
   EquivalentFormatter,
@@ -136,5 +185,6 @@ export {
   PropertyFormatter,
   PropertyParser,
   MaterialFormatter,
-  MaterialParser
+  MaterialParser,
+  NoteCellEditor
 };


### PR DESCRIPTION
I bundled four UI updates in this PR. The updates are small and atomic and I want to avoid the overhead of four separate PRs. There's one commit for each of the four updates, i.e., you best review this PR commit by commit.

1. cc008b321c69b22f6d42b7f9ebec9f882e9ffcdf: The first column didn't have a header name. It's now called "Tools".
![tools](https://github.com/user-attachments/assets/c44dc6c7-55f7-49c9-8779-3c750db69cc1)

2. 67f60e69344dfcf3bf88e7dd062bca1b2c70fa9b: The columns automatically fit their width to their content. Prior to this commit, this auto-sizing caused the entire table to "twitch" whenever there was a click on the header or a cell-edit. This commit removes the twitching.

3. bd0c2547aec7e31218ad5afb1972fdb472e77b83: This commit highlights two header elements. A) the column title on hover-over, and B) the currently active sort icon. A) is meant as an [affordance](https://en.wikipedia.org/wiki/Affordance#As_perceived_action_possibilities) to signify that the title can be toggled. B) is meant for keeping track of how the table is sorted.
![header_affordance](https://github.com/user-attachments/assets/2cc2244b-a338-4ffa-90a8-50997d6316b9)

4. 6376199142853d34218cbd01e7173b9daffde914: The note editor now has a close and a save button.
![note_editor](https://github.com/user-attachments/assets/4e5b6b34-76cd-4949-b30f-0f1ddf131ee1)
