### PR TITLE
style(UI): correct formatting of a sample molarity added to the description of a reaction

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
@@ -599,7 +599,7 @@ class Material extends Component {
     const solVol = vol.slice(0, -2);
     const mol = molUnit ? `${molUnit}mol, ` : '';
     const mlt = m.molarity_value === 0.0 ?
-      '' : `${validDigit(m.molarity_value, 3)}${m.molarity_unit}, `;
+      '' : `${validDigit(m.molarity_value, 3)} ${m.molarity_unit}, `;
     const eqv = `${validDigit(m.equivalent, 3)}`;
     const yld = `${Math.round(m.equivalent * 100)}%`;
 


### PR DESCRIPTION
correct the formatting of a sample molarity from a reaction scheme, when pushing the details of it into the reaction description.

For example  `pyridine (14.7 mg, 190 μL, 186 μmol, 0.980M, 0.163 equiv) `   becomes
 `pyridine (14.7 mg, 190 μL, 186 μmol, 0.980 M, 0.163 equiv)`
 
----------------------------------------------------------
- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
