### PR TITLE
fix: differentiate analysis and tab att

### DIFF
--- a/app/assets/stylesheets/attachment-list.scss
+++ b/app/assets/stylesheets/attachment-list.scss
@@ -76,7 +76,6 @@
 
 .attachment-row-image .large-preview-modal {
   position: absolute;
-  left: 1000%;
   top: -300%;
   width: 400px;
   height: 400px;
@@ -88,6 +87,14 @@
   visibility: hidden;
   transition: opacity 0.8s ease, visibility 0s linear 0.8s;
   z-index: 10;
+}
+
+.attachment-row-image .large-preview-modal.default-left {
+  left: 1000%;
+}
+
+.attachment-row-image .large-preview-modal.tab-left {
+  left: 300%;
 }
 
 .attachment-row-image:hover .large-preview-modal {

--- a/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
+++ b/app/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
@@ -260,7 +260,7 @@ export default class ResearchPlanDetailsAttachments extends Component {
         ) : (
           filteredAttachments.map((attachment) => (
             <div className="attachment-row" key={attachment.id}>
-              {attachmentThumbnail(attachment)}
+              {attachmentThumbnail(attachment, true)}
               <div className="attachment-row-text" title={attachment.filename}>
                 {attachment.is_deleted ? (
                   <strike>{attachment.filename}</strike>

--- a/app/packs/src/apps/mydb/elements/details/wellplates/attachmentsTab/WellplateDetailsAttachments.js
+++ b/app/packs/src/apps/mydb/elements/details/wellplates/attachmentsTab/WellplateDetailsAttachments.js
@@ -295,7 +295,7 @@ export default class WellplateDetailsAttachments extends Component {
         ) : (
           filteredAttachments.map((attachment) => (
             <div className="attachment-row" key={attachment.id}>
-              {attachmentThumbnail(attachment)}
+              {attachmentThumbnail(attachment, true)}
 
               <div className="attachment-row-text" title={attachment.filename}>
                 {attachment.is_deleted ? (

--- a/app/packs/src/apps/mydb/elements/list/AttachmentList.js
+++ b/app/packs/src/apps/mydb/elements/list/AttachmentList.js
@@ -9,7 +9,7 @@ import Dropzone from 'react-dropzone';
 import Utils from 'src/utilities/Functions';
 import ImageModal from 'src/components/common/ImageModal';
 
-export const attachmentThumbnail = (attachment) => (
+export const attachmentThumbnail = (attachment, tab = false) => (
   <div className="attachment-row-image">
     <ImageModal
       imageStyle={{
@@ -27,8 +27,9 @@ export const attachmentThumbnail = (attachment) => (
       }}
       popObject
       disableClick
+      className={`large-preview-modal ${tab ? 'tab-left' : 'default-left'}`}
     />
-    <div className="large-preview-modal">
+    <div className={`large-preview-modal ${tab ? 'tab-left' : 'default-left'}`}>
       <ImageModal
         imageStyle={{
           width: '400px',
@@ -46,14 +47,14 @@ export const attachmentThumbnail = (attachment) => (
           src: attachment.preview,
         }}
         popObject={
-        attachment.filename && attachment.filename.toLowerCase().match(/\.(png|jpg|bmp|tif|svg|jpeg|tiff)$/)
-          ? {
-            fetchNeeded:true,
-            src: `/api/v1/attachments/${attachment.id}/annotated_image`,
-          }
-          : {
-            src: attachment.preview,
-          }
+          attachment.filename && attachment.filename.toLowerCase().match(/\.(png|jpg|bmp|tif|svg|jpeg|tiff)$/)
+            ? {
+              fetchNeeded: true,
+              src: `/api/v1/attachments/${attachment.id}/annotated_image`,
+            }
+            : {
+              src: attachment.preview,
+            }
         }
         disableClick
       />


### PR DESCRIPTION
Bigger thumbnails will not cover the buttons anymore in the tabs attachment lists of Reseach Plans and Wellplates