### PR TITLE
fix: reaction report generation for gas products when the vessel size is not given

### DIFF
--- a/lib/reporter/docx/detail_reaction.rb
+++ b/lib/reporter/docx/detail_reaction.rb
@@ -296,7 +296,7 @@ module Reporter
         return sample.real_amount_mmol unless sample.gas_type == 'gas'
 
         vessel_size = @obj.vessel_size
-        return unless vessel_size
+        return if vessel_size['amount'].blank? || vessel_size['unit'].blank?
 
         vessel_volume = case vessel_size['unit']
                         when 'ml'
@@ -324,7 +324,7 @@ module Reporter
 
         mass = met_pre_conv(mass, 'n', assigned_metric_pref(s, 0))
         vol = met_pre_conv(vol, 'm', assigned_metric_pref(s, 1))
-        mmol = met_pre_conv(mmol, 'm', assigned_metric_pref(s, 2, %w[m n]))
+        mmol = met_pre_conv(mmol, 'm', assigned_metric_pref(s, 2, %w[m n])) if mmol.present?
 
         [mass, vol, mmol]
       end

--- a/spec/support/reaction_report_setup.rb
+++ b/spec/support/reaction_report_setup.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'reaction report setup' do
+  def create_reaction_report(reaction, sample)
+    gas_phase_data = {
+      'part_per_million' => 900_000_0,
+      'temperature' => { unit: 'K', value: 306 },
+      'time' => { unit: 'h', value: 2 },
+      'turnover_frequency' => { unit: 'TON/h', value: 0.000007688 },
+      'turnover_number' => 0.00001538,
+    }
+    CollectionsReaction.create!(reaction: reaction, collection: c1)
+
+    CollectionsSample.find_or_create_by(sample_id: sample.id, collection_id: c1.id)
+    ReactionsProductSample.find_or_create_by(
+      reaction: reaction,
+      sample: sample,
+      equivalent: equiv,
+      position: 2,
+      gas_type: 3,
+      gas_phase_data: gas_phase_data,
+    )
+    Entities::ReactionReportEntity.represent(
+      reaction,
+      current_user: build(:user),
+      detail_levels: ElementDetailLevelCalculator.new(user: user, element: reaction).detail_levels,
+    ).serializable_hash
+  end
+end

--- a/spec/usecases/reactions/update_materials_spec.rb
+++ b/spec/usecases/reactions/update_materials_spec.rb
@@ -187,7 +187,7 @@ describe Usecases::Reactions::UpdateMaterials do
 
     context 'updates samples using set_mole_value_gas_product' do
       it 'returns nil when reaction vessel size amount is nil' do
-        result = class_instance.send(:set_mole_value_gas_product, sample, product_sample)
+        result = class_instance.send(:set_mole_value_gas_product, sample, product_material)
         expect(result).to be_nil
       end
 


### PR DESCRIPTION

- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
