### PR TITLE
allow header for yield/equiv. column in reaction scheme for shared collections with read only rights

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/MaterialGroup.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/schemeTab/MaterialGroup.js
@@ -214,7 +214,7 @@ function GeneralMaterialGroup({
               <th />
               {showLoadingColumn && <th>{headers.loading}</th>}
               <th>{headers.concn}</th>
-              {!isReactants && permitOn(reaction) && (
+              {!isReactants && (
                 <th>
                   {headers.eq}
                   {materialGroup !== 'products' && SwitchEquivButton(lockEquivColumn, switchEquiv)}


### PR DESCRIPTION
column headers can/should displayed independently of the permission level. 