### PR TITLE
feat: multiple print-code config

### DIFF
--- a/app/api/chemotion/code_log_api.rb
+++ b/app/api/chemotion/code_log_api.rb
@@ -99,7 +99,7 @@ module Chemotion
         params do
           requires :element_type, type: String, values: %w[sample reaction wellplate screen]
           requires :id, type: Integer, desc: 'Element id'
-          requires :analyses_ids, type: Array[Integer]
+          requires :analyses_ids, type: Array[String]
           requires :size, type: String, values: %w[small big]
         end
 

--- a/app/packs/src/components/common/PrintCodeButton.js
+++ b/app/packs/src/components/common/PrintCodeButton.js
@@ -1,12 +1,31 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Tooltip, OverlayTrigger, Button } from 'react-bootstrap';
+import { Tooltip, OverlayTrigger, MenuItem, DropdownButton, ButtonGroup } from 'react-bootstrap';
 import PrintCodeModal from 'src/components/common/PrintCodeModal';
 
 // Component that allows users to print a PDF.
-export default function PrintCodeButton({ element }) {
+export default function PrintCodeButton({element, analyses}) {
   // State for the modal and preview
   const [showModal, setShowModal] = useState(false);
+  const [selectedConfig, setSelectedConfig] = useState('');
+  const [json, setJson] = useState({});
+
+  useEffect(() => {
+    // Import the file when the component mounts
+    async function loadData() {
+      try {
+        const response = await fetch('/json/printingConfig/defaultConfig.json');
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const tmpJson = await response.json();
+        setJson(tmpJson);
+      } catch (err) {
+        console.error('Failed to fetch JSON', err);
+      }
+    }
+    loadData();
+  }, []); // Empty dependency array ensures this runs only once when the component mounts
 
   // Handles the show event for the modal.
   const handleModalShow = () => {
@@ -21,6 +40,31 @@ export default function PrintCodeButton({ element }) {
   // Set the tooltip text for the button
   const tooltipText = 'Print code Label';
 
+  // Create the menu items for the dropdown button
+  const menuItemsAnalyses = [
+    {
+      key: 'smallCode',
+      contents: 'small',
+      text: 'Small Label',
+    },
+    {
+      key: 'bigCode',
+      contents: 'big',
+      text: 'Large Label',
+    },
+  ];
+
+
+
+  // Create the menu items for the split button
+  const menuItems = analyses.length > 0
+    ? menuItemsAnalyses
+    : Object.entries(json).map(([key]) => ({
+      key,
+      text: key,
+      contents: key,
+    }));
+
   // Render the component
   return (
     <>
@@ -34,26 +78,47 @@ export default function PrintCodeButton({ element }) {
           </Tooltip>
         )}
       >
-        {/* Button to open the modal */}
-        <Button
-          className="button-right"
-          id="print-code"
-          pullRight
-          bsStyle="default"
-          disabled={element.isNew}
-          bsSize="xsmall"
-          onClick={handleModalShow}
-        >
-          <i className="fa fa-barcode fa-lg" />
-        </Button>
+        <ButtonGroup className="button-right">
+          <DropdownButton
+            id="print-code"
+            pullRight
+            bsStyle="default"
+            disabled={element.isNew}
+            bsSize="xsmall"
+            onToggle={(isOpen, event) => { if (event) { event.stopPropagation(); } }}
+            title={<i className="fa fa-barcode fa-lg" />}
+          >
+            {menuItems.map((e) => (
+              <MenuItem
+                key={e.key}
+                onSelect={() => {
+                  setSelectedConfig(e.contents);
+                  handleModalShow();
+                }}
+              >
+                {e.text}
+              </MenuItem>
+            ))}
+          </DropdownButton>
+        </ButtonGroup>
       </OverlayTrigger>
 
       {/* Display the modal */}
-      <PrintCodeModal showModal={showModal} handleModalClose={handleModalClose} element={element} />
+      <PrintCodeModal
+        showModal={showModal}
+        handleModalClose={handleModalClose}
+        element={element}
+        selectedConfig={selectedConfig}
+        analyses={analyses}
+      />
     </>
   );
 }
 
 PrintCodeButton.propTypes = {
   element: PropTypes.object.isRequired,
+};
+
+PrintCodeButton.defaultProps = {
+  analyses: [],
 };

--- a/app/pdfs/code_pdf.rb
+++ b/app/pdfs/code_pdf.rb
@@ -186,12 +186,13 @@ class CodePdf < Prawn::Document
   # @return [Array<String, String, String>] An array containing the width, height and URL of the SVG image.
   def image_data_getter
     element = elements.first
-    doc = Nokogiri::XML(File.read("public/images/samples/#{element.sample_svg_file}"))
+    full_svg_path = element.send(:full_svg_path)
+    doc = Nokogiri::XML(File.read(full_svg_path))
     # Extract the width and height attributes from the SVG element
     svg_width = doc.at_css('svg')['width']
     svg_height = doc.at_css('svg')['height']
 
-    [svg_width, svg_height, "public/images/samples/#{element.sample_svg_file}"]
+    [svg_width, svg_height, full_svg_path]
   end
 
   # ratio use to scale the text on the PDF based on the width of the page

--- a/public/json/printingConfig/defaultConfig.json
+++ b/public/json/printingConfig/defaultConfig.json
@@ -1,12 +1,38 @@
 {
-    "code_type": "qr_code",
-    "code_image_size": 30,
-    "name": true,
-    "short_label": true,
-    "external_label": true,
-    "code_log": true,
-    "molecule_name": true,
-    "displaySample": true,
-    "text_position" : "below",
-    "width": 100
+    "QR code" : {
+        "code_type": "qr_code",
+        "code_image_size": 30,
+        "name": true,
+        "short_label": true,
+        "external_label": true,
+        "code_log": true,
+        "molecule_name": true,
+        "displaySample": true,
+        "text_position" : "below",
+        "width": 100
+    },
+    "Data Matrix code" : {
+        "code_type": "data_matrix_code",
+        "code_image_size": 30,
+        "name": true,
+        "short_label": true,
+        "external_label": true,
+        "code_log": true,
+        "molecule_name": true,
+        "displaySample": true,
+        "text_position" : "below",
+        "width": 100
+    },
+    "Bar code" : {
+        "code_type": "bar_code",
+        "code_image_size": 100,
+        "name": true,
+        "short_label": true,
+        "external_label": true,
+        "code_log": true,
+        "molecule_name": true,
+        "displaySample": true,
+        "text_position" : "below",
+        "width": 100
+    }
 }


### PR DESCRIPTION
Fix : 
- [x]  Multiple configurations can be defined in the defaultConfig.json
- [x] By ticking sample and reactions, multiple pdf will be downloaded
