### PR TITLE
fix: save research plan inside screen

### DIFF
--- a/app/packs/src/fetchers/BaseFetcher.js
+++ b/app/packs/src/fetchers/BaseFetcher.js
@@ -158,6 +158,9 @@ export default class BaseFetcher {
 
   static updateAnnotationsOfAttachments(element) {
     const updateTasks = [];
+    if(!element.attachments){
+      return Promise.resolve();
+    }
     element.attachments
       .filter(((attach) => attach.hasOwnProperty('updatedAnnotation')))
       .forEach((attach) => {

--- a/app/packs/src/models/ResearchPlan.js
+++ b/app/packs/src/models/ResearchPlan.js
@@ -260,12 +260,12 @@ export default class ResearchPlan extends Element {
   }
 
   getNewAttachments() {
-    return this.attachments
+    return (this.attachments || [])
       .filter((attachment) => attachment.is_new === true && !attachment.is_deleted);
   }
 
   getMarkedAsDeletedAttachments() {
-    return this.attachments
+    return (this.attachments || [])
       .filter((attachment) => attachment.is_deleted === true && !attachment.is_new);
   }
 

--- a/spec/javascripts/packs/src/models/ResearchPlan.spec.js
+++ b/spec/javascripts/packs/src/models/ResearchPlan.spec.js
@@ -203,6 +203,15 @@ describe('ResearchPlan', () => {
         expect(researchPlan.getNewAttachments().length).toEqual(1);
       });
     });
+
+    describe('.when attachment property is not defined', () => {
+      it('empty array was returned', () => {
+        const researchPlanWithoutAttachments = ResearchPlan.buildEmpty();
+        delete (researchPlanWithoutAttachments.attachments);
+
+        expect(researchPlanWithoutAttachments.getNewAttachments().length).toEqual(0);
+      });
+    });
   });
 
   describe('.getMarkedAsDeletedAttachments', () => {
@@ -222,6 +231,14 @@ describe('ResearchPlan', () => {
 
       it('one attachment was found', () => {
         expect(researchPlan.getNewAttachments().length).toEqual(1);
+      });
+    });
+    describe('.when attachment property is not defined', () => {
+      it('empty array was returned', () => {
+        const researchPlanWithoutAttachments = ResearchPlan.buildEmpty();
+        delete (researchPlanWithoutAttachments.attachments);
+
+        expect(researchPlanWithoutAttachments.getNewAttachments().length).toEqual(0);
       });
     });
   });


### PR DESCRIPTION
This PR will fix the crash if a user wants so **edit** a **researchplan** inside a **screen**. In the current state there are no attachments linked as a property in a screen researchplan. This would lead to a null pointer access. 
By adding a **default empty array** and adding a **guard clause** at the annotation updater the bug should be gone.