### PR TITLE
fix: sample attribute assignment wrongly rm by cop

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -445,7 +445,7 @@ class Sample < ApplicationRecord
     return if inchikey.blank?
 
     is_partial = babel_info[:is_partial]
-    babel_info[:version]
+    molfile_version = babel_info[:version]
     return unless molecule&.inchikey != inchikey || molecule.is_partial != is_partial
 
     self.molecule = Molecule.find_or_create_by_molfile(molfile, babel_info)

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -445,7 +445,7 @@ class Sample < ApplicationRecord
     return if inchikey.blank?
 
     is_partial = babel_info[:is_partial]
-    molfile_version = babel_info[:version]
+    self.molfile_version = babel_info[:version]
     return unless molecule&.inchikey != inchikey || molecule.is_partial != is_partial
 
     self.molecule = Molecule.find_or_create_by_molfile(molfile, babel_info)


### PR DESCRIPTION
since: 2f8ad4f67

Sample attribute name not recognized and tagged as `Useless assignement to variable` rm in
style: rubocop app/models/sample.rb (#2325)

refs: #2325

