### PR TITLE
fix: align style of the analysis section

### DIFF
--- a/app/assets/stylesheets/sample.scss
+++ b/app/assets/stylesheets/sample.scss
@@ -221,6 +221,7 @@
 
       .sub-title {
         font-size: 14px;
+        font-weight: normal;
         margin-left: 10px;
         margin-top: 3px;
       }
@@ -228,6 +229,7 @@
       .desc {
         // font-size: 12px;
         // display: inline-flex;
+        font-weight: normal;
         margin-left: 10px;
         margin-right: 0px;
         // overflow: hidden;

--- a/app/packs/src/components/generic/GenericElDetails.js
+++ b/app/packs/src/components/generic/GenericElDetails.js
@@ -413,7 +413,7 @@ export default class GenericElDetails extends Component {
             &nbsp;
           </span>
         </OverlayTrigger>
-        <ElementCollectionLabels element={genericEl} />
+        {genericEl.isNew ? null : <ElementCollectionLabels element={genericEl} />}
         <ShowUserLabels element={genericEl} />
         <ConfirmClose el={genericEl} />
         {copyBtn}


### PR DESCRIPTION
Align the style of the analysis section in both the linked view and the analysis tab.
