### PR TITLE
chore(js): bump react-date-picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "react-color": "^2.17.3",
     "react-contextmenu": "^2.14.0",
     "react-cookie": "^0.4.8",
+    "react-date-picker": "^10.0.0",
     "react-datepicker": "~7.3.0",
     "react-datetime-picker": "^4.1.1",
     "react-dnd": "^14.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12128,7 +12128,7 @@ react-bootstrap@~2.10.5:
     uncontrollable "^7.2.1"
     warning "^4.0.3"
 
-react-calendar@^4.2.0:
+react-calendar@^4.2.0, react-calendar@^4.6.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/react-calendar/-/react-calendar-4.8.0.tgz#61edbba6d17e7ef8a8012de9143b5e5ff41104c8"
   integrity sha512-qFgwo+p58sgv1QYMI1oGNaop90eJVKuHTZ3ZgBfrrpUb+9cAexxsKat0sAszgsizPMVo7vOXedV7Lqa0GQGMvA==
@@ -12194,6 +12194,20 @@ react-copy-to-clipboard@^5.1.0:
   dependencies:
     copy-to-clipboard "^3.3.1"
     prop-types "^15.8.1"
+
+react-date-picker@^10.0.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/react-date-picker/-/react-date-picker-10.6.0.tgz#b49ad556cff7009255a8dcbd0f59f4d9e9fdeab1"
+  integrity sha512-db5lcmU/52X8ur8SU1QU3PYBiaDG5SbzZDlqWk3YruPx5Ti9w6UpqCRsd1TXycVla9Ut2I3Qb4BUe27jxSwHeg==
+  dependencies:
+    "@wojtekmaj/date-utils" "^1.1.3"
+    clsx "^2.0.0"
+    get-user-locale "^2.2.1"
+    make-event-props "^1.6.0"
+    prop-types "^15.6.0"
+    react-calendar "^4.6.0"
+    react-fit "^1.7.0"
+    update-input-width "^1.4.0"
 
 react-date-picker@^9.2.0:
   version "9.3.0"
@@ -12289,7 +12303,7 @@ react-dropzone@^8.0.3:
     prop-types "^15.6.2"
     prop-types-extra "^1.1.0"
 
-react-fit@^1.4.0, react-fit@^1.5.1:
+react-fit@^1.4.0, react-fit@^1.5.1, react-fit@^1.7.0:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/react-fit/-/react-fit-1.7.1.tgz#95259e90cfa9c4d243a8013d03ea59c9c5c51a6f"
   integrity sha512-y/TYovCCBzfIwRJsbLj0rH4Es40wPQhU5GPPq9GlbdF09b0OdzTdMSkBza0QixSlgFzTm6dkM7oTFzaVvaBx+w==
@@ -14464,7 +14478,7 @@ update-browserslist-db@^1.1.1:
     escalade "^3.2.0"
     picocolors "^1.1.1"
 
-update-input-width@^1.2.2, update-input-width@^1.3.1:
+update-input-width@^1.2.2, update-input-width@^1.3.1, update-input-width@^1.4.0:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/update-input-width/-/update-input-width-1.4.2.tgz#49d327a39395185b0fd440b9c3b1d6f81173655c"
   integrity sha512-/p0XLhrQQQ4bMWD7bL9duYObwYCO1qGr8R19xcMmoMSmXuQ7/1//veUnCObQ7/iW6E2pGS6rFkS4TfH4ur7e/g==


### PR DESCRIPTION
#2329 bumps `react-date-picker` from version `9.2.0` to `9.3.0`.
However, there is no version `9.3.0`. The next available version is `10.0.0`.
See https://www.npmjs.com/package/react-date-picker?activeTab=versions and https://github.com/wojtekmaj/react-date-picker/issues/645.

Consequently, `react-date-picker` couldn't be installed, which resulted in:
`Module not found: Can't resolve 'react-date-picker/dist/DateInput/DayInput' in '/home/chemotion-dev/app/node_modules/react-datetime-picker/dist'
node_modules/react-datetime-picker/dist/DateTimeInput.js`.

This PR fixes the problem by bumping `react-date-picker` to the next available version `10.0.0`.