### PR TITLE
refactor(UI):Rearrange the order of elemental composition

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -746,15 +746,13 @@ export default class SampleDetails extends React.Component {
           enableSampleDecoupled={this.enableSampleDecoupled}
           decoupleMolecule={this.decoupleMolecule}
         />
-        <div className="my-2">
+        <div className="mb-2">
           {this.chemicalIdentifiersItem(sample)}
+          {sample.molecule_formula && (
+            this.elementalPropertiesItem(sample)
+          )}
         </div>
         <EditUserLabels element={sample} fnCb={this.handleSampleChanged} />
-        {sample.molecule_formula && (
-          <div className="mt-2">
-            {this.elementalPropertiesItem(sample)}
-          </div>
-        )}
         <div className="mt-2">
           <PrivateNoteElement element={sample} disabled={!sample.can_update} />
         </div>


### PR DESCRIPTION
Rearrange the order of Elemental Composition in Sample Properties as below:

Chemical Identifiers, Elemental composition, My Labels, Private Note

![image](https://github.com/user-attachments/assets/36762b56-0c3f-40a4-88a0-ebe648ef0705)
