### PR TITLE
chore: bump labimotion-2.0.0 rc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'kaminari-grape'
 # gem 'ketcherails', git: 'https://github.com/complat/ketcher-rails.git', branch: 'upgrade-to-rails-6'
 gem 'ketcherails', git: 'https://github.com/complat/ketcher-rails.git', ref: 'd4ae864a0e2d9e853eac8e4fc4ce7e3ab8174f80'
 
-gem 'labimotion', '2.0.0.rc6'
+gem 'labimotion', '2.0.0.rc8'
 gem 'logidze'
 
 gem 'mimemagic', '0.3.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -425,7 +425,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    labimotion (2.0.0.rc6)
+    labimotion (2.0.0.rc8)
       rails (~> 6.1.7)
     language_server-protocol (3.17.0.3)
     latex-decode (0.4.0)
@@ -912,7 +912,7 @@ DEPENDENCIES
   kaminari
   kaminari-grape
   ketcherails!
-  labimotion (= 2.0.0.rc6)
+  labimotion (= 2.0.0.rc8)
   launchy
   listen
   logidze

--- a/app/api/chemotion/attachment_api.rb
+++ b/app/api/chemotion/attachment_api.rb
@@ -65,7 +65,6 @@ module Chemotion
         env['api.format'] = :binary
         export = Labimotion::ExportDataset.new(params[:container_id])
         export.export
-        export.spectra
         content_type('application/vnd.ms-excel')
         ds_filename = export.res_name
         filename = URI.escape(ds_filename)
@@ -325,7 +324,6 @@ module Chemotion
           if Labimotion::Dataset.find_by(element_id: params[:container_id], element_type: 'Container').present?
             export = Labimotion::ExportDataset.new(params[:container_id])
             export.export
-            export.spectra
             zip.put_next_entry export.res_name
             zip.write export.read
           end

--- a/app/javascript/src/components/generic/GenericElDetails.js
+++ b/app/javascript/src/components/generic/GenericElDetails.js
@@ -67,7 +67,8 @@ export default class GenericElDetails extends Component {
       genericEl: props.genericEl,
       activeTab: 0,
       // List of all visible segment tabs.
-      visible: Immutable.List()
+      visible: Immutable.List(),
+      expandAll: undefined,
     };
     this.onChangeUI = this.onChangeUI.bind(this);
     this.onChangeElement = this.onChangeElement.bind(this);
@@ -84,6 +85,7 @@ export default class GenericElDetails extends Component {
     this.handleElChanged = this.handleElChanged.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleExport = this.handleExport.bind(this);
+    this.handleExpandAll = this.handleExpandAll.bind(this);
   }
 
   componentDidMount() {
@@ -197,6 +199,10 @@ export default class GenericElDetails extends Component {
     ElementActions.exportElement(genericEl, 'Element', 'docx');
   }
 
+  handleExpandAll(expanded) {
+    this.setState({ expandAll: expanded });
+  }
+
   handleAttachmentDrop(files) {
     this.setState((prevState) => {
       const newAttachments = files.map((file) => Attachment.fromFile(file));
@@ -290,6 +296,7 @@ export default class GenericElDetails extends Component {
   }
 
   elementalPropertiesItem(genericEl) {
+    const { expandAll } = this.state;
     const options = [];
     options.push({
       generic: genericEl,
@@ -330,6 +337,7 @@ export default class GenericElDetails extends Component {
         isActiveWF
         fnNavi={onNaviClick}
         aiComp={aiComs}
+        expandAll={expandAll}
       />
     );
     return (
@@ -341,6 +349,7 @@ export default class GenericElDetails extends Component {
           fnExport={this.handleExport}
           fnReload={this.handleReload}
           fnRetrieve={this.handleRetrieveRevision}
+          onExpandAll={this.handleExpandAll}
         />
         {layersLayout}
         <EditUserLabels

--- a/app/javascript/src/components/generic/GenericSGDetails.js
+++ b/app/javascript/src/components/generic/GenericSGDetails.js
@@ -8,9 +8,13 @@ import ElementActions from 'src/stores/alt/actions/ElementActions';
 class GenericSGDetails extends Component {
   constructor(props) {
     super(props);
+    this.state = {
+      expandAll: undefined,
+    };
     this.handleReload = this.handleReload.bind(this);
     this.handleExport = this.handleExport.bind(this);
     this.handleRetrieveRevision = this.handleRetrieveRevision.bind(this);
+    this.handleExpandAll = this.handleExpandAll.bind(this);
   }
 
   handleReload(segment) {
@@ -23,6 +27,10 @@ class GenericSGDetails extends Component {
     ElementActions.exportElement(segment, 'Segment', 'docx');
   }
 
+  handleExpandAll(expanded) {
+    this.setState({ expandAll: expanded });
+  }
+
   handleRetrieveRevision(revision, cb) {
     const { segment, onChange } = this.props;
     segment.properties = revision;
@@ -33,6 +41,7 @@ class GenericSGDetails extends Component {
 
   elementalPropertiesItem(segment) {
     const { onChange, fnNavi, isSearch } = this.props;
+    const { expandAll } = this.state;
     const layersLayout = (
       <GenInterface
         generic={segment}
@@ -43,6 +52,7 @@ class GenericSGDetails extends Component {
         isSearch={isSearch}
         isActiveWF
         fnNavi={fnNavi}
+        expandAll={expandAll}
       />
     );
     return <div style={{ margin: '5px' }}>{layersLayout}</div>;
@@ -60,6 +70,7 @@ class GenericSGDetails extends Component {
           fnExport={this.handleExport}
           fnReload={this.handleReload}
           fnRetrieve={this.handleRetrieveRevision}
+          onExpandAll={this.handleExpandAll}
         />
         {this.elementalPropertiesItem(segment)}
       </div>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "antd": "^5.17.2",
     "aviator": "v0.6.1",
     "base-64": "^0.1.0",
-    "chem-generic-ui": "2.0.0-rc17",
+    "chem-generic-ui": "2.0.0-rc18",
     "citation-js": "0.6.8",
     "classnames": "^2.2.5",
     "commonmark": "^0.28.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5143,10 +5143,10 @@ cheerio@^1.0.0-rc.3:
     parse5-htmlparser2-tree-adapter "^6.0.1"
     tslib "^2.2.0"
 
-chem-generic-ui@2.0.0-rc17:
-  version "2.0.0-rc17"
-  resolved "https://registry.yarnpkg.com/chem-generic-ui/-/chem-generic-ui-2.0.0-rc17.tgz#210367008b3b80e65bb1945e31b53ff803e56b67"
-  integrity sha512-2CSAhD2ltua/BnDn3e/3jljf6eJOs6+NSnzfwI3B6EBswVbqbAoCmhvrA2C2+uRVXf2ZgwTy5iTuF8wAD0fePA==
+chem-generic-ui@2.0.0-rc18:
+  version "2.0.0-rc18"
+  resolved "https://registry.yarnpkg.com/chem-generic-ui/-/chem-generic-ui-2.0.0-rc18.tgz#e9f551b674f7e5893722e59a3c0099ce171a955a"
+  integrity sha512-Ulu4GwlrhGyfQNA3kprgbioj5BxHxQVp2iK6BuZ+Y8NeUD/jGpO3oOL2wGoP6u14bgQlZH0I/atYgkMPGMFzNg==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.5.2"
     "@fortawesome/free-regular-svg-icons" "^6.5.2"


### PR DESCRIPTION
This PR updates labimotion v2-rc and fixes the issue with downloading single attachment.

* dependencies updates:

  -- Bumps [Labimotion](https://github.com/labimotion/labimotion) from 2.0.0.rc2 to 2.0.0.rc8
https://my.diffend.io/gems/labimotion/2.0.0.rc2/2.0.0.rc8

  -- Bumps [chem-generic-ui](https://github.com/LabIMotion/chem-generic-ui/) from 2.0.0-rc15 to 2.0.0-rc18
https://github.com/LabIMotion/chem-generic-ui/compare/v2.0.0-rc15...v2.0.0-rc18
https://www.npmjs.com/package/chem-generic-ui/v/2.0.0-rc18
