### PR TITLE
fix(db): matrice sequence

### DIFF
--- a/app/models/concerns/sequence_utilities.rb
+++ b/app/models/concerns/sequence_utilities.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# multiple upsert/delete for collections_elements and collection info tag update for associated element
+module SequenceUtilities
+  extend ActiveSupport::Concern
+  included do
+    # Reset the sequence of the table if the id is an Integer
+    #  and the last id is less than the current sequence value
+    def reset_sequence
+      return unless self.class.column_type(:id) == :integer
+
+      self.class.reset_sequence unless self.class.sequence_val <= self.class.last_id
+    end
+  end
+
+  # rubocop:disable Metrics/BlockLength
+  class_methods do
+    # Get the last id of the table
+    #
+    # @return [Integer] the last id of the table
+    def last_id
+      (respond_to?(:with_deleted) ? with_deleted : all).maximum(:id) || 0
+    end
+
+    # Get the current value of the sequence
+    # @return [Integer] the current value of the sequence
+    def sequence_val
+      ActiveRecord::Base.connection.execute("SELECT last_value FROM #{sequence_name};")
+                        .first.fetch('last_value', nil)
+    end
+
+    # Get the type of the a column
+    #
+    # @param type [String, Symbol] the name of the column
+    # @return [Symbol] the type of the column
+    def column_type(name)
+      columns_hash[name.to_s].type
+    rescue NoMethodError
+      logger.error("Column #{name} not found in #{table_name}")
+      nil
+    end
+
+    # Reset the sequence of the table if the id is an Integer
+    #
+    # @param id [Integer] the id to reset the sequence to
+    # @return [Boolean] true if the sequence was reset, false otherwise
+    def reset_sequence(id = last_id)
+      unless column_type(:id) == :integer
+        logger.info("Not resetting sequence id for #{table_name} as id is not an integer")
+        return false
+      end
+
+      if id >= last_id && id.positive?
+        ActiveRecord::Base.connection.execute("SELECT setval('#{sequence_name}', #{id}, true);").first
+        logger.info("Reset sequence id for #{table_name} to #{id}")
+        true
+      else
+        logger.info("Not resetting sequence id for #{table_name} as given id <= max existing id")
+        false
+      end
+    end
+  end
+  # rubocop:enable Metrics/BlockLength
+end

--- a/app/models/matrice.rb
+++ b/app/models/matrice.rb
@@ -17,18 +17,26 @@
 #
 #  index_matrices_on_name  (name) UNIQUE
 #
+# Configuration settings for some features
+# - set visibility/activation of features globaly or for users and group
+#
+# @note: db/triggers/update_users_matrix_trg on update/insert to update user matrix
 class Matrice < ApplicationRecord
+  include SequenceUtilities
+
   acts_as_paranoid
+  before_create :clean_invalid_ids
+  before_create :reset_sequence
   after_create :gen_json
+  after_destroy :gen_json
 
   def self.gen_matrices_json
     mx = pluck(:name, :id).to_h || {}
   rescue ActiveRecord::StatementInvalid, PG::ConnectionBad, PG::UndefinedTable
     mx = {}
   ensure
-    File.write(
-      Rails.root.join('config', 'matrices.json'),
-      mx.to_json.concat("\n")
+    Rails.root.join('config/matrices.json').write(
+      mx.to_json.concat("\n"),
     )
   end
 
@@ -46,5 +54,11 @@ class Matrice < ApplicationRecord
 
   def gen_json
     Matrice.gen_matrices_json
+  end
+
+  # Remove matrices with id > 31
+  # @note: this is a temporary solution to remove invalid matrices
+  def clean_invalid_ids
+    self.class.where('id > 31').find_each(&:really_destroy!)
   end
 end

--- a/db/migrate/20230323115540_matrice_user_provider.rb
+++ b/db/migrate/20230323115540_matrice_user_provider.rb
@@ -1,5 +1,5 @@
 class MatriceUserProvider < ActiveRecord::Migration[5.2]
-  def change
+  def up
     Matrice.create(
       name: 'userProvider',
       enabled: false,
@@ -7,6 +7,10 @@ class MatriceUserProvider < ActiveRecord::Migration[5.2]
       include_ids: [],
       exclude_ids: [],
       configs: {}
-    )
+    ) unless Matrice.find_by(name: 'userProvider')
+  end
+
+  def down
+    Matrice.find_by(name: 'userProvider')&.really_destroy!
   end
 end

--- a/db/migrate/20230323160712_matrice_molecule_viewer.rb
+++ b/db/migrate/20230323160712_matrice_molecule_viewer.rb
@@ -1,11 +1,15 @@
 class MatriceMoleculeViewer < ActiveRecord::Migration[6.1]
-  def change
+  def up
     Matrice.create(
       name: 'moleculeViewer',
       enabled: true,
       label: 'moleculeViewer',
       include_ids: [],
       exclude_ids: []
-    ) if Matrice.find_by(name: 'moleculeViewer').nil?
+    ) unless Matrice.find_by(name: 'moleculeViewer')
+  end
+
+  def down
+    Matrice.find_by(name: 'moleculeViewer')&.really_destroy!
   end
 end

--- a/db/migrate/20230420121233_matrice_comment.rb
+++ b/db/migrate/20230420121233_matrice_comment.rb
@@ -1,5 +1,5 @@
 class MatriceComment < ActiveRecord::Migration[6.1]
-  def change
+  def up
     Matrice.create(
       name: 'commentActivation',
       enabled: false,
@@ -7,6 +7,10 @@ class MatriceComment < ActiveRecord::Migration[6.1]
       include_ids: [],
       exclude_ids: [],
       configs: {}
-    )
+    ) unless Matrice.find_by(name: 'commentActivation')
+  end
+
+  def down
+    Matrice.find_by(name: 'commentActivation')&.really_destroy!
   end
 end

--- a/db/migrate/20240530000001_remove_user_labels_from_matrix.rb
+++ b/db/migrate/20240530000001_remove_user_labels_from_matrix.rb
@@ -1,6 +1,6 @@
 class RemoveUserLabelsFromMatrix < ActiveRecord::Migration[6.1]
   def change
-    Matrice.find_by(name: 'userLabel')&.destroy!
+    Matrice.find_by(name: 'userLabel')&.really_destroy!
   rescue StandardError => e
     Rails.logger.error "Error changing channel msg: #{e.message}"
   end

--- a/spec/factories/matrices.rb
+++ b/spec/factories/matrices.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :matrice do
+    name { Faker::Name.name }
+    label { name }
+    include_ids { [] }
+    exclude_ids { [] }
+    configs { { 'description' => Faker::Lorem.sentence } }
+    enabled { [true, false].sample }
+
+    trait :disabled do
+      enabled { false }
+    end
+
+    trait :enabled do
+      enabled { true }
+    end
+  end
+end

--- a/spec/models/matrice_spec.rb
+++ b/spec/models/matrice_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Matrice do
+  describe 'creation' do
+    let(:matrice) { build(:matrice) }
+    let(:matrice_disabled) { build(:matrice, :disabled, id: nil) }
+    let(:matrice_enabled) { build(:matrice, :enabled, id: nil) }
+
+    it 'is valid' do
+      matrice.save!
+      described_class.reset_sequence(52)
+      matrice_enabled.save!
+      expect(matrice).to be_valid
+      expect(matrice.id).to be < 31
+    end
+
+    it 'remove out of range matrices' do
+      described_class.reset_sequence
+      matrice_disabled.save!
+      matrice_disabled.update_column(:id, 355_555) # rubocop:disable Rails/SkipsModelValidations
+      matrice_enabled.save!
+      expect(matrice_enabled.id).to be < 31
+      expect(described_class.where(name: matrice_disabled.name)).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
try to manage matrice id on create so that new matrices does not increment the sequence over 32 as this leads error when recalculating the users.matrix.
 on matrice create:
    - reset the sequence to the latest  i used id (no unused id)
    - force delete of matrices that are out of range
   
also ensure matrice migration are not trying to create duplicate entries, as that leads to increment the sequence while raising an error.

TODO: move matrice data  to a proper db/seed/