### PR TITLE
fix: find_each order by on view notify_message

### DIFF
--- a/app/models/notify_message.rb
+++ b/app/models/notify_message.rb
@@ -16,4 +16,5 @@
 #
 
 class NotifyMessage < ApplicationRecord
+  self.primary_key = 'id'
 end


### PR DESCRIPTION
introduced by rubocop formating

since: #2322

- NotifyMessage is a view with no primary key

- [find_each](https://api.rubyonrails.org/classes/ActiveRecord/Batches.html#method-i-find_each) automatically `order by ` primary key

ref: #2322


