### PR TITLE
feat(wellplates): allow resizing after creation when no filled well is lost

### DIFF
--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -143,6 +143,8 @@ module Chemotion
         optional :user_labels, type: Array
         optional :readout_titles, type: Array
         requires :container, type: Hash
+        requires :height, type: Integer, values: 0..100
+        requires :width, type: Integer, values: 0..100
         optional :segments, type: Array, desc: 'Segments'
       end
       route_param :id do
@@ -179,8 +181,8 @@ module Chemotion
         optional :readout_titles, type: Array
         requires :collection_id, type: Integer
         requires :container, type: Hash
-        optional :height, type: Integer, default: 8, values: 1..100
-        optional :width, type: Integer, default: 12, values: 1..100
+        optional :height, type: Integer, default: 8, values: 0..100
+        optional :width, type: Integer, default: 12, values: 0..100
         optional :segments, type: Array, desc: 'Segments'
         optional :user_labels, type: Array
       end

--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -143,8 +143,8 @@ module Chemotion
         optional :user_labels, type: Array
         optional :readout_titles, type: Array
         requires :container, type: Hash
-        requires :height, type: Integer, values: 0..100
-        requires :width, type: Integer, values: 0..100
+        requires :height, type: Integer, values: 0..101
+        requires :width, type: Integer, values: 0..101
         optional :segments, type: Array, desc: 'Segments'
       end
       route_param :id do
@@ -181,8 +181,8 @@ module Chemotion
         optional :readout_titles, type: Array
         requires :collection_id, type: Integer
         requires :container, type: Hash
-        optional :height, type: Integer, default: 8, values: 0..100
-        optional :width, type: Integer, default: 12, values: 0..100
+        optional :height, type: Integer, default: 8, values: 0..101
+        optional :width, type: Integer, default: 12, values: 0..101
         optional :segments, type: Array, desc: 'Segments'
         optional :user_labels, type: Array
       end

--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -198,8 +198,8 @@ module Chemotion
         optional :readout_titles, type: Array
         requires :collection_id, type: Integer
         requires :container, type: Hash
-        optional :height, type: Integer, default: 8, values: 0..Usecases::Wellplates::Resize::MAX_DIMENSION
-        optional :width, type: Integer, default: 12, values: 0..Usecases::Wellplates::Resize::MAX_DIMENSION
+        optional :height, type: Integer, default: 8, values: 0..Usecases::Wellplates::Dimensions::MAX_DIMENSION
+        optional :width, type: Integer, default: 12, values: 0..Usecases::Wellplates::Dimensions::MAX_DIMENSION
         optional :segments, type: Array, desc: 'Segments'
         optional :user_labels, type: Array
       end
@@ -297,8 +297,8 @@ module Chemotion
         # impose `requires :container` on this route too.
         params do
           requires :id, type: Integer, desc: 'Wellplate id'
-          requires :width, type: Integer, values: 0..Usecases::Wellplates::Resize::MAX_DIMENSION
-          requires :height, type: Integer, values: 0..Usecases::Wellplates::Resize::MAX_DIMENSION
+          requires :width, type: Integer, values: 0..Usecases::Wellplates::Dimensions::MAX_DIMENSION
+          requires :height, type: Integer, values: 0..Usecases::Wellplates::Dimensions::MAX_DIMENSION
         end
         route_param :id do
           before do

--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -16,7 +16,12 @@ module Chemotion
     end
 
     # Wellplate.find in the before blocks below would otherwise surface as a 500.
-    rescue_from ActiveRecord::RecordNotFound do
+    # Scoped to the wellplate itself on purpose: a RecordNotFound raised deeper in
+    # (User.find in Update, Well.find in WellplateUpdater, the collection lookup in
+    # Create) is a genuine server error and must not be disguised as a 404.
+    rescue_from ActiveRecord::RecordNotFound do |error|
+      raise error unless error.model == 'Wellplate'
+
       error!('Resource not found', 404)
     end
 

--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -138,6 +138,8 @@ module Chemotion
         optional :user_labels, type: Array
         optional :readout_titles, type: Array
         requires :container, type: Hash
+        requires :height, type: Integer, values: 0..100
+        requires :width, type: Integer, values: 0..100
         optional :segments, type: Array, desc: 'Segments'
       end
       route_param :id do
@@ -176,8 +178,8 @@ module Chemotion
         optional :readout_titles, type: Array
         requires :collection_id, type: Integer
         requires :container, type: Hash
-        optional :height, type: Integer, default: 8, values: 1..100
-        optional :width, type: Integer, default: 12, values: 1..100
+        optional :height, type: Integer, default: 8, values: 0..100
+        optional :width, type: Integer, default: 12, values: 0..100
         optional :segments, type: Array, desc: 'Segments'
         optional :user_labels, type: Array
       end

--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -10,6 +10,16 @@ module Chemotion
     helpers ProfileHelpers
     helpers UserLabelHelpers
 
+    rescue_from Usecases::Wellplates::Errors::ResizeNotAllowedError,
+                Usecases::Wellplates::Errors::InvalidDimensionsError do |error|
+      error!(error.message, 422)
+    end
+
+    # Wellplate.find in the before blocks below would otherwise surface as a 500.
+    rescue_from ActiveRecord::RecordNotFound do
+      error!('Resource not found', 404)
+    end
+
     resource :wellplates do
       namespace :bulk do
         desc 'Bulk create wellplates'
@@ -138,8 +148,10 @@ module Chemotion
         optional :user_labels, type: Array
         optional :readout_titles, type: Array
         requires :container, type: Hash
-        requires :height, type: Integer, values: 0..101
-        requires :width, type: Integer, values: 0..101
+        # width/height are deliberately absent: the grid is resized only through
+        # PUT /api/v1/wellplates/resize/:id, which reconciles the well rows and
+        # refuses to drop wells that hold data. Accepting them here would let a
+        # stale tab silently revert someone else's resize.
         optional :segments, type: Array, desc: 'Segments'
       end
       route_param :id do
@@ -178,8 +190,8 @@ module Chemotion
         optional :readout_titles, type: Array
         requires :collection_id, type: Integer
         requires :container, type: Hash
-        optional :height, type: Integer, default: 8, values: 0..101
-        optional :width, type: Integer, default: 12, values: 0..101
+        optional :height, type: Integer, default: 8, values: 0..Usecases::Wellplates::Resize::MAX_DIMENSION
+        optional :width, type: Integer, default: 12, values: 0..Usecases::Wellplates::Resize::MAX_DIMENSION
         optional :segments, type: Array, desc: 'Segments'
         optional :user_labels, type: Array
       end
@@ -266,6 +278,41 @@ module Chemotion
             rescue StandardError => e
               error!(e, 500)
             end
+          end
+        end
+      end
+
+      namespace :resize do
+        desc 'Change the grid dimensions of a wellplate'
+        # Declared inside this namespace on purpose: the params block preceding
+        # the PUT route_param above is namespace-scoped and would otherwise
+        # impose `requires :container` on this route too.
+        params do
+          requires :id, type: Integer, desc: 'Wellplate id'
+          requires :width, type: Integer, values: 0..Usecases::Wellplates::Resize::MAX_DIMENSION
+          requires :height, type: Integer, values: 0..Usecases::Wellplates::Resize::MAX_DIMENSION
+        end
+        route_param :id do
+          before do
+            @element_policy = ElementPolicy.new(current_user, Wellplate.find(params[:id]))
+            error!('401 Unauthorized', 401) unless @element_policy.update?
+          end
+
+          put do
+            wellplate = Usecases::Wellplates::Resize.new(
+              wellplate: Wellplate.find(params[:id]),
+              width: params[:width],
+              height: params[:height],
+            ).execute!
+
+            present(
+              wellplate,
+              with: Entities::WellplateEntity,
+              detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: wellplate).detail_levels,
+              root: :wellplate,
+              policy: @element_policy,
+            )
+            present wellplate.attachments, with: Entities::AttachmentEntity, root: :attachments
           end
         end
       end

--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -138,8 +138,8 @@ module Chemotion
         optional :user_labels, type: Array
         optional :readout_titles, type: Array
         requires :container, type: Hash
-        requires :height, type: Integer, values: 0..100
-        requires :width, type: Integer, values: 0..100
+        requires :height, type: Integer, values: 0..101
+        requires :width, type: Integer, values: 0..101
         optional :segments, type: Array, desc: 'Segments'
       end
       route_param :id do
@@ -178,8 +178,8 @@ module Chemotion
         optional :readout_titles, type: Array
         requires :collection_id, type: Integer
         requires :container, type: Hash
-        optional :height, type: Integer, default: 8, values: 0..100
-        optional :width, type: Integer, default: 12, values: 0..100
+        optional :height, type: Integer, default: 8, values: 0..101
+        optional :width, type: Integer, default: 12, values: 0..101
         optional :segments, type: Array, desc: 'Segments'
         optional :user_labels, type: Array
       end

--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -18,7 +18,10 @@ module Chemotion
     # Wellplate.find in the before blocks below would otherwise surface as a 500.
     # Scoped to the wellplate itself on purpose: a RecordNotFound raised deeper in
     # (User.find in Update, Well.find in WellplateUpdater, the collection lookup in
-    # Create) is a genuine server error and must not be disguised as a 404.
+    # Create) is a genuine fault, so it is deliberately not answered here. Re-raising
+    # takes it out of Grape's error middleware and leaves it to Rails, which keeps it
+    # visible to error reporting rather than reporting a tidy 404 as if the wellplate
+    # were simply missing.
     rescue_from ActiveRecord::RecordNotFound do |error|
       raise error unless error.model == 'Wellplate'
 

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
@@ -250,7 +250,7 @@ export default class WellplateDetails extends Component {
           iconClass="fa fa-print"
           header={false}
           onClick={() => this.handlePrint()}
-          disabled={wellplate.width > 12}
+          disabled={wellplate.width > 12 || wellplate.size === 0}
         />
       </>
     );

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
@@ -73,10 +73,10 @@ export default class WellplateDetails extends Component {
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     const { wellplate: newWellplate } = this.props;
-    const { wellplate: currentWellplate } = this.state;
-    if (newWellplate.id !== currentWellplate.id || newWellplate.updated_at !== currentWellplate.updated_at) {
+    const { wellplate: previousWellplate } = prevProps;
+    if (newWellplate.id !== previousWellplate.id || newWellplate.updated_at !== previousWellplate.updated_at) {
       this.setState({
         wellplate: newWellplate,
       });

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
@@ -158,6 +158,7 @@ export default class WellplateDetails extends Component {
     if (type == 'readoutTitles') wellplate.readout_titles = value;
     if (type == 'size') wellplate.changeSize(value.width, value.height);
 
+
     this.setState({ wellplate });
   }
 

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
@@ -153,11 +153,13 @@ export default class WellplateDetails extends Component {
     const { wellplate } = this.state;
     const { type, value } = change;
 
-    if (type == 'name') wellplate.name = value === '' ? 'New Wellplate' : value;
-    if (type == 'description') wellplate.description = value;
-    if (type == 'readoutTitles') wellplate.readout_titles = value;
-    if (type == 'size') wellplate.changeSize(value.width, value.height);
-
+    if (type === 'name') wellplate.name = value === '' ? 'New Wellplate' : value;
+    if (type === 'description') wellplate.description = value;
+    if (type === 'readoutTitles') wellplate.readout_titles = value;
+    if (type === 'size') {
+      wellplate.changeSize(value.width, value.height);
+      wellplate.changed = true;
+    }
 
     this.setState({ wellplate });
   }

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
@@ -268,7 +268,7 @@ export default class WellplateDetails extends Component {
           iconClass="fa fa-print"
           header={false}
           onClick={() => this.handlePrint()}
-          disabled={wellplate.width > 12}
+          disabled={wellplate.width > 12 || wellplate.size === 0}
         />
       </>
     );

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
@@ -169,11 +169,33 @@ export default class WellplateDetails extends Component {
     if (type === 'description') wellplate.description = value;
     if (type === 'readoutTitles') wellplate.readout_titles = value;
     if (type === 'size') {
-      wellplate.changeSize(value.width, value.height);
-      wellplate.changed = true;
+      this.handleSizeChange(value.width, value.height);
+      return;
     }
 
     this.setState({ wellplate });
+  }
+
+  /**
+   * A resize is its own persisted operation rather than part of the next save.
+   *
+   * The server reconciles the well rows and refuses a size that would drop a
+   * well still holding data, so it has to act on what is actually stored. A
+   * wellplate that does not exist yet has nothing stored, so its grid is just
+   * rebuilt in memory and goes out with the create request.
+   */
+  handleSizeChange(width, height) {
+    const { wellplate } = this.state;
+    if (wellplate.isReadOnly) { return; }
+
+    if (wellplate.isNew) {
+      wellplate.changeSize(width, height);
+      this.setState({ wellplate });
+      return;
+    }
+
+    LoadingActions.start();
+    ElementActions.resizeWellplate(wellplate.id, width, height);
   }
 
   handleTabChange(eventKey) {

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
@@ -170,6 +170,7 @@ export default class WellplateDetails extends Component {
     if (type == 'readoutTitles') wellplate.readout_titles = value;
     if (type == 'size') wellplate.changeSize(value.width, value.height);
 
+
     this.setState({ wellplate });
   }
 

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
@@ -165,11 +165,13 @@ export default class WellplateDetails extends Component {
 
     const { type, value } = change;
 
-    if (type == 'name') wellplate.name = value === '' ? 'New Wellplate' : value;
-    if (type == 'description') wellplate.description = value;
-    if (type == 'readoutTitles') wellplate.readout_titles = value;
-    if (type == 'size') wellplate.changeSize(value.width, value.height);
-
+    if (type === 'name') wellplate.name = value === '' ? 'New Wellplate' : value;
+    if (type === 'description') wellplate.description = value;
+    if (type === 'readoutTitles') wellplate.readout_titles = value;
+    if (type === 'size') {
+      wellplate.changeSize(value.width, value.height);
+      wellplate.changed = true;
+    }
 
     this.setState({ wellplate });
   }

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal.js
@@ -7,40 +7,47 @@ import Wellplate from 'src/models/Wellplate';
 import AppModal from 'src/components/common/AppModal';
 
 const isInteger = (value) => {
-  if (Number.isNaN(value)) return false
+  if (Number.isNaN(value)) return false;
 
-  return Number.isInteger(Number(value))
-}
+  return Number.isInteger(Number(value));
+};
 
 const dimensionIsValid = (value) => {
-  if (value <= 0) return false
-  if (value > Wellplate.MAX_DIMENSION) return false
+  if (value <= 0) return false;
+  if (value > Wellplate.MAX_DIMENSION) return false;
 
-  return true
-}
+  return true;
+};
 
-const errorMessage = (label) => {
-  return (
-    <div class="invalid-wellplate-size-text">
+const errorMessage = (label) => (
+    <div className="invalid-wellplate-size-text">
       {label} must be between 1 and 100
     </div>
-  )
-}
+  );
 
 const CustomSizeModal = ({ show, wellplate, updateWellplate, handleClose }) => {
-  const [width, setWidth] = useState(wellplate.width)
-  const [height, setHeight] = useState(wellplate.height)
+  const [width, setWidth] = useState(wellplate.width);
+  const [height, setHeight] = useState(wellplate.height);
+  const [wasShown, setWasShown] = useState(show);
 
-  const widthIsValid = dimensionIsValid(width)
-  const heightIsValid = dimensionIsValid(height)
-  const widthChanged = width != wellplate.width
-  const heightChanged = height != wellplate.height
-  const canSubmit = widthIsValid && heightIsValid && (widthChanged || heightChanged)
+  if (show !== wasShown) {
+    setWasShown(show);
+    if (show) {
+      setWidth(wellplate.width);
+      setHeight(wellplate.height);
+    }
+  }
+
+  const widthIsValid = dimensionIsValid(width);
+  const heightIsValid = dimensionIsValid(height);
+  const widthChanged = width != wellplate.width;
+  const heightChanged = height != wellplate.height;
+  const canSubmit = widthIsValid && heightIsValid && (widthChanged || heightChanged);
 
   const handleApply = () => {
-    updateWellplate({ type: 'size', value: { width, height } })
-    handleClose()
-  }
+    updateWellplate({ type: 'size', value: { width, height } });
+    handleClose();
+  };
 
   return (
     <AppModal
@@ -84,13 +91,13 @@ const CustomSizeModal = ({ show, wellplate, updateWellplate, handleClose }) => {
         </Col>
       </Row>
     </AppModal>
-  )
-}
+  );
+};
 
 CustomSizeModal.propTypes = {
   wellplate: PropTypes.instanceOf(Wellplate).isRequired,
   show: PropTypes.bool.isRequired,
   handleClose: PropTypes.func.isRequired,
-}
+};
 
-export default CustomSizeModal
+export default CustomSizeModal;

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal.js
@@ -6,46 +6,84 @@ import PropTypes from 'prop-types';
 import Wellplate from 'src/models/Wellplate';
 import AppModal from 'src/components/common/AppModal';
 
+// Seeds for the fields when the wellplate has no size yet.
+const DEFAULT_WIDTH = 12;
+const DEFAULT_HEIGHT = 8;
+
 const isInteger = (value) => {
+  if (value === '' || value === null || value === undefined) return false;
   if (Number.isNaN(value)) return false;
 
   return Number.isInteger(Number(value));
 };
 
+// Without the integer check, 'abc' and '5.5' both validate; changeSize then
+// hands Array() a NaN length, which throws a RangeError out of a React event
+// handler and takes the whole detail view down with it.
 const dimensionIsValid = (value) => {
-  if (value <= 0) return false;
-  if (value > Wellplate.MAX_DIMENSION) return false;
+  if (!isInteger(value)) return false;
 
-  return true;
+  const dimension = Number(value);
+
+  return dimension > 0 && dimension <= Wellplate.MAX_DIMENSION;
 };
 
 const errorMessage = (label) => (
     <div className="invalid-wellplate-size-text">
-      {label} must be between 1 and 100
+      {label} must be between 1 and {Wellplate.MAX_DIMENSION}
     </div>
   );
 
+const blockedMessage = (blockedWells) => (
+  <div className="invalid-wellplate-size-text">
+    {blockedWells.length}
+    {' '}
+    well
+    {blockedWells.length === 1 ? '' : 's'}
+    {' '}
+    outside this size still
+    {blockedWells.length === 1 ? ' holds' : ' hold'}
+    {' '}
+    data (
+    {blockedWells.slice(0, 5).map((well) => well.alphanumericPosition).join(', ')}
+    {blockedWells.length > 5 ? ', ...' : ''}
+    ). Empty them and save before resizing.
+  </div>
+);
+
 const CustomSizeModal = ({ show, wellplate, updateWellplate, handleClose }) => {
-  const [width, setWidth] = useState(wellplate.width);
-  const [height, setHeight] = useState(wellplate.height);
+  // An unsized wellplate would otherwise open with both fields at 0 and two
+  // validation errors already showing, before the user has typed anything.
+  const seedWidth = () => wellplate.width || DEFAULT_WIDTH;
+  const seedHeight = () => wellplate.height || DEFAULT_HEIGHT;
+
+  const [width, setWidth] = useState(seedWidth);
+  const [height, setHeight] = useState(seedHeight);
   const [wasShown, setWasShown] = useState(show);
 
   if (show !== wasShown) {
     setWasShown(show);
     if (show) {
-      setWidth(wellplate.width);
-      setHeight(wellplate.height);
+      setWidth(seedWidth());
+      setHeight(seedHeight());
     }
   }
 
   const widthIsValid = dimensionIsValid(width);
   const heightIsValid = dimensionIsValid(height);
-  const widthChanged = width != wellplate.width;
-  const heightChanged = height != wellplate.height;
-  const canSubmit = widthIsValid && heightIsValid && (widthChanged || heightChanged);
+  const widthChanged = Number(width) !== wellplate.width;
+  const heightChanged = Number(height) !== wellplate.height;
+  const blockedWells = widthIsValid && heightIsValid
+    ? wellplate.occupiedWellsOutside(Number(width), Number(height))
+    : [];
+  const canSubmit = widthIsValid && heightIsValid
+    && (widthChanged || heightChanged)
+    && blockedWells.length === 0;
 
   const handleApply = () => {
-    updateWellplate({ type: 'size', value: { width, height } });
+    // Numbers, not the raw input strings the inputs hand back: the model and
+    // the API both expect integers.
+    updateWellplate({ type: 'size', value: { width: Number(width), height: Number(height) } });
     handleClose();
   };
 
@@ -90,6 +128,11 @@ const CustomSizeModal = ({ show, wellplate, updateWellplate, handleClose }) => {
           </Form.Group>
         </Col>
       </Row>
+      {blockedWells.length > 0 && (
+        <Row>
+          <Col xs={12}>{blockedMessage(blockedWells)}</Col>
+        </Row>
+      )}
     </AppModal>
   );
 };
@@ -98,6 +141,7 @@ CustomSizeModal.propTypes = {
   wellplate: PropTypes.instanceOf(Wellplate).isRequired,
   show: PropTypes.bool.isRequired,
   handleClose: PropTypes.func.isRequired,
+  updateWellplate: PropTypes.func.isRequired,
 };
 
 export default CustomSizeModal;

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal.js
@@ -10,9 +10,15 @@ import AppModal from 'src/components/common/AppModal';
 const DEFAULT_WIDTH = 12;
 const DEFAULT_HEIGHT = 8;
 
+// How many blocking positions the message names before it elides the rest;
+// mirrors Usecases::Wellplates::Resize::POSITIONS_IN_ERROR.
+const POSITIONS_IN_MESSAGE = 5;
+
+// Number('') and Number(null) are both 0, which would pass the integer test,
+// so the blank cases have to be rejected first. Number(anything else
+// unparseable) is NaN, which Number.isInteger already rejects.
 const isInteger = (value) => {
   if (value === '' || value === null || value === undefined) return false;
-  if (Number.isNaN(value)) return false;
 
   return Number.isInteger(Number(value));
 };
@@ -45,8 +51,8 @@ const blockedMessage = (blockedWells) => (
     {blockedWells.length === 1 ? ' holds' : ' hold'}
     {' '}
     data (
-    {blockedWells.slice(0, 5).map((well) => well.alphanumericPosition).join(', ')}
-    {blockedWells.length > 5 ? ', ...' : ''}
+    {blockedWells.slice(0, POSITIONS_IN_MESSAGE).map((well) => well.alphanumericPosition).join(', ')}
+    {blockedWells.length > POSITIONS_IN_MESSAGE ? ', ...' : ''}
     ). Empty them and save before resizing.
   </div>
 );

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal.js
@@ -35,10 +35,14 @@ const dimensionIsValid = (value) => {
 };
 
 const errorMessage = (label) => (
-    <div className="invalid-wellplate-size-text">
-      {label} must be between 1 and {Wellplate.MAX_DIMENSION}
-    </div>
-  );
+  <div className="invalid-wellplate-size-text">
+    {label}
+    {' '}
+    must be between 1 and
+    {' '}
+    {Wellplate.MAX_DIMENSION}
+  </div>
+);
 
 const blockedMessage = (blockedWells) => (
   <div className="invalid-wellplate-size-text">
@@ -110,7 +114,7 @@ const CustomSizeModal = ({ show, wellplate, updateWellplate, handleClose }) => {
               type="text"
               value={width}
               className={widthIsValid ? 'size-without-error' : 'invalid-wellplate-size'}
-              onChange={event => setWidth(event.target.value)}
+              onChange={(event) => setWidth(event.target.value)}
             />
             {!widthIsValid && errorMessage('Width')}
           </Form.Group>
@@ -122,7 +126,7 @@ const CustomSizeModal = ({ show, wellplate, updateWellplate, handleClose }) => {
               type="text"
               value={height}
               className={heightIsValid ? 'size-without-error' : 'invalid-wellplate-size'}
-              onChange={event => setHeight(event.target.value)}
+              onChange={(event) => setHeight(event.target.value)}
             />
             {!heightIsValid && errorMessage('Height')}
           </Form.Group>
@@ -130,7 +134,13 @@ const CustomSizeModal = ({ show, wellplate, updateWellplate, handleClose }) => {
         <Col xs={2}>
           <Form.Group>
             <Form.Label>Size</Form.Label>
-            <Form.Control type="text" disabled value={height * width} />
+            {/* Both fields hand back strings; multiplying them while one is
+                still being typed (or invalid) would render "NaN". */}
+            <Form.Control
+              type="text"
+              disabled
+              value={widthIsValid && heightIsValid ? Number(width) * Number(height) : ''}
+            />
           </Form.Group>
         </Col>
       </Row>

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
@@ -1,6 +1,8 @@
 // eslint-disable-next-line max-classes-per-file
 import React, { useState } from 'react';
-import { Button, Form, InputGroup } from 'react-bootstrap';
+import {
+  Button, Form, InputGroup, OverlayTrigger, Tooltip
+} from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import Wellplate from 'src/models/Wellplate';
 import CustomSizeModal from 'src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal';
@@ -35,6 +37,29 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
     options.push(Option(wellplate.width, wellplate.height));
   }
 
+  const inputGroup = (
+    <InputGroup>
+      {shouldBeDisabled ? (
+        <Form.Control type="text" disabled value={`${wellplate.size} (${wellplate.width}x${wellplate.height})`} />
+      ) : (
+        <Form.Select
+          required={true}
+          value={size}
+          onChange={onChange}
+        >
+          {options}
+        </Form.Select>
+      )}
+      <Button
+        className="create-own-size-button"
+        disabled={shouldBeDisabled}
+        onClick={() => setShowCustomSizeModal(true)}
+      >
+        <i className="fa fa-braille" />
+      </Button>
+    </InputGroup>
+  );
+
   return (
     <>
       <CustomSizeModal
@@ -44,23 +69,18 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
         handleClose={() => setShowCustomSizeModal(false)}
         key={`${wellplate.id}-custom-size-modal`}
       />
-      <InputGroup>
-        <Form.Select
-          required={true}
-          value={size}
-          onChange={onChange}
-          disabled={shouldBeDisabled}
+      {shouldBeDisabled ? (
+        <OverlayTrigger
+          placement="bottom"
+          overlay={(
+            <Tooltip id={`wellplate-${wellplate.id}-size-locked-tooltip`}>
+              The size cannot be changed.
+            </Tooltip>
+          )}
         >
-          {options}
-        </Form.Select>
-        <Button
-          className="create-own-size-button"
-          disabled={shouldBeDisabled}
-          onClick={() => setShowCustomSizeModal(true)}
-        >
-          <i className="fa fa-braille" />
-        </Button>
-      </InputGroup>
+          {inputGroup}
+        </OverlayTrigger>
+      ) : inputGroup}
     </>
   );
 };

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
@@ -15,6 +15,7 @@ const Option = (width, height) => {
 const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
   const size = `${wellplate.width} ${wellplate.height}`
   const [showCustomSizeModal, setShowCustomSizeModal] = useState(false)
+  const shouldBeDisabled = !wellplate.is_new && wellplate.oldWidth > 0
 
   const onChange = (event) => {
     const values = event.target.value.split(" ").map(x => parseInt(x, 10))
@@ -25,6 +26,7 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
   }
 
   const options = [
+    Option(0, 0),
     Option(24, 16),
     Option(12, 8),
     Option(6, 4),
@@ -45,13 +47,13 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
           required={true}
           value={size}
           onChange={onChange}
-          disabled={!wellplate.is_new}
+          disabled={shouldBeDisabled}
         >
           {options}
         </Form.Select>
         <Button
           className="create-own-size-button"
-          disabled={!wellplate.is_new}
+          disabled={shouldBeDisabled}
           onClick={() => setShowCustomSizeModal(true)}
         >
           <i className="fa fa-braille" />

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
@@ -5,34 +5,35 @@ import PropTypes from 'prop-types';
 import Wellplate from 'src/models/Wellplate';
 import CustomSizeModal from 'src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal';
 
-const Option = (width, height) => {
-  const size = height * width
-  const label = size === 0 ? 'Define later' : `${size} (${width}x${height})`
-  const value = `${width} ${height}`
+const STANDARD_SIZES = [[0, 0], [24, 16], [12, 8], [6, 4], [4, 3]];
 
-  return (<option key={`${label}-${value}`} label={label} value={value} />)
-}
+const Option = (width, height) => {
+  const size = height * width;
+  const label = size === 0 ? 'Define later' : `${size} (${width}x${height})`;
+  const value = `${width} ${height}`;
+
+  return (<option key={`${label}-${value}`} label={label} value={value} />);
+};
 
 const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
-  const size = `${wellplate.width} ${wellplate.height}`
-  const [showCustomSizeModal, setShowCustomSizeModal] = useState(false)
-  const shouldBeDisabled = !wellplate.is_new && wellplate.originalSize > 0
+  const size = `${wellplate.width} ${wellplate.height}`;
+  const [showCustomSizeModal, setShowCustomSizeModal] = useState(false);
+  const shouldBeDisabled = !wellplate.is_new && wellplate.originalSize > 0;
 
   const onChange = (event) => {
-    const values = event.target.value.split(" ").map(x => parseInt(x, 10))
-    const width = values[0]
-    const height = values[1]
+    const values = event.target.value.split(' ').map(x => parseInt(x, 10));
+    const width = values[0];
+    const height = values[1];
 
-    updateWellplate({ type: 'size', value: { width: width, height: height } });
+    updateWellplate({ type: 'size', value: { width, height } });
+  };
+
+  const isStandardSize = STANDARD_SIZES.some(([w, h]) => w === wellplate.width && h === wellplate.height);
+
+  const options = STANDARD_SIZES.map(([w, h]) => Option(w, h));
+  if (!isStandardSize) {
+    options.push(Option(wellplate.width, wellplate.height));
   }
-
-  const options = [
-    Option(0, 0),
-    Option(24, 16),
-    Option(12, 8),
-    Option(6, 4),
-    Option(4, 3)
-  ]
 
   return (
     <>
@@ -62,11 +63,11 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
       </InputGroup>
     </>
   );
-}
+};
 
 WellplateSizeDropdown.propTypes = {
   wellplate: PropTypes.instanceOf(Wellplate).isRequired,
   updateWellplate: PropTypes.func.isRequired,
 };
 
-export default WellplateSizeDropdown
+export default WellplateSizeDropdown;

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
@@ -7,7 +7,7 @@ import CustomSizeModal from 'src/apps/mydb/elements/details/wellplates/propertie
 
 const Option = (width, height) => {
   const size = height * width
-  const label = size === 0 ? 'not yet chosen' : `${size} (${width}x${height})`
+  const label = size === 0 ? 'Define later' : `${size} (${width}x${height})`
   const value = `${width} ${height}`
 
   return (<option key={`${label}-${value}`} label={label} value={value} />)

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
@@ -15,7 +15,7 @@ const Option = (width, height) => {
 const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
   const size = `${wellplate.width} ${wellplate.height}`
   const [showCustomSizeModal, setShowCustomSizeModal] = useState(false)
-  const shouldBeDisabled = !wellplate.is_new && wellplate.oldWidth > 0
+  const shouldBeDisabled = !wellplate.is_new && wellplate.originalSize > 0
 
   const onChange = (event) => {
     const values = event.target.value.split(" ").map(x => parseInt(x, 10))

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
@@ -6,7 +6,8 @@ import Wellplate from 'src/models/Wellplate';
 import CustomSizeModal from 'src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal';
 
 const Option = (width, height) => {
-  const label = `${height * width} (${width}x${height})`
+  const size = height * width
+  const label = size === 0 ? 'not yet chosen' : `${size} (${width}x${height})`
   const value = `${width} ${height}`
 
   return (<option key={`${label}-${value}`} label={label} value={value} />)

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
@@ -9,23 +9,39 @@ import CustomSizeModal from 'src/apps/mydb/elements/details/wellplates/propertie
 
 const STANDARD_SIZES = [[0, 0], [24, 16], [12, 8], [6, 4], [4, 3]];
 
-const Option = (width, height) => {
+const Option = (width, height, wellplate) => {
   const size = height * width;
-  const label = size === 0 ? 'Define later' : `${size} (${width}x${height})`;
+  const baseLabel = size === 0 ? 'Define later' : `${size} (${width}x${height})`;
   const value = `${width} ${height}`;
+  // Offering a size that would silently delete filled wells is the whole
+  // hazard here - "Define later" in particular used to wipe every placed
+  // sample without a word.
+  const wouldDropData = wellplate.occupiedWellsOutside(width, height).length > 0;
+  const label = wouldDropData ? `${baseLabel} - would delete filled wells` : baseLabel;
 
-  return (<option key={`${label}-${value}`} label={label} value={value} />);
+  return (<option key={`${label}-${value}`} label={label} value={value} disabled={wouldDropData} />);
 };
 
 const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
   const size = `${wellplate.width} ${wellplate.height}`;
   const [showCustomSizeModal, setShowCustomSizeModal] = useState(false);
-  const shouldBeDisabled = wellplate.isReadOnly || (!wellplate.is_new && wellplate.originalSize > 0);
+  // Resizing a saved wellplate is its own persisted step: the server
+  // reconciles the well rows and hands back a fresh wellplate that replaces
+  // this one, so ANY unsaved edit would be discarded by it - not just an edit
+  // to the wells. A wellplate that is not saved yet resizes in memory, with
+  // nothing to lose.
+  const hasUnsavedChanges = !wellplate.isNew && (wellplate.isEdited || wellplate.changed === true);
+  const shouldBeDisabled = wellplate.isReadOnly || hasUnsavedChanges;
+
+  const unsavedReason = wellplate.hasPendingWellChanges
+    ? 'Save your changes to the wells before changing the size.'
+    : 'Save your changes before changing the size.';
+  const disabledReason = wellplate.isReadOnly ? 'You cannot edit this wellplate.' : unsavedReason;
 
   const onChange = (event) => {
-    if (wellplate.isReadOnly) { return; }
+    if (shouldBeDisabled) { return; }
 
-    const values = event.target.value.split(' ').map(x => parseInt(x, 10));
+    const values = event.target.value.split(' ').map((x) => parseInt(x, 10));
     const width = values[0];
     const height = values[1];
 
@@ -34,24 +50,24 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
 
   const isStandardSize = STANDARD_SIZES.some(([w, h]) => w === wellplate.width && h === wellplate.height);
 
-  const options = STANDARD_SIZES.map(([w, h]) => Option(w, h));
+  const options = STANDARD_SIZES.map(([w, h]) => Option(w, h, wellplate));
   if (!isStandardSize) {
-    options.push(Option(wellplate.width, wellplate.height));
+    options.push(Option(wellplate.width, wellplate.height, wellplate));
   }
 
   const inputGroup = (
-    <InputGroup>
-      {shouldBeDisabled ? (
-        <Form.Control type="text" disabled value={`${wellplate.size} (${wellplate.width}x${wellplate.height})`} />
-      ) : (
-        <Form.Select
-          required={true}
-          value={size}
-          onChange={onChange}
-        >
-          {options}
-        </Form.Select>
-      )}
+    // A disabled control emits no mouse events and they do not bubble, so the
+    // OverlayTrigger below would never fire on it. Muting pointer events here
+    // lets the hover land on the wrapper span instead.
+    <InputGroup style={shouldBeDisabled ? { pointerEvents: 'none' } : undefined}>
+      <Form.Select
+        required
+        value={size}
+        onChange={onChange}
+        disabled={shouldBeDisabled}
+      >
+        {options}
+      </Form.Select>
       <Button
         className="create-own-size-button"
         disabled={shouldBeDisabled}
@@ -76,11 +92,18 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
           placement="bottom"
           overlay={(
             <Tooltip id={`wellplate-${wellplate.id}-size-locked-tooltip`}>
-              The size cannot be changed.
+              {disabledReason}
             </Tooltip>
           )}
         >
-          {inputGroup}
+          {/* The wrapper has to be focusable so keyboard users can reach the
+              explanation too; the control it describes is disabled and cannot
+              take focus itself. This is the standard recipe for a tooltip on a
+              disabled control. */}
+          {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+          <span className="d-inline-block w-100" tabIndex={0}>
+            {inputGroup}
+          </span>
         </OverlayTrigger>
       ) : inputGroup}
     </>

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
@@ -30,13 +30,20 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
   // this one, so ANY unsaved edit would be discarded by it - not just an edit
   // to the wells. A wellplate that is not saved yet resizes in memory, with
   // nothing to lose.
-  const hasUnsavedChanges = !wellplate.isNew && (wellplate.isEdited || wellplate.changed === true);
+  const hasUnsavedChanges = !wellplate.isNew && wellplate.isPendingToSave;
   const shouldBeDisabled = wellplate.isReadOnly || hasUnsavedChanges;
 
-  const unsavedReason = wellplate.hasPendingWellChanges
-    ? 'Save your changes to the wells before changing the size.'
-    : 'Save your changes before changing the size.';
-  const disabledReason = wellplate.isReadOnly ? 'You cannot edit this wellplate.' : unsavedReason;
+  // Deliberately a function, not a value: hasPendingWellChanges re-serializes
+  // and re-hashes every well (building a Sample per occupied one), and the
+  // answer is only ever needed for the tooltip below - which only renders while
+  // the control is locked.
+  const disabledReason = () => {
+    if (wellplate.isReadOnly) return 'You cannot edit this wellplate.';
+
+    return wellplate.hasPendingWellChanges
+      ? 'Save your changes to the wells before changing the size.'
+      : 'Save your changes before changing the size.';
+  };
 
   const onChange = (event) => {
     if (shouldBeDisabled) { return; }
@@ -92,7 +99,7 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
           placement="bottom"
           overlay={(
             <Tooltip id={`wellplate-${wellplate.id}-size-locked-tooltip`}>
-              {disabledReason}
+              {disabledReason()}
             </Tooltip>
           )}
         >

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
@@ -1,6 +1,8 @@
 // eslint-disable-next-line max-classes-per-file
 import React, { useState } from 'react';
-import { Button, Form, InputGroup } from 'react-bootstrap';
+import {
+  Button, Form, InputGroup, OverlayTrigger, Tooltip
+} from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import Wellplate from 'src/models/Wellplate';
 import CustomSizeModal from 'src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal';
@@ -37,6 +39,29 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
     options.push(Option(wellplate.width, wellplate.height));
   }
 
+  const inputGroup = (
+    <InputGroup>
+      {shouldBeDisabled ? (
+        <Form.Control type="text" disabled value={`${wellplate.size} (${wellplate.width}x${wellplate.height})`} />
+      ) : (
+        <Form.Select
+          required={true}
+          value={size}
+          onChange={onChange}
+        >
+          {options}
+        </Form.Select>
+      )}
+      <Button
+        className="create-own-size-button"
+        disabled={shouldBeDisabled}
+        onClick={() => setShowCustomSizeModal(true)}
+      >
+        <i className="fa fa-braille" />
+      </Button>
+    </InputGroup>
+  );
+
   return (
     <>
       <CustomSizeModal
@@ -46,23 +71,18 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
         handleClose={() => setShowCustomSizeModal(false)}
         key={`${wellplate.id}-custom-size-modal`}
       />
-      <InputGroup>
-        <Form.Select
-          required={true}
-          value={size}
-          onChange={onChange}
-          disabled={shouldBeDisabled}
+      {shouldBeDisabled ? (
+        <OverlayTrigger
+          placement="bottom"
+          overlay={(
+            <Tooltip id={`wellplate-${wellplate.id}-size-locked-tooltip`}>
+              The size cannot be changed.
+            </Tooltip>
+          )}
         >
-          {options}
-        </Form.Select>
-        <Button
-          className="create-own-size-button"
-          disabled={shouldBeDisabled}
-          onClick={() => setShowCustomSizeModal(true)}
-        >
-          <i className="fa fa-braille" />
-        </Button>
-      </InputGroup>
+          {inputGroup}
+        </OverlayTrigger>
+      ) : inputGroup}
     </>
   );
 };

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
@@ -37,10 +37,10 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
   const hasUnsavedChanges = !wellplate.isNew && wellplate.isPendingToSave;
   const shouldBeDisabled = wellplate.isReadOnly || hasUnsavedChanges;
 
-  // Deliberately a function, not a value: hasPendingWellChanges re-serializes
-  // and re-hashes every well (building a Sample per occupied one), and the
-  // answer is only ever needed for the tooltip below - which only renders while
-  // the control is locked.
+  // Deliberately a function, and called from a function overlay below, so that
+  // hasPendingWellChanges - which re-serializes and re-hashes every well,
+  // building a Sample per occupied one - runs only when a tooltip is actually
+  // shown.
   const disabledReason = () => {
     if (wellplate.isReadOnly) return 'You cannot edit this wellplate.';
 
@@ -48,6 +48,16 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
       ? 'Save your changes to the wells before changing the size.'
       : 'Save your changes before changing the size.';
   };
+
+  // Passed to OverlayTrigger as a function rather than a ready-made element: an
+  // `overlay={<Tooltip>…</Tooltip>}` prop is built on every render, and the
+  // control is locked exactly while the user is typing in the fields beside it.
+  // The injected props carry the positioning and have to reach the Tooltip.
+  const renderReasonTooltip = (overlayProps) => (
+    <Tooltip id={`wellplate-${wellplate.id}-size-locked-tooltip`} {...overlayProps}>
+      {disabledReason()}
+    </Tooltip>
+  );
 
   const onChange = (event) => {
     if (shouldBeDisabled) { return; }
@@ -100,14 +110,7 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
         key={`${wellplate.id}-custom-size-modal`}
       />
       {shouldBeDisabled ? (
-        <OverlayTrigger
-          placement="bottom"
-          overlay={(
-            <Tooltip id={`wellplate-${wellplate.id}-size-locked-tooltip`}>
-              {disabledReason()}
-            </Tooltip>
-          )}
-        >
+        <OverlayTrigger placement="bottom" overlay={renderReasonTooltip}>
           {/* The wrapper has to be focusable so keyboard users can reach the
               explanation too; the control it describes is disabled and cannot
               take focus itself. This is the standard recipe for a tooltip on a

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
@@ -15,7 +15,7 @@ const Option = (width, height) => {
 const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
   const size = `${wellplate.width} ${wellplate.height}`
   const [showCustomSizeModal, setShowCustomSizeModal] = useState(false)
-  const shouldBeDisabled = wellplate.isReadOnly || (!wellplate.is_new && wellplate.oldWidth > 0)
+  const shouldBeDisabled = wellplate.isReadOnly || (!wellplate.is_new && wellplate.originalSize > 0)
 
   const onChange = (event) => {
     if (wellplate.isReadOnly) { return; }

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
@@ -5,36 +5,37 @@ import PropTypes from 'prop-types';
 import Wellplate from 'src/models/Wellplate';
 import CustomSizeModal from 'src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal';
 
-const Option = (width, height) => {
-  const size = height * width
-  const label = size === 0 ? 'Define later' : `${size} (${width}x${height})`
-  const value = `${width} ${height}`
+const STANDARD_SIZES = [[0, 0], [24, 16], [12, 8], [6, 4], [4, 3]];
 
-  return (<option key={`${label}-${value}`} label={label} value={value} />)
-}
+const Option = (width, height) => {
+  const size = height * width;
+  const label = size === 0 ? 'Define later' : `${size} (${width}x${height})`;
+  const value = `${width} ${height}`;
+
+  return (<option key={`${label}-${value}`} label={label} value={value} />);
+};
 
 const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
-  const size = `${wellplate.width} ${wellplate.height}`
-  const [showCustomSizeModal, setShowCustomSizeModal] = useState(false)
-  const shouldBeDisabled = wellplate.isReadOnly || (!wellplate.is_new && wellplate.originalSize > 0)
+  const size = `${wellplate.width} ${wellplate.height}`;
+  const [showCustomSizeModal, setShowCustomSizeModal] = useState(false);
+  const shouldBeDisabled = wellplate.isReadOnly || (!wellplate.is_new && wellplate.originalSize > 0);
 
   const onChange = (event) => {
     if (wellplate.isReadOnly) { return; }
 
-    const values = event.target.value.split(" ").map(x => parseInt(x, 10))
-    const width = values[0]
-    const height = values[1]
+    const values = event.target.value.split(' ').map(x => parseInt(x, 10));
+    const width = values[0];
+    const height = values[1];
 
-    updateWellplate({ type: 'size', value: { width: width, height: height } });
+    updateWellplate({ type: 'size', value: { width, height } });
+  };
+
+  const isStandardSize = STANDARD_SIZES.some(([w, h]) => w === wellplate.width && h === wellplate.height);
+
+  const options = STANDARD_SIZES.map(([w, h]) => Option(w, h));
+  if (!isStandardSize) {
+    options.push(Option(wellplate.width, wellplate.height));
   }
-
-  const options = [
-    Option(0, 0),
-    Option(24, 16),
-    Option(12, 8),
-    Option(6, 4),
-    Option(4, 3)
-  ]
 
   return (
     <>
@@ -64,11 +65,11 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
       </InputGroup>
     </>
   );
-}
+};
 
 WellplateSizeDropdown.propTypes = {
   wellplate: PropTypes.instanceOf(Wellplate).isRequired,
   updateWellplate: PropTypes.func.isRequired,
 };
 
-export default WellplateSizeDropdown
+export default WellplateSizeDropdown;

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
@@ -9,14 +9,18 @@ import CustomSizeModal from 'src/apps/mydb/elements/details/wellplates/propertie
 
 const STANDARD_SIZES = [[0, 0], [24, 16], [12, 8], [6, 4], [4, 3]];
 
-const Option = (width, height, wellplate) => {
+// `filledWells` is the plate's occupied wells, computed once for the whole
+// option list: asking the model per option re-scans every well (and re-runs
+// `hasContent` on each) five or six times per render, which on a 100x100 plate
+// is 50_000 evaluations for an answer that never varies within a render.
+const Option = (width, height, filledWells) => {
   const size = height * width;
   const baseLabel = size === 0 ? 'Define later' : `${size} (${width}x${height})`;
   const value = `${width} ${height}`;
   // Offering a size that would silently delete filled wells is the whole
   // hazard here - "Define later" in particular used to wipe every placed
   // sample without a word.
-  const wouldDropData = wellplate.occupiedWellsOutside(width, height).length > 0;
+  const wouldDropData = filledWells.some((well) => Wellplate.positionOutside(well.position, width, height));
   const label = wouldDropData ? `${baseLabel} - would delete filled wells` : baseLabel;
 
   return (<option key={`${label}-${value}`} label={label} value={value} disabled={wouldDropData} />);
@@ -57,9 +61,10 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
 
   const isStandardSize = STANDARD_SIZES.some(([w, h]) => w === wellplate.width && h === wellplate.height);
 
-  const options = STANDARD_SIZES.map(([w, h]) => Option(w, h, wellplate));
+  const filledWells = wellplate.wells.filter((well) => well.hasContent);
+  const options = STANDARD_SIZES.map(([w, h]) => Option(w, h, filledWells));
   if (!isStandardSize) {
-    options.push(Option(wellplate.width, wellplate.height, wellplate));
+    options.push(Option(wellplate.width, wellplate.height, filledWells));
   }
 
   const inputGroup = (

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
@@ -15,6 +15,7 @@ const Option = (width, height) => {
 const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
   const size = `${wellplate.width} ${wellplate.height}`
   const [showCustomSizeModal, setShowCustomSizeModal] = useState(false)
+  const shouldBeDisabled = wellplate.isReadOnly || (!wellplate.is_new && wellplate.oldWidth > 0)
 
   const onChange = (event) => {
     if (wellplate.isReadOnly) { return; }
@@ -27,6 +28,7 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
   }
 
   const options = [
+    Option(0, 0),
     Option(24, 16),
     Option(12, 8),
     Option(6, 4),
@@ -47,13 +49,13 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
           required={true}
           value={size}
           onChange={onChange}
-          disabled={!wellplate.is_new || wellplate.isReadOnly}
+          disabled={shouldBeDisabled}
         >
           {options}
         </Form.Select>
         <Button
           className="create-own-size-button"
-          disabled={!wellplate.is_new || wellplate.isReadOnly}
+          disabled={shouldBeDisabled}
           onClick={() => setShowCustomSizeModal(true)}
         >
           <i className="fa fa-braille" />

--- a/app/javascript/src/fetchers/WellplatesFetcher.js
+++ b/app/javascript/src/fetchers/WellplatesFetcher.js
@@ -109,6 +109,27 @@ export default class WellplatesFetcher {
       });
   }
 
+  /**
+   * Resizes a persisted wellplate. The server reconciles the well rows and
+   * answers 422 when a well outside the new grid still holds data; ApiClient
+   * resolves the body either way, so that arrives as `json.error`.
+   */
+  static resize(wellplateId, width, height) {
+    return ApiClient.putJson(`/api/v1/wellplates/resize/${wellplateId}`, { body: { width, height } })
+      .then((json) => {
+        if (json.error) {
+          rootStore.notificationsStore.add({
+            title: 'Wellplate not resized',
+            message: json.error,
+            level: 'error',
+          });
+          return json;
+        }
+
+        return this.wellplateElement(json, wellplateId);
+      });
+  }
+
   static wellplateElement(json, id) {
     if (json.error) {
       return new Wellplate({ id: `${id}:error:Wellplate ${id} is not accessible!` });

--- a/app/javascript/src/models/Well.js
+++ b/app/javascript/src/models/Well.js
@@ -50,12 +50,17 @@ export default class Well extends Element {
    * and `readouts` have non-null column defaults, so a bare presence check
    * would report every untouched well as occupied and make shrinking a
    * wellplate impossible.
+   *
+   * `additive`, `color_code` and `label` are exposed at detail level 10, so
+   * below that WellEntity hands back the '***' placeholder for them. Counting
+   * a placeholder as content would mark every well of such a plate occupied -
+   * `label` alone would do it - and grey out every smaller size.
    */
   get hasContent() {
     if (this.sample) return true;
-    if (this.additive) return true;
-    if (this.color_code) return true;
-    if (this.label && this.label !== Well.DEFAULT_LABEL) return true;
+    if (this.additive && !this.isMethodDisabled('additive')) return true;
+    if (this.color_code && !this.isMethodDisabled('color_code')) return true;
+    if (this.label && this.label !== Well.DEFAULT_LABEL && !this.isMethodDisabled('label')) return true;
 
     return (this.readouts || []).some((readout) => readout && (readout.value || readout.unit));
   }

--- a/app/javascript/src/models/Well.js
+++ b/app/javascript/src/models/Well.js
@@ -62,7 +62,13 @@ export default class Well extends Element {
     if (this.color_code && !this.isMethodDisabled('color_code')) return true;
     if (this.label && this.label !== Well.DEFAULT_LABEL && !this.isMethodDisabled('label')) return true;
 
-    return (this.readouts || []).some((readout) => readout && (readout.value || readout.unit));
+    // Array.isArray, not a truthiness check: readouts is exposed at
+    // anonymize_below 1, so below that detail level the entity hands back the
+    // '***' placeholder string and `.some` would not exist. Any non-array is
+    // treated as "no readouts we can read", which is the safe reading.
+    if (!Array.isArray(this.readouts)) return false;
+
+    return this.readouts.some((readout) => readout && (readout.value || readout.unit));
   }
 
   get alphanumericPosition() {

--- a/app/javascript/src/models/Well.js
+++ b/app/javascript/src/models/Well.js
@@ -3,10 +3,29 @@ import Element from 'src/models/Element';
 import Sample from 'src/models/Sample';
 import Wellplate from 'src/models/Wellplate';
 
+// Mirrors ActiveSupport's `.present?`, which the server's Well#content? uses.
+// A plain truthiness test disagrees with it on a numeric 0 - and a spreadsheet
+// import stores raw cell values, so `{ value: 0 }` is a real readout. The
+// server would call that well occupied and refuse a shrink while the client
+// called it empty and offered the size as safe.
+const isPresent = (value) => value !== null && value !== undefined && String(value).trim() !== '';
+
 export default class Well extends Element {
   // Mirrors the wells.label column default; see `hasContent`.
   static get DEFAULT_LABEL() {
     return 'Molecular structure';
+  }
+
+  /**
+   * Whether a position is one some grid could actually hold. A non-positive
+   * row is not: rowLabel(0) is '' here and indexes the label table from the end
+   * on the server, so the same well would be named two different
+   * non-existent cells.
+   */
+  static isPlaceable(position) {
+    if (!position || position.x == null || position.y == null) return false;
+
+    return position.x > 0 && position.y > 0;
   }
 
   serialize() {
@@ -68,7 +87,7 @@ export default class Well extends Element {
     // treated as "no readouts we can read", which is the safe reading.
     if (!Array.isArray(this.readouts)) return false;
 
-    return this.readouts.some((readout) => readout && (readout.value || readout.unit));
+    return this.readouts.some((readout) => readout && (isPresent(readout.value) || isPresent(readout.unit)));
   }
 
   get alphanumericPosition() {
@@ -77,7 +96,7 @@ export default class Well extends Element {
     // outside any grid, so it can reach the "these wells block the resize"
     // message. Without this, rowLabel(null) is undefined and the position
     // renders as NaN - or throws outright when position itself is absent.
-    if (!this.position || this.position.x == null || this.position.y == null) return 'n/a';
+    if (!Well.isPlaceable(this.position)) return 'n/a';
 
     const positionY = Wellplate.rowLabel(this.position.y)
     const position = positionY + this.position.x;

--- a/app/javascript/src/models/Well.js
+++ b/app/javascript/src/models/Well.js
@@ -4,6 +4,11 @@ import Sample from 'src/models/Sample';
 import Wellplate from 'src/models/Wellplate';
 
 export default class Well extends Element {
+  // Mirrors the wells.label column default; see `hasContent`.
+  static get DEFAULT_LABEL() {
+    return 'Molecular structure';
+  }
+
   serialize() {
     return super.serialize({
       position: this.position,
@@ -36,6 +41,23 @@ export default class Well extends Element {
 
   set label(label) {
     this._label = label;
+  }
+
+  /**
+   * Whether the well holds anything a user put there.
+   *
+   * Mirrors Well#content? on the server, which is the authority. Both `label`
+   * and `readouts` have non-null column defaults, so a bare presence check
+   * would report every untouched well as occupied and make shrinking a
+   * wellplate impossible.
+   */
+  get hasContent() {
+    if (this.sample) return true;
+    if (this.additive) return true;
+    if (this.color_code) return true;
+    if (this.label && this.label !== Well.DEFAULT_LABEL) return true;
+
+    return (this.readouts || []).some((readout) => readout && (readout.value || readout.unit));
   }
 
   get alphanumericPosition() {

--- a/app/javascript/src/models/Well.js
+++ b/app/javascript/src/models/Well.js
@@ -72,6 +72,13 @@ export default class Well extends Element {
   }
 
   get alphanumericPosition() {
+    // Mirrors Well#alphanumeric_position on the server. A well with no usable
+    // position is reachable here: positionOutside deliberately counts one as
+    // outside any grid, so it can reach the "these wells block the resize"
+    // message. Without this, rowLabel(null) is undefined and the position
+    // renders as NaN - or throws outright when position itself is absent.
+    if (!this.position || this.position.x == null || this.position.y == null) return 'n/a';
+
     const positionY = Wellplate.rowLabel(this.position.y)
     const position = positionY + this.position.x;
 

--- a/app/javascript/src/models/Wellplate.js
+++ b/app/javascript/src/models/Wellplate.js
@@ -11,7 +11,7 @@ export default class Wellplate extends Element {
     this.#initEmptyWells();
   }
 
-  static buildEmpty(collectionId, width = 12, height = 8) {
+  static buildEmpty(collectionId, width = 0, height = 0) {
     return new Wellplate(
       {
         collection_id: collectionId,

--- a/app/javascript/src/models/Wellplate.js
+++ b/app/javascript/src/models/Wellplate.js
@@ -51,22 +51,22 @@ export default class Wellplate extends Element {
   }
 
   static columnLabel(columnIndex) {
-    if (columnIndex == 0) return ''
+    if (columnIndex === 0) return '';
 
-    return columnIndex
+    return columnIndex;
   }
 
   static rowLabel(rowIndex) {
-    if (rowIndex == 0) return ''
+    if (rowIndex === 0) return '';
 
     const rowLabels = [
       ...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''), // row 1-26
       ...'AA AB AC AD AE AF AG AH AI AJ AK AL AM AN AO AP AQ AR AS AT AU AV AW AX AY AZ'.split(' '), // row 27-52
       ...'BA BB BC BD BE BF BG BH BI BJ BK BL BM BN BO BP BQ BR BS BT BU BV BW BX BY BZ'.split(' '), // row 53-78
       ...'CA CB CC CD CE CF CG CH CI CJ CK CL CM CN CO CP CQ CR CS CT CU CV CW CX CY CZ'.split(' ')  // row 79-104
-    ]
+    ];
 
-  return rowLabels[rowIndex - 1]
+  return rowLabels[rowIndex - 1];
   }
 
   get name() {

--- a/app/javascript/src/models/Wellplate.js
+++ b/app/javascript/src/models/Wellplate.js
@@ -7,6 +7,7 @@ import Segment from 'src/models/Segment';
 export default class Wellplate extends Element {
   constructor(args) {
     super(args);
+    this.originalSize = this.width * this.height;
     this.#initEmptyWells();
   }
 
@@ -139,7 +140,6 @@ export default class Wellplate extends Element {
 
   changeSize(width, height) {
     // change actual dimensions
-    this.oldWidth=this.width;
     this.width = Number(width);
     this.height = Number(height);
 
@@ -164,7 +164,7 @@ export default class Wellplate extends Element {
   }
 
   #initEmptyWells() {
-    if (!this.isNew && this.oldWidth > 0) return
+    if (!this.isNew && this.originalSize > 0) return;
 
     this.wells = Array(this.size).fill({});
     this.wells = this.wells.map((well, i) => this.#initWellWithPositionByIndex(well, i));

--- a/app/javascript/src/models/Wellplate.js
+++ b/app/javascript/src/models/Wellplate.js
@@ -139,6 +139,7 @@ export default class Wellplate extends Element {
 
   changeSize(width, height) {
     // change actual dimensions
+    this.oldWidth=this.width;
     this.width = Number(width);
     this.height = Number(height);
 
@@ -163,7 +164,7 @@ export default class Wellplate extends Element {
   }
 
   #initEmptyWells() {
-    if (!this.isNew) return
+    if (!this.isNew && this.oldWidth > 0) return
 
     this.wells = Array(this.size).fill({});
     this.wells = this.wells.map((well, i) => this.#initWellWithPositionByIndex(well, i));

--- a/app/javascript/src/models/Wellplate.js
+++ b/app/javascript/src/models/Wellplate.js
@@ -47,7 +47,7 @@ export default class Wellplate extends Element {
   }
 
   static get MAX_DIMENSION() {
-    return 99;
+    return 100;
   }
 
   static columnLabel(columnIndex) {

--- a/app/javascript/src/models/Wellplate.js
+++ b/app/javascript/src/models/Wellplate.js
@@ -146,13 +146,33 @@ export default class Wellplate extends Element {
    * Wells holding data that a grid of `width` x `height` would have no room
    * for. Non-empty means the resize must be refused; the server enforces the
    * same rule in Usecases::Wellplates::Resize.
+   *
+   * The predicate mirrors that use case exactly, down to counting a missing or
+   * below-one position as outside: such a well fits no grid at all, and if the
+   * client left it out the server would refuse every size on offer without the
+   * UI being able to say which well was in the way.
    */
   occupiedWellsOutside(width, height) {
-    return this.wells.filter((well) => (
-      well.position
-      && (well.position.x > width || well.position.y > height)
-      && well.hasContent
-    ));
+    return this.wells.filter((well) => Wellplate.positionOutside(well.position, width, height)
+      && well.hasContent);
+  }
+
+  static positionOutside(position, width, height) {
+    if (!position || position.x == null || position.y == null) return true;
+
+    return position.x < 1 || position.y < 1 || position.x > width || position.y > height;
+  }
+
+  /**
+   * One blank readout per readout title, matching what
+   * Usecases::Wellplates::Resize#blank_readouts gives a well it materialises.
+   * The list tab pairs `readout_titles[i]` with `readouts[i]` and writes
+   * through without a bounds check, so a well short of entries throws there.
+   */
+  blankReadouts() {
+    const count = Math.max((this.readout_titles || []).length, 1);
+
+    return Array.from({ length: count }, () => ({ value: '', unit: '' }));
   }
 
   title() {
@@ -195,8 +215,7 @@ export default class Wellplate extends Element {
 
     const keptByPosition = new Map();
     this.wells.forEach((well) => {
-      if (!well.position) return;
-      if (well.position.x > this.width || well.position.y > this.height) return;
+      if (Wellplate.positionOutside(well.position, this.width, this.height)) return;
 
       keptByPosition.set(`${well.position.x}:${well.position.y}`, well);
     });
@@ -204,7 +223,8 @@ export default class Wellplate extends Element {
     this.wells = Array.from({ length: this.size }, (_, index) => {
       const position = this.#calculatePositionFromIndex(index);
 
-      return keptByPosition.get(`${position.x}:${position.y}`) || { position, readouts: [] };
+      return keptByPosition.get(`${position.x}:${position.y}`)
+        || { position, readouts: this.blankReadouts() };
     });
   }
 
@@ -228,7 +248,7 @@ export default class Wellplate extends Element {
     return {
       ...well,
       position: this.#calculatePositionFromIndex(i),
-      readouts: well.readouts || []
+      readouts: well.readouts || this.blankReadouts()
     };
   }
 

--- a/app/javascript/src/models/Wellplate.js
+++ b/app/javascript/src/models/Wellplate.js
@@ -48,7 +48,7 @@ export default class Wellplate extends Element {
   }
 
   static get MAX_DIMENSION() {
-    return 99;
+    return 100;
   }
 
   static columnLabel(columnIndex) {

--- a/app/javascript/src/models/Wellplate.js
+++ b/app/javascript/src/models/Wellplate.js
@@ -8,11 +8,12 @@ import Segment from 'src/models/Segment';
 export default class Wellplate extends Element {
   constructor(args) {
     super(args);
-    this.#initEmptyWells();
-    // #initEmptyWells may have built the grid after Element's constructor
-    // already hashed the element, so re-baseline both checksums here. Nothing
-    // else may reset them: a resize has to register as a real change.
-    this.updateChecksum();
+    // When #initEmptyWells builds a grid it does so after Element's constructor
+    // already hashed the element, so both checksums have to be re-baselined.
+    // Only then: Element's constructor has already hashed a wellplate whose
+    // wells were left alone, and hashing the well list is not cheap. Nothing
+    // else may reset them either - a resize has to register as a real change.
+    if (this.#initEmptyWells()) this.updateChecksum();
   }
 
   static buildEmpty(collectionId, width = 0, height = 0) {
@@ -207,14 +208,20 @@ export default class Wellplate extends Element {
     });
   }
 
+  /**
+   * @returns {boolean} whether the grid was (re)built, i.e. whether the
+   *   checksums the constructor took before this ran are now stale
+   */
   #initEmptyWells() {
     // A persisted wellplate keeps whatever wells the server sent, including
     // none at all: re-initialising here would discard them, and saving the
     // emptied list makes the server destroy every sample they held.
-    if (!this.isNew) return;
+    if (!this.isNew) return false;
 
     this.wells = Array(this.size).fill({});
     this.wells = this.wells.map((well, i) => this.#initWellWithPositionByIndex(well, i));
+
+    return true;
   }
 
   #initWellWithPositionByIndex(well, i) {

--- a/app/javascript/src/models/Wellplate.js
+++ b/app/javascript/src/models/Wellplate.js
@@ -52,22 +52,22 @@ export default class Wellplate extends Element {
   }
 
   static columnLabel(columnIndex) {
-    if (columnIndex == 0) return ''
+    if (columnIndex === 0) return '';
 
-    return columnIndex
+    return columnIndex;
   }
 
   static rowLabel(rowIndex) {
-    if (rowIndex == 0) return ''
+    if (rowIndex === 0) return '';
 
     const rowLabels = [
       ...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''), // row 1-26
       ...'AA AB AC AD AE AF AG AH AI AJ AK AL AM AN AO AP AQ AR AS AT AU AV AW AX AY AZ'.split(' '), // row 27-52
       ...'BA BB BC BD BE BF BG BH BI BJ BK BL BM BN BO BP BQ BR BS BT BU BV BW BX BY BZ'.split(' '), // row 53-78
       ...'CA CB CC CD CE CF CG CH CI CJ CK CL CM CN CO CP CQ CR CS CT CU CV CW CX CY CZ'.split(' ')  // row 79-104
-    ]
+    ];
 
-  return rowLabels[rowIndex - 1]
+  return rowLabels[rowIndex - 1];
   }
 
   get name() {

--- a/app/javascript/src/models/Wellplate.js
+++ b/app/javascript/src/models/Wellplate.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-underscore-dangle */
+import sha256 from 'sha256';
 import Element from 'src/models/Element';
 import Well from 'src/models/Well';
 import Container from 'src/models/Container';
@@ -7,8 +8,11 @@ import Segment from 'src/models/Segment';
 export default class Wellplate extends Element {
   constructor(args) {
     super(args);
-    this.originalSize = this.width * this.height;
     this.#initEmptyWells();
+    // #initEmptyWells may have built the grid after Element's constructor
+    // already hashed the element, so re-baseline both checksums here. Nothing
+    // else may reset them: a resize has to register as a real change.
+    this.updateChecksum();
   }
 
   static buildEmpty(collectionId, width = 0, height = 0) {
@@ -115,7 +119,39 @@ export default class Wellplate extends Element {
   }
 
   checksum(fieldsToOmit = []) {
-    return super.checksum(['attachments', ...fieldsToOmit]);
+    return super.checksum(['attachments', '_wellsChecksum', ...fieldsToOmit]);
+  }
+
+  /**
+   * Hash of the wells alone, so an unsaved well edit can be told apart from any
+   * other unsaved edit. The size control keys off this: resizing is refused
+   * while well changes are pending, because the two must be persisted as
+   * separate steps.
+   */
+  wellsChecksum() {
+    return sha256(JSON.stringify(this.wells.map((well) => well.serialize())));
+  }
+
+  get hasPendingWellChanges() {
+    return this._wellsChecksum !== this.wellsChecksum();
+  }
+
+  updateChecksum(cs) {
+    this._wellsChecksum = this.wellsChecksum();
+    super.updateChecksum(cs);
+  }
+
+  /**
+   * Wells holding data that a grid of `width` x `height` would have no room
+   * for. Non-empty means the resize must be refused; the server enforces the
+   * same rule in Usecases::Wellplates::Resize.
+   */
+  occupiedWellsOutside(width, height) {
+    return this.wells.filter((well) => (
+      well.position
+      && (well.position.x > width || well.position.y > height)
+      && well.hasContent
+    ));
   }
 
   title() {
@@ -139,37 +175,46 @@ export default class Wellplate extends Element {
     });
   }
 
+  /**
+   * Rebuilds the grid, keeping every well whose position still fits and
+   * dropping the rest.
+   *
+   * Wells are matched by position, not by index: indexing against the *new*
+   * width used to wrap an out-of-range well into the next row instead of
+   * dropping it, and left the survivors carrying stale positions that the
+   * server then persisted verbatim.
+   *
+   * On a persisted wellplate the server owns this reconciliation
+   * (Usecases::Wellplates::Resize); this runs for wellplates that have not been
+   * created yet, where the grid only exists in memory.
+   */
   changeSize(width, height) {
-    // change actual dimensions
     this.width = Number(width);
     this.height = Number(height);
 
-    // copy wells, so that we can set a new size for the wells while keeping the old positions
-    const oldWells = this.wells.map((well) => well);
+    const keptByPosition = new Map();
+    this.wells.forEach((well) => {
+      if (!well.position) return;
+      if (well.position.x > this.width || well.position.y > this.height) return;
 
-    // initalize wells with new size
-    this.#initEmptyWells();
-
-    // calculate new index from old position and set well at new index if it is within the new size
-    this.#moveWellsToNewIndexWhileKeepingOldPosition(oldWells);
-  }
-
-  #moveWellsToNewIndexWhileKeepingOldPosition(oldWells) {
-    oldWells.forEach((well) => {
-      const index = this.#calculateIndexFromPosition(well.position);
-      if (index < this.size) {
-        this.wells[index] = well;
-      }
+      keptByPosition.set(`${well.position.x}:${well.position.y}`, well);
     });
-    this._checksum = this.checksum();
+
+    this.wells = Array.from({ length: this.size }, (_, index) => {
+      const position = this.#calculatePositionFromIndex(index);
+
+      return keptByPosition.get(`${position.x}:${position.y}`) || { position, readouts: [] };
+    });
   }
 
   #initEmptyWells() {
-    if (!this.isNew && this.originalSize > 0) return;
+    // A persisted wellplate keeps whatever wells the server sent, including
+    // none at all: re-initialising here would discard them, and saving the
+    // emptied list makes the server destroy every sample they held.
+    if (!this.isNew) return;
 
     this.wells = Array(this.size).fill({});
     this.wells = this.wells.map((well, i) => this.#initWellWithPositionByIndex(well, i));
-    this._checksum = this.checksum();
   }
 
   #initWellWithPositionByIndex(well, i) {
@@ -187,9 +232,5 @@ export default class Wellplate extends Element {
     const y = Math.floor(i / this.width) + 1;
 
     return { x, y };
-  }
-
-  #calculateIndexFromPosition(position) {
-    return (position.y - 1) * this.width + position.x - 1;
   }
 }

--- a/app/javascript/src/models/Wellplate.js
+++ b/app/javascript/src/models/Wellplate.js
@@ -140,6 +140,7 @@ export default class Wellplate extends Element {
 
   changeSize(width, height) {
     // change actual dimensions
+    this.oldWidth=this.width;
     this.width = Number(width);
     this.height = Number(height);
 
@@ -164,7 +165,7 @@ export default class Wellplate extends Element {
   }
 
   #initEmptyWells() {
-    if (!this.isNew) return
+    if (!this.isNew && this.oldWidth > 0) return
 
     this.wells = Array(this.size).fill({});
     this.wells = this.wells.map((well, i) => this.#initWellWithPositionByIndex(well, i));

--- a/app/javascript/src/models/Wellplate.js
+++ b/app/javascript/src/models/Wellplate.js
@@ -7,6 +7,7 @@ import Segment from 'src/models/Segment';
 export default class Wellplate extends Element {
   constructor(args) {
     super(args);
+    this.originalSize = this.width * this.height;
     this.#initEmptyWells();
   }
 
@@ -140,7 +141,6 @@ export default class Wellplate extends Element {
 
   changeSize(width, height) {
     // change actual dimensions
-    this.oldWidth=this.width;
     this.width = Number(width);
     this.height = Number(height);
 
@@ -165,7 +165,7 @@ export default class Wellplate extends Element {
   }
 
   #initEmptyWells() {
-    if (!this.isNew && this.oldWidth > 0) return
+    if (!this.isNew && this.originalSize > 0) return;
 
     this.wells = Array(this.size).fill({});
     this.wells = this.wells.map((well, i) => this.#initWellWithPositionByIndex(well, i));

--- a/app/javascript/src/stores/alt/actions/ElementActions.js
+++ b/app/javascript/src/stores/alt/actions/ElementActions.js
@@ -874,6 +874,21 @@ class ElementActions {
     };
   }
 
+  resizeWellplate(wellplateId, width, height) {
+    return (dispatch) => {
+      WellplatesFetcher.resize(wellplateId, width, height)
+        .then((result) => {
+          // Stamp updated_at so WellplateDetails#componentDidUpdate adopts the
+          // reconciled wellplate coming back from the server.
+          if (!result.error) { result.updated_at = new Date(); }
+          dispatch(result);
+        }).catch((errorMessage) => {
+          console.log(errorMessage);
+          LoadingActions.stop();
+        });
+    };
+  }
+
   importWellplateSpreadsheet(wellplateId, attachmentId) {
     return (dispatch) => {
       WellplatesFetcher.importWellplateSpreadsheet(wellplateId, attachmentId)

--- a/app/javascript/src/stores/alt/actions/ElementActions.js
+++ b/app/javascript/src/stores/alt/actions/ElementActions.js
@@ -878,9 +878,18 @@ class ElementActions {
     return (dispatch) => {
       WellplatesFetcher.resize(wellplateId, width, height)
         .then((result) => {
-          // Stamp updated_at so WellplateDetails#componentDidUpdate adopts the
-          // reconciled wellplate coming back from the server.
-          if (!result.error) { result.updated_at = new Date(); }
+          if (!result.error) {
+            // Stamp updated_at so WellplateDetails#componentDidUpdate adopts the
+            // reconciled wellplate coming back from the server: eln_timestamp has
+            // second resolution, so the server's own value can be byte-identical
+            // to the one already on screen.
+            result.updated_at = new Date();
+            // The stamp lands after WellplatesFetcher baselined the checksum, and
+            // a Date drops out of the hash where the string did not - without
+            // this the freshly persisted wellplate reads as edited and locks the
+            // size control it just came out of.
+            result.updateChecksum();
+          }
           dispatch(result);
         }).catch((errorMessage) => {
           console.log(errorMessage);

--- a/app/javascript/src/stores/alt/stores/ElementStore.js
+++ b/app/javascript/src/stores/alt/stores/ElementStore.js
@@ -228,6 +228,7 @@ class ElementStore {
         ElementActions.bulkCreateWellplatesFromSamples,
       handleFetchWellplateById: ElementActions.fetchWellplateById,
       handleImportWellplateSpreadsheet: ElementActions.importWellplateSpreadsheet,
+      handleResizeWellplate: ElementActions.resizeWellplate,
       handleCreateWellplate: ElementActions.createWellplate,
       handleGenerateWellplateFromClipboard:
         ElementActions.generateWellplateFromClipboard,
@@ -999,6 +1000,12 @@ class ElementStore {
     if (updated) {
       this.setState({ selecteds: newSelecteds });
     }
+  }
+
+  handleResizeWellplate(result) {
+    if (result.error) { return; }
+
+    this.handleUpdateWellplate(result);
   }
 
   handleImportWellplateSpreadsheet(result) {

--- a/app/javascript/src/stores/alt/stores/LoadingStore.js
+++ b/app/javascript/src/stores/alt/stores/LoadingStore.js
@@ -35,6 +35,7 @@ class LoadingStore {
           ElementActions.createWellplate,
           ElementActions.updateWellplate,
           ElementActions.importWellplateSpreadsheet,
+          ElementActions.resizeWellplate,
           ElementActions.createDeviceDescription,
           ElementActions.updateDeviceDescription,
           ElementActions.createVessel,

--- a/app/models/well.rb
+++ b/app/models/well.rb
@@ -68,17 +68,28 @@ class Well < ApplicationRecord
 
   # translates well position within wellplate: X=2 Y=3 -> C2
   def alphanumeric_position
-    return 'n/a' if position_x.nil? || position_y.nil?
+    # A non-positive row would index the label table from the end (y=0 -> "ZZ"),
+    # naming a cell that does not exist. Reachable since Resize reports wells
+    # with a below-one position as blocking a shrink.
+    return 'n/a' unless placeable?
 
     row = ('A'..'ZZ').to_a[position_y - 1]
     "#{row}#{position_x}"
   end
 
   def sortable_alphanumeric_position
-    return 'n/a' if position_x.nil? || position_y.nil?
+    return 'n/a' unless placeable?
 
     row = ('A'..'ZZ').to_a[position_y - 1]
     "#{row}#{format('%02i', position_x)}"
+  end
+
+  # Whether the well sits at a position any grid could hold. Mirrors
+  # Wellplate.positionOutside on the client.
+  #
+  # @return [Boolean]
+  def placeable?
+    position_x.present? && position_y.present? && position_x.positive? && position_y.positive?
   end
 
   private

--- a/app/models/well.rb
+++ b/app/models/well.rb
@@ -74,6 +74,15 @@ class Well < ApplicationRecord
     "#{row}#{position_x}"
   end
 
+  def sortable_alphanumeric_position
+    return 'n/a' if position_x.nil? || position_y.nil?
+
+    row = ('A'..'ZZ').to_a[position_y - 1]
+    "#{row}#{format('%02i', position_x)}"
+  end
+
+  private
+
   # @param readout [Object] one entry of {#readouts}; jsonb yields string keys
   #   when loaded from the DB and symbol keys when built in memory
   # @return [Boolean] whether the entry carries a value or a unit
@@ -82,12 +91,5 @@ class Well < ApplicationRecord
 
     entry = readout.with_indifferent_access
     entry[:value].present? || entry[:unit].present?
-  end
-
-  def sortable_alphanumeric_position
-    return 'n/a' if position_x.nil? || position_y.nil?
-
-    row = ('A'..'ZZ').to_a[position_y - 1]
-    "#{row}#{format('%02i', position_x)}"
   end
 end

--- a/app/models/well.rb
+++ b/app/models/well.rb
@@ -26,6 +26,9 @@
 
 class Well < ApplicationRecord
   HEX_COLOR_REGEX = /\A#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})\z/.freeze
+  # Mirrors the +wells.label+ column default; a well still carrying it has not
+  # been labelled by a user. See {#content?}.
+  DEFAULT_LABEL = 'Molecular structure'
   has_logidze
   acts_as_paranoid
   belongs_to :wellplate
@@ -45,12 +48,40 @@ class Well < ApplicationRecord
     read_attribute(:readouts) || []
   end
 
+  # Whether the well holds anything a user put there.
+  #
+  # Used to decide whether shrinking a wellplate may drop this well. Both
+  # +label+ and +readouts+ have non-null column defaults, so a bare presence
+  # check would report every untouched well as occupied and make shrinking
+  # impossible. +sample+ is read through the association rather than
+  # +sample_id+ on purpose: {Sample} is +acts_as_paranoid+ and
+  # {Usecases::Wellplates::WellplateUpdater#update_wells} destroys samples
+  # without nulling the column, so dangling ids are common and must read as
+  # empty.
+  #
+  # @return [Boolean]
+  def content?
+    sample.present? || additive.present? || color_code.present? ||
+      (label.present? && label != DEFAULT_LABEL) ||
+      readouts.any? { |readout| readout_filled?(readout) }
+  end
+
   # translates well position within wellplate: X=2 Y=3 -> C2
   def alphanumeric_position
     return 'n/a' if position_x.nil? || position_y.nil?
 
     row = ('A'..'ZZ').to_a[position_y - 1]
     "#{row}#{position_x}"
+  end
+
+  # @param readout [Object] one entry of {#readouts}; jsonb yields string keys
+  #   when loaded from the DB and symbol keys when built in memory
+  # @return [Boolean] whether the entry carries a value or a unit
+  def readout_filled?(readout)
+    return false unless readout.is_a?(Hash)
+
+    entry = readout.with_indifferent_access
+    entry[:value].present? || entry[:unit].present?
   end
 
   def sortable_alphanumeric_position

--- a/app/services/versioning/reverters/wellplate_reverter.rb
+++ b/app/services/versioning/reverters/wellplate_reverter.rb
@@ -1,7 +1,16 @@
 # frozen_string_literal: true
 
 class Versioning::Reverters::WellplateReverter < Versioning::Reverters::BaseReverter
+  # Reverting the grid dimensions here would bypass Wellplate#changeSize's well
+  # re-indexing and could orphan or misalign wells that already hold samples.
+  FORBIDDEN_FIELDS = %w[width height heigth].freeze
+
   def self.scope
     Wellplate.with_deleted
+  end
+
+  def call
+    self.fields = fields.reject { |field| FORBIDDEN_FIELDS.include?(field['name'].to_s) }
+    super
   end
 end

--- a/app/services/versioning/serializers/wellplate_serializer.rb
+++ b/app/services/versioning/serializers/wellplate_serializer.rb
@@ -24,11 +24,9 @@ module Versioning
           },
           width: {
             label: 'Width',
-            revert: %i[width],
           },
           height: {
             label: 'Height',
-            revert: %i[heigth],
           },
           readout_titles: {
             label: 'Readout Title',

--- a/app/usecases/wellplates/create.rb
+++ b/app/usecases/wellplates/create.rb
@@ -4,6 +4,12 @@ module Usecases
   module Wellplates
     class Create
       include UserLabelHelpers
+
+      # Mirror the wellplates column defaults, which are what actually applies
+      # when a caller declares no dimensions at all - the bulk endpoint does not.
+      DEFAULT_WIDTH = 12
+      DEFAULT_HEIGHT = 8
+
       attr_reader :params, :current_user
 
       def initialize(params, current_user)
@@ -12,6 +18,10 @@ module Usecases
       end
 
       def execute! # rubocop:disable Metrics/AbcSize
+        # The same rule Usecases::Wellplates::Resize enforces. Without it here a
+        # wellplate could be created in a shape no resize would ever accept.
+        Dimensions.validate!(width: params.fetch(:width, DEFAULT_WIDTH), height: params.fetch(:height, DEFAULT_HEIGHT))
+
         ActiveRecord::Base.transaction do
           wellplate = Wellplate.create(
             params.except(:collection_id, :wells, :segments, :size, :user_labels)

--- a/app/usecases/wellplates/dimensions.rb
+++ b/app/usecases/wellplates/dimensions.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Usecases
+  module Wellplates
+    # The rules a wellplate grid has to satisfy, in one place so that every path
+    # which sets +width+/+height+ enforces the same ones. Living in a single use
+    # case is what previously let the create endpoint accept a grid the resize
+    # endpoint would refuse.
+    module Dimensions
+      # Largest grid dimension, matching {WellPosition}'s own bound and
+      # {Usecases::Wellplates::TemplateCreation}'s +max+.
+      MAX_DIMENSION = 100
+
+      module_function
+
+      # @param width [Integer]
+      # @param height [Integer]
+      # @raise [Usecases::Wellplates::Errors::InvalidDimensionsError] for an
+      #   out-of-bounds dimension, or one dimension zero while the other is not
+      # @return [void]
+      def validate!(width:, height:)
+        { 'width' => width, 'height' => height }.each do |name, value|
+          next if value.between?(0, MAX_DIMENSION)
+
+          raise Errors::InvalidDimensionsError,
+                "Wellplate #{name} of #{value} must be between 0 and #{MAX_DIMENSION}."
+        end
+
+        # An unsized wellplate is 0x0. One dimension alone at zero yields a
+        # wellplate with no wells but a non-zero edge, which the designer renders
+        # as headers around an empty grid and which no resize can repair.
+        return unless width.zero? ^ height.zero?
+
+        raise Errors::InvalidDimensionsError,
+              'A wellplate size of 0 requires both width and height to be 0.'
+      end
+    end
+  end
+end

--- a/app/usecases/wellplates/errors.rb
+++ b/app/usecases/wellplates/errors.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Usecases
+  module Wellplates
+    module Errors
+      # Raised when a requested grid size would drop a well that still holds
+      # data. See {Usecases::Wellplates::Resize}.
+      class ResizeNotAllowedError < StandardError; end
+
+      # Raised for a grid size that is out of bounds or internally inconsistent
+      # (e.g. one dimension zero while the other is not).
+      class InvalidDimensionsError < StandardError; end
+    end
+  end
+end

--- a/app/usecases/wellplates/resize.rb
+++ b/app/usecases/wellplates/resize.rb
@@ -79,6 +79,10 @@ module Usecases
       # edge) would otherwise be unrepairable, since no size can be asked for
       # that both reconciles it and differs from what it already claims.
       #
+      # Note this covers drift *outside* the grid only. A plate short of wells
+      # *inside* its grid still short-circuits here and is not repaired, because
+      # create_missing_wells runs after this check.
+      #
       # @param outside [Array<Well>] the wells the requested grid has no room for
       # @return [Boolean]
       def unchanged?(outside)

--- a/app/usecases/wellplates/resize.rb
+++ b/app/usecases/wellplates/resize.rb
@@ -22,6 +22,11 @@ module Usecases
       # is elided; the full count is always reported.
       POSITIONS_IN_ERROR = 5
 
+      # Rows per INSERT when materialising the grid. A 100x100 plate is 10_000
+      # wells; one statement per well would put 10_000 round trips (each firing
+      # the logidze trigger) inside a single request.
+      INSERT_BATCH_SIZE = 1_000
+
       attr_reader :wellplate, :width, :height
 
       # @param wellplate [Wellplate]
@@ -40,11 +45,15 @@ module Usecases
       #   holding data lies outside the requested grid
       def execute!
         validate_dimensions!
-        return wellplate if unchanged?
-
-        guard_occupied_wells!
 
         ActiveRecord::Base.transaction do
+          # Serialise against a concurrent well edit. guard_occupied_wells!
+          # decides what may be destroyed; without the lock a sample placed
+          # between that check and the delete below would go with it.
+          wellplate.lock!
+          next if unchanged?
+
+          guard_occupied_wells!
           wells_outside_new_grid.destroy_all
           # destroy_all leaves the has_many cache holding the rows it just
           # removed, and a loaded association answers pluck from that cache.
@@ -58,8 +67,13 @@ module Usecases
 
       private
 
+      # Only a request that neither moves the grid nor leaves a well outside it
+      # is a genuine no-op. Matching dimensions alone are not enough: a plate
+      # whose rows drifted out of the grid (a null position, a row beyond the
+      # edge) would otherwise be unrepairable, since no size can be asked for
+      # that both reconciles it and differs from what it already claims.
       def unchanged?
-        wellplate.width == width && wellplate.height == height
+        wellplate.width == width && wellplate.height == height && !wells_outside_new_grid.exists?
       end
 
       def validate_dimensions!
@@ -77,14 +91,17 @@ module Usecases
               'A wellplate size of 0 requires both width and height to be 0.'
       end
 
-      # Wells the requested grid has no room for. A null position counts as
-      # outside: such a well cannot be placed on any grid and would break
-      # rendering.
+      # Wells the requested grid has no room for. A null or below-one position
+      # counts as outside: such a well cannot be placed on any grid, and the
+      # designer indexes its row array by position, so a 0 would overwrite the
+      # row header and a negative would land off the end.
       #
       # @return [ActiveRecord::Relation]
       def wells_outside_new_grid
         wellplate.wells.where(
-          'position_x IS NULL OR position_y IS NULL OR position_x > ? OR position_y > ?',
+          'position_x IS NULL OR position_y IS NULL ' \
+          'OR position_x < 1 OR position_y < 1 ' \
+          'OR position_x > ? OR position_y > ?',
           width,
           height,
         )
@@ -112,15 +129,45 @@ module Usecases
       # Materialises the full grid. The designer tab builds its cells from the
       # well list, so positions without a row are simply not there to drop a
       # sample onto.
+      #
+      # Inserted in batches rather than one {Well} at a time: the largest grid
+      # this allows is 100x100, and a row-at-a-time create would be 10_000
+      # statements in one request.
       def create_missing_wells
         taken = wellplate.wells.pluck(:position_x, :position_y).to_set
+        now = Time.current
 
-        (1..height).each do |pos_y|
-          (1..width).each do |pos_x|
-            next if taken.include?([pos_x, pos_y])
+        rows = WellPosition.from_dimension(width, height).filter_map do |position|
+          next if taken.include?([position.x, position.y])
 
-            wellplate.wells.create!(position_x: pos_x, position_y: pos_y)
-          end
+          {
+            wellplate_id: wellplate.id,
+            position_x: position.x,
+            position_y: position.y,
+            readouts: blank_readouts,
+            created_at: now,
+            updated_at: now,
+          }
+        end
+
+        # Well's only validation is the hex format of color_code, which these
+        # rows do not set; logidze is a database trigger and still fires.
+        rows.each_slice(INSERT_BATCH_SIZE) do |batch|
+          Well.insert_all(batch) # rubocop:disable Rails/SkipsModelValidations
+        end
+      end
+
+      # One blank readout per readout title, matching what the wells already on
+      # the plate carry — the list tab pairs +readout_titles[i]+ with
+      # +readouts[i]+ and writes through without a bounds check, so a well that
+      # is short of entries raises there. The +wells.readouts+ column default is
+      # a single blank entry, which is only right for a plate with at most one
+      # title.
+      #
+      # @return [Array<Hash>]
+      def blank_readouts
+        @blank_readouts ||= Array.new([Array(wellplate.readout_titles).size, 1].max) do
+          { 'value' => '', 'unit' => '' }
         end
       end
     end

--- a/app/usecases/wellplates/resize.rb
+++ b/app/usecases/wellplates/resize.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+module Usecases
+  module Wellplates
+    # Changes a wellplate's grid dimensions and reconciles its {Well} rows.
+    #
+    # Growing is always allowed. Shrinking is refused when it would drop a well
+    # that still holds data ({Well#content?}) — the caller is expected to clear
+    # those wells and persist that first, making "empty the wells" and "resize"
+    # two separate operations. That separation is what makes the invariant
+    # checkable at all: a single request can change the grid or the wells, never
+    # both.
+    #
+    # This is the only write path for +width+/+height+ on a persisted wellplate;
+    # +PUT /api/v1/wellplates/:id+ deliberately does not accept them.
+    class Resize
+      # Largest grid dimension, matching {WellPosition}'s own bound and
+      # {Usecases::Wellplates::TemplateCreation}'s +max+.
+      MAX_DIMENSION = 100
+
+      # Number of blocking well positions named in the error message before it
+      # is elided; the full count is always reported.
+      POSITIONS_IN_ERROR = 5
+
+      attr_reader :wellplate, :width, :height
+
+      # @param wellplate [Wellplate]
+      # @param width [Integer] requested number of columns
+      # @param height [Integer] requested number of rows
+      def initialize(wellplate:, width:, height:)
+        @wellplate = wellplate
+        @width = width.to_i
+        @height = height.to_i
+      end
+
+      # @return [Wellplate] the wellplate, reloaded when it changed
+      # @raise [Usecases::Wellplates::Errors::InvalidDimensionsError] for an
+      #   out-of-bounds size, or one dimension zero while the other is not
+      # @raise [Usecases::Wellplates::Errors::ResizeNotAllowedError] when a well
+      #   holding data lies outside the requested grid
+      def execute!
+        validate_dimensions!
+        return wellplate if unchanged?
+
+        guard_occupied_wells!
+
+        ActiveRecord::Base.transaction do
+          wells_outside_new_grid.destroy_all
+          # destroy_all leaves the has_many cache holding the rows it just
+          # removed, and a loaded association answers pluck from that cache.
+          wellplate.wells.reset
+          create_missing_wells
+          wellplate.update!(width: width, height: height)
+        end
+
+        wellplate.reload
+      end
+
+      private
+
+      def unchanged?
+        wellplate.width == width && wellplate.height == height
+      end
+
+      def validate_dimensions!
+        %w[width height].each do |dimension|
+          value = public_send(dimension)
+          next if value.between?(0, MAX_DIMENSION)
+
+          raise Errors::InvalidDimensionsError,
+                "Wellplate #{dimension} of #{value} must be between 0 and #{MAX_DIMENSION}."
+        end
+
+        return unless width.zero? ^ height.zero?
+
+        raise Errors::InvalidDimensionsError,
+              'A wellplate size of 0 requires both width and height to be 0.'
+      end
+
+      # Wells the requested grid has no room for. A null position counts as
+      # outside: such a well cannot be placed on any grid and would break
+      # rendering.
+      #
+      # @return [ActiveRecord::Relation]
+      def wells_outside_new_grid
+        wellplate.wells.where(
+          'position_x IS NULL OR position_y IS NULL OR position_x > ? OR position_y > ?',
+          width,
+          height,
+        )
+      end
+
+      def guard_occupied_wells!
+        blocking = wells_outside_new_grid.includes(:sample).select(&:content?)
+        return if blocking.empty?
+
+        raise Errors::ResizeNotAllowedError, blocking_message(blocking)
+      end
+
+      # @param blocking [Array<Well>]
+      # @return [String]
+      def blocking_message(blocking)
+        positions = blocking.first(POSITIONS_IN_ERROR).map(&:alphanumeric_position)
+        positions << "and #{blocking.size - POSITIONS_IN_ERROR} more" if blocking.size > POSITIONS_IN_ERROR
+
+        "Cannot resize to #{width}x#{height}: #{blocking.size} " \
+          "#{'well'.pluralize(blocking.size)} outside the new size still " \
+          "#{blocking.size == 1 ? 'holds' : 'hold'} data (#{positions.join(', ')}). " \
+          'Empty them and save before resizing.'
+      end
+
+      # Materialises the full grid. The designer tab builds its cells from the
+      # well list, so positions without a row are simply not there to drop a
+      # sample onto.
+      def create_missing_wells
+        taken = wellplate.wells.pluck(:position_x, :position_y).to_set
+
+        (1..height).each do |pos_y|
+          (1..width).each do |pos_x|
+            next if taken.include?([pos_x, pos_y])
+
+            wellplate.wells.create!(position_x: pos_x, position_y: pos_y)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/usecases/wellplates/resize.rb
+++ b/app/usecases/wellplates/resize.rb
@@ -14,10 +14,6 @@ module Usecases
     # This is the only write path for +width+/+height+ on a persisted wellplate;
     # +PUT /api/v1/wellplates/:id+ deliberately does not accept them.
     class Resize
-      # Largest grid dimension, matching {WellPosition}'s own bound and
-      # {Usecases::Wellplates::TemplateCreation}'s +max+.
-      MAX_DIMENSION = 100
-
       # Number of blocking well positions named in the error message before it
       # is elided; the full count is always reported.
       POSITIONS_IN_ERROR = 5
@@ -90,18 +86,7 @@ module Usecases
       end
 
       def validate_dimensions!
-        %w[width height].each do |dimension|
-          value = public_send(dimension)
-          next if value.between?(0, MAX_DIMENSION)
-
-          raise Errors::InvalidDimensionsError,
-                "Wellplate #{dimension} of #{value} must be between 0 and #{MAX_DIMENSION}."
-        end
-
-        return unless width.zero? ^ height.zero?
-
-        raise Errors::InvalidDimensionsError,
-              'A wellplate size of 0 requires both width and height to be 0.'
+        Dimensions.validate!(width: width, height: height)
       end
 
       # Wells the requested grid has no room for. A null or below-one position

--- a/app/usecases/wellplates/resize.rb
+++ b/app/usecases/wellplates/resize.rb
@@ -50,16 +50,26 @@ module Usecases
           # Serialise against a concurrent well edit. guard_occupied_wells!
           # decides what may be destroyed; without the lock a sample placed
           # between that check and the delete below would go with it.
+          # Usecases::Wellplates::Update takes the same lock, which is what
+          # makes that window closed rather than merely narrow.
           wellplate.lock!
-          next if unchanged?
 
-          guard_occupied_wells!
-          wells_outside_new_grid.destroy_all
-          # destroy_all leaves the has_many cache holding the rows it just
+          # Loaded once and reused: the no-op check, the guard and the delete
+          # all ask the same question, and the rows carry the samples the guard
+          # needs anyway.
+          outside = wells_outside_new_grid.includes(:sample).to_a
+          next if unchanged?(outside)
+
+          guard_occupied_wells!(outside)
+          outside.each(&:destroy)
+          # The destroys leave the has_many cache holding the rows they just
           # removed, and a loaded association answers pluck from that cache.
           wellplate.wells.reset
           create_missing_wells
-          wellplate.update!(width: width, height: height)
+          # updated_at is set explicitly: a reconciliation that only repaired
+          # drifted wells leaves width/height untouched, so Rails would skip the
+          # UPDATE and no other client would ever learn the grid had changed.
+          wellplate.update!(width: width, height: height, updated_at: Time.current)
         end
 
         wellplate.reload
@@ -72,8 +82,11 @@ module Usecases
       # whose rows drifted out of the grid (a null position, a row beyond the
       # edge) would otherwise be unrepairable, since no size can be asked for
       # that both reconciles it and differs from what it already claims.
-      def unchanged?
-        wellplate.width == width && wellplate.height == height && !wells_outside_new_grid.exists?
+      #
+      # @param outside [Array<Well>] the wells the requested grid has no room for
+      # @return [Boolean]
+      def unchanged?(outside)
+        wellplate.width == width && wellplate.height == height && outside.empty?
       end
 
       def validate_dimensions!
@@ -96,6 +109,9 @@ module Usecases
       # designer indexes its row array by position, so a 0 would overwrite the
       # row header and a negative would land off the end.
       #
+      # Ordered so the positions named in the error message are stable between
+      # requests and read in the same order as the designer grid.
+      #
       # @return [ActiveRecord::Relation]
       def wells_outside_new_grid
         wellplate.wells.where(
@@ -104,11 +120,13 @@ module Usecases
           'OR position_x > ? OR position_y > ?',
           width,
           height,
-        )
+        ).order(:position_y, :position_x)
       end
 
-      def guard_occupied_wells!
-        blocking = wells_outside_new_grid.includes(:sample).select(&:content?)
+      # @param outside [Array<Well>] the wells the requested grid has no room for
+      # @raise [Usecases::Wellplates::Errors::ResizeNotAllowedError]
+      def guard_occupied_wells!(outside)
+        blocking = outside.select(&:content?)
         return if blocking.empty?
 
         raise Errors::ResizeNotAllowedError, blocking_message(blocking)

--- a/app/usecases/wellplates/template_creation.rb
+++ b/app/usecases/wellplates/template_creation.rb
@@ -21,7 +21,9 @@ module Usecases
       private
 
       def check_wellplate_bounds
-        max = 100
+        # Shared with the resize guard and the API param bounds so the two
+        # cannot drift apart again.
+        max = Resize::MAX_DIMENSION
 
         value = @wellplate.width > max ? @wellplate.width : @wellplate.height
         parameter = @wellplate.width > max ? 'width' : 'height'

--- a/app/usecases/wellplates/template_creation.rb
+++ b/app/usecases/wellplates/template_creation.rb
@@ -23,7 +23,7 @@ module Usecases
       def check_wellplate_bounds
         # Shared with the resize guard and the API param bounds so the two
         # cannot drift apart again.
-        max = Resize::MAX_DIMENSION
+        max = Dimensions::MAX_DIMENSION
 
         value = @wellplate.width > max ? @wellplate.width : @wellplate.height
         parameter = @wellplate.width > max ? 'width' : 'height'

--- a/app/usecases/wellplates/update.rb
+++ b/app/usecases/wellplates/update.rb
@@ -14,6 +14,11 @@ module Usecases
       def execute!
         ActiveRecord::Base.transaction do
           wellplate = Wellplate.find(params[:id])
+          # Same row lock Usecases::Wellplates::Resize takes. Its occupied-well
+          # guard only holds if the well-editing path serialises against it:
+          # otherwise a sample placed here between that guard and its delete is
+          # destroyed by a concurrent shrink.
+          wellplate.lock!
           # width/height are not declared on the update endpoint; excluding them
           # here as well keeps a future param addition from silently resizing the
           # grid behind Usecases::Wellplates::Resize's guard.

--- a/app/usecases/wellplates/update.rb
+++ b/app/usecases/wellplates/update.rb
@@ -14,7 +14,10 @@ module Usecases
       def execute!
         ActiveRecord::Base.transaction do
           wellplate = Wellplate.find(params[:id])
-          wellplate.update(params.except(:wells, :segments, :size, :user_labels))
+          # width/height are not declared on the update endpoint; excluding them
+          # here as well keeps a future param addition from silently resizing the
+          # grid behind Usecases::Wellplates::Resize's guard.
+          wellplate.update(params.except(:wells, :segments, :size, :user_labels, :width, :height))
           WellplateUpdater
             .new(wellplate: wellplate, current_user: User.find(@user_id))
             .update_wells(well_data: params[:wells])

--- a/app/usecases/wellplates/wellplate_updater.rb
+++ b/app/usecases/wellplates/wellplate_updater.rb
@@ -48,7 +48,13 @@ module Usecases
           if well[:is_new]
             wellplate.wells.create(well_attributes)
           else
-            Well.find(well[:id]).update(well_attributes)
+            # Scoped to this wellplate, and tolerant of a well that is no longer
+            # on it. A concurrent resize soft-deletes the wells outside the new
+            # grid, and an unscoped Well.find would then raise RecordNotFound
+            # and roll back the whole save, losing every other edit in it. The
+            # scope also keeps a payload from reaching a well that belongs to a
+            # different wellplate.
+            wellplate.wells.find_by(id: well[:id])&.update(well_attributes)
           end
         end
 

--- a/lib/import/import_wellplate_spreadsheet.rb
+++ b/lib/import/import_wellplate_spreadsheet.rb
@@ -85,6 +85,14 @@ module Import
     end
 
     def check_wells
+      # WellPosition.from_dimension(0, 0) is an empty list, so on an unsized
+      # plate the loop below would validate nothing and let any sheet through.
+      # import_data would then create wells at positions no grid can hold.
+      if @wellplate.width.to_i.zero? || @wellplate.height.to_i.zero?
+        error_messages << 'Set the wellplate size before importing data.'
+        fail!
+      end
+
       expected_positions = WellPosition.from_dimension(@wellplate.width, @wellplate.height)
       wells = xlsx.column(1).drop(1)
 

--- a/spec/api/chemotion/wellplate_api_spec.rb
+++ b/spec/api/chemotion/wellplate_api_spec.rb
@@ -164,6 +164,8 @@ describe Chemotion::WellplateAPI do
         id: wellplate.id,
         name: 'Another Testname',
         wells: [attributes_for(:well).merge(position: { x: 1, y: 1 }, is_new: true)],
+        height: 1,
+        width: 1,
         container: { id: container.id },
       }
     end

--- a/spec/api/chemotion/wellplate_api_spec.rb
+++ b/spec/api/chemotion/wellplate_api_spec.rb
@@ -212,6 +212,8 @@ describe Chemotion::WellplateAPI do
         id: wellplate.id,
         name: 'Another Testname',
         wells: [attributes_for(:well).merge(position: { x: 1, y: 1 }, is_new: true)],
+        height: 1,
+        width: 1,
         container: { id: container.id },
       }
     end

--- a/spec/api/chemotion/wellplate_api_spec.rb
+++ b/spec/api/chemotion/wellplate_api_spec.rb
@@ -365,6 +365,35 @@ describe Chemotion::WellplateAPI do
       end
     end
 
+    context 'with only one dimension zero' do
+      # A wellplate must be either fully sized or unsized (0x0). One dimension
+      # alone at zero produced a plate with no wells but a non-zero edge, which
+      # no resize could later repair.
+      let(:width) { 0 }
+      let(:height) { 8 }
+
+      it 'returns 422 unprocessable entity' do
+        expect(response).to have_http_status :unprocessable_entity
+      end
+
+      it 'explains the rule' do
+        expect(response.parsed_body['error']).to include('both width and height')
+      end
+
+      it 'does not create the wellplate' do
+        expect(Wellplate.find_by(name: name)).to be_nil
+      end
+    end
+
+    context 'with both dimensions zero' do
+      let(:width) { 0 }
+      let(:height) { 0 }
+
+      it 'is accepted as an unsized wellplate' do
+        expect(Wellplate.find_by(name: name).size).to eq 0
+      end
+    end
+
     context 'with wellplate width 200' do
       let(:width) { 200 }
 

--- a/spec/api/chemotion/wellplate_api_spec.rb
+++ b/spec/api/chemotion/wellplate_api_spec.rb
@@ -212,8 +212,6 @@ describe Chemotion::WellplateAPI do
         id: wellplate.id,
         name: 'Another Testname',
         wells: [attributes_for(:well).merge(position: { x: 1, y: 1 }, is_new: true)],
-        height: 1,
-        width: 1,
         container: { id: container.id },
       }
     end
@@ -234,6 +232,34 @@ describe Chemotion::WellplateAPI do
 
       it 'returns can_update as true after a successful update' do
         expect(JSON.parse(response.body)['wellplate']['can_update']).to be true
+      end
+    end
+
+    context 'when the payload carries a different size' do
+      # The grid is resized only through PUT /wellplates/resize/:id. A stale tab
+      # echoing cached dimensions must not silently revert someone else's resize.
+      let(:params) do
+        {
+          id: wellplate.id,
+          name: 'Another Testname',
+          wells: [attributes_for(:well).merge(position: { x: 1, y: 1 }, is_new: true)],
+          height: 1,
+          width: 1,
+          container: { id: container.id },
+        }
+      end
+
+      before do
+        CollectionsWellplate.create!(wellplate: wellplate, collection: collection_shared_with_user)
+        put "/api/v1/wellplates/#{wellplate.id}", params: params
+      end
+
+      it 'succeeds' do
+        expect(response).to have_http_status :success
+      end
+
+      it 'ignores the dimensions' do
+        expect([wellplate.reload.width, wellplate.height]).to eq [12, 8]
       end
     end
 
@@ -466,6 +492,113 @@ describe Chemotion::WellplateAPI do
 
       it 'response data not empty' do
         expect(response.body.length).to satisfy('not empty') { |n| n > 0 }
+      end
+    end
+  end
+
+  describe 'PUT /api/v1/wellplates/resize/:id' do
+    let(:wellplate) { create(:wellplate, width: 4, height: 3) }
+    let(:params) { { width: width, height: height } }
+    let(:width) { 2 }
+    let(:height) { 2 }
+
+    before do
+      (1..wellplate.height).each do |pos_y|
+        (1..wellplate.width).each { |pos_x| wellplate.wells.create!(position_x: pos_x, position_y: pos_y) }
+      end
+      wellplate.wells.reset
+    end
+
+    context 'when the user can update the wellplate and no well holds data' do
+      before do
+        CollectionsWellplate.create!(wellplate: wellplate, collection: collection_shared_with_user)
+        put "/api/v1/wellplates/resize/#{wellplate.id}", params: params
+      end
+
+      it 'succeeds' do
+        expect(response).to have_http_status :success
+      end
+
+      it 'applies the new dimensions' do
+        expect([wellplate.reload.width, wellplate.height]).to eq [2, 2]
+      end
+
+      it 'returns the reconciled wellplate' do
+        expect(response.parsed_body['wellplate']['wells'].size).to eq 4
+      end
+    end
+
+    context 'when a dropped well still holds data' do
+      before do
+        wellplate.wells.find_by(position_x: 4, position_y: 3).update!(sample: create(:sample))
+        CollectionsWellplate.create!(wellplate: wellplate, collection: collection_shared_with_user)
+        put "/api/v1/wellplates/resize/#{wellplate.id}", params: params
+      end
+
+      it 'returns 422 unprocessable entity' do
+        expect(response).to have_http_status :unprocessable_entity
+      end
+
+      it 'explains which well blocks the resize' do
+        expect(response.parsed_body['error']).to include('C4')
+      end
+
+      it 'does not resize the wellplate' do
+        expect([wellplate.reload.width, wellplate.height]).to eq [4, 3]
+      end
+    end
+
+    context 'when the wellplate is in a read-only shared collection' do
+      let(:read_only_collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements],
+                                    wellplate_detail_level: 10)
+        end
+      end
+
+      before do
+        CollectionsWellplate.create!(wellplate: wellplate, collection: read_only_collection)
+        put "/api/v1/wellplates/resize/#{wellplate.id}", params: params
+      end
+
+      it 'returns 401 unauthorized' do
+        expect(response).to have_http_status :unauthorized
+      end
+
+      it 'does not resize the wellplate' do
+        expect([wellplate.reload.width, wellplate.height]).to eq [4, 3]
+      end
+    end
+
+    context 'with a dimension above the maximum' do
+      let(:width) { 101 }
+
+      before do
+        CollectionsWellplate.create!(wellplate: wellplate, collection: collection_shared_with_user)
+        put "/api/v1/wellplates/resize/#{wellplate.id}", params: params
+      end
+
+      it 'status code 400 was returned' do
+        expect(response).to have_http_status :bad_request
+      end
+
+      it 'correct error message was returned' do
+        expect(response.parsed_body).to eq({ 'error' => 'width does not have a valid value' })
+      end
+    end
+
+    context 'with only one dimension zero' do
+      let(:width) { 0 }
+      let(:height) { 3 }
+
+      before do
+        CollectionsWellplate.create!(wellplate: wellplate, collection: collection_shared_with_user)
+        put "/api/v1/wellplates/resize/#{wellplate.id}", params: params
+      end
+
+      it 'returns 422 unprocessable entity' do
+        expect(response).to have_http_status :unprocessable_entity
       end
     end
   end

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/WellplateDetails.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/WellplateDetails.spec.js
@@ -1,0 +1,55 @@
+/* eslint-disable import/no-unresolved, no-undef */
+import React from 'react';
+import expect from 'expect';
+import { configure, shallow } from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import WellplateDetails from 'src/apps/mydb/elements/details/wellplates/WellplateDetails';
+import Wellplate from 'src/models/Wellplate';
+import UserStore from 'src/stores/alt/stores/UserStore';
+import wellplate2x3EmptyJson from 'fixture/wellplates/wellplate_2_3_empty';
+
+configure({ adapter: new Adapter() });
+
+describe('WellplateDetails', () => {
+  beforeEach(() => {
+    UserStore.state.currentUser = { id: 1, name: 'Test User' };
+  });
+
+  describe('componentDidUpdate()', () => {
+    it('does not overwrite a locally-updated wellplate (e.g. after a history revert) when props have not changed', () => {
+      const wellplate = new Wellplate({
+        ...wellplate2x3EmptyJson, is_new: false, updated_at: '2024-01-01T00:00:00Z'
+      });
+      const wrapper = shallow(
+        <WellplateDetails wellplate={wellplate} openedFromCollectionId={1} />
+      );
+
+      const revertedWellplate = new Wellplate({
+        ...wellplate2x3EmptyJson, is_new: false, name: 'Reverted name', updated_at: '2024-02-02T00:00:00Z'
+      });
+
+      // simulates VersionsTable#reloadEntity calling parent.setState({ wellplate })
+      // directly after a revert, without props.wellplate itself changing
+      wrapper.instance().setState({ wellplate: revertedWellplate });
+      wrapper.update();
+
+      expect(wrapper.state().wellplate.name).toEqual('Reverted name');
+    });
+
+    it('still adopts a genuinely new wellplate coming in from props', () => {
+      const wellplate = new Wellplate({
+        ...wellplate2x3EmptyJson, is_new: false, updated_at: '2024-01-01T00:00:00Z'
+      });
+      const wrapper = shallow(
+        <WellplateDetails wellplate={wellplate} openedFromCollectionId={1} />
+      );
+
+      const updatedWellplate = new Wellplate({
+        ...wellplate2x3EmptyJson, is_new: false, name: 'Updated elsewhere', updated_at: '2024-02-02T00:00:00Z'
+      });
+      wrapper.setProps({ wellplate: updatedWellplate });
+
+      expect(wrapper.state().wellplate.name).toEqual('Updated elsewhere');
+    });
+  });
+});

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal.spec.js
@@ -135,3 +135,64 @@ describe.skip('CustomSizeModal', () => {
     });
   });
 });
+
+describe('CustomSizeModal (functional component)', () => {
+  function mountModal(props) {
+    return mount(
+      <CustomSizeModal
+        show
+        handleClose={emptyFunction}
+        updateWellplate={emptyFunction}
+        {...props}
+      />
+    );
+  }
+
+  function widthInput(wrapper) {
+    return wrapper.find('input').first();
+  }
+
+  it('resyncs its fields to the wellplate size whenever it is reopened', () => {
+    const wellplate = Wellplate.buildEmpty(1); // 0x0
+    const wrapper = mountModal({ show: false, wellplate });
+
+    // size changed elsewhere (e.g. via the size dropdown) while the modal was closed
+    wellplate.changeSize(12, 8);
+    wrapper.setProps({ show: true, wellplate });
+    wrapper.update();
+
+    expect(widthInput(wrapper).props().value).toEqual(12);
+  });
+
+  it('discards an unapplied edit when the modal is closed and reopened', () => {
+    const wellplate = Wellplate.buildEmpty(1);
+    wellplate.changeSize(12, 8);
+    const wrapper = mountModal({ wellplate });
+
+    widthInput(wrapper).simulate('change', { target: { value: '55' } });
+    wrapper.update();
+    expect(widthInput(wrapper).props().value).toEqual('55');
+
+    wrapper.setProps({ show: false });
+    wrapper.setProps({ show: true });
+    wrapper.update();
+
+    expect(widthInput(wrapper).props().value).toEqual(12);
+  });
+
+  it('applies a valid custom size via updateWellplate', () => {
+    const wellplate = Wellplate.buildEmpty(1);
+    const updateWellplate = spy();
+    const wrapper = mountModal({ wellplate, updateWellplate });
+
+    widthInput(wrapper).simulate('change', { target: { value: '5' } });
+    wrapper.find('input').at(1).simulate('change', { target: { value: '7' } });
+    wrapper.update();
+
+    const applyButton = wrapper.find('button').filterWhere((b) => b.text() === 'Apply');
+    expect(applyButton.props().disabled).toEqual(false);
+    applyButton.simulate('click');
+
+    expect(updateWellplate.calledWith({ type: 'size', value: { width: '5', height: '7' } })).toEqual(true);
+  });
+});

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal.spec.js
@@ -193,6 +193,68 @@ describe('CustomSizeModal (functional component)', () => {
     expect(applyButton.props().disabled).toEqual(false);
     applyButton.simulate('click');
 
-    expect(updateWellplate.calledWith({ type: 'size', value: { width: '5', height: '7' } })).toEqual(true);
+    // Numbers, not the raw input strings: the model and the API both want integers.
+    expect(updateWellplate.calledWith({ type: 'size', value: { width: 5, height: 7 } })).toEqual(true);
+  });
+
+  // These are the boundary cases the old (skipped) updateDimension() block
+  // covered. Without the integer check, 'abc' and '5.5' validated and
+  // changeSize handed Array() a NaN length, throwing a RangeError out of a
+  // React handler and taking the detail view down with it.
+  describe('rejects a dimension that is not a positive integer', () => {
+    [
+      ['a non-numeric string', 'abc'],
+      ['a decimal', '5.5'],
+      ['zero', '0'],
+      ['a negative number', '-5'],
+      ['an empty value', ''],
+      ['a value above the maximum', '101'],
+    ].forEach(([description, value]) => {
+      it(`keeps Apply disabled for ${description}`, () => {
+        const wellplate = Wellplate.buildEmpty(1);
+        const wrapper = mountModal({ wellplate });
+
+        widthInput(wrapper).simulate('change', { target: { value } });
+        wrapper.update();
+
+        const applyButton = wrapper.find('button').filterWhere((b) => b.text() === 'Apply');
+        expect(applyButton.props().disabled).toEqual(true);
+      });
+    });
+  });
+
+  it('accepts the maximum dimension', () => {
+    const wellplate = Wellplate.buildEmpty(1);
+    const wrapper = mountModal({ wellplate });
+
+    widthInput(wrapper).simulate('change', { target: { value: '100' } });
+    wrapper.update();
+
+    const applyButton = wrapper.find('button').filterWhere((b) => b.text() === 'Apply');
+    expect(applyButton.props().disabled).toEqual(false);
+  });
+
+  it('seeds a default size instead of 0 so an unsized wellplate opens without errors', () => {
+    const wellplate = Wellplate.buildEmpty(1); // 0x0
+    const wrapper = mountModal({ wellplate });
+
+    expect(widthInput(wrapper).props().value).toEqual(12);
+    expect(wrapper.find('.invalid-wellplate-size-text').length).toEqual(0);
+  });
+
+  it('refuses a size that would delete wells holding data', () => {
+    const wellplate = new Wellplate({ ...wellplate2x3EmptyJson, is_new: false });
+    wellplate.changeSize(2, 3);
+    // C2 sits outside a 1x1 grid and carries a readout.
+    wellplate.wells[5].readouts = [{ value: '42', unit: 'nM' }];
+
+    const wrapper = mountModal({ wellplate });
+    widthInput(wrapper).simulate('change', { target: { value: '1' } });
+    wrapper.find('input').at(1).simulate('change', { target: { value: '1' } });
+    wrapper.update();
+
+    const applyButton = wrapper.find('button').filterWhere((b) => b.text() === 'Apply');
+    expect(applyButton.props().disabled).toEqual(true);
+    expect(wrapper.text()).toContain('Empty them and save before resizing');
   });
 });

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.spec.js
@@ -116,4 +116,18 @@ describe('WellplateSizeDropdown (functional component)', () => {
     expect(matching.length).toEqual(1);
     expect(selectedOption(wrapper).props().label).toEqual('96 (12x8)');
   });
+
+  it('shows a plain read-only field with an explanatory tooltip once the size is locked', () => {
+    const wellplate = new Wellplate({ ...wellplate8x12EmptyJson, is_new: false });
+    const wrapper = mount(
+      <WellplateSizeDropdown wellplate={wellplate} updateWellplate={emptyFunction} />
+    );
+
+    expect(wrapper.find('select').length).toEqual(0);
+    expect(wrapper.find('input').first().props().value).toEqual('96 (12x8)');
+    expect(wrapper.find('input').first().props().disabled).toEqual(true);
+    expect(wrapper.find('button.create-own-size-button').props().disabled).toEqual(true);
+    const overlay = wrapper.find('OverlayTrigger').props().overlay;
+    expect(shallow(overlay).text()).toEqual('The size cannot be changed.');
+  });
 });

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import expect from 'expect';
-import { configure, shallow } from 'enzyme';
+import { configure, shallow, mount } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import WellplateSizeDropdown from 'src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown';
 import wellplate2x3EmptyJson from 'fixture/wellplates/wellplate_2_3_empty';
@@ -88,5 +88,32 @@ describe.skip('WellplateSizeDropdown', () => {
         expect(wellplate.wells.length).toEqual(2);
       });
     });
+  });
+});
+
+describe('WellplateSizeDropdown (functional component)', () => {
+  function selectedOption(wrapper) {
+    return wrapper.find('option').filterWhere((o) => o.props().value === wrapper.find('select').props().value);
+  }
+
+  it('shows the actual size in the dropdown when it is not one of the standard options', () => {
+    const wellplate = new Wellplate(wellplate2x3EmptyJson); // 2x3 is not a standard size
+    const wrapper = mount(
+      <WellplateSizeDropdown wellplate={wellplate} updateWellplate={emptyFunction} />
+    );
+
+    expect(wrapper.find('select').props().value).toEqual('2 3');
+    expect(selectedOption(wrapper).props().label).toEqual('6 (2x3)');
+  });
+
+  it('does not add a duplicate option for a standard size', () => {
+    const wellplate = new Wellplate(wellplate8x12EmptyJson); // 12x8 is a standard size
+    const wrapper = mount(
+      <WellplateSizeDropdown wellplate={wellplate} updateWellplate={emptyFunction} />
+    );
+
+    const matching = wrapper.find('option').filterWhere((o) => o.props().value === '12 8');
+    expect(matching.length).toEqual(1);
+    expect(selectedOption(wrapper).props().label).toEqual('96 (12x8)');
   });
 });

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.spec.js
@@ -92,6 +92,21 @@ describe.skip('WellplateSizeDropdown', () => {
 });
 
 describe('WellplateSizeDropdown (functional component)', () => {
+  // A saved wellplate keeps whatever wells the server sent rather than
+  // fabricating a grid, so a realistic one has to carry them.
+  function savedWellplate(attrs = {}) {
+    const wells = [];
+    for (let y = 1; y <= 8; y += 1) {
+      for (let x = 1; x <= 12; x += 1) {
+        wells.push({ id: `well-${x}-${y}`, position: { x, y }, readouts: [] });
+      }
+    }
+
+    return new Wellplate({
+      ...wellplate8x12EmptyJson, is_new: false, wells, ...attrs
+    });
+  }
+
   function selectedOption(wrapper) {
     return wrapper.find('option').filterWhere((o) => o.props().value === wrapper.find('select').props().value);
   }
@@ -117,17 +132,101 @@ describe('WellplateSizeDropdown (functional component)', () => {
     expect(selectedOption(wrapper).props().label).toEqual('96 (12x8)');
   });
 
-  it('shows a plain read-only field with an explanatory tooltip once the size is locked', () => {
-    const wellplate = new Wellplate({ ...wellplate8x12EmptyJson, is_new: false });
+  // A saved wellplate can be resized now; what locks the control is an unsaved
+  // well edit, because a resize is persisted separately and must not race one.
+  it('stays editable on a saved wellplate with no pending well changes', () => {
+    const wellplate = savedWellplate();
     const wrapper = mount(
       <WellplateSizeDropdown wellplate={wellplate} updateWellplate={emptyFunction} />
     );
 
-    expect(wrapper.find('select').length).toEqual(0);
-    expect(wrapper.find('input').first().props().value).toEqual('96 (12x8)');
-    expect(wrapper.find('input').first().props().disabled).toEqual(true);
+    expect(wrapper.find('select').props().disabled).toEqual(false);
+    expect(wrapper.find('button.create-own-size-button').props().disabled).toEqual(false);
+  });
+
+  // The resize round-trip replaces the whole element, so any unsaved edit
+  // would go with it - not only an edit to the wells.
+  it('locks the size while an unrelated edit is unsaved', () => {
+    const wellplate = savedWellplate();
+    wellplate.name = 'Renamed but not saved';
+
+    const wrapper = mount(
+      <WellplateSizeDropdown wellplate={wellplate} updateWellplate={emptyFunction} />
+    );
+
+    expect(wellplate.hasPendingWellChanges).toEqual(false);
+    expect(wrapper.find('select').props().disabled).toEqual(true);
+    const overlay = wrapper.find('OverlayTrigger').props().overlay;
+    expect(shallow(overlay).text()).toEqual('Save your changes before changing the size.');
+  });
+
+  it('does not lock a wellplate that has not been saved yet', () => {
+    // Nothing is persisted, so changeSize runs in memory and loses nothing.
+    const wellplate = Wellplate.buildEmpty(1, 4, 3);
+
+    const wrapper = mount(
+      <WellplateSizeDropdown wellplate={wellplate} updateWellplate={emptyFunction} />
+    );
+
+    expect(wrapper.find('select').props().disabled).toEqual(false);
+  });
+
+  it('locks the size while well changes are unsaved, and explains why', () => {
+    const wellplate = savedWellplate();
+    wellplate.wells[0].readouts = [{ value: '42', unit: 'nM' }];
+
+    const wrapper = mount(
+      <WellplateSizeDropdown wellplate={wellplate} updateWellplate={emptyFunction} />
+    );
+
+    expect(wellplate.hasPendingWellChanges).toEqual(true);
+    expect(wrapper.find('select').props().disabled).toEqual(true);
     expect(wrapper.find('button.create-own-size-button').props().disabled).toEqual(true);
     const overlay = wrapper.find('OverlayTrigger').props().overlay;
-    expect(shallow(overlay).text()).toEqual('The size cannot be changed.');
+    expect(shallow(overlay).text()).toEqual('Save your changes to the wells before changing the size.');
+  });
+
+  // A disabled control dispatches no mouse events and they do not bubble, so
+  // the trigger has to sit on a wrapper that is not itself disabled.
+  it('puts the tooltip on a wrapper that can actually receive the hover', () => {
+    const wellplate = savedWellplate();
+    wellplate.wells[0].readouts = [{ value: '42', unit: 'nM' }];
+
+    const wrapper = mount(
+      <WellplateSizeDropdown wellplate={wellplate} updateWellplate={emptyFunction} />
+    );
+
+    const trigger = wrapper.find('OverlayTrigger');
+    expect(trigger.find('span').first().props().tabIndex).toEqual(0);
+    expect(trigger.find('InputGroup').props().style).toEqual({ pointerEvents: 'none' });
+  });
+
+  it('locks the size on a read-only wellplate', () => {
+    const wellplate = savedWellplate({ can_update: false });
+    const wrapper = mount(
+      <WellplateSizeDropdown wellplate={wellplate} updateWellplate={emptyFunction} />
+    );
+
+    expect(wrapper.find('select').props().disabled).toEqual(true);
+    const overlay = wrapper.find('OverlayTrigger').props().overlay;
+    expect(shallow(overlay).text()).toEqual('You cannot edit this wellplate.');
+  });
+
+  // "Define later" (0x0) used to be offered unconditionally and wiped every
+  // placed sample without a word.
+  it('disables sizes that would delete wells holding data', () => {
+    const wellplate = savedWellplate();
+    wellplate.wells[95].readouts = [{ value: '42', unit: 'nM' }]; // H12, the far corner
+    wellplate.updateChecksum(); // treat that as the saved state
+
+    const wrapper = mount(
+      <WellplateSizeDropdown wellplate={wellplate} updateWellplate={emptyFunction} />
+    );
+
+    const optionFor = (value) => wrapper.find('option').filterWhere((o) => o.props().value === value);
+    expect(optionFor('0 0').props().disabled).toEqual(true);
+    expect(optionFor('4 3').props().disabled).toEqual(true);
+    expect(optionFor('24 16').props().disabled).toEqual(false);
+    expect(optionFor('0 0').props().label).toContain('would delete filled wells');
   });
 });

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.spec.js
@@ -157,7 +157,7 @@ describe('WellplateSizeDropdown (functional component)', () => {
     expect(wellplate.hasPendingWellChanges).toEqual(false);
     expect(wrapper.find('select').props().disabled).toEqual(true);
     const overlay = wrapper.find('OverlayTrigger').props().overlay;
-    expect(shallow(overlay).text()).toEqual('Save your changes before changing the size.');
+    expect(shallow(overlay({})).text()).toEqual('Save your changes before changing the size.');
   });
 
   it('does not lock a wellplate that has not been saved yet', () => {
@@ -183,7 +183,7 @@ describe('WellplateSizeDropdown (functional component)', () => {
     expect(wrapper.find('select').props().disabled).toEqual(true);
     expect(wrapper.find('button.create-own-size-button').props().disabled).toEqual(true);
     const overlay = wrapper.find('OverlayTrigger').props().overlay;
-    expect(shallow(overlay).text()).toEqual('Save your changes to the wells before changing the size.');
+    expect(shallow(overlay({})).text()).toEqual('Save your changes to the wells before changing the size.');
   });
 
   // A disabled control dispatches no mouse events and they do not bubble, so
@@ -209,7 +209,30 @@ describe('WellplateSizeDropdown (functional component)', () => {
 
     expect(wrapper.find('select').props().disabled).toEqual(true);
     const overlay = wrapper.find('OverlayTrigger').props().overlay;
-    expect(shallow(overlay).text()).toEqual('You cannot edit this wellplate.');
+    expect(shallow(overlay({})).text()).toEqual('You cannot edit this wellplate.');
+  });
+
+  // The reason is worked out by hashing every well, so it must not be computed
+  // while merely rendering - only when a tooltip is actually shown.
+  it('does not compute the lock reason until the tooltip is rendered', () => {
+    const wellplate = savedWellplate();
+    wellplate.name = 'Renamed but not saved';
+
+    let reasonComputed = 0;
+    Object.defineProperty(wellplate, 'hasPendingWellChanges', {
+      get() { reasonComputed += 1; return false; },
+    });
+
+    const wrapper = mount(
+      <WellplateSizeDropdown wellplate={wellplate} updateWellplate={emptyFunction} />
+    );
+
+    expect(reasonComputed).toEqual(0);
+
+    const overlay = wrapper.find('OverlayTrigger').props().overlay;
+    expect(typeof overlay).toEqual('function');
+    shallow(overlay({}));
+    expect(reasonComputed).toEqual(1);
   });
 
   // "Define later" (0x0) used to be offered unconditionally and wiped every

--- a/spec/javascripts/packs/src/models/Wellplate.spec.js
+++ b/spec/javascripts/packs/src/models/Wellplate.spec.js
@@ -54,10 +54,10 @@ describe('Wellplate', () => {
       const collectionId = 1;
       const wellplate = Wellplate.buildEmpty(collectionId);
 
-      it('created a wellplate of size 12 x 8', () => {
-        expect(wellplate.size).toEqual(96);
-        expect(wellplate.height).toEqual(8);
-        expect(wellplate.width).toEqual(12);
+      it('created a wellplate of size 0 x 0', () => {
+        expect(wellplate.size).toEqual(0);
+        expect(wellplate.height).toEqual(0);
+        expect(wellplate.width).toEqual(0);
       });
     });
 

--- a/spec/javascripts/packs/src/models/Wellplate.spec.js
+++ b/spec/javascripts/packs/src/models/Wellplate.spec.js
@@ -267,6 +267,143 @@ describe('Wellplate', () => {
         expect(wellplate.wells[6].sample).not.toBeUndefined();
       });
     });
+
+    // Wells used to be re-keyed by index against the NEW width, which quietly
+    // moved an out-of-range well into the next row instead of dropping it, and
+    // left the survivors carrying stale positions.
+    context('shrinking past a filled well', () => {
+      const buildFive = () => {
+        const wellplate = Wellplate.buildEmpty(1, 5, 4);
+        wellplate.wells[4].sample = sampleMock; // index 4 = position 5x1
+        return wellplate;
+      };
+
+      it('drops the out-of-range well instead of wrapping it into the next row', () => {
+        const wellplate = buildFive();
+        wellplate.changeSize(4, 4);
+
+        const carriesSample = wellplate.wells.filter((well) => well.sample);
+        expect(carriesSample.length).toEqual(0);
+      });
+
+      it('leaves every surviving well at a position inside the new grid', () => {
+        const wellplate = buildFive();
+        wellplate.changeSize(4, 4);
+
+        const outside = wellplate.wells.filter((w) => w.position.x > 4 || w.position.y > 4);
+        expect(outside.length).toEqual(0);
+      });
+
+      it('keeps positions and wells consistent after the resize', () => {
+        const wellplate = buildFive();
+        wellplate.changeSize(4, 4);
+
+        expect(wellplate.wells.length).toEqual(16);
+        expect(wellplate.wells[4].position).toEqual({ x: 1, y: 2 });
+      });
+    });
+
+    it('registers as an unsaved change instead of resetting the baseline', () => {
+      // changeSize used to rewrite _checksum, so a resize looked saved already.
+      const wellplate = Wellplate.buildEmpty(1, 2, 2);
+      wellplate.updateChecksum();
+
+      wellplate.changeSize(4, 4);
+
+      expect(wellplate.isEdited).toEqual(true);
+    });
+  });
+
+  describe('wells the server sent', () => {
+    const serverWells = [
+      { id: 'w1', position: { x: 1, y: 1 }, readouts: [] },
+      { id: 'w2', position: { x: 2, y: 1 }, readouts: [] },
+    ];
+
+    it('keeps them on a saved wellplate that has no size yet', () => {
+      // These used to be discarded, and saving the emptied list made the server
+      // destroy every sample they held.
+      const wellplate = new Wellplate({
+        id: 1, name: 'WP', type: 'wellplate', width: 0, height: 0, wells: serverWells, is_new: false
+      });
+
+      expect(wellplate.wells.length).toEqual(2);
+    });
+
+    it('still builds an empty grid for a wellplate that is not saved yet', () => {
+      const wellplate = Wellplate.buildEmpty(1, 2, 2);
+
+      expect(wellplate.wells.length).toEqual(4);
+    });
+  });
+
+  describe('hasPendingWellChanges', () => {
+    const build = () => new Wellplate({
+      id: 1,
+      name: 'WP',
+      type: 'wellplate',
+      width: 2,
+      height: 1,
+      is_new: false,
+      wells: [
+        { id: 'w1', position: { x: 1, y: 1 }, readouts: [] },
+        { id: 'w2', position: { x: 2, y: 1 }, readouts: [] },
+      ],
+    });
+
+    it('is false for a freshly loaded wellplate', () => {
+      expect(build().hasPendingWellChanges).toEqual(false);
+    });
+
+    it('is true once a well is edited', () => {
+      const wellplate = build();
+      wellplate.wells[0].readouts = [{ value: '42', unit: 'nM' }];
+
+      expect(wellplate.hasPendingWellChanges).toEqual(true);
+    });
+
+    it('is false again after the wellplate is saved', () => {
+      const wellplate = build();
+      wellplate.wells[0].readouts = [{ value: '42', unit: 'nM' }];
+      wellplate.updateChecksum();
+
+      expect(wellplate.hasPendingWellChanges).toEqual(false);
+    });
+
+    it('ignores a change to a field that is not a well', () => {
+      const wellplate = build();
+      wellplate.name = 'Renamed';
+
+      expect(wellplate.hasPendingWellChanges).toEqual(false);
+    });
+  });
+
+  describe('occupiedWellsOutside()', () => {
+    const wellplate = new Wellplate({
+      id: 1,
+      name: 'WP',
+      type: 'wellplate',
+      width: 2,
+      height: 2,
+      is_new: false,
+      wells: [
+        { id: 'w1', position: { x: 1, y: 1 }, readouts: [] },
+        { id: 'w2', position: { x: 2, y: 2 }, readouts: [{ value: '42', unit: 'nM' }] },
+      ],
+    });
+
+    it('reports a filled well that the smaller grid has no room for', () => {
+      expect(wellplate.occupiedWellsOutside(1, 1).length).toEqual(1);
+    });
+
+    it('ignores untouched wells outside the grid', () => {
+      // w1 is empty, so shrinking onto it destroys nothing.
+      expect(wellplate.occupiedWellsOutside(2, 2).length).toEqual(0);
+    });
+
+    it('reports nothing when the grid grows', () => {
+      expect(wellplate.occupiedWellsOutside(4, 4).length).toEqual(0);
+    });
   });
 
   describe('can_update', () => {

--- a/spec/javascripts/packs/src/models/Wellplate.spec.js
+++ b/spec/javascripts/packs/src/models/Wellplate.spec.js
@@ -431,6 +431,47 @@ describe('Wellplate', () => {
     it('still labels a real position', () => {
       expect(wellFrom({ x: 2, y: 1 }).alphanumericPosition).toEqual('A2');
     });
+
+    // rowLabel(0) is '' here while the server's label table indexes from the
+    // end, so the same well used to be named two different cells that do not
+    // exist. Both sides now say n/a.
+    it('reports n/a for a non-positive row instead of an empty label', () => {
+      expect(wellFrom({ x: 3, y: 0 }).alphanumericPosition).toEqual('n/a');
+    });
+
+    it('reports n/a for a non-positive column', () => {
+      expect(wellFrom({ x: 0, y: 1 }).alphanumericPosition).toEqual('n/a');
+    });
+  });
+
+  describe('a readout of numeric zero', () => {
+    // ActiveSupport counts 0 as present, so the server calls such a well
+    // occupied. A plain truthiness test here disagreed, and the UI offered a
+    // size the server then refused with a 422.
+    const plate = () => new Wellplate({
+      id: 1,
+      name: 'WP',
+      type: 'wellplate',
+      width: 2,
+      height: 1,
+      is_new: false,
+      wells: [
+        { id: 'w1', position: { x: 1, y: 1 }, readouts: [] },
+        { id: 'w2', position: { x: 2, y: 1 }, readouts: [{ value: 0, unit: '' }] },
+      ],
+    });
+
+    it('counts as well content', () => {
+      expect(plate().wells[1].hasContent).toEqual(true);
+    });
+
+    it('blocks a shrink that would drop it, as the server would', () => {
+      expect(plate().occupiedWellsOutside(1, 1).length).toEqual(1);
+    });
+
+    it('does not count a genuinely blank readout', () => {
+      expect(plate().wells[0].hasContent).toEqual(false);
+    });
   });
 
   describe('occupiedWellsOutside()', () => {

--- a/spec/javascripts/packs/src/models/Wellplate.spec.js
+++ b/spec/javascripts/packs/src/models/Wellplate.spec.js
@@ -378,6 +378,33 @@ describe('Wellplate', () => {
     });
   });
 
+  describe('anonymized wellplates', () => {
+    // Below detail level 1 the entity replaces readouts with the '***'
+    // placeholder string. hasContent used to call .some on it, which threw from
+    // the render path and took the whole detail view down.
+    const anonymized = () => new Wellplate({
+      id: 1,
+      name: 'WP',
+      type: 'wellplate',
+      width: 2,
+      height: 1,
+      is_new: false,
+      can_update: false,
+      wells: [
+        { id: 'w1', position: { x: 1, y: 1 }, readouts: '***', label: '***', color_code: '***', additive: '***' },
+        { id: 'w2', position: { x: 2, y: 1 }, readouts: '***', label: '***', color_code: '***', additive: '***' },
+      ],
+    });
+
+    it('does not throw when asked which wells a smaller grid would drop', () => {
+      expect(() => anonymized().occupiedWellsOutside(1, 1)).not.toThrow();
+    });
+
+    it('does not mistake the placeholder for well content', () => {
+      expect(anonymized().occupiedWellsOutside(1, 1).length).toEqual(0);
+    });
+  });
+
   describe('occupiedWellsOutside()', () => {
     const wellplate = new Wellplate({
       id: 1,

--- a/spec/javascripts/packs/src/models/Wellplate.spec.js
+++ b/spec/javascripts/packs/src/models/Wellplate.spec.js
@@ -405,6 +405,34 @@ describe('Wellplate', () => {
     });
   });
 
+  describe('alphanumericPosition on an unplaceable well', () => {
+    // positionOutside counts a well with no usable position as outside any
+    // grid, so one can reach the "these wells block the resize" message. The
+    // label used to come out as NaN, or throw when position was absent.
+    const wellFrom = (position) => new Wellplate({
+      id: 1,
+      name: 'WP',
+      type: 'wellplate',
+      width: 1,
+      height: 1,
+      is_new: false,
+      wells: [{ id: 'w1', position, readouts: [] }],
+    }).wells[0];
+
+    it('reports n/a for a null coordinate instead of NaN', () => {
+      expect(wellFrom({ x: null, y: null }).alphanumericPosition).toEqual('n/a');
+    });
+
+    it('reports n/a rather than throwing when the position is missing', () => {
+      expect(() => wellFrom(undefined).alphanumericPosition).not.toThrow();
+      expect(wellFrom(undefined).alphanumericPosition).toEqual('n/a');
+    });
+
+    it('still labels a real position', () => {
+      expect(wellFrom({ x: 2, y: 1 }).alphanumericPosition).toEqual('A2');
+    });
+  });
+
   describe('occupiedWellsOutside()', () => {
     const wellplate = new Wellplate({
       id: 1,

--- a/spec/lib/import/import_wellplate_spreadsheet_spec.rb
+++ b/spec/lib/import/import_wellplate_spreadsheet_spec.rb
@@ -117,6 +117,23 @@ RSpec.describe 'ImportWellplateSpreadsheet' do
       end
     end
 
+    context 'when the wellplate has no size yet' do
+      # WellPosition.from_dimension(0, 0) is empty, so without an explicit guard
+      # the position check would pass any sheet and then create wells at
+      # positions the (nonexistent) grid cannot hold.
+      let!(:wellplate) { create(:wellplate, width: 0, height: 0, attachments: [attachment]) }
+      let(:file_path) { Rails.root.join('spec/fixtures/import/wellplate_import_template_with_molarity.xlsx') }
+
+      it 'refuses the import' do
+        expect { import.process! }.to raise_error(StandardError, /Set the wellplate size before importing/)
+      end
+
+      it 'creates no wells' do
+        expect { import.process! }.to raise_error(StandardError)
+        expect(wellplate.reload.wells).to be_empty
+      end
+    end
+
     context 'when a well has no sample' do
       let!(:wellplate) { create(:wellplate, attachments: [attachment]) }
       let(:file_path) { Rails.root.join('spec/fixtures/import/wellplate_import_template_with_molarity.xlsx') }

--- a/spec/models/well_spec.rb
+++ b/spec/models/well_spec.rb
@@ -84,6 +84,59 @@ RSpec.describe Well do
     end
   end
 
+  describe '#content?' do
+    # A well straight from the column defaults: no sample, the default label and
+    # the default blank readout. Both label and readouts are non-null columns,
+    # so this is the case that must NOT read as occupied - otherwise a wellplate
+    # could never be shrunk.
+    let(:untouched) { wellplate.wells.create!(position_x: 1, position_y: 1) }
+
+    it 'is false for an untouched well' do
+      expect(untouched.content?).to be false
+    end
+
+    it 'is true when a sample is placed' do
+      untouched.update!(sample: create(:sample, collections: [collection]))
+      expect(untouched.content?).to be true
+    end
+
+    it 'is false when the sample was soft-deleted but the id still dangles' do
+      sample = create(:sample, collections: [collection])
+      untouched.update!(sample: sample)
+      sample.destroy
+
+      expect(untouched.reload.content?).to be false
+    end
+
+    it 'is false for the default label' do
+      untouched.update!(label: described_class::DEFAULT_LABEL)
+      expect(untouched.content?).to be false
+    end
+
+    it 'is false for readouts that are present but blank' do
+      untouched.update!(readouts: [{ 'value' => '', 'unit' => '' }])
+      expect(untouched.content?).to be false
+    end
+
+    {
+      'a readout value' => { readouts: [{ 'value' => '42', 'unit' => '' }] },
+      'a readout unit' => { readouts: [{ 'value' => '', 'unit' => 'nM' }] },
+      'a user label' => { label: 'my label' },
+      'a colour code' => { color_code: '#aabbcc' },
+      'an additive' => { additive: 'DMSO' },
+    }.each do |description, attributes|
+      it "is true for #{description}" do
+        untouched.update!(attributes)
+        expect(untouched.content?).to be true
+      end
+    end
+
+    it 'is true for symbol-keyed readouts built in memory' do
+      well = wellplate.wells.new(position_x: 1, position_y: 1, readouts: [{ value: '42', unit: 'nM' }])
+      expect(well.content?).to be true
+    end
+  end
+
   describe '.get_samples_in_wellplates()' do
     context 'when no sample is attached' do
       it 'empty array is returned' do

--- a/spec/models/well_spec.rb
+++ b/spec/models/well_spec.rb
@@ -40,7 +40,35 @@ RSpec.describe Well do
     end
   end
 
+  describe '#content? with a numeric zero readout' do
+    # A spreadsheet import stores raw cell values, so a 0 in a _Value column is
+    # a real readout. ActiveSupport counts 0 as present; the client must agree.
+    it 'counts a zero value as content' do
+      well = wellplate.wells.create!(position_x: 1, position_y: 1, readouts: [{ 'value' => 0, 'unit' => '' }])
+      expect(well.content?).to be true
+    end
+  end
+
   describe '.alphanumeric_position()' do
+    context 'when the row is not positive' do
+      # ('A'..'ZZ').to_a[-1] is "ZZ", so a drifted well used to be reported as
+      # blocking a cell that does not exist.
+      it 'returns n/a for row 0 rather than wrapping to ZZ' do
+        expect(create(:well, wellplate_id: wellplate.id, position_x: 3, position_y: 0)
+                 .alphanumeric_position).to eq('n/a')
+      end
+
+      it 'returns n/a for a negative row' do
+        expect(create(:well, wellplate_id: wellplate.id, position_x: 3, position_y: -1)
+                 .alphanumeric_position).to eq('n/a')
+      end
+
+      it 'sorts such a well as n/a too' do
+        expect(create(:well, wellplate_id: wellplate.id, position_x: 0, position_y: 1)
+                 .sortable_alphanumeric_position).to eq('n/a')
+      end
+    end
+
     context 'when position is [nil,nil]' do
       let(:well) { create(:well, wellplate_id: wellplate.id, position_x: nil, position_y: nil) }
 

--- a/spec/services/versioning/reverters/wellplate_reverter_spec.rb
+++ b/spec/services/versioning/reverters/wellplate_reverter_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Versioning::Reverters::WellplateReverter do
+  let(:wellplate) { create(:wellplate, name: 'Original name', width: 12, height: 8) }
+
+  def revert(fields)
+    described_class.call('db_id' => wellplate.id, 'fields' => fields)
+    wellplate.reload
+  end
+
+  it 'reverts an ordinary field' do
+    revert([{ 'name' => 'name', 'value' => 'Reverted name' }])
+
+    expect(wellplate.name).to eq 'Reverted name'
+  end
+
+  # BaseReverter writes with update_columns, bypassing validations and
+  # callbacks, so the FORBIDDEN_FIELDS filter is the only thing standing between
+  # a crafted payload and a grid resized behind Usecases::Wellplates::Resize's
+  # occupied-well guard.
+  it 'ignores width' do
+    expect { revert([{ 'name' => 'width', 'value' => 2 }]) }.not_to change(wellplate, :width)
+  end
+
+  it 'ignores height' do
+    expect { revert([{ 'name' => 'height', 'value' => 2 }]) }.not_to change(wellplate, :height)
+  end
+
+  # Old logidze snapshots carry the misspelling from before the column was
+  # renamed, so the blacklist has to cover it too.
+  it 'ignores the legacy heigth misspelling' do
+    expect { revert([{ 'name' => 'heigth', 'value' => 2 }]) }.not_to raise_error
+  end
+
+  it 'still applies allowed fields alongside a forbidden one' do
+    revert([{ 'name' => 'width', 'value' => 2 }, { 'name' => 'name', 'value' => 'Reverted name' }])
+
+    expect([wellplate.name, wellplate.width]).to eq ['Reverted name', 12]
+  end
+end

--- a/spec/usecases/wellplates/resize_spec.rb
+++ b/spec/usecases/wellplates/resize_spec.rb
@@ -156,6 +156,90 @@ RSpec.describe Usecases::Wellplates::Resize do
     end
   end
 
+  describe 'readouts on newly created wells' do
+    # The list tab pairs readout_titles[i] with readouts[i] and writes through
+    # without a bounds check, so a well short of entries raises there.
+    let(:wellplate) { create(:wellplate, width: 0, height: 0) }
+    let(:width) { 2 }
+    let(:height) { 1 }
+
+    it 'gives each new well one blank readout per readout title' do
+      expect(resize.wells.map { |well| well.readouts.size }.uniq).to eq [wellplate.readout_titles.size]
+    end
+
+    it 'leaves those readouts blank, so they do not block a later shrink' do
+      expect(resize.wells.none?(&:content?)).to be true
+    end
+
+    context 'when the wellplate has no readout titles' do
+      let(:wellplate) { create(:wellplate, width: 0, height: 0, readout_titles: []) }
+
+      it 'still gives each well one blank readout' do
+        expect(resize.wells.map { |well| well.readouts.size }.uniq).to eq [1]
+      end
+    end
+  end
+
+  describe 'wells that drifted outside the declared grid' do
+    let(:wellplate) { create(:wellplate, width: 2, height: 2) }
+
+    before do
+      fill_grid(wellplate)
+      wellplate.wells.create!(position_x: 1, position_y: 3) # a row beyond the edge
+      wellplate.wells.reset
+    end
+
+    # Matching dimensions alone are not a no-op: no size could otherwise be
+    # asked for that both repairs the plate and differs from what it claims.
+    context 'when the requested size matches the current one' do
+      let(:width) { 2 }
+      let(:height) { 2 }
+
+      it 'still reconciles the grid' do
+        expect(resize.wells.count).to eq 4
+      end
+
+      it 'removes the drifted well' do
+        positions = resize.wells.pluck(:position_x, :position_y)
+        expect(positions).not_to include([1, 3])
+      end
+    end
+
+    context 'when a drifted well holds data' do
+      let(:width) { 2 }
+      let(:height) { 2 }
+
+      before { wellplate.wells.find_by(position_y: 3).update!(additive: 'DMSO') }
+
+      it 'refuses to reconcile it away' do
+        expect { resize }.to raise_error(Usecases::Wellplates::Errors::ResizeNotAllowedError)
+      end
+    end
+  end
+
+  describe 'wells at an impossible position' do
+    let(:wellplate) { create(:wellplate, width: 2, height: 2) }
+    let(:width) { 3 }
+    let(:height) { 2 }
+
+    before do
+      fill_grid(wellplate)
+      # The designer indexes its row array by position: a 0 would overwrite the
+      # row header and a negative would land off the end.
+      wellplate.wells.create!(position_x: 0, position_y: 1)
+      wellplate.wells.create!(position_x: -1, position_y: 1)
+      wellplate.wells.reset
+    end
+
+    it 'treats them as outside the grid and removes them' do
+      expect(resize.wells.where('position_x < 1')).to be_empty
+    end
+
+    it 'leaves exactly the wells the new grid calls for' do
+      expect(resize.wells.count).to eq 6
+    end
+  end
+
   describe 'no-op' do
     let(:wellplate) { create(:wellplate, :with_transient_wells, width: 2, height: 2) }
     let(:width) { 2 }

--- a/spec/usecases/wellplates/resize_spec.rb
+++ b/spec/usecases/wellplates/resize_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+RSpec.describe Usecases::Wellplates::Resize do
+  subject(:resize) { described_class.new(wellplate: wellplate, width: width, height: height).execute! }
+
+  # A well created straight from the column defaults: no sample, the default
+  # label, and the default single blank readout. This is what an untouched well
+  # of a freshly sized plate looks like, and it must never block a shrink.
+  def untouched_well(plate, pos_x, pos_y)
+    plate.wells.create!(position_x: pos_x, position_y: pos_y)
+  end
+
+  def fill_grid(plate)
+    (1..plate.height).each { |pos_y| (1..plate.width).each { |pos_x| untouched_well(plate, pos_x, pos_y) } }
+  end
+
+  describe 'growing' do
+    context 'when the wellplate has no size yet' do
+      let(:wellplate) { create(:wellplate, width: 0, height: 0) }
+      let(:width) { 2 }
+      let(:height) { 3 }
+
+      it 'applies the new dimensions' do
+        expect([resize.width, resize.height]).to eq [2, 3]
+      end
+
+      it 'materialises the full grid of wells' do
+        expect(resize.wells.count).to eq 6
+      end
+
+      it 'creates one well per position' do
+        positions = resize.wells.pluck(:position_x, :position_y)
+        expect(positions).to contain_exactly([1, 1], [2, 1], [1, 2], [2, 2], [1, 3], [2, 3])
+      end
+    end
+
+    context 'when the wellplate already holds samples' do
+      # :with_transient_wells builds its wells rather than creating them, which
+      # leaves sample_id nil, so place the samples explicitly here.
+      let(:wellplate) { create(:wellplate, width: 2, height: 3) }
+      let(:width) { 4 }
+      let(:height) { 3 }
+
+      before do
+        (1..3).each do |pos_y|
+          (1..2).each { |pos_x| wellplate.wells.create!(position_x: pos_x, position_y: pos_y, sample: create(:sample)) }
+        end
+        wellplate.wells.reset
+      end
+
+      it 'keeps every existing well' do
+        existing = wellplate.wells.pluck(:position_x, :position_y)
+        expect(resize.wells.pluck(:position_x, :position_y)).to include(*existing)
+      end
+
+      it 'adds only the missing wells' do
+        expect(resize.wells.count).to eq 12
+      end
+
+      it 'keeps the samples that were already placed' do
+        expect(resize.wells.filter_map(&:sample).size).to eq 6
+      end
+    end
+  end
+
+  describe 'shrinking' do
+    let(:wellplate) { create(:wellplate, width: 4, height: 3) }
+    let(:width) { 2 }
+    let(:height) { 2 }
+
+    before { fill_grid(wellplate) }
+
+    context 'when every dropped well is untouched' do
+      it 'applies the new dimensions' do
+        expect([resize.width, resize.height]).to eq [2, 2]
+      end
+
+      it 'deletes the wells outside the new grid' do
+        expect(resize.wells.count).to eq 4
+      end
+
+      it 'leaves no well outside the new grid' do
+        outside = resize.wells.select { |well| well.position_x > 2 || well.position_y > 2 }
+        expect(outside).to be_empty
+      end
+    end
+
+    context 'when a dropped well holds a sample' do
+      before { wellplate.wells.find_by(position_x: 4, position_y: 3).update!(sample: create(:sample)) }
+
+      it 'refuses the resize' do
+        expect { resize }.to raise_error(Usecases::Wellplates::Errors::ResizeNotAllowedError, /still hold/)
+      end
+
+      it 'names the blocking position' do
+        expect { resize }.to raise_error(/C4/)
+      end
+
+      it 'leaves the dimensions untouched' do
+        expect { resize }.to raise_error(Usecases::Wellplates::Errors::ResizeNotAllowedError)
+        expect([wellplate.reload.width, wellplate.height]).to eq [4, 3]
+      end
+
+      it 'leaves the wells untouched' do
+        expect { resize }.to raise_error(Usecases::Wellplates::Errors::ResizeNotAllowedError)
+        expect(wellplate.reload.wells.count).to eq 12
+      end
+    end
+
+    context 'when a dropped well holds data other than a sample' do
+      # Each of these is user-entered content that a shrink would silently
+      # destroy, so each must block it on its own.
+      {
+        'readouts' => { readouts: [{ 'value' => '42', 'unit' => 'nM' }] },
+        'a label' => { label: 'my label' },
+        'a colour code' => { color_code: '#aabbcc' },
+        'an additive' => { additive: 'DMSO' },
+      }.each do |description, attributes|
+        it "refuses the resize for a well with #{description}" do
+          wellplate.wells.find_by(position_x: 4, position_y: 3).update!(attributes)
+          expect { resize }.to raise_error(Usecases::Wellplates::Errors::ResizeNotAllowedError)
+        end
+      end
+    end
+
+    context 'when a dropped well points at a soft-deleted sample' do
+      # update_wells destroys samples without nulling wells.sample_id, so a
+      # dangling id is a normal state and must read as empty.
+      before do
+        sample = create(:sample)
+        wellplate.wells.find_by(position_x: 4, position_y: 3).update!(sample: sample)
+        sample.destroy
+      end
+
+      it 'allows the resize' do
+        expect(resize.wells.count).to eq 4
+      end
+    end
+  end
+
+  describe 'wells with no position' do
+    let(:wellplate) { create(:wellplate, width: 2, height: 2) }
+    let(:width) { 2 }
+    let(:height) { 2 }
+
+    before do
+      fill_grid(wellplate)
+      wellplate.wells.create!(position_x: nil, position_y: nil)
+      wellplate.wells.reset
+    end
+
+    it 'treats an unplaceable well as outside the grid and removes it' do
+      # The size is unchanged, so force the reconciliation with a real change.
+      resized = described_class.new(wellplate: wellplate, width: 3, height: 2).execute!
+      expect(resized.wells.where(position_x: nil)).to be_empty
+    end
+  end
+
+  describe 'no-op' do
+    let(:wellplate) { create(:wellplate, :with_transient_wells, width: 2, height: 2) }
+    let(:width) { 2 }
+    let(:height) { 2 }
+
+    it 'returns the wellplate unchanged' do
+      expect([resize.width, resize.height]).to eq [2, 2]
+    end
+
+    it 'does not touch the wells' do
+      expect { resize }.not_to(change { wellplate.wells.count })
+    end
+  end
+
+  describe 'invalid dimensions' do
+    let(:wellplate) { create(:wellplate, width: 2, height: 2) }
+
+    context 'with only one dimension zero' do
+      let(:width) { 0 }
+      let(:height) { 8 }
+
+      it 'is rejected' do
+        expect { resize }.to raise_error(Usecases::Wellplates::Errors::InvalidDimensionsError, /both width and height/)
+      end
+    end
+
+    context 'with a dimension above the maximum' do
+      let(:width) { described_class::MAX_DIMENSION + 1 }
+      let(:height) { 8 }
+
+      it 'is rejected' do
+        expect { resize }.to raise_error(Usecases::Wellplates::Errors::InvalidDimensionsError, /between 0 and 100/)
+      end
+    end
+
+    context 'with a negative dimension' do
+      let(:width) { -1 }
+      let(:height) { 8 }
+
+      it 'is rejected' do
+        expect { resize }.to raise_error(Usecases::Wellplates::Errors::InvalidDimensionsError)
+      end
+    end
+  end
+end

--- a/spec/usecases/wellplates/resize_spec.rb
+++ b/spec/usecases/wellplates/resize_spec.rb
@@ -254,6 +254,8 @@ RSpec.describe Usecases::Wellplates::Resize do
     end
   end
 
+  # The rule lives in Usecases::Wellplates::Dimensions so that create and resize
+  # cannot disagree about what a valid grid is.
   describe 'invalid dimensions' do
     let(:wellplate) { create(:wellplate, width: 2, height: 2) }
 
@@ -267,7 +269,7 @@ RSpec.describe Usecases::Wellplates::Resize do
     end
 
     context 'with a dimension above the maximum' do
-      let(:width) { described_class::MAX_DIMENSION + 1 }
+      let(:width) { Usecases::Wellplates::Dimensions::MAX_DIMENSION + 1 }
       let(:height) { 8 }
 
       it 'is rejected' do

--- a/spec/usecases/wellplates/wellplate_updater_spec.rb
+++ b/spec/usecases/wellplates/wellplate_updater_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/NestedGroups
+
+RSpec.describe Usecases::Wellplates::WellplateUpdater do
+  let(:user) { create(:user) }
+  let(:wellplate) { create(:wellplate) }
+
+  let(:usecase) { described_class.new(wellplate: wellplate, current_user: user) }
+
+  describe 'update_wells' do
+    before do
+      usecase.update_wells(well_data: new_wells)
+    end
+
+    context 'when original wells were empty' do
+      context 'with empty array as new wells' do
+        let(:new_wells) { [] }
+
+        it 'empty wells should remain' do
+          expect(wellplate.wells).to eq []
+        end
+      end
+
+      context 'with 2x3 wells arrays without samples in it' do
+        let(:new_wells) do
+          new_wells = []
+          (1..2).each do |pos_y|
+            (1..3).each do |pos_x|
+              well_hash = {}
+              well_hash[:is_new] = true
+              well_hash[:readout] = ''
+              well_hash[:additive] = ''
+              well_hash[:sample_id] = nil
+              well_hash[:position] = {}
+              well_hash[:position][:x] = pos_x
+              well_hash[:position][:y] = pos_y
+              new_wells << well_hash
+            end
+          end
+          new_wells
+        end
+
+        it '2x3 wells array should be attached to wellplate' do
+          expect(wellplate.wells.size).to eq 6
+        end
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/NestedGroups

--- a/spec/usecases/wellplates/wellplate_updater_spec.rb
+++ b/spec/usecases/wellplates/wellplate_updater_spec.rb
@@ -9,13 +9,50 @@ RSpec.describe Usecases::Wellplates::WellplateUpdater do
   let(:usecase) { described_class.new(wellplate: wellplate, current_user: user) }
 
   describe 'update_wells' do
-    before do
-      usecase.update_wells(well_data: new_wells)
+    context 'when a submitted well is no longer on the wellplate' do
+      # A concurrent resize soft-deletes the wells outside the new grid. An
+      # unscoped Well.find would raise and roll back the whole save.
+      let(:wellplate) { create(:wellplate, width: 2, height: 1) }
+      let(:surviving) { wellplate.wells.create!(position_x: 1, position_y: 1) }
+      let(:removed) { wellplate.wells.create!(position_x: 2, position_y: 1) }
+
+      let(:new_wells) do
+        [
+          { id: surviving.id, position: { x: 1, y: 1 }, readouts: [{ 'value' => '7', 'unit' => 'nM' }] },
+          { id: removed.id, position: { x: 2, y: 1 }, readouts: [] },
+        ]
+      end
+
+      before { removed.destroy }
+
+      it 'does not raise' do
+        expect { usecase.update_wells(well_data: new_wells) }.not_to raise_error
+      end
+
+      it 'still applies the edits to the wells that remain' do
+        usecase.update_wells(well_data: new_wells)
+        expect(surviving.reload.readouts).to eq [{ 'value' => '7', 'unit' => 'nM' }]
+      end
+    end
+
+    context 'when a submitted well belongs to a different wellplate' do
+      let(:wellplate) { create(:wellplate, width: 1, height: 1) }
+      let(:other_wellplate) { create(:wellplate, width: 1, height: 1) }
+      let(:foreign_well) { other_wellplate.wells.create!(position_x: 1, position_y: 1, label: 'untouched') }
+
+      let(:new_wells) { [{ id: foreign_well.id, position: { x: 1, y: 1 }, label: 'hijacked' }] }
+
+      it 'leaves it alone' do
+        usecase.update_wells(well_data: new_wells)
+        expect(foreign_well.reload.label).to eq 'untouched'
+      end
     end
 
     context 'when original wells were empty' do
       context 'with empty array as new wells' do
         let(:new_wells) { [] }
+
+        before { usecase.update_wells(well_data: new_wells) }
 
         it 'empty wells should remain' do
           expect(wellplate.wells).to eq []
@@ -40,6 +77,8 @@ RSpec.describe Usecases::Wellplates::WellplateUpdater do
           end
           new_wells
         end
+
+        before { usecase.update_wells(well_data: new_wells) }
 
         it '2x3 wells array should be attached to wellplate' do
           expect(wellplate.wells.size).to eq 6


### PR DESCRIPTION
### What this adds

A wellplate can be created without a size — the size dropdown offers **"Define later"** — and sized afterwards, from either a predefined option or the custom-size dialog.

The size is no longer frozen once set. A wellplate can be resized at any time, subject to one rule:

> **Growing is always allowed. Shrinking is refused when a well outside the new grid still holds data.**

"Holds data" means a sample, a readout value or unit, a label, a colour code, or an additive — anything a user put there. Untouched wells never block a resize, so shrinking an empty region of a plate just works.

When a smaller size *would* discard filled wells, the ELN does not ask for confirmation and does not silently delete them. It refuses, and says which wells are in the way:

- sizes that would drop filled wells are greyed out in the dropdown;
- the custom-size dialog disables **Apply** and names the blocking positions.

Clearing those wells and resizing are therefore two separate, separately-saved steps: empty the wells, save, then resize. The same order applies when growing to make room for new samples — save the larger size first, then place samples in the new wells.

### Why not keep "the size can only be set once"

That rule only ever existed in the browser, as a disabled dropdown. The API still accepted new dimensions, and nothing reconciled the `wells` table against the new grid, so a second resize — from a stale second tab, or any direct API call — left the plate holding wells outside its own grid. That state destroyed the affected samples on the next save and broke the Designer tab on reload, with no way back through the UI.

Enforcing the rule properly required moving it to the server. Once it lives there, "resize only when nothing is lost" is both safer and less restrictive than "resize only once", so the stricter rule was dropped in favour of it.

### Behaviour worth knowing

- **Resizing is its own save.** Choosing a size on a saved wellplate applies immediately and persists on its own; it is not part of the next Save. The size control is therefore locked while the wellplate has unsaved changes, with a tooltip explaining why — a resize replaces the wellplate with the reconciled one from the server, which would otherwise discard those edits. A wellplate that has not been created yet resizes in memory, as before.
- **Size changes cannot be undone from the version history.** Reverting dimensions would bypass the same guard, so `width`/`height` are shown in the history but are not revertible.
- **Importing a spreadsheet into an unsized wellplate is refused** with a message asking for a size first. Previously the position check validated nothing at 0×0 and created wells at positions no grid could hold.

### API changes

- **New:** `PUT /api/v1/wellplates/resize/:id` with `width` and `height` (each `0..100`). Validates the request, refuses a shrink that would drop a filled well (`422` naming the wells), then reconciles the well rows and returns the updated wellplate.
- **`PUT /api/v1/wellplates/:id` no longer accepts `width`/`height`.** They are ignored, as they were before this branch. This is deliberate: a client echoing cached dimensions must not be able to revert someone else's resize.
- `POST /api/v1/wellplates` dimensions are bounded at `100`, matching `WellPosition` and the xlsx template generator. `101` was previously accepted and produced a wellplate whose template endpoint returned a 500.

### Tests

New coverage for the resize use case and endpoint (including every way a well can count as "filled", the two-tab conflict, and out-of-grid repair), the `content?` predicate, the spreadsheet-import guard, and the first spec for a versioning reverter in the repo. On the frontend, coverage for the resize semantics, the pending-changes lock, the greyed-out sizes, and the custom-size validation boundaries — restoring the `describe.skip`ped boundary cases that had gone stale.
