### PR TITLE
fix: Reaction Variations: Update variations' sample IDs when reaction is copied

### DIFF
--- a/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -4,7 +4,8 @@ import React, {
   useRef, useState, useEffect, useCallback
 } from 'react';
 import {
-  Button, OverlayTrigger, Tooltip, Alert
+  Button, OverlayTrigger, Tooltip, Alert,
+  ButtonGroup, Modal
 } from 'react-bootstrap';
 import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
@@ -404,26 +405,71 @@ export default function ReactionVariations({ reaction, onReactionChange }) {
     gridRef.current.api.autoSizeColumns([column], false);
   };
 
+  const removeAllVariations = () => {
+    const [showModal, setShowModal] = useState(false);
+
+    const handleClose = () => setShowModal(false);
+    const handleShow = () => setShowModal(true);
+    const handleConfirm = () => {
+      setReactionVariations([]);
+      handleClose();
+    };
+
+    return (
+      <>
+        <Button size="sm" variant="danger" onClick={handleShow} className="mb-2">
+          <i className="fa fa-trash me-1" />
+          {' '}
+          Remove all Variations
+        </Button>
+
+        <Modal show={showModal} onHide={handleClose}>
+          <Modal.Header closeButton>
+            <Modal.Title>Confirm Removal</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>Are you sure you want to remove all variations?</Modal.Body>
+          <Modal.Footer>
+            <Button variant="secondary" onClick={handleClose}>
+              Keep variations
+            </Button>
+            <Button variant="danger" onClick={handleConfirm}>
+              Remove variations
+            </Button>
+          </Modal.Footer>
+        </Modal>
+      </>
+    );
+  };
+
+  const addVariation = () => (
+    <OverlayTrigger
+      placement="bottom"
+      overlay={(
+        <Tooltip>
+          Add row with current data from &quot;Scheme&quot; tab.
+          <br />
+          Changes in &quot;Scheme&quot; tab are not applied to
+          {' '}
+          <i>existing</i>
+          {' '}
+          rows.
+        </Tooltip>
+          )}
+    >
+      <Button size="sm" variant="success" onClick={addRow} className="mb-2">
+        <i className="fa fa-plus me-1" />
+        {' '}
+        Add Variation
+      </Button>
+    </OverlayTrigger>
+  );
+
   return (
     <div>
-      <OverlayTrigger
-        placement="bottom"
-        overlay={(
-          <Tooltip>
-            Add row with current data from &quot;Scheme&quot; tab.
-            <br />
-            Changes in &quot;Scheme&quot; tab are not applied to
-            {' '}
-            <i>existing</i>
-            {' '}
-            rows.
-          </Tooltip>
-        )}
-      >
-        <Button size="sm" variant="success" onClick={addRow} className="mb-2">
-          <i className="fa fa-plus me-1" /> Add Variation
-        </Button>
-      </OverlayTrigger>
+      <ButtonGroup>
+        {addVariation()}
+        {removeAllVariations()}
+      </ButtonGroup>
       <div className="ag-theme-alpine">
         <AgGridReact
           ref={gridRef}

--- a/app/usecases/reactions/update_variations.rb
+++ b/app/usecases/reactions/update_variations.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Once a reaction is copied, the samples of the copied reaction get new IDs.
+# When the reaction has variations, those get copied as well.
+# However, the variations keep a reference to the original sample IDs instead of the copied sample IDs.
+# This UseCase updates the variations to match the copied sample IDs.
+
+module Usecases
+  module Reactions
+    class UpdateVariations
+      def initialize(reaction)
+        @variations = reaction.variations.deep_dup
+        @material_ids = {
+          startingMaterials: reaction.starting_materials.pluck('id'),
+          reactants: reaction.reactants.pluck('id'),
+          products: reaction.products.pluck('id'),
+          solvents: reaction.solvents.pluck('id'),
+        }
+      end
+
+      def execute!
+        material_groups = %w[startingMaterials reactants products solvents]
+        @variations.each do |variation|
+          material_groups.each do |material_group|
+            variation_material_ids = variation[material_group].keys
+            if variation_material_ids.size != @material_ids[material_group.to_sym].size
+              raise "The variations do not contain the same number of #{material_group} as the reaction."
+            end
+
+            variation_material_ids.each_with_index do |key, index|
+              variation[material_group][@material_ids[material_group.to_sym][index]] =
+                variation[material_group].delete(key)
+            end
+          end
+        end
+        @variations
+      end
+    end
+  end
+end

--- a/spec/usecases/reactions/update_variations_spec.rb
+++ b/spec/usecases/reactions/update_variations_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Usecases::Reactions::UpdateVariations do
+  let(:variations) do
+    [
+      {
+        'startingMaterials' => { '42' => {} },
+        'reactants' => { '43' => {} },
+        'products' => { '44' => {}, '45' => {} },
+        'solvents' => {},
+      },
+      {
+        'startingMaterials' => { '42' => {} },
+        'reactants' => { '43' => {} },
+        'products' => { '44' => {}, '45' => {} },
+        'solvents' => {},
+      },
+    ]
+  end
+  let(:user) { create(:user) }
+  let(:collection) { Collection.create!(user: user, label: 'collection') }
+  let(:reaction) { Reaction.create!(variations: variations, collections: [collection], creator: user) }
+  let(:sample_a) { create(:sample) }
+  let(:sample_b) { create(:sample) }
+  let(:sample_c) { create(:sample) }
+  let(:sample_d) { create(:sample) }
+  let(:material_ids) do
+    {
+      startingMaterials: [sample_a.id],
+      reactants: [sample_b.id],
+      products: [sample_c.id, sample_d.id],
+      solvents: [],
+    }
+  end
+  let(:material_groups) { %w[startingMaterials reactants products solvents] }
+
+  before do
+    ReactionsStartingMaterialSample.create!(reaction_id: reaction.id, sample_id: sample_a.id)
+    ReactionsReactantSample.create!(reaction_id: reaction.id, sample_id: sample_b.id)
+    ReactionsProductSample.create!(reaction_id: reaction.id, sample_id: sample_c.id)
+    ReactionsProductSample.create!(reaction_id: reaction.id, sample_id: sample_d.id)
+    reaction.reload
+  end
+
+  it "updates variations' material IDs" do
+    updated_variations = described_class.new(reaction).execute!
+    updated_variations.each do |variation|
+      material_groups.each do |material_group|
+        expect(variation[material_group].keys).to eq(material_ids[material_group.to_sym])
+      end
+    end
+  end
+
+  it 'raises when number of materials is inconsistent' do
+    reaction.variations.first['startingMaterials'].delete('42')
+    expect do
+      described_class.new(reaction).execute!
+    end.to raise_error(RuntimeError,
+                       'The variations do not contain the same number of startingMaterials as the reaction.')
+  end
+end


### PR DESCRIPTION
This PR addresses #2264.

How to test this PR?
1. Copy a reaction with variations.
2. Create / Save the copied reaction.
3. Navigate to the reaction's "Variations" tab.

Pre-PR, 3. results in the crash described in #2264.
Post-PR, 3. does not crash and shows the copied variations table with updated material IDs.

Copying all variations when copying a reaction might be undesirable.
That's why I've added a "Remove all Variations" button (with confirmation modal):
![image](https://github.com/user-attachments/assets/0236ae8d-5147-4b14-b371-fd0a0641fe91)