### PR TITLE
fix: element filter when selecting ui-state

### DIFF
--- a/app/packs/src/components/managingActions/ManagingModalSharing.js
+++ b/app/packs/src/components/managingActions/ManagingModalSharing.js
@@ -184,15 +184,16 @@ export default class ManagingModalSharing extends React.Component {
       currentSearchSelection: uiState.currentSearchSelection
     };
 
-    elementNames(false).forEach((klass) => {
-      filterParams[`${klass}`] = {
-        all: uiState[`${klass}`].checkedAll,
-        included_ids: uiState[`${klass}`].checkedIds,
-        excluded_ids: uiState[`${klass}`].uncheckedIds,
-        collection_id: collectionId
-      };
+    elementNames(false).then((klassArray) => {
+      klassArray.forEach((klass) => {
+        filterParams[`${klass}`] = {
+          all: uiState[`${klass}`].checkedAll,
+          included_ids: uiState[`${klass}`].checkedIds,
+          excluded_ids: uiState[`${klass}`].uncheckedIds,
+          collection_id: collectionId
+        };
+      });
     });
-    console.log(filterParams);
 
     return filterParams;
   }


### PR DESCRIPTION
filter  params from ui-state is missing the implementation of elementNames as async  (see 6294592248).

This  prevents selected element to be shared.

```
TypeError: elementNames(false).forEach is not a function
```