### PR TITLE
feat: labimotion-2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'kaminari-grape'
 # gem 'ketcherails', git: 'https://github.com/complat/ketcher-rails.git', branch: 'upgrade-to-rails-6'
 gem 'ketcherails', git: 'https://github.com/complat/ketcher-rails.git', ref: 'd4ae864a0e2d9e853eac8e4fc4ce7e3ab8174f80'
 
-gem 'labimotion', '2.0.0.rc2'
+gem 'labimotion', '2.0.0.rc6'
 gem 'logidze'
 
 gem 'mimemagic', '0.3.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -425,7 +425,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    labimotion (2.0.0.rc2)
+    labimotion (2.0.0.rc6)
       rails (~> 6.1.7)
     language_server-protocol (3.17.0.3)
     latex-decode (0.4.0)
@@ -912,7 +912,7 @@ DEPENDENCIES
   kaminari
   kaminari-grape
   ketcherails!
-  labimotion (= 2.0.0.rc2)
+  labimotion (= 2.0.0.rc6)
   launchy
   listen
   logidze

--- a/app/api/chemotion/attachment_api.rb
+++ b/app/api/chemotion/attachment_api.rb
@@ -63,11 +63,11 @@ module Chemotion
       desc 'Download the dataset attachment file'
       get 'dataset/:container_id' do
         env['api.format'] = :binary
-        export = Labimotion::ExportDataset.new
-        export.export(params[:container_id])
-        export.spectra(params[:container_id])
+        export = Labimotion::ExportDataset.new(params[:container_id])
+        export.export
+        export.spectra
         content_type('application/vnd.ms-excel')
-        ds_filename = export.res_name(params[:container_id])
+        ds_filename = export.res_name
         filename = URI.escape(ds_filename)
         header('Content-Disposition', "attachment; filename=\"#{filename}\"")
         export.read
@@ -323,10 +323,10 @@ module Chemotion
           end
 
           if Labimotion::Dataset.find_by(element_id: params[:container_id], element_type: 'Container').present?
-            export = Labimotion::ExportDataset.new
-            export.export(params[:container_id])
-            export.spectra(params[:container_id])
-            zip.put_next_entry export.res_name(params[:container_id])
+            export = Labimotion::ExportDataset.new(params[:container_id])
+            export.export
+            export.spectra
+            zip.put_next_entry export.res_name
             zip.write export.read
           end
 

--- a/db/migrate/20240718021724_add_trigger_layer_standards.rb
+++ b/db/migrate/20240718021724_add_trigger_layer_standards.rb
@@ -1,5 +1,7 @@
 class AddTriggerLayerStandards < ActiveRecord::Migration[6.1]
   def change
-    create_trigger :lab_trg_layers_changes, on: :layers
+    unless table_exists? :layers
+      create_trigger :lab_trg_layers_changes, on: :layers
+    end
   end
 end

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "antd": "^5.17.2",
     "aviator": "v0.6.1",
     "base-64": "^0.1.0",
-    "chem-generic-ui": "2.0.0-rc15",
+    "chem-generic-ui": "2.0.0-rc17",
     "citation-js": "0.6.8",
     "classnames": "^2.2.5",
     "commonmark": "^0.28.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5129,10 +5129,10 @@ cheerio@^1.0.0-rc.3:
     parse5-htmlparser2-tree-adapter "^6.0.1"
     tslib "^2.2.0"
 
-chem-generic-ui@2.0.0-rc15:
-  version "2.0.0-rc15"
-  resolved "https://registry.yarnpkg.com/chem-generic-ui/-/chem-generic-ui-2.0.0-rc15.tgz#0cc3a4896715b6639515e1371d633e42b40062f3"
-  integrity sha512-ic/sVW6Xy7zTf3S+C/AQo0HaVtdqXJQSYPpD3NnRbWHpzHlu4L1PErx1A/cnUzQWEP6x3VxHTdrtaDdib5FHxw==
+chem-generic-ui@2.0.0-rc17:
+  version "2.0.0-rc17"
+  resolved "https://registry.yarnpkg.com/chem-generic-ui/-/chem-generic-ui-2.0.0-rc17.tgz#210367008b3b80e65bb1945e31b53ff803e56b67"
+  integrity sha512-2CSAhD2ltua/BnDn3e/3jljf6eJOs6+NSnzfwI3B6EBswVbqbAoCmhvrA2C2+uRVXf2ZgwTy5iTuF8wAD0fePA==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.5.2"
     "@fortawesome/free-regular-svg-icons" "^6.5.2"
@@ -5140,7 +5140,8 @@ chem-generic-ui@2.0.0-rc15:
     "@fortawesome/react-fontawesome" "^0.2.1"
     ag-grid-community "^32.3.3"
     ag-grid-react "^32.3.3"
-    generic-ui-core "^1.5.0"
+    copy-to-clipboard "^3.3.3"
+    generic-ui-core "1.5.2"
     html-to-image "^1.11.11"
     humps "^2.0.1"
     lodash "^4.17.21"
@@ -7851,10 +7852,10 @@ gauge@^4.0.3:
     strip-ansi "^6.0.1"
     wide-align "^1.1.5"
 
-generic-ui-core@^1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/generic-ui-core/-/generic-ui-core-1.5.1.tgz#ab37123284b36983d8ee23e06f324acce9a74e83"
-  integrity sha512-vYRrzDwZMgcYajRu3K3mWID+3Zq3z4PVeDjeS1LrC2hekqgc88BfPolHK10nvZtsEcYqCNfHqTRHOYyZkWJRTQ==
+generic-ui-core@1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/generic-ui-core/-/generic-ui-core-1.5.2.tgz#d5b01974196808083d7d2c65f3dd84126b0cbc9c"
+  integrity sha512-zzA/I2m2Lo4POIeCBV44vmOt9lVAgd3BvNWpwjOIaXlnXlA5/a7zfnNgNwZcU62QQPxO+cRjm84hvDPCDKg76A==
   dependencies:
     chem-units "^1.2.0"
     lodash "^4.17.21"


### PR DESCRIPTION
This PR  update labimotion to v2-rc:

- chore: components updated react-boostrap 
- feat: LabIMotion Vocabulary (Lab-Vocab)
- feat: Generic Layers: reuse set of fields across multiple templates. 

see   https://github.com/LabIMotion/labimotion/discussions/37 for the features

see   https://github.com/LabIMotion/labimotion/discussions/39 for the features

Code changes: 
* db migration for lab-vocab and generic layer
* ELN generic react-components update and linting
* unified labimotion api namespace

* dependencies updates:

  -- Bumps [Labimotion](https://github.com/labimotion/labimotion) from 1.4.1 to 2.0.0.rc6
https://github.com/LabIMotion/labimotion/compare/v1.4.1...2.0.0.rc6
https://my.diffend.io/gems/labimotion/1.4.1/2.0.0.rc6


  -- Bumps [chem-generic-ui](https://github.com/LabIMotion/chem-generic-ui/) from 1.4.9 to 2.0.0-rc17
https://github.com/LabIMotion/chem-generic-ui/compare/v1.4.9...v2.0.0-rc17
https://www.npmjs.com/package/chem-generic-ui/v/2.0.0-rc17



