### PR TITLE
fix(UI): Display short label on reaction scheme hover

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
@@ -96,6 +96,7 @@ const iupacNameTooltip = material => (
         <tr><td>IUPAC&#58;&nbsp;</td><td style={{ wordBreak: 'break-all' }}>{material.molecule.iupac_name || ''}</td></tr>
         <tr><td>Name&#58;&nbsp;</td><td style={{ wordBreak: 'break-all' }}>{material.name || ''}</td></tr>
         <tr><td>Ext.Label&#58;&nbsp;</td><td style={{ wordBreak: 'break-all' }}>{material.external_label || ''}</td></tr>
+        <tr><td>Short Label&#58;&nbsp;</td><td style={{ wordBreak: 'break-all' }}>{material.short_label || ''}</td></tr>
       </tbody>
     </table>
   </Tooltip>);


### PR DESCRIPTION
This PR fixes an issue where the sample short label was missing from the tooltip when hovering over elements in the reaction scheme. The tooltip now correctly displays the short label.

Before : 
![withoutlabel](https://github.com/user-attachments/assets/2b54ff45-6b29-4a6b-9a37-7b893299c706)

After : 
![withlabel](https://github.com/user-attachments/assets/892e2e29-d8ef-4c86-b786-5d1c2f953ae0)

Issue linked:
Fixes [#2295](https://github.com/ComPlat/chemotion_ELN/issues/2295)