### PR TITLE
fix(UI): blank page on dropping research plan into a screen

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/screens/researchPlansTab/EmbeddedResearchPlanDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/researchPlansTab/EmbeddedResearchPlanDetails.js
@@ -57,7 +57,7 @@ export default class EmbeddedResearchPlanDetails extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    let { researchPlan } = this.props;
+    let { researchPlan, expanded } = this.props;
     if (researchPlan !== prevProps.researchPlan) {
       if (!(researchPlan instanceof ResearchPlan)) {
         researchPlan = new ResearchPlan(researchPlan);
@@ -66,7 +66,6 @@ export default class EmbeddedResearchPlanDetails extends Component {
       this.setState({ researchPlan, expanded });
     }
 
-    const { expanded } = this.props;
     if (expanded !== prevProps.expanded) {
       this.setState({ expanded });
     }


### PR DESCRIPTION
**Description:**

When Research Plan is drop in screen attachment it goes blank and throws the error "Cannot access expanded before initalization.". This has been fixed in EmbeddedResearchPlanDetails.js. 


since c85856e3936f

