### PR TITLE
fix: enabling rdkit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
 
     services:
       postgres:
-        # image: complat/dev:postgres16-rdkit
-        image: postgres:16
+        image: complat/dev:postgres16-rdkit
+        #image: postgres:16
         env:
           POSTGRES_PASSWORD: postgres    # env variable required by postgres Docker container
           POSTGRES_USER: chemotion    # optional env variable used in conjunction with POSTGRES_PASSWORD to set a user and their password

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,9 @@ module Chemotion
 
     config.active_job.queue_adapter = :delayed_job
 
+    # Get ActiveRecord to look for tables in multiple schemas
+    config.active_record.schema_format = :sql
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/initializers/eln_features.rb
+++ b/config/initializers/eln_features.rb
@@ -1,30 +1,85 @@
 # frozen_string_literal: true
 
-module Chemotion
-  class Application < Rails::Application
-    pack_path = Shakapacker.manifest.send(:data)&.fetch('application.js', nil)
-    ENV['VERSION_ASSETS'] = pack_path && File.basename(pack_path)
+# This file is used to set the features of the ELN
+#
+# define version of the assets to notifiy the user to reload the page
+pack_path = Shakapacker.manifest.send(:data)&.fetch('application.js', nil)
+ENV['VERSION_ASSETS'] = pack_path && File.basename(pack_path)
 
-    # PG Cartridge for structure search
-    cartridge = ENV.fetch('PG_CARTRIDGE', nil)
-    cartridge_version = ENV.fetch('PG_CARTRIDGE_VERSION', nil)
+# PG Cartridge feature for structure search
+#
+# initialize the default value
+Rails.application.config.pg_cartridge = 'none'
 
-    cartridge_present = false
-    if cartridge.in?(['rdkit']) && cartridge_version =~ /\d+\.\d+\.\d+/
-      cartridge_present = ActiveRecord::Base.connection.exec_query(
-        "select * from pg_available_extensions
-    where name = '#{cartridge}' and installed_version =   '#{cartridge_version}' ;",
-      ).first
-      puts "Warning: PG cartridge #{cartridge} version #{cartridge_version} is not installed" unless cartridge_present
-    end
+# Some functions to help setting the pg_cartridge feature
+# check if the pg extension is available
+# generate sql queries from name and version
+# @param [String] name
+# @param [String] version
+# @return [String] sql query
+extension_available = lambda do |name, version|
+  ActiveRecord::Base.connection.execute(
+    "SELECT * FROM pg_available_extensions WHERE name = '#{name}' AND default_version = '#{version}'",
+  ).count&.positive?
+end
 
-    config.pg_cartridge = cartridge_present ? cartridge : 'none'
+# check if the pg extension is installed
+extension_installed = lambda do |name, version|
+  ActiveRecord::Base.connection.execute(
+    "SELECT * FROM pg_extension WHERE extname = '#{name}' AND extversion = '#{version}'",
+  ).count&.positive?
+end
 
-    ActiveSupport.on_load(:active_record) do
-      Matrice.gen_matrices_json if ActiveRecord::Base.connection.table_exists?('matrices')
-      Labimotion::ElementKlass.gen_klasses_json if ActiveRecord::Base.connection.table_exists?('element_klasses')
-    rescue PG::ConnectionBad, ActiveRecord::NoDatabaseError => e
-      puts e.message
-    end
-  end
+# get the name and version of the extension or use default values
+cartridge_name    = -> { ENV.fetch('PG_CARTRIDGE', 'rdkit') }
+cartridge_version = -> { ENV.fetch('PG_CARTRIDGE_VERSION', '4.4.0') }
+cartridge_setting_valid = ->(name, version) { name.in?(%w[rdkit]) && version.match?(/\d+\.\d+\.\d+/) }
+
+output_message = lambda do |level, message, name = '', version = ''|
+  header = "PG structure search #{name}-#{version}"
+  puts "#{level.upcase} - #{header}: #{message}"
+  Rails.logger.send(level, "#{header}: #{message}")
+end
+messages = {
+  init: 'checking whether to enable the feature',
+  setting_invalid: 'WARN PG cartridge setting invalid - feature disabled',
+  extension_not_available: 'WARN PG cartridge extension not available - feature disabled',
+  extension_not_installed: 'WARN PG cartridge extension available but not installed !!
+                            feature enabled but ensure the extension is installed',
+  extension_installed: 'INFO PG cartridge extension installed - feature enabled',
+}
+
+ActiveSupport.on_load(:active_record) do
+  cartridge = cartridge_name.call
+  version = cartridge_version.call
+  output_message.call(:info, messages[:init], cartridge, version)
+  # Set whether PG Cartridge for structure search can be used
+  valid = cartridge_setting_valid.call(cartridge, version)
+  available = valid     && extension_available.call(cartridge, version)
+  installed = available && extension_installed.call(cartridge, version)
+  Rails.configuration.pg_cartridge = case
+                                     when !valid
+                                       output_message.call(:warn, messages[:setting_invalid])
+                                       'none'
+                                     when valid && !available
+                                       output_message.call(:warn, messages[:extension_not_available], cartridge,
+                                                           version)
+                                       'none'
+                                     when available && !installed
+                                       output_message.call(:warn, messages[:extension_not_installed], cartridge,
+                                                           version)
+                                       cartridge
+                                     when installed
+                                       output_message.call(:info, messages[:extension_installed], cartridge, version)
+                                       cartridge
+                                     end
+rescue PG::ConnectionBad, ActiveRecord::NoDatabaseError => e
+  Rails.logger.warn e.message
+end
+
+ActiveSupport.on_load(:active_record) do
+  Matrice.gen_matrices_json if ActiveRecord::Base.connection.table_exists?('matrices')
+  Labimotion::ElementKlass.gen_klasses_json if ActiveRecord::Base.connection.table_exists?('element_klasses')
+rescue PG::ConnectionBad, ActiveRecord::NoDatabaseError => e
+  Rails.logger.warn e.message
 end

--- a/db/migrate/20240808125800_init_rdkit_schema.rb
+++ b/db/migrate/20240808125800_init_rdkit_schema.rb
@@ -2,12 +2,14 @@
 
 class InitRdkitSchema < ActiveRecord::Migration[6.1]
   def up
-    if Chemotion::Application.config.pg_cartridge == 'rdkit'
-      create_schema 'rdkit'
-    end
+    return unless Chemotion::Application.config.pg_cartridge == 'rdkit'
+
+    enable_extension 'rdkit' unless extension_enabled?('rdkit')
+    create_schema 'rdkit'
   end
 
   def down
     drop_schema 'rdkit' if schema_exists? 'rdkit'
+    execute 'DROP EXTENSION IF EXISTS rdkit CASCADE' if extension_enabled?('rdkit')
   end
 end

--- a/db/migrate/20240808125801_init_rdkit_table.rb
+++ b/db/migrate/20240808125801_init_rdkit_table.rb
@@ -2,12 +2,12 @@
 
 class InitRdkitTable < ActiveRecord::Migration[6.1]
   def up
-    if Chemotion::Application.config.pg_cartridge == 'rdkit'
-      create_table 'rdkit.mols', as:
-        "select id, mol_from_ctab(encode(molfile, 'escape')::cstring) m from samples
+    return unless Chemotion::Application.config.pg_cartridge == 'rdkit'
+
+    create_table 'rdkit.mols', as:
+      "select id, mol_from_ctab(encode(molfile, 'escape')::cstring) m from samples
           where mol_from_ctab(encode(molfile, 'escape')::cstring) is not null;"
-      add_index 'rdkit.mols', :m, using: 'gist'
-    end
+    add_index 'rdkit.mols', :m, using: 'gist'
   end
 
   def down

--- a/db/migrate/20240808125802_init_rdkit_functions.rb
+++ b/db/migrate/20240808125802_init_rdkit_functions.rb
@@ -2,9 +2,17 @@
 
 class InitRdkitFunctions < ActiveRecord::Migration[6.1]
   def change
-    if Chemotion::Application.config.pg_cartridge == 'rdkit'
-      create_function :set_samples_mol_rdkit
-      create_trigger :set_samples_mol_rdkit_trg, on: :samples
+    reversible do |direction|
+      direction.up do
+        if Chemotion::Application.config.pg_cartridge == 'rdkit'
+          create_function :set_samples_mol_rdkit
+          create_trigger :set_samples_mol_rdkit_trg, on: :samples
+        end
+      end
+      direction.down do
+        execute 'DROP TRIGGER IF EXISTS set_samples_mol_rdkit_trg ON samples'
+        execute 'DROP FUNCTION IF EXISTS set_samples_mol_rdkit()'
+      end
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,6 +17,7 @@ ActiveRecord::Schema.define(version: 2025_02_18_161800) do
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+  enable_extension "rdkit"
   enable_extension "uuid-ossp"
 
   create_table "affiliations", id: :serial, force: :cascade do |t|
@@ -1874,6 +1875,24 @@ ActiveRecord::Schema.define(version: 2025_02_18_161800) do
       END;
       $function$
   SQL
+  create_function :set_samples_mol_rdkit, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION public.set_samples_mol_rdkit()
+       RETURNS trigger
+       LANGUAGE plpgsql
+      AS $function$
+      begin
+      	if (TG_OP='INSERT') then
+      		insert into rdkit.mols values (new.id, mol_from_ctab(encode(new.molfile, 'escape')::cstring));
+      	end if;
+      	if (TG_OP='UPDATE') then
+      		if new.MOLFILE <> old.MOLFILE then
+      			update rdkit.mols set m = mol_from_ctab(encode(new.molfile, 'escape')::cstring) where id = new.id;
+      		end if;
+      	end if;
+      	return new;
+      end
+      $function$
+  SQL
   create_function :calculate_dataset_space, sql_definition: <<-'SQL'
       CREATE OR REPLACE FUNCTION public.calculate_dataset_space(cid integer)
        RETURNS bigint
@@ -2389,6 +2408,9 @@ ActiveRecord::Schema.define(version: 2025_02_18_161800) do
 
   create_trigger :logidze_on_reactions, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_reactions BEFORE INSERT OR UPDATE ON public.reactions FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :set_samples_mol_rdkit_trg, sql_definition: <<-SQL
+      CREATE TRIGGER set_samples_mol_rdkit_trg BEFORE INSERT OR UPDATE ON public.samples FOR EACH ROW EXECUTE FUNCTION set_samples_mol_rdkit()
   SQL
   create_trigger :logidze_on_samples, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_samples BEFORE INSERT OR UPDATE ON public.samples FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')

--- a/db/seeds/shared/rdkit.seed.rb
+++ b/db/seeds/shared/rdkit.seed.rb
@@ -1,12 +1,60 @@
 # frozen_string_literal: true
+#
+pg_cartridge = Chemotion::Application.config.pg_cartridge
 
-if Chemotion::Application.config.pg_cartridge == 'rdkit'
-  mols = ActiveRecord::Base.connection.exec_query("select count(*) c from information_schema.tables
-                                                    where table_schema = 'rdkit' AND table_name = 'mols';")
-  return unless mols[0]['c'].zero? # Nothing to do
+# function: output log message 
+output_log_message = lambda do |message|
+  puts "INFO : pg_cartrige set to '#{pg_cartridge}': #{message}"
+  Rails.logger.info(message)
+end
 
-  [20240808125800, 20240808125801, 20240808125802].each do |migration_stamp|
-    ActiveRecord::MigrationContext.new(
+schema_table_exists = lambda do |schema, table|
+  ActiveRecord::Base.connection.exec_query(
+    "select count(*) c from information_schema.tables where table_schema = '#{schema}' AND table_name = '#{table}';"
+  )[0]['c'].positive?
+ 
+end
+
+extension_installed = lambda do |name|
+  ActiveRecord::Base.connection.execute(
+    "SELECT * FROM pg_extension WHERE extname = '#{name}' "
+  ).count.positive?
+end
+
+info_messages = {
+  init: 'pg structure search cartridge - checking whether to (re)run migrations and create the search table',
+  pg_cartridge_not_set: 'cartridge is not set - skipping migrations',
+  pg_cartridge_set: 'cartridge is set and pg_extension is available - checking whether to (re)run migrations',
+  extension_not_installed: 'extension is not installed - (re)run migrations',
+  schema_table_not_exists: 'search schema table does not exist - (re)run migrations',
+  feature_ready: 'RDKit schema table exists - skipping migrations',
+}
+
+# initial message
+output_log_message.call(info_messages[:init])
+
+# if pg_cartridge is set then the pg_extension is at least available
+if pg_cartridge == 'none'
+  output_log_message.call(info_messages[:pg_cartridge_not_set])
+  return
+end
+
+extension_ready = extension_installed.call(pg_cartridge)
+schema_ready = schema_table_exists.call(pg_cartridge, 'mols')
+
+case 
+when !extension_ready 
+  output_log_message.call(info_messages[:extension_not_installed])
+when !schema_ready
+  output_log_message.call(info_messages[:schema_table_not_exists])
+else
+  output_log_message.call(info_messages[:feature_ready])
+  return
+end
+
+
+[20240808125800, 20240808125801, 20240808125802].each do |migration_stamp|
+   ActiveRecord::MigrationContext.new(
       'db/migrate',
       ActiveRecord::Base.connection.schema_migration,
     ).run(:down, migration_stamp)
@@ -15,4 +63,3 @@ if Chemotion::Application.config.pg_cartridge == 'rdkit'
       ActiveRecord::Base.connection.schema_migration,
     ).run(:up, migration_stamp)
   end
-end


### PR DESCRIPTION
## PG catridge setting

refactor the setting of the rails configuration pg_cartridge:
- initialize value to 'none' (feature disabled - empty migration)
- use default value rdkit@4.4.0 if ENV not set
- validate cartridge name/ version format -> disable if not
- check if pg extension is available -> disable if not
- check if pg extension is installed -> enable and warn if not / expect migration to
  be run

refactor the db/seeds/shared/rdkit.seed.rb:
- check if pg_cartridge is not 'none' -> settings correct and extension
  available
- (re)run migrations if schema or mol tables is not there OR extension
  is not installed (restoring db)
- more verbose log message

This ensures
- Rails.configuration.pg_cartridge is defined in any cases
- the app can boot if the db is not created yet and pg_cartridge is not
  'none'
- ensure migration create the extension if available but not installed:
  20240808125800_init_rdkit_schema drop and recreate the extension


