### PR TITLE
feat(dev): admin api to trigger recommended ket2 installation

### DIFF
--- a/.service-dependencies
+++ b/.service-dependencies
@@ -3,4 +3,4 @@ CONVERTER=ComPlat/chemotion-converter-app@1.2.0
 KETCHER=ptrxyz/chemotion-ketchersvc@main
 SPECTRA=ComPlat/chem-spectra-app@1.2.3
 NMRIUMWRAPPER=NFDI4Chem/nmrium-react-wrapper@v0.4.0
-KETCHER2=epam/ketcher@v2.20.0
+KETCHER2=epam/ketcher@v2.21.0

--- a/app/api/chemotion/admin_api.rb
+++ b/app/api/chemotion/admin_api.rb
@@ -258,7 +258,7 @@ module Chemotion
         namespace :queue_task do
           desc 'queue task'
           params do
-            requires :task, type: String, desc: 'Admin task name'
+            requires :task, type: String, desc: 'Admin task name', values: %w[collection_restore install_ketcher2]
           end
 
           get do

--- a/app/jobs/admin_job.rb
+++ b/app/jobs/admin_job.rb
@@ -9,6 +9,8 @@ class AdminJob < ApplicationJob
     case task
     when 'collection_restore'
       load Rails.root.join('db/seeds/shared/collections.seed.rb')
+    when 'install_ketcher2'
+      Open3.popen3('bin/chem-ket2-install.sh', chdir: Rails.root)
     end
   end
 end


### PR DESCRIPTION
allow admin to trigger the ket2 installation script by api call :

 get  `/api/v1/admin/jobs/queue_task?task=install_ketcher2`