### PR TITLE
Make edit function visible for reaction variation notes

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -25,7 +25,7 @@ import {
   PropertyFormatter, PropertyParser,
   MaterialFormatter, MaterialParser,
   EquivalentFormatter, EquivalentParser,
-  RowToolsCellRenderer, NoteCellEditor
+  RowToolsCellRenderer, NoteCellRenderer, NoteCellEditor
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsCellComponents';
 
 function MenuHeader({
@@ -194,6 +194,7 @@ export default function ReactionVariations({ reaction, onReactionChange }) {
     {
       headerName: 'Notes',
       field: 'notes',
+      cellRenderer: NoteCellRenderer,
       sortable: false,
       cellDataType: 'text',
       cellEditor: NoteCellEditor,

--- a/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsCellComponents.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsCellComponents.js
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { AgGridReact } from 'ag-grid-react';
 import {
-  Button, ButtonGroup, Badge, Modal, Form
+  Button, ButtonGroup, Badge, Modal, Form, OverlayTrigger, Tooltip
 } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import {
@@ -128,6 +128,21 @@ function MaterialParser({
   );
 }
 
+function NoteCellRenderer(props) {
+  return (
+    <OverlayTrigger
+      placement="right"
+      overlay={
+        <Tooltip id={"note-tooltip-" + props.data.id}>
+          double click to edit
+        </Tooltip>
+      }
+    >
+      <span>{props.value ? props.value : '_'}</span>
+    </OverlayTrigger>
+  );
+}
+
 function NoteCellEditor({
   data: variationsRow,
   value,
@@ -185,5 +200,6 @@ export {
   PropertyParser,
   MaterialFormatter,
   MaterialParser,
+  NoteCellRenderer,
   NoteCellEditor
 };


### PR DESCRIPTION

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
