### PR TITLE
fix(UI): color-coding of save-status in reaction detail card

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -98,7 +98,7 @@ export default class ReactionDetails extends Component {
 
   componentDidUpdate(prevProps) {
     const { reaction } = this.props;
-    if (reaction.id !== prevProps.reaction.id) {
+    if (reaction !== prevProps.reaction) {
       this.setState({ reaction });
     }
   }


### PR DESCRIPTION
The save status of a reaction is indicated by the blue bar at the top of the reaction detail card.
Dark-blue means "no unsaved changes" and light-blue indicates "unsaved changes".
Currently, the color does not change back from light-blue to dark-blue upon saving changes.

To reproduce, change a reaction's temperature in the "Scheme tab" and subsequently save the reaction. The bar should turn from light-blue to dark-blue, which it doesn't. See https://github.com/ComPlat/chemotion_ELN/issues/2000 for a visualization of the color changes.
	
The cause of the missing color-transition is the following refactoring of the `componentDidUpdate` hook in `ReactionDetails`:
https://github.com/ComPlat/chemotion_ELN/pull/2196/files#diff-7a0497f1fbd063dc74585549f8849c2f7323ed96769b82c44208b91b1464b64d
	
This PR changes the guard in `componentDidUpdate` such that the reaction's state is set upon *any* changes to the reaction, not only when a different reaction is being rendered (as was previously enforced by means of the check for changes in `reaction.id`).
	
Prior to this PR, the guard in `componentDidUpdate` lead to unexpected behavior downstream since child components of `ReactionDetails` rely on being re-rendered when the reaction changes.