### PR TITLE
fix: ketcher-options fetching on load

### DIFF
--- a/app/api/chemotion/profile_api.rb
+++ b/app/api/chemotion/profile_api.rb
@@ -98,12 +98,12 @@ module Chemotion
           optional :layout_detail_wellplate, type: Hash, profile_layout_hash: true
           optional :layout_detail_screen, type: Hash, profile_layout_hash: true
           optional :export_selection, type: Hash do
-            optional :sample, type: Array[Boolean]
-            optional :reaction, type: Array[Boolean]
-            optional :wellplate, type: Array[Boolean]
+            optional :sample, type: [Boolean]
+            optional :reaction, type: [Boolean]
+            optional :wellplate, type: [Boolean]
           end
           optional :computed_props, type: Hash do
-            optional :graph_templates, type: Array[Hash]
+            optional :graph_templates, type: [Hash]
             optional :cur_template_idx, type: Integer
           end
           optional :default_structure_editor, type: String
@@ -203,11 +203,16 @@ module Chemotion
         complete_folder_path = Rails.root.join('uploads', Rails.env, file_path)
         error_messages = []
 
-        begin
-          JSON(File.read(complete_folder_path))
-        rescue StandardError
-          error_messages.push('Issues with reading settings file')
-          error!({ status: false, error_messages: error_messages.flatten }, 500)
+        if File.exist?(complete_folder_path)
+          begin
+            settings = JSON.parse(File.read(complete_folder_path))
+            { status: true, settings: settings }
+          rescue StandardError => e
+            error_messages.push('Issues with reading settings file', e.message)
+            { status: false, error_messages: error_messages.flatten }
+          end
+        else
+          { status: true, settings: {}, message: 'Settings file not found, using default settings' }
         end
       end
 

--- a/app/packs/src/components/contextActions/ScanCodeButton.js
+++ b/app/packs/src/components/contextActions/ScanCodeButton.js
@@ -1,16 +1,19 @@
-import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  Alert, Button, Modal, SplitButton,
-  FormGroup, FormControl, MenuItem
-} from 'react-bootstrap';
-import 'whatwg-fetch';
 import Quagga from 'quagga';
+import React from 'react';
+import {
+  Alert, Button,
+  FormControl,
+  FormGroup,
+  MenuItem,
+  Modal, SplitButton
+} from 'react-bootstrap';
 import QrReader from 'react-qr-reader';
-import UIActions from 'src/stores/alt/actions/UIActions';
-import Utils from 'src/utilities/Functions';
-import UIStore from 'src/stores/alt/stores/UIStore';
 import PrintCodeFetcher from 'src/fetchers/PrintCodeFetcher';
+import UIActions from 'src/stores/alt/actions/UIActions';
+import UIStore from 'src/stores/alt/stores/UIStore';
+import Utils from 'src/utilities/Functions';
+import 'whatwg-fetch';
 
 export default class ScanCodeButton extends React.Component {
   constructor(props) {
@@ -78,10 +81,10 @@ export default class ScanCodeButton extends React.Component {
       decoder: {
         readers: ["code_128_reader"],
       }
-    }, function (err) {
+    }, function(err) {
       if (err) {
         console.log(err);
-        return
+        return;
       }
       console.log("Initialization finished. Ready to start");
       Quagga.start();
@@ -138,14 +141,14 @@ export default class ScanCodeButton extends React.Component {
       return;
     }
 
-    stopQuagga && Quagga.stop()
+    stopQuagga && Quagga.stop();
     fetch(`/api/v1/code_logs/generic?code=${data}`, {
       credentials: 'same-origin'
     })
       .then(response => response.json())
       .then(this.checkJSONResponse)
       .then((json) => {
-        code_log = json.code_log
+        code_log = json.code_log;
         if (code_log.source === 'container') {
           // open active analysis
           UIActions.selectTab({ tabKey: 1, type: code_log.root_code.source });
@@ -257,7 +260,6 @@ export default class ScanCodeButton extends React.Component {
 
   render() {
     const { json } = this.state;
-    console.log(json);
     const ids = this.state.checkedIds.toArray();
     const disabledPrint = !(ids.length > 0);
     const menuItems = Object.entries(json).map(([key]) => ({ key, name: key }));

--- a/app/packs/src/stores/alt/actions/UserActions.js
+++ b/app/packs/src/stores/alt/actions/UserActions.js
@@ -1,8 +1,8 @@
 /* eslint-disable class-methods-use-this */
-import alt from 'src/stores/alt/alt';
-import UsersFetcher from 'src/fetchers/UsersFetcher';
-import GenericSgsFetcher from 'src/fetchers/GenericSgsFetcher';
 import GenericDSsFetcher from 'src/fetchers/GenericDSsFetcher';
+import GenericSgsFetcher from 'src/fetchers/GenericSgsFetcher';
+import UsersFetcher from 'src/fetchers/UsersFetcher';
+import alt from 'src/stores/alt/alt';
 
 import DocumentHelper from 'src/utilities/DocumentHelper';
 
@@ -185,8 +185,10 @@ class UserActions {
     return () => {
       UsersFetcher.fetchUserKetcher2Options()
         .then((result) => {
-          if (result) {
-            localStorage.setItem('ketcher-opts', JSON.stringify(result));
+          if (result && result?.settings) {
+            if (Object.keys(result?.settings).length) {
+              localStorage.setItem('ketcher-opts', JSON.stringify(result.settings));
+            }
           }
         })
         .catch((errorMessage) => { console.log(errorMessage); });


### PR DESCRIPTION
Purpose of this PR is to fix ketcher-options response fail.

![image](https://github.com/user-attachments/assets/087e7363-d966-4f08-b73a-56c5a9727017)

 Error occured with new account or when user has not saved settings before.
 
------------------------------
- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
