### PR TITLE
fix: element list (un)collapse of sample group

### DIFF
--- a/app/javascript/src/apps/mydb/elements/list/ElementsTableSampleEntries.js
+++ b/app/javascript/src/apps/mydb/elements/list/ElementsTableSampleEntries.js
@@ -226,9 +226,6 @@ export default class ElementsTableSampleEntries extends Component {
 
   componentDidUpdate(prevProps) {
     const { elements, moleculeSort, collapseAll } = this.props;
-    if (elements === prevProps.elements && moleculeSort === prevProps.moleculeSort) {
-      return;
-    }
 
     if (collapseAll !== prevProps.collapseAll) {
       this.setState({
@@ -236,7 +233,9 @@ export default class ElementsTableSampleEntries extends Component {
         userManuallyCollapsedLast: !collapseAll
       });
     }
-
+    if (elements === prevProps.elements && moleculeSort === prevProps.moleculeSort) {
+      return;
+    }
     const moleculeList = elements.reduce((acc, sample) => {
       const key = this.getMolId(sample);
       if (!acc[key]) {
@@ -441,7 +440,7 @@ export default class ElementsTableSampleEntries extends Component {
 
   renderMoleculeGroup(moleculeGroup, index) {
     const { showDragColumn, collapseAll } = this.props;
-    const { showPreviews, moleculeGroupsShown, userManuallyCollapsedLast, targetType, moleculeToggle } = this.state;
+    const { showPreviews, moleculeGroupsShown, userManuallyCollapsedLast, targetType } = this.state;
     const { molecule } = moleculeGroup[0];
     const moleculeName = molecule.iupac_name || molecule.inchistring;
     const showGroup = collapseAll

--- a/app/javascript/src/models/Sample.js
+++ b/app/javascript/src/models/Sample.js
@@ -225,7 +225,17 @@ export default class Sample extends Element {
     sample.short_label = Sample.buildNewShortLabel();
     return sample;
   }
-  
+
+  static getMoleculeId(sample) {
+    if (sample.decoupled && sample.molfile) {
+      return `M${sample.id}`;
+    } else if (sample.stereo == null) {
+      return `M${sample.molecule.id}_any_any`;
+    } else {
+      return `M${sample.molecule.id}_${sample.stereo.abs || 'any'}_${sample.stereo.rel || 'any'}`;
+    }
+  }
+
   getChildrenCount() {
     return parseInt(Sample.children_count[this.id] || this.children_count, 10);
   }

--- a/app/javascript/src/models/Sample.js
+++ b/app/javascript/src/models/Sample.js
@@ -226,13 +226,13 @@ export default class Sample extends Element {
     return sample;
   }
 
-  static getMoleculeId(sample) {
-    if (sample.decoupled && sample.molfile) {
-      return `M${sample.id}`;
-    } else if (sample.stereo == null) {
-      return `M${sample.molecule.id}_any_any`;
+  getMoleculeId() {
+    if (this.decoupled && this.molfile) {
+      return `M${this.id}`;
+    } else if (this.stereo == null) {
+      return `M${this.molecule.id}_any_any`;
     } else {
-      return `M${sample.molecule.id}_${sample.stereo.abs || 'any'}_${sample.stereo.rel || 'any'}`;
+      return `M${this.molecule.id}_${this.stereo.abs || 'any'}_${this.stereo.rel || 'any'}`;
     }
   }
 

--- a/app/javascript/src/utilities/SampleUtils.js
+++ b/app/javascript/src/utilities/SampleUtils.js
@@ -1,8 +1,6 @@
-import Sample from 'src/models/Sample';
-
 const getDisplayedMoleculeGroup = (elements, moleculeSort) => {
   const moleculeList = elements.reduce((acc, sample) => {
-    const key = Sample.getMoleculeId(sample);
+    const key = sample.getMoleculeId(sample);
     if (!acc[key]) {
       acc[key] = [sample];
     } else {

--- a/app/javascript/src/utilities/SampleUtils.js
+++ b/app/javascript/src/utilities/SampleUtils.js
@@ -1,43 +1,36 @@
-const getMolId = (sample) => {
-    if (sample.decoupled && sample.molfile) {
-        return `M${sample.id}`;
-    } else if (sample.stereo == null) {
-        return `M${sample.molecule.id}_any_any`;
-    } else {
-        return `M${sample.molecule.id}_${sample.stereo.abs || 'any'}_${sample.stereo.rel || 'any'}`;
-    }
-};
+import Sample from 'src/models/Sample';
 
 const getDisplayedMoleculeGroup = (elements, moleculeSort) => {
-    const moleculeList = elements.reduce((acc, sample) => {
-        const key = getMolId(sample);
-        if (!acc[key]) {
-            acc[key] = [sample];
-        } else {
-            acc[key].push(sample);
-        }
-        return acc;
-    }, {});
-    const displayedMoleculeGroup =  Object.keys(moleculeList).map((molId) => {
-        const m = moleculeList[molId];
-        if (moleculeSort && m.length > 3) {
-          m.numSamples = 3;
-        } else {
-          m.numSamples = m.length;
-        }
-        return m;
-      });
-    return displayedMoleculeGroup;
-}
+  const moleculeList = elements.reduce((acc, sample) => {
+    const key = Sample.getMoleculeId(sample);
+    if (!acc[key]) {
+      acc[key] = [sample];
+    } else {
+      acc[key].push(sample);
+    }
+    return acc;
+  }, {});
+  const displayedMoleculeGroup = Object.keys(moleculeList).map((molId) => {
+    const m = moleculeList[molId];
+    if (moleculeSort && m.length > 3) {
+      m.numSamples = 3;
+    } else {
+      m.numSamples = m.length;
+    }
+    return m;
+  });
+  return displayedMoleculeGroup;
+};
 
 const getMoleculeGroupsShown = (displayedMoleculeGroup) => {
-    const moleculeGroupsShown = displayedMoleculeGroup.map((moleculeGroup) => {
-        const { molecule } = moleculeGroup[0];
-        return molecule.iupac_name || molecule.inchistring;
-    });
-    return moleculeGroupsShown;
-}
+  const moleculeGroupsShown = displayedMoleculeGroup.map((moleculeGroup) => {
+    const { molecule } = moleculeGroup[0];
+    return molecule.iupac_name || molecule.inchistring;
+  });
+  return moleculeGroupsShown;
+};
+
 export {
-    getDisplayedMoleculeGroup,
-    getMoleculeGroupsShown
-  };
+  getDisplayedMoleculeGroup,
+  getMoleculeGroupsShown
+};

--- a/app/javascript/src/utilities/SampleUtils.js
+++ b/app/javascript/src/utilities/SampleUtils.js
@@ -1,3 +1,10 @@
+/**
+ * Groups elements by their molecule ID and limits the number of samples per group if sorting is applied.
+ *
+ * @param {Array} elements - List of sample elements.
+ * @param {boolean} moleculeSort - Flag to determine if sorting and limiting should be applied.
+ * @returns {Array} - Array of grouped molecule samples.
+ */
 const getDisplayedMoleculeGroup = (elements, moleculeSort) => {
   const moleculeList = elements.reduce((acc, sample) => {
     const key = sample.getMoleculeId(sample);
@@ -8,25 +15,28 @@ const getDisplayedMoleculeGroup = (elements, moleculeSort) => {
     }
     return acc;
   }, {});
+
   const displayedMoleculeGroup = Object.keys(moleculeList).map((molId) => {
     const m = moleculeList[molId];
-    if (moleculeSort && m.length > 3) {
-      m.numSamples = 3;
-    } else {
-      m.numSamples = m.length;
-    }
+    m.numSamples = moleculeSort && m.length > 3 ? 3 : m.length;
     return m;
   });
+
   return displayedMoleculeGroup;
 };
 
-const getMoleculeGroupsShown = (displayedMoleculeGroup) => {
-  const moleculeGroupsShown = displayedMoleculeGroup.map((moleculeGroup) => {
+/**
+ * Extracts the IUPAC name or InChI string of the first molecule in each group.
+ *
+ * @param {Array} displayedMoleculeGroup - List of grouped molecules.
+ * @returns {Array} - Array of IUPAC names or InChI strings.
+ */
+const getMoleculeGroupsShown = (displayedMoleculeGroup) => displayedMoleculeGroup.map(
+  (moleculeGroup) => {
     const { molecule } = moleculeGroup[0];
     return molecule.iupac_name || molecule.inchistring;
-  });
-  return moleculeGroupsShown;
-};
+  }
+);
 
 export {
   getDisplayedMoleculeGroup,

--- a/app/javascript/src/utilities/SampleUtils.js
+++ b/app/javascript/src/utilities/SampleUtils.js
@@ -1,0 +1,43 @@
+const getMolId = (sample) => {
+    if (sample.decoupled && sample.molfile) {
+        return `M${sample.id}`;
+    } else if (sample.stereo == null) {
+        return `M${sample.molecule.id}_any_any`;
+    } else {
+        return `M${sample.molecule.id}_${sample.stereo.abs || 'any'}_${sample.stereo.rel || 'any'}`;
+    }
+};
+
+const getDisplayedMoleculeGroup = (elements, moleculeSort) => {
+    const moleculeList = elements.reduce((acc, sample) => {
+        const key = getMolId(sample);
+        if (!acc[key]) {
+            acc[key] = [sample];
+        } else {
+            acc[key].push(sample);
+        }
+        return acc;
+    }, {});
+    const displayedMoleculeGroup =  Object.keys(moleculeList).map((molId) => {
+        const m = moleculeList[molId];
+        if (moleculeSort && m.length > 3) {
+          m.numSamples = 3;
+        } else {
+          m.numSamples = m.length;
+        }
+        return m;
+      });
+    return displayedMoleculeGroup;
+}
+
+const getMoleculeGroupsShown = (displayedMoleculeGroup) => {
+    const moleculeGroupsShown = displayedMoleculeGroup.map((moleculeGroup) => {
+        const { molecule } = moleculeGroup[0];
+        return molecule.iupac_name || molecule.inchistring;
+    });
+    return moleculeGroupsShown;
+}
+export {
+    getDisplayedMoleculeGroup,
+    getMoleculeGroupsShown
+  };


### PR DESCRIPTION
This PR fixes the collapse/uncollapse bug in the Sample table.


**Explanation of the current collapse/uncollapse feature in Sample based on this bugfix:**

top chevron btn:

- the btn that toggles many samples at once

grouping chevron btn: 

- the btn that toggles samples individually

initial  state -> action -> resulting state

given a list of 10 samples grouped by xxx

_Initial state:_
top chevron btn  : {to the bottom}
grouping chevron btn : {all to the bottom}

_action-> resulting state:_

1. click top chevron btn->[bottom (uncollapsed) to right (collapsed) and viceversa]
current state: top and grouping chevron btn - all to the right
2. click on grouping chevron btn for sample x-> grouping btn for x to the bottom (x is uncollapsed)
   current state:
      grouping chevron btn for sample x: to the bottom
      all other grouping btn: to the right
3. click on top chevron btn->
- toggles only sample x to right if it is already uncollapsed.
- If no sample is uncollapsed, all samples are collapsed/uncollapsed (right/bottom)

