### PR TITLE
fix(mass-spec): change theoryMass to exactMass

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/ViewSpectra.js
+++ b/app/javascript/src/apps/mydb/elements/details/ViewSpectra.js
@@ -713,7 +713,7 @@ class ViewSpectra extends React.Component {
         operations={operations}
         forecast={forecast}
         molSvg={sample.svgPath}
-        theoryMass={sample.molecule_molecular_weight}
+        exactMass={sample.molecule_exact_molecular_weight}
         descriptions={descriptions}
         canChangeDescription
         onDescriptionChanged={this.onSpectraDescriptionChanged}


### PR DESCRIPTION
This PR ensures that exactMass is sent to the Spectra Editor instead of theoryMass, improving the accuracy and consistency of the data being passed.

Closes [#2260](https://github.com/ComPlat/chemotion_ELN/issues/2260)

Dependency
This change depends on the following PR in the React Spectra Editor repository: [ComPlat/react-spectra-editor#240](https://github.com/ComPlat/react-spectra-editor/pull/240). Please ensure both PRs are merged and deployed together for the changes to work as expected.