### PR TITLE
Fix user template duplicate tab crash

### DIFF
--- a/app/api/chemotion/profile_api.rb
+++ b/app/api/chemotion/profile_api.rb
@@ -192,7 +192,7 @@ module Chemotion
       end
       delete do
         path = params[:path]
-        error!({ error_messages: ['path cannot be blank'] }, 422) if path.empty? || !File.exist?(path)
+        error!({ error_messages: ['path cannot be blank'] }, 422) if path.empty?
         FileUtils.rm_f(path)
         { status: true }
       end

--- a/app/packs/src/apps/mydb/App.js
+++ b/app/packs/src/apps/mydb/App.js
@@ -1,20 +1,20 @@
+import { FlowViewerModal } from 'chem-generic-ui';
 import React, { Component } from 'react';
 import { Col, Grid, Row } from 'react-bootstrap';
-import { FlowViewerModal } from 'chem-generic-ui';
 import CollectionManagement from 'src/apps/mydb/collections/CollectionManagement';
 import CollectionTree from 'src/apps/mydb/collections/CollectionTree';
 import Elements from 'src/apps/mydb/elements/Elements';
 import InboxModal from 'src/apps/mydb/inbox/InboxModal';
-import KeyboardActions from 'src/stores/alt/actions/KeyboardActions';
+import Calendar from 'src/components/calendar/Calendar';
 import LoadingModal from 'src/components/common/LoadingModal';
+import ProgressModal from 'src/components/common/ProgressModal';
 import Navigation from 'src/components/navigation/Navigation';
 import Notifications from 'src/components/Notifications';
-import ProgressModal from 'src/components/common/ProgressModal';
-import UIActions from 'src/stores/alt/actions/UIActions';
-import UIStore from 'src/stores/alt/stores/UIStore';
-import UserActions from 'src/stores/alt/actions/UserActions';
-import Calendar from 'src/components/calendar/Calendar';
 import SampleTaskInbox from 'src/components/sampleTaskInbox/SampleTaskInbox';
+import KeyboardActions from 'src/stores/alt/actions/KeyboardActions';
+import UIActions from 'src/stores/alt/actions/UIActions';
+import UserActions from 'src/stores/alt/actions/UserActions';
+import UIStore from 'src/stores/alt/stores/UIStore';
 import OnEventListen from 'src/utilities/UserTemplatesHelpers';
 
 class App extends Component {
@@ -61,6 +61,7 @@ class App extends Component {
   componentWillUnmount() {
     UIStore.unlisten(this.handleUiStoreChange);
     document.removeEventListener('keydown', this.documentKeyDown);
+    this.removeLocalStorageEventListener();
   }
 
   removeLocalStorageEventListener() {

--- a/app/packs/src/utilities/UserTemplatesHelpers.js
+++ b/app/packs/src/utilities/UserTemplatesHelpers.js
@@ -1,6 +1,6 @@
 import ProfilesFetcher from 'src/fetchers/ProfilesFetcher';
-const key = 'ketcher-tmpls';
 import UsersFetcher from 'src/fetchers/UsersFetcher';
+const key = 'ketcher-tmpls';
 
 const createAddAttachmentidToNewUserTemplate = async (newValue, newItem, deleteIdx) => {
   const res = await ProfilesFetcher.uploadUserTemplates({
@@ -50,20 +50,22 @@ const updateUserTemplateDetails = async (oldValue, newValue) => {
 
 const onEventListen = async (event) => {
   let { newValue, oldValue } = event;
-  newValue = JSON.parse(newValue);
-  oldValue = JSON.parse(oldValue);
-  if (event.key === key) { // matching key && deleteAllowed
-    if (newValue.length > oldValue.length) { // when a new template is added
-      let newItem = newValue[newValue.length - 1];
-      createAddAttachmentidToNewUserTemplate(newValue, newItem);
-    } else if (newValue.length < oldValue.length) { // when a template is deleted
-      const listOfLocalid = newValue.map((item) => item.props.path);
-      removeUserTemplate(listOfLocalid, oldValue);
-    } else if (newValue.length == oldValue.length) { // when a template is update atom id, bond id
-      updateUserTemplateDetails(oldValue, newValue);
+  if (newValue.length && oldValue.length) {
+    newValue = JSON.parse(newValue);
+    oldValue = JSON.parse(oldValue);
+    if (event.key === key) { // matching key && deleteAllowed
+      if (newValue.length > oldValue.length) { // when a new template is added
+        let newItem = newValue[newValue.length - 1];
+        createAddAttachmentidToNewUserTemplate(newValue, newItem);
+      } else if (newValue.length < oldValue.length) { // when a template is deleted
+        const listOfLocalid = newValue.map((item) => item.props.path);
+        removeUserTemplate(listOfLocalid, oldValue);
+      } else if (newValue.length == oldValue.length) { // when a template is update atom id, bond id
+        updateUserTemplateDetails(oldValue, newValue);
+      }
+    } else if (event.key === 'ketcher-opts') {
+      UsersFetcher.updateUserKetcher2Options(event.newValue);
     }
-  } else if (event.key === 'ketcher-opts') {
-    UsersFetcher.updateUserKetcher2Options(event.newValue);
   }
 };
 


### PR DESCRIPTION
Purpose of this PR is resolve duplicate tab browser crash -> Reason UserTemplates:

https://github.com/user-attachments/assets/777e8784-aec8-4c3c-9566-398a80b662dc

-----------------------------
- [ ] rather 1-story 1-commit than sub-atomic commits




- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
