### PR TITLE
fix: sorting export template, fix import button.

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/wellplates/attachmentsTab/WellplateDetailsAttachments.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/attachmentsTab/WellplateDetailsAttachments.js
@@ -80,6 +80,12 @@ export class WellplateDetailsAttachments extends Component {
   }
 
   componentDidMount() {
+    const { attachments } = this.props;
+    const updatedImportConfirm = attachments.reduce((acc, attachment) => {
+      acc[attachment.id] = false;
+      return acc;
+    }, {});
+    this.setState({ showImportConfirm: updatedImportConfirm });
     this.editorInitial();
     this.createAttachmentPreviews();
   }
@@ -294,13 +300,13 @@ export class WellplateDetailsAttachments extends Component {
           <div className="ms-3 align-self-center">
             {
               attachments.length > 0
-                && sortingAndFilteringUI(
-                  sortDirection,
-                  this.handleSortChange,
-                  this.toggleSortDirection,
-                  this.handleFilterChange,
-                  true
-                )
+              && sortingAndFilteringUI(
+                sortDirection,
+                this.handleSortChange,
+                this.toggleSortDirection,
+                this.handleFilterChange,
+                true
+              )
             }
           </div>
         </div>
@@ -353,9 +359,9 @@ export class WellplateDetailsAttachments extends Component {
                         extension,
                         attachmentEditor,
                         attachment.aasm_state === 'oo_editing' && new Date().getTime()
-                          < (new Date(attachment.updated_at).getTime() + 15 * 60 * 1000),
+                        < (new Date(attachment.updated_at).getTime() + 15 * 60 * 1000),
                         !attachmentEditor || attachment.aasm_state === 'oo_editing'
-                          || attachment.is_new || this.documentType(attachment.filename) === null,
+                        || attachment.is_new || this.documentType(attachment.filename) === null,
                         this.handleEdit
                       )}
                       {annotateButton(attachment, () => {
@@ -372,7 +378,7 @@ export class WellplateDetailsAttachments extends Component {
                         this.hideImportConfirm,
                         this.confirmAttachmentImport
                       )}
-                    &nbsp;
+                      &nbsp;
                       {removeButton(attachment, this.props.onDelete, this.props.readOnly)}
                     </>
                   )}

--- a/app/javascript/src/stores/alt/actions/ElementActions.js
+++ b/app/javascript/src/stores/alt/actions/ElementActions.js
@@ -804,6 +804,7 @@ class ElementActions {
     return (dispatch) => {
       WellplatesFetcher.importWellplateSpreadsheet(wellplateId, attachmentId)
         .then((result) => {
+          result.updated_at = new Date();
           dispatch(result);
         }).catch((errorMessage) => {
           console.log(errorMessage);

--- a/app/usecases/wellplates/template_creation.rb
+++ b/app/usecases/wellplates/template_creation.rb
@@ -49,7 +49,7 @@ module Usecases
       def create_data_content(sheet)
         mock_value_mg = 0.1
         mock_value_gw = 1
-        @wellplate.wells.each do |well|
+        @wellplate.wells.sort_by(&:sortable_alphanumeric_position).each do |well|
           well_data = [well.sortable_alphanumeric_position, '', '', '',
                        mock_value_mg.round(2), 'mg', mock_value_gw, 'GW']
           mock_value_gw += 1


### PR DESCRIPTION
**Description:**

- Sorted the wellplate export template based on the well position to ensure consistent ordering when downloading.
- Implemented functionality for users to import data from a spreadsheet.
- Added support for importing templates for wellplates of different sizes.
- Ensured real-time updates to the template after an upload, reflecting changes immediately.

---------------------------------------------------------------------------------

- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
