### PR TITLE
fix(spectra): bump service chem-spectra-app to v.1.2.4

### DIFF
--- a/.service-dependencies
+++ b/.service-dependencies
@@ -1,6 +1,6 @@
 #syntax=v1
 CONVERTER=ComPlat/chemotion-converter-app@1.3.0
 KETCHER=ptrxyz/chemotion-ketchersvc@main
-SPECTRA=ComPlat/chem-spectra-app@1.2.3
+SPECTRA=ComPlat/chem-spectra-app@1.2.4
 NMRIUMWRAPPER=NFDI4Chem/nmrium-react-wrapper@v0.8.0
 KETCHER2=epam/ketcher@v2.21.0


### PR DESCRIPTION
* fix: conditional header generation for NMR JCAMP export [#219](https://github.com/ComPlat/chem-spectra-app/pull/219)
* fix: data normalization and improve handling of runs in JcampMSConverter [#220](https://github.com/ComPlat/chem-spectra-app/pull/220)
* chore: Bump werkzeug from 3.0.3 to 3.0.6 [#217](https://github.com/ComPlat/chem-spectra-app/pull/217)

