### PR TITLE
fix: no more uploading of deleted attachments

### DIFF
--- a/app/packs/src/fetchers/AttachmentFetcher.js
+++ b/app/packs/src/fetchers/AttachmentFetcher.js
@@ -132,7 +132,7 @@ export default class AttachmentFetcher {
   static filterAllAttachments(files, containers) {
     containers.forEach((container) => {
       const tmpArray = (container.attachments || [])
-        .filter((a) => a.is_new)
+        .filter((a) => a.is_new && !a.is_deleted)
         .map((a) => fileFromAttachment(a, container.id));
       files.push(...tmpArray);
 


### PR DESCRIPTION
When deleting attachments after adding them in a dataset and before saving, they are no longer uploaded and deleted afterwards.