### PR TITLE
feat: user-selectable columns for reaction variations table

### DIFF
--- a/app/api/entities/reaction_variation_entity.rb
+++ b/app/api/entities/reaction_variation_entity.rb
@@ -13,17 +13,13 @@ module Entities
     expose :starting_materials, as: :startingMaterials
 
     def properties
-      {}.tap do |properties|
-        properties[:temperature] = ReactionVariationPropertyEntity.represent(object[:properties][:temperature])
-        properties[:duration] = ReactionVariationPropertyEntity.represent(object[:properties][:duration])
+      object[:properties].slice(:duration, :temperature).transform_values do |value|
+        ReactionVariationPropertyEntity.represent(value)
       end
     end
 
     def metadata
-      {}.tap do |metadata|
-        metadata[:notes] = object[:metadata][:notes]
-        metadata[:analyses] = object[:metadata][:analyses]
-      end
+      object[:metadata].slice(:notes, :analyses)
     end
 
     def materials(material_type, entity)

--- a/app/api/entities/reaction_variation_entity.rb
+++ b/app/api/entities/reaction_variation_entity.rb
@@ -4,9 +4,8 @@ module Entities
   class ReactionVariationEntity < ApplicationEntity
     expose(
       :id,
-      :notes,
       :properties,
-      :analyses,
+      :metadata,
       :reactants,
       :products,
       :solvents,
@@ -17,6 +16,13 @@ module Entities
       {}.tap do |properties|
         properties[:temperature] = ReactionVariationPropertyEntity.represent(object[:properties][:temperature])
         properties[:duration] = ReactionVariationPropertyEntity.represent(object[:properties][:duration])
+      end
+    end
+
+    def metadata
+      {}.tap do |metadata|
+        metadata[:notes] = object[:metadata][:notes]
+        metadata[:analyses] = object[:metadata][:analyses]
       end
     end
 

--- a/app/assets/stylesheets/global-styles/package-mods/ag-grid.scss
+++ b/app/assets/stylesheets/global-styles/package-mods/ag-grid.scss
@@ -5,3 +5,8 @@
 .ag-theme-reaction-variations .ag-body-horizontal-scroll {
     position: absolute !important;
 }
+
+.ag-header-group-cell-label {
+    overflow: hidden !important;
+  }
+  

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -12,8 +12,9 @@ import PropTypes from 'prop-types';
 import Reaction from 'src/models/Reaction';
 import {
   createVariationsRow, copyVariationsRow, updateVariationsRow,
-  materialTypes, instantiateSelectedColumns,
+  materialTypes, getVariationsColumns,
   addMissingColumnsToVariations, removeObsoleteColumnsFromVariations,
+  getMetadataColumnGroupChild, getPropertyColumnGroupChild
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
 import {
   getReactionAnalyses, updateAnalyses
@@ -21,7 +22,7 @@ import {
 import {
   updateVariationsGasTypes,
   getReactionMaterials, getReactionMaterialsIDs, getReactionMaterialsGasTypes,
-  removeObsoleteMaterialColumns
+  removeObsoleteMaterialColumns, getMaterialColumnGroupChild
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
 import {
   PropertyFormatter, PropertyParser,
@@ -43,9 +44,7 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
   const [gasMode, setGasMode] = useState(reaction.gaseous);
   const [allReactionAnalyses, setAllReactionAnalyses] = useState(getReactionAnalyses(reaction));
   const [reactionMaterials, setReactionMaterials] = useState(getReactionMaterials(reaction));
-  const [selectedColumns, setSelectedColumns] = useState(
-    instantiateSelectedColumns
-  );
+  const [selectedColumns, setSelectedColumns] = useState(getVariationsColumns(reactionVariations));
   const [columnDefinitions, setColumnDefinitions] = useReducer(columnDefinitionsReducer, [
     {
       headerName: 'Tools',
@@ -59,20 +58,26 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
       headerName: 'Metadata',
       groupId: 'metadata',
       marryChildren: true,
-      children: []
+      children: selectedColumns.metadata.map((entry) => getMetadataColumnGroupChild(entry))
     },
     {
       headerName: 'Properties',
       groupId: 'properties',
       marryChildren: true,
-      children: []
+      children: selectedColumns.properties.map((entry) => getPropertyColumnGroupChild(entry, gasMode))
     },
   ].concat(
     Object.entries(materialTypes).map(([materialType, { label }]) => ({
       headerName: label,
       groupId: materialType,
       marryChildren: true,
-      children: []
+      children: selectedColumns[materialType].map(
+        (materialID) => getMaterialColumnGroupChild(
+          reactionMaterials[materialType].find((material) => material.id.toString() === materialID),
+          materialType,
+          gasMode
+        )
+      )
     }))
   ));
 

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -406,7 +406,6 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
           headerHeight={70}
           columnDefs={columnDefinitions}
           suppressPropertyNamesCheck
-          stopEditingWhenCellsLoseFocus
           defaultColDef={defaultColumnDefinitions}
           dataTypeDefinitions={dataTypeDefinitions}
           tooltipShowDelay={0}

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -19,7 +19,7 @@ import {
 import {
   getMaterialColumnGroupChild, updateVariationsGasTypes,
   getReactionMaterials, getReactionMaterialsIDs, getReactionMaterialsGasTypes,
-  removeObsoleteMaterialsFromVariations, addMissingMaterialsToVariations
+  removeObsoleteMaterialsFromVariations
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
 import {
   PropertyFormatter, PropertyParser,
@@ -188,21 +188,9 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
       getReactionMaterialsIDs(updatedReactionMaterials)
     )
   ) {
-    let updatedReactionVariations = removeObsoleteMaterialsFromVariations(reactionVariations, updatedReactionMaterials);
-    updatedReactionVariations = addMissingMaterialsToVariations(
-      updatedReactionVariations,
-      updatedReactionMaterials,
-      updatedGasMode
-    );
+    const updatedReactionVariations = removeObsoleteMaterialsFromVariations(reactionVariations, updatedReactionMaterials);
 
     setReactionVariations(updatedReactionVariations);
-    setColumnDefinitions(
-      {
-        type: 'update_material_set',
-        gasMode: updatedGasMode,
-        reactionMaterials: updatedReactionMaterials
-      }
-    );
     setReactionMaterials(updatedReactionMaterials);
   }
 

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -185,13 +185,13 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
       getReactionMaterialsIDs(updatedReactionMaterials)
     )
   ) {
-    const updatedReactionVariations = removeObsoleteMaterialsFromVariations(
-      reactionVariations,
-      updatedReactionMaterials
-    );
     const updatedSelectedReactionMaterialIDs = removeObsoleteSelectedReactionMaterialIDs(
       selectedReactionMaterialIDs,
       updatedReactionMaterials
+    );
+    const updatedReactionVariations = removeObsoleteMaterialsFromVariations(
+      reactionVariations,
+      updatedSelectedReactionMaterialIDs
     );
 
     setColumnDefinitions(

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -37,6 +37,8 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
   const gridRef = useRef(null);
   const reactionVariations = reaction.variations;
   const reactionHasPolymers = reaction.hasPolymers();
+  const { dispValue: durationValue = null, dispUnit: durationUnit = 'None' } = reaction.durationDisplay ?? {};
+  const { userText: temperatureValue = null, valueUnit: temperatureUnit = 'None' } = reaction.temperature ?? {};
   const [gasMode, setGasMode] = useState(reaction.gaseous);
   const [allReactionAnalyses, setAllReactionAnalyses] = useState(getReactionAnalyses(reaction));
   const [reactionMaterials, setReactionMaterials] = useState(getReactionMaterials(reaction));
@@ -298,7 +300,20 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
     setReactionVariations(
       [
         ...reactionVariations,
-        createVariationsRow(reaction, selectedReactionMaterialIDs, reactionVariations, gasMode, vesselVolume)
+        createVariationsRow(
+          {
+            materials: reactionMaterials,
+            materialIDs: selectedReactionMaterialIDs,
+            variations: reactionVariations,
+            reactionHasPolymers,
+            durationValue,
+            durationUnit,
+            temperatureValue,
+            temperatureUnit,
+            gasMode,
+            vesselVolume
+          }
+        )
       ]
     );
   }, [reaction, reactionVariations, gasMode]);

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -296,7 +296,10 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
   const addRow = useCallback(() => {
     const vesselVolume = GasPhaseReactionStore.getState().reactionVesselSizeValue;
     setReactionVariations(
-      [...reactionVariations, createVariationsRow(reaction, reactionVariations, gasMode, vesselVolume)]
+      [
+        ...reactionVariations,
+        createVariationsRow(reaction, selectedReactionMaterialIDs, reactionVariations, gasMode, vesselVolume)
+      ]
     );
   }, [reaction, reactionVariations, gasMode]);
 

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/display-name */
 import { AgGridReact } from 'ag-grid-react';
 import React, {
-  useRef, useState, useCallback, useReducer, useEffect
+  useRef, useState, useCallback, useReducer, useEffect, useMemo
 } from 'react';
 import {
   Button, OverlayTrigger, Tooltip, Alert,
@@ -43,10 +43,8 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
   const [allReactionAnalyses, setAllReactionAnalyses] = useState(getReactionAnalyses(reaction));
   const [reactionMaterials, setReactionMaterials] = useState(getReactionMaterials(reaction));
   const [selectedColumns, setSelectedColumns] = useState(getVariationsColumns(reactionVariations));
-  const [columnDefinitions, setColumnDefinitions] = useReducer(
-    columnDefinitionsReducer,
-    getColumnDefinitions(selectedColumns, reactionMaterials, gasMode)
-  );
+  const initialColumnDefinitions = useMemo(() => getColumnDefinitions(selectedColumns, reactionMaterials, gasMode), []);
+  const [columnDefinitions, setColumnDefinitions] = useReducer(columnDefinitionsReducer, initialColumnDefinitions);
 
   const dataTypeDefinitions = {
     property: {

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses.js
@@ -27,8 +27,8 @@ function updateAnalyses(variations, allReactionAnalyses) {
   return updatedVariations;
 }
 
-function getAnalysesOverlay({ data: variationsRow, context }) {
-  const { analyses: analysesIDs } = variationsRow;
+function getAnalysesOverlay({ data: row, context }) {
+  const { analyses: analysesIDs } = row;
   const { allReactionAnalyses } = context;
 
   return allReactionAnalyses.filter((analysis) => analysesIDs.includes(analysis.id));
@@ -94,7 +94,7 @@ AnalysesCellRenderer.propTypes = {
 };
 
 function AnalysesCellEditor({
-  data: variationsRow,
+  data: row,
   value: analysesIDs,
   onValueChange,
   stopEditing,
@@ -150,7 +150,7 @@ function AnalysesCellEditor({
   const cellContent = (
     <Modal centered show>
       <Modal.Header>
-        {`Link analyses to ${getVariationsRowName(reactionShortLabel, variationsRow.id)}`}
+        {`Link analyses to ${getVariationsRowName(reactionShortLabel, row.id)}`}
       </Modal.Header>
       <Modal.Body>{analysesSelection}</Modal.Body>
       <Modal.Footer>

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses.js
@@ -21,7 +21,7 @@ function updateAnalyses(variations, allReactionAnalyses) {
   const updatedVariations = cloneDeep(variations);
   updatedVariations.forEach((row) => {
     // eslint-disable-next-line no-param-reassign
-    row.analyses = row.analyses.filter((id) => analysesIDs.includes(id));
+    row.metadata.analyses = row.metadata.analyses.filter((id) => analysesIDs.includes(id));
   });
 
   return updatedVariations;
@@ -61,7 +61,7 @@ AnalysisOverlay.propTypes = {
 
 function AnalysisVariationLink({ reaction, analysisID }) {
   const { variations } = cloneDeep(reaction);
-  const linkedVariations = variations.filter((row) => row.analyses.includes(analysisID)) ?? [];
+  const linkedVariations = variations.filter((row) => row.metadata.analyses.includes(analysisID)) ?? [];
 
   if (linkedVariations.length === 0) {
     return null;

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents.js
@@ -6,6 +6,7 @@ import {
   Button, ButtonGroup, Modal, Form, OverlayTrigger, Tooltip
 } from 'react-bootstrap';
 import PropTypes from 'prop-types';
+import { cloneDeep, isEqual } from 'lodash';
 import {
   getVariationsRowName, convertUnit, getStandardUnits, getUserFacingUnit
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
@@ -518,6 +519,19 @@ MenuHeader.defaultProps = {
 function ColumnSelection(selectedColumns, availableColumns, onApply) {
   const [showModal, setShowModal] = useState(false);
   const [currentColumns, setCurrentColumns] = useState(selectedColumns);
+
+  useEffect(() => {
+    // Remove currently selected columns that are no longer available.
+    const updatedCurrentColumns = cloneDeep(currentColumns);
+
+    Object.entries(updatedCurrentColumns).forEach(([key, values]) => {
+      const { [key]: availableValues } = availableColumns;
+      updatedCurrentColumns[key] = values.filter((value) => availableValues.includes(value));
+    });
+    if (!isEqual(updatedCurrentColumns, currentColumns)) {
+      setCurrentColumns(updatedCurrentColumns);
+    }
+  }, [availableColumns]);
 
   const handleApply = () => {
     onApply(currentColumns);

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents.js
@@ -18,7 +18,7 @@ import {
 } from 'src/utilities/UnitsConversion';
 
 function RowToolsCellRenderer({
-  data: variationsRow, context
+  data: row, context
 }) {
   const { reactionShortLabel, copyRow, removeRow } = context;
   return (
@@ -26,14 +26,14 @@ function RowToolsCellRenderer({
       <ButtonGroup>
         <OverlayTrigger
           placement="bottom"
-          overlay={<Tooltip>{getVariationsRowName(reactionShortLabel, variationsRow.id)}</Tooltip>}
+          overlay={<Tooltip>{getVariationsRowName(reactionShortLabel, row.id)}</Tooltip>}
         >
-          <Button size="xsm" variant="secondary">{variationsRow.id}</Button>
+          <Button size="xsm" variant="secondary">{row.id}</Button>
         </OverlayTrigger>
-        <Button size="xsm" variant="success" onClick={() => copyRow(variationsRow)}>
+        <Button size="xsm" variant="success" onClick={() => copyRow(row)}>
           <i className="fa fa-clone" />
         </Button>
-        <Button size="xsm" variant="danger" onClick={() => removeRow(variationsRow)}>
+        <Button size="xsm" variant="danger" onClick={() => removeRow(row)}>
           <i className="fa fa-trash-o" />
         </Button>
       </ButtonGroup>
@@ -52,13 +52,13 @@ RowToolsCellRenderer.propTypes = {
   }).isRequired,
 };
 
-function EquivalentParser({ data: variationsRow, oldValue: cellData, newValue }) {
+function EquivalentParser({ data: row, oldValue: cellData, newValue }) {
   let equivalent = parseNumericString(newValue);
   if (equivalent < 0) {
     equivalent = 0;
   }
   // Adapt mass to updated equivalent.
-  const referenceMaterial = getReferenceMaterial(variationsRow);
+  const referenceMaterial = getReferenceMaterial(row);
   const referenceMol = getMolFromGram(referenceMaterial.mass.value, referenceMaterial);
   const mass = getGramFromMol(referenceMol * equivalent, cellData);
 
@@ -106,7 +106,7 @@ function MaterialFormatter({ value: cellData, colDef }) {
 }
 
 function MaterialParser({
-  data: variationsRow, oldValue: cellData, newValue, colDef, context
+  data: row, oldValue: cellData, newValue, colDef, context
 }) {
   const { currentEntry, displayUnit } = colDef.entryDefs;
   let value = convertUnit(parseNumericString(newValue), displayUnit, cellData[currentEntry].unit);
@@ -129,7 +129,7 @@ function MaterialParser({
     return updatedCellData;
   }
 
-  const referenceMaterial = getReferenceMaterial(variationsRow);
+  const referenceMaterial = getReferenceMaterial(row);
 
   // Adapt equivalent to updated mass.
   if ('equivalent' in updatedCellData) {
@@ -147,7 +147,7 @@ function MaterialParser({
 }
 
 function GasParser({
-  data: variationsRow, oldValue: cellData, newValue, colDef
+  data: row, oldValue: cellData, newValue, colDef
 }) {
   const { currentEntry, displayUnit } = colDef.entryDefs;
   let value = convertUnit(parseNumericString(newValue), displayUnit, cellData[currentEntry].unit);
@@ -170,11 +170,11 @@ function GasParser({
       const amount = calculateGasMoles(vesselVolume, concentration, temperatureInKelvin);
       const mass = getGramFromMol(amount, updatedCellData);
 
-      const catalyst = getCatalystMaterial(variationsRow);
+      const catalyst = getCatalystMaterial(row);
       const catalystAmount = catalyst?.amount.value ?? 0;
       const turnoverNumber = calculateTON(amount, catalystAmount);
 
-      const percentYield = computePercentYieldGas(amount, getFeedstockMaterial(variationsRow), vesselVolume);
+      const percentYield = computePercentYieldGas(amount, getFeedstockMaterial(row), vesselVolume);
 
       updatedCellData = {
         ...updatedCellData,
@@ -204,7 +204,7 @@ function GasParser({
 }
 
 function FeedstockParser({
-  data: variationsRow, oldValue: cellData, newValue, colDef
+  data: row, oldValue: cellData, newValue, colDef
 }) {
   const { currentEntry, displayUnit } = colDef.entryDefs;
   let value = convertUnit(parseNumericString(newValue), displayUnit, cellData[currentEntry].unit);
@@ -253,7 +253,7 @@ function FeedstockParser({
     return updatedCellData;
   }
 
-  const referenceMaterial = getReferenceMaterial(variationsRow);
+  const referenceMaterial = getReferenceMaterial(row);
   const equivalent = computeEquivalent(updatedCellData, referenceMaterial);
 
   return { ...updatedCellData, equivalent: { ...updatedCellData.equivalent, value: equivalent } };
@@ -275,7 +275,7 @@ function NoteCellRenderer(props) {
 }
 
 function NoteCellEditor({
-  data: variationsRow,
+  data: row,
   value,
   onValueChange,
   stopEditing,
@@ -296,7 +296,7 @@ function NoteCellEditor({
   const cellContent = (
     <Modal show onHide={onClose}>
       <Modal.Header closeButton>
-        {`Edit note for ${getVariationsRowName(reactionShortLabel, variationsRow.id)}`}
+        {`Edit note for ${getVariationsRowName(reactionShortLabel, row.id)}`}
       </Modal.Header>
       <Modal.Body>
         <Form.Control

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents.js
@@ -515,39 +515,42 @@ MenuHeader.defaultProps = {
   gasType: 'off',
 };
 
-function ColumnConfiguration(selectedMaterialIDs, availableMaterialIDs, onChange, onApply) {
+function ColumnSelection(selectedColumns, availableColumns, onApply) {
   const [showModal, setShowModal] = useState(false);
+  const [currentColumns, setCurrentColumns] = useState(selectedColumns);
 
-  const handleShow = () => setShowModal(true);
   const handleApply = () => {
-    onApply();
+    onApply(currentColumns);
     setShowModal(false);
   };
 
   const handleSelectChange = (key) => (selectedOptions) => {
-    const updatedSelectedMaterialIDs = { ...selectedMaterialIDs };
-    updatedSelectedMaterialIDs[key] = selectedOptions ? selectedOptions.map((option) => option.value) : [];
-    onChange(updatedSelectedMaterialIDs);
+    const updatedCurrentColumns = { ...currentColumns };
+    updatedCurrentColumns[key] = selectedOptions ? selectedOptions.map((option) => option.value) : [];
+    setCurrentColumns(updatedCurrentColumns);
   };
+
+  const splitCamelCase = (str) => str.replace(/([a-z])([A-Z])/g, '$1 $2');
+  const toUpperCase = (str) => str.charAt(0).toUpperCase() + str.slice(1);
 
   return (
     <>
-      <Button size="sm" variant="primary" onClick={handleShow} className="mb-2">
-        Configure Columns
+      <Button size="sm" variant="primary" onClick={() => setShowModal(true)} className="mb-2">
+        Select Columns
       </Button>
 
-      <Modal show={showModal} onHide={handleApply}>
+      <Modal show={showModal} onHide={() => setShowModal(false)}>
         <Modal.Header closeButton>
-          <Modal.Title>Column Configuration</Modal.Title>
+          <Modal.Title>Column Selection</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          {Object.entries(availableMaterialIDs).map(([key, values]) => (
+          {Object.entries(availableColumns).map(([key, values]) => (
             <div key={key}>
-              <h5>{key}</h5>
+              <h5>{toUpperCase(splitCamelCase(key))}</h5>
               <Select
                 isMulti
-                options={values.map((value) => ({ value, label: value }))}
-                value={selectedMaterialIDs[key]?.map((value) => ({ value, label: value })) || []}
+                options={values.map((value) => ({ value, label: toUpperCase(value) }))}
+                value={currentColumns[key]?.map((value) => ({ value, label: toUpperCase(value) })) || []}
                 onChange={handleSelectChange(key)}
               />
             </div>
@@ -576,5 +579,5 @@ export {
   NoteCellEditor,
   MaterialOverlay,
   MenuHeader,
-  ColumnConfiguration,
+  ColumnSelection,
 };

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/display-name */
 import React, { useState, useEffect } from 'react';
+import Select from 'react-select';
 import { AgGridReact } from 'ag-grid-react';
 import {
   Button, ButtonGroup, Modal, Form, OverlayTrigger, Tooltip
@@ -514,6 +515,54 @@ MenuHeader.defaultProps = {
   gasType: 'off',
 };
 
+function ColumnConfiguration(selectedMaterialIDs, availableMaterialIDs, onChange, onApply) {
+  const [showModal, setShowModal] = useState(false);
+
+  const handleShow = () => setShowModal(true);
+  const handleApply = () => {
+    onApply();
+    setShowModal(false);
+  };
+
+  const handleSelectChange = (key) => (selectedOptions) => {
+    const updatedSelectedMaterialIDs = { ...selectedMaterialIDs };
+    updatedSelectedMaterialIDs[key] = selectedOptions ? selectedOptions.map((option) => option.value) : [];
+    onChange(updatedSelectedMaterialIDs);
+  };
+
+  return (
+    <>
+      <Button size="sm" variant="primary" onClick={handleShow} className="mb-2">
+        Configure Columns
+      </Button>
+
+      <Modal show={showModal} onHide={handleApply}>
+        <Modal.Header closeButton>
+          <Modal.Title>Column Configuration</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {Object.entries(availableMaterialIDs).map(([key, values]) => (
+            <div key={key}>
+              <h5>{key}</h5>
+              <Select
+                isMulti
+                options={values.map((value) => ({ value, label: value }))}
+                value={selectedMaterialIDs[key]?.map((value) => ({ value, label: value })) || []}
+                onChange={handleSelectChange(key)}
+              />
+            </div>
+          ))}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={handleApply}>
+            Apply
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}
+
 export {
   RowToolsCellRenderer,
   EquivalentParser,
@@ -527,4 +576,5 @@ export {
   NoteCellEditor,
   MaterialOverlay,
   MenuHeader,
+  ColumnConfiguration,
 };

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.js
@@ -241,12 +241,12 @@ function getMaterialColumnGroupChild(material, materialType, headerComponent, ga
   };
 }
 
-function removeObsoleteMaterialsFromVariations(variations, currentMaterials) {
+function removeObsoleteMaterialsFromVariations(variations, materialIDs) {
   const updatedVariations = cloneDeep(variations);
   updatedVariations.forEach((row) => {
     Object.keys(materialTypes).forEach((materialType) => {
       Object.keys(row[materialType]).forEach((materialName) => {
-        if (!currentMaterials[materialType].map((material) => material.id.toString()).includes(materialName)) {
+        if (!materialIDs[materialType].includes(materialName)) {
           delete row[materialType][materialName];
         }
       });

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.js
@@ -332,7 +332,7 @@ function updateVariationsRowOnReferenceMaterialChange(row, reactionHasPolymers) 
 
 function updateVariationsRowOnCatalystMaterialChange(row) {
   const updatedRow = cloneDeep(row);
-  const catalystMaterialAmount = getCatalystMaterial(updatedRow).amount.value;
+  const catalystMaterialAmount = getCatalystMaterial(updatedRow)?.amount.value;
 
   Object.values(updatedRow.products).forEach((productMaterial) => {
     if (productMaterial.aux.gasType === 'gas') {

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.js
@@ -300,7 +300,7 @@ function updateVariationsGasTypes(variations, currentMaterials, gasMode) {
   return updatedVariations;
 }
 
-function updateColumnDefinitionsMaterialTypes(columnDefinitions, currentMaterials, selectedMaterialIDs, gasMode) {
+function resetColumnDefinitionsMaterials(columnDefinitions, currentMaterials, selectedMaterialIDs, gasMode) {
   let updatedColumnDefinitions = cloneDeep(columnDefinitions);
 
   Object.entries(currentMaterials).forEach(([materialType, materials]) => {
@@ -377,7 +377,7 @@ export {
   getReactionMaterialsIDs,
   getReactionMaterialsGasTypes,
   getMaterialData,
-  updateColumnDefinitionsMaterialTypes,
+  resetColumnDefinitionsMaterials,
   updateVariationsRowOnReferenceMaterialChange,
   updateVariationsRowOnCatalystMaterialChange,
   updateVariationsRowOnFeedstockMaterialChange,

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.js
@@ -202,7 +202,7 @@ function getMaterialData(material, materialType, gasMode = false, vesselVolume =
   return materialData;
 }
 
-function getMaterialColumnGroupChild(material, materialType, headerComponent, gasMode) {
+function getMaterialColumnGroupChild(material, materialType, gasMode) {
   const materialCopy = cloneDeep(material);
 
   let gasType = materialCopy.gas_type ?? 'off';
@@ -233,7 +233,7 @@ function getMaterialColumnGroupChild(material, materialType, headerComponent, ga
     },
     editable: (params) => cellIsEditable(params),
     cellDataType: getCellDataType(entry, gasType),
-    headerComponent,
+    headerComponent: MenuHeader,
     headerComponentParams: {
       names,
       gasType,
@@ -308,7 +308,7 @@ function resetColumnDefinitionsMaterials(columnDefinitions, materials, materialI
       (material) => materialIDs[materialType].includes(material.id.toString())
     );
     const updatedMaterials = selectedMaterials.map(
-      (material) => getMaterialColumnGroupChild(material, materialType, MenuHeader, gasMode)
+      (material) => getMaterialColumnGroupChild(material, materialType, gasMode)
     );
 
     updatedColumnDefinitions = updateColumnDefinitions(

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.js
@@ -243,20 +243,6 @@ function removeObsoleteMaterialsFromVariations(variations, currentMaterials) {
   return updatedVariations;
 }
 
-function addMissingMaterialsToVariations(variations, currentMaterials, gasMode) {
-  const updatedVariations = cloneDeep(variations);
-  updatedVariations.forEach((row) => {
-    Object.keys(materialTypes).forEach((materialType) => {
-      currentMaterials[materialType].forEach((material) => {
-        if (!(material.id in row[materialType])) {
-          row[materialType][material.id] = getMaterialData(material, materialType, gasMode);
-        }
-      });
-    });
-  });
-  return updatedVariations;
-}
-
 function updateVariationsGasTypes(variations, currentMaterials, gasMode) {
   const updatedVariations = cloneDeep(variations);
   updatedVariations.forEach((row) => {
@@ -285,36 +271,6 @@ function updateColumnDefinitionsMaterialTypes(columnDefinitions, currentMaterial
       'children',
       updatedMaterials
     );
-  });
-
-  return updatedColumnDefinitions;
-}
-
-function updateColumnDefinitionsMaterials(columnDefinitions, currentMaterials, headerComponent, gasMode) {
-  const updatedColumnDefinitions = cloneDeep(columnDefinitions);
-
-  Object.entries(currentMaterials).forEach(([materialType, materials]) => {
-    const materialIDs = materials.map((material) => material.id.toString());
-    const materialColumnGroup = updatedColumnDefinitions.find((columnGroup) => columnGroup.groupId === materialType);
-
-    // Remove obsolete materials.
-    materialColumnGroup.children = materialColumnGroup.children.filter((child) => {
-      const childID = child.field.split('.').splice(1).join('.'); // Ensure that IDs that contain "." are handled correctly.
-      return materialIDs.includes(childID);
-    });
-    // Add missing materials.
-    materials.forEach((material) => {
-      if (!materialColumnGroup.children.some((child) => child.field === `${materialType}.${material.id}`)) {
-        materialColumnGroup.children.push(
-          getMaterialColumnGroupChild(
-            material,
-            materialType,
-            headerComponent,
-            gasMode
-          )
-        );
-      }
-    });
   });
 
   return updatedColumnDefinitions;
@@ -375,13 +331,11 @@ export {
   getReactionMaterialsIDs,
   getReactionMaterialsGasTypes,
   getMaterialData,
-  updateColumnDefinitionsMaterials,
   updateColumnDefinitionsMaterialTypes,
   updateVariationsRowOnReferenceMaterialChange,
   updateVariationsRowOnCatalystMaterialChange,
   updateVariationsRowOnFeedstockMaterialChange,
   removeObsoleteMaterialsFromVariations,
-  addMissingMaterialsToVariations,
   updateVariationsGasTypes,
   getReferenceMaterial,
   getCatalystMaterial,

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsReducers.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsReducers.js
@@ -1,29 +1,28 @@
 import {
-  resetColumnDefinitionsMaterials, addMissingMaterialsToColumnDefinitions, removeObsoleteMaterialsFromColumnDefinitions
+  resetColumnDefinitionsMaterials
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
 import {
-  getCellDataType,
-  updateColumnDefinitions
+  getCellDataType, updateColumnDefinitions, addMissingColumnDefinitions, removeObsoleteColumnDefinitions
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
 
 export default function columnDefinitionsReducer(columnDefinitions, action) {
   switch (action.type) {
     case 'remove_obsolete_materials': {
-      return removeObsoleteMaterialsFromColumnDefinitions(
+      return removeObsoleteColumnDefinitions(
         columnDefinitions,
-        action.materialIDs,
+        action.selectedColumns,
       );
     }
-    case 'apply_material_selection': {
-      let updatedColumnDefinitions = addMissingMaterialsToColumnDefinitions(
+    case 'apply_column_selection': {
+      let updatedColumnDefinitions = addMissingColumnDefinitions(
         columnDefinitions,
+        action.selectedColumns,
         action.materials,
-        action.materialIDs,
         action.gasMode
       );
-      updatedColumnDefinitions = removeObsoleteMaterialsFromColumnDefinitions(
+      updatedColumnDefinitions = removeObsoleteColumnDefinitions(
         updatedColumnDefinitions,
-        action.materialIDs
+        action.selectedColumns
       );
       return updatedColumnDefinitions;
     }
@@ -52,7 +51,7 @@ export default function columnDefinitionsReducer(columnDefinitions, action) {
       updatedColumnDefinitions = resetColumnDefinitionsMaterials(
         updatedColumnDefinitions,
         action.materials,
-        action.materialIDs,
+        action.selectedColumns,
         action.gasMode
       );
 
@@ -62,7 +61,7 @@ export default function columnDefinitionsReducer(columnDefinitions, action) {
       return resetColumnDefinitionsMaterials(
         columnDefinitions,
         action.materials,
-        action.materialIDs,
+        action.selectedColumns,
         action.gasMode
       );
     }

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsReducers.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsReducers.js
@@ -1,6 +1,5 @@
-import { MenuHeader } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents';
 import {
-  updateColumnDefinitionsMaterials, updateColumnDefinitionsMaterialTypes
+  updateColumnDefinitionsMaterialTypes
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
 import {
   getCellDataType,
@@ -9,14 +8,6 @@ import {
 
 function columnDefinitionsReducer(columnDefinitions, action) {
   switch (action.type) {
-    case 'update_material_set': {
-      return updateColumnDefinitionsMaterials(
-        columnDefinitions,
-        action.reactionMaterials,
-        MenuHeader,
-        action.gasMode
-      );
-    }
     case 'update_entry_defs': {
       let updatedColumnDefinitions = updateColumnDefinitions(
         columnDefinitions,

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsReducers.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsReducers.js
@@ -2,7 +2,8 @@ import {
   resetColumnDefinitionsMaterials
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
 import {
-  getCellDataType, updateColumnDefinitions, addMissingColumnDefinitions, removeObsoleteColumnDefinitions
+  getCellDataType, updateColumnDefinitions, addMissingColumnDefinitions, removeObsoleteColumnDefinitions,
+  getColumnDefinitions
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
 
 export default function columnDefinitionsReducer(columnDefinitions, action) {
@@ -42,20 +43,11 @@ export default function columnDefinitionsReducer(columnDefinitions, action) {
       return updatedColumnDefinitions;
     }
     case 'toggle_gas_mode': {
-      let updatedColumnDefinitions = updateColumnDefinitions(
-        columnDefinitions,
-        'properties.duration',
-        'editable',
-        !action.gasMode
-      );
-      updatedColumnDefinitions = resetColumnDefinitionsMaterials(
-        updatedColumnDefinitions,
-        action.materials,
+      return getColumnDefinitions(
         action.selectedColumns,
+        action.materials,
         action.gasMode
       );
-
-      return updatedColumnDefinitions;
     }
     case 'update_gas_type': {
       return resetColumnDefinitionsMaterials(

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsReducers.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsReducers.js
@@ -1,18 +1,31 @@
 import {
-  resetColumnDefinitionsMaterials, removeObsoleteMaterialsFromColumnDefinitions
+  resetColumnDefinitionsMaterials, addMissingMaterialsToColumnDefinitions, removeObsoleteMaterialsFromColumnDefinitions
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
 import {
   getCellDataType,
   updateColumnDefinitions
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
 
-function columnDefinitionsReducer(columnDefinitions, action) {
+export default function columnDefinitionsReducer(columnDefinitions, action) {
   switch (action.type) {
     case 'remove_obsolete_materials': {
       return removeObsoleteMaterialsFromColumnDefinitions(
         columnDefinitions,
-        action.reactionMaterialIDs,
+        action.materialIDs,
       );
+    }
+    case 'apply_material_selection': {
+      let updatedColumnDefinitions = addMissingMaterialsToColumnDefinitions(
+        columnDefinitions,
+        action.materials,
+        action.materialIDs,
+        action.gasMode
+      );
+      updatedColumnDefinitions = removeObsoleteMaterialsFromColumnDefinitions(
+        updatedColumnDefinitions,
+        action.materialIDs
+      );
+      return updatedColumnDefinitions;
     }
     case 'update_entry_defs': {
       let updatedColumnDefinitions = updateColumnDefinitions(
@@ -38,8 +51,8 @@ function columnDefinitionsReducer(columnDefinitions, action) {
       );
       updatedColumnDefinitions = resetColumnDefinitionsMaterials(
         updatedColumnDefinitions,
-        action.reactionMaterials,
-        action.selectedReactionMaterialIDs,
+        action.materials,
+        action.materialIDs,
         action.gasMode
       );
 
@@ -48,8 +61,8 @@ function columnDefinitionsReducer(columnDefinitions, action) {
     case 'update_gas_type': {
       return resetColumnDefinitionsMaterials(
         columnDefinitions,
-        action.reactionMaterials,
-        action.selectedReactionMaterialIDs,
+        action.materials,
+        action.materialIDs,
         action.gasMode
       );
     }
@@ -58,7 +71,3 @@ function columnDefinitionsReducer(columnDefinitions, action) {
     }
   }
 }
-
-export {
-  columnDefinitionsReducer
-};

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsReducers.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsReducers.js
@@ -1,5 +1,5 @@
 import {
-  updateColumnDefinitionsMaterialTypes
+  updateColumnDefinitionsMaterialTypes, removeObsoleteMaterialsFromColumnDefinitions
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
 import {
   getCellDataType,
@@ -8,6 +8,12 @@ import {
 
 function columnDefinitionsReducer(columnDefinitions, action) {
   switch (action.type) {
+    case 'remove_obsolete_materials': {
+      return removeObsoleteMaterialsFromColumnDefinitions(
+        columnDefinitions,
+        action.reactionMaterialIDs,
+      );
+    }
     case 'update_entry_defs': {
       let updatedColumnDefinitions = updateColumnDefinitions(
         columnDefinitions,
@@ -33,6 +39,7 @@ function columnDefinitionsReducer(columnDefinitions, action) {
       updatedColumnDefinitions = updateColumnDefinitionsMaterialTypes(
         updatedColumnDefinitions,
         action.reactionMaterials,
+        action.selectedReactionMaterialIDs,
         action.gasMode
       );
 
@@ -42,6 +49,7 @@ function columnDefinitionsReducer(columnDefinitions, action) {
       return updateColumnDefinitionsMaterialTypes(
         columnDefinitions,
         action.reactionMaterials,
+        action.selectedReactionMaterialIDs,
         action.gasMode
       );
     }

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsReducers.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsReducers.js
@@ -1,5 +1,5 @@
 import {
-  updateColumnDefinitionsMaterialTypes, removeObsoleteMaterialsFromColumnDefinitions
+  resetColumnDefinitionsMaterials, removeObsoleteMaterialsFromColumnDefinitions
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
 import {
   getCellDataType,
@@ -36,7 +36,7 @@ function columnDefinitionsReducer(columnDefinitions, action) {
         'editable',
         !action.gasMode
       );
-      updatedColumnDefinitions = updateColumnDefinitionsMaterialTypes(
+      updatedColumnDefinitions = resetColumnDefinitionsMaterials(
         updatedColumnDefinitions,
         action.reactionMaterials,
         action.selectedReactionMaterialIDs,
@@ -46,7 +46,7 @@ function columnDefinitionsReducer(columnDefinitions, action) {
       return updatedColumnDefinitions;
     }
     case 'update_gas_type': {
-      return updateColumnDefinitionsMaterialTypes(
+      return resetColumnDefinitionsMaterials(
         columnDefinitions,
         action.reactionMaterials,
         action.selectedReactionMaterialIDs,

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.js
@@ -168,7 +168,7 @@ function getSequentialId(variations) {
   return (ids.length === 0) ? 1 : Math.max(...ids) + 1;
 }
 
-function createVariationsRow(reaction, variations, gasMode = false, vesselVolume = null) {
+function createVariationsRow(reaction, selectedReactionMaterialIDs, variations, gasMode = false, vesselVolume = null) {
   const reactionCopy = cloneDeep(reaction);
   const { dispValue: durationValue = null, dispUnit: durationUnit = 'None' } = reactionCopy.durationDisplay ?? {};
   const { userText: temperatureValue = null, valueUnit: temperatureUnit = 'None' } = reactionCopy.temperature ?? {};
@@ -189,7 +189,10 @@ function createVariationsRow(reaction, variations, gasMode = false, vesselVolume
   };
   Object.entries(materialTypes).forEach(([materialType, { reactionAttributeName }]) => {
     row[materialType] = reactionCopy[reactionAttributeName].reduce((a, v) => (
-      { ...a, [v.id]: getMaterialData(v, materialType, gasMode, vesselVolume) }), {});
+      selectedReactionMaterialIDs[materialType].includes(v.id)
+        ? { ...a, [v.id]: getMaterialData(v, materialType, gasMode, vesselVolume) }
+        : a
+    ), {});
   });
 
   // Compute dependent values that aren't supplied by initial data.

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.js
@@ -5,7 +5,7 @@ import {
   updateVariationsRowOnReferenceMaterialChange,
   updateVariationsRowOnCatalystMaterialChange,
   updateVariationsRowOnFeedstockMaterialChange,
-  getMaterialData
+  getMaterialData, getReferenceMaterial
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
 
 const REACTION_VARIATIONS_TAB_KEY = 'reactionVariationsTab';
@@ -197,14 +197,17 @@ function createVariationsRow({
   };
   Object.entries(materials).forEach(([materialType, materialsOfType]) => {
     row[materialType] = materialsOfType.reduce((entry, material) => (
-      materialIDs[materialType].includes(material.id)
+      materialIDs[materialType].includes(material.id.toString())
         ? { ...entry, [material.id]: getMaterialData(material, materialType, gasMode, vesselVolume) }
         : entry
     ), {});
   });
 
   // Compute dependent values that aren't supplied by initial data.
-  let updatedRow = updateVariationsRowOnReferenceMaterialChange(row, reactionHasPolymers);
+  let updatedRow = row;
+  if (getReferenceMaterial(row)) {
+    updatedRow = updateVariationsRowOnReferenceMaterialChange(row, reactionHasPolymers);
+  }
   if (gasMode) {
     updatedRow = updateVariationsRowOnCatalystMaterialChange(updatedRow);
     updatedRow = updateVariationsRowOnFeedstockMaterialChange(updatedRow);

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.js
@@ -10,7 +10,7 @@ import {
   AnalysesCellRenderer, AnalysesCellEditor, getAnalysesOverlay, AnalysisOverlay
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses';
 import {
-  NoteCellRenderer, NoteCellEditor, MenuHeader,
+  NoteCellRenderer, NoteCellEditor, MenuHeader, RowToolsCellRenderer
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents';
 
 const REACTION_VARIATIONS_TAB_KEY = 'reactionVariationsTab';
@@ -470,6 +470,44 @@ function updateColumnDefinitions(columnDefinitions, field, property, newValue) {
   return updatedColumnDefinitions;
 }
 
+function getColumnDefinitions(selectedColumns, materials, gasMode) {
+  return [
+    {
+      headerName: 'Tools',
+      cellRenderer: RowToolsCellRenderer,
+      lockPosition: 'left',
+      sortable: false,
+      maxWidth: 100,
+      cellDataType: false,
+    },
+    {
+      headerName: 'Metadata',
+      groupId: 'metadata',
+      marryChildren: true,
+      children: selectedColumns.metadata.map((entry) => getMetadataColumnGroupChild(entry))
+    },
+    {
+      headerName: 'Properties',
+      groupId: 'properties',
+      marryChildren: true,
+      children: selectedColumns.properties.map((entry) => getPropertyColumnGroupChild(entry, gasMode))
+    },
+  ].concat(
+    Object.entries(materialTypes).map(([materialType, { label }]) => ({
+      headerName: label,
+      groupId: materialType,
+      marryChildren: true,
+      children: selectedColumns[materialType].map(
+        (materialID) => getMaterialColumnGroupChild(
+          materials[materialType].find((material) => material.id.toString() === materialID),
+          materialType,
+          gasMode
+        )
+      )
+    }))
+  );
+}
+
 function getVariationsColumns(variations) {
   const variationsRow = variations[0];
   const materialColumns = Object.entries(materialTypes).reduce((materialsByType, [materialType]) => {
@@ -498,6 +536,7 @@ export {
   copyVariationsRow,
   updateVariationsRow,
   updateColumnDefinitions,
+  getColumnDefinitions,
   getCellDataType,
   getUserFacingUnit,
   getStandardValue,

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.js
@@ -168,10 +168,18 @@ function getSequentialId(variations) {
   return (ids.length === 0) ? 1 : Math.max(...ids) + 1;
 }
 
-function createVariationsRow(reaction, selectedReactionMaterialIDs, variations, gasMode = false, vesselVolume = null) {
-  const reactionCopy = cloneDeep(reaction);
-  const { dispValue: durationValue = null, dispUnit: durationUnit = 'None' } = reactionCopy.durationDisplay ?? {};
-  const { userText: temperatureValue = null, valueUnit: temperatureUnit = 'None' } = reactionCopy.temperature ?? {};
+function createVariationsRow({
+  materials,
+  materialIDs,
+  variations,
+  reactionHasPolymers = false,
+  durationValue = null,
+  durationUnit = 'None',
+  temperatureValue = null,
+  temperatureUnit = 'None',
+  gasMode = false,
+  vesselVolume = null
+}) {
   const row = {
     id: getSequentialId(variations),
     properties: {
@@ -187,16 +195,16 @@ function createVariationsRow(reaction, selectedReactionMaterialIDs, variations, 
     analyses: [],
     notes: '',
   };
-  Object.entries(materialTypes).forEach(([materialType, { reactionAttributeName }]) => {
-    row[materialType] = reactionCopy[reactionAttributeName].reduce((a, v) => (
-      selectedReactionMaterialIDs[materialType].includes(v.id)
-        ? { ...a, [v.id]: getMaterialData(v, materialType, gasMode, vesselVolume) }
-        : a
+  Object.entries(materials).forEach(([materialType, materialsOfType]) => {
+    row[materialType] = materialsOfType.reduce((entry, material) => (
+      materialIDs[materialType].includes(material.id)
+        ? { ...entry, [material.id]: getMaterialData(material, materialType, gasMode, vesselVolume) }
+        : entry
     ), {});
   });
 
   // Compute dependent values that aren't supplied by initial data.
-  let updatedRow = updateVariationsRowOnReferenceMaterialChange(row, reactionCopy.has_polymers);
+  let updatedRow = updateVariationsRowOnReferenceMaterialChange(row, reactionHasPolymers);
   if (gasMode) {
     updatedRow = updateVariationsRowOnCatalystMaterialChange(updatedRow);
     updatedRow = updateVariationsRowOnFeedstockMaterialChange(updatedRow);

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.js
@@ -470,13 +470,16 @@ function updateColumnDefinitions(columnDefinitions, field, property, newValue) {
   return updatedColumnDefinitions;
 }
 
-function instantiateSelectedColumns() {
+function getVariationsColumns(variations) {
+  const variationsRow = variations[0];
   const materialColumns = Object.entries(materialTypes).reduce((materialsByType, [materialType]) => {
-    materialsByType[materialType] = [];
+    materialsByType[materialType] = Object.keys(variationsRow ? variationsRow[materialType] : []);
     return materialsByType;
   }, {});
+  const propertyColumns = Object.keys(variationsRow ? variationsRow.properties : {});
+  const metadataColumns = Object.keys(variationsRow ? variationsRow.metadata : {});
 
-  return { ...materialColumns, properties: [], metadata: [] };
+  return { ...materialColumns, properties: propertyColumns, metadata: metadataColumns };
 }
 
 export {
@@ -490,6 +493,7 @@ export {
   convertUnit,
   materialTypes,
   getVariationsRowName,
+  getVariationsColumns,
   createVariationsRow,
   copyVariationsRow,
   updateVariationsRow,
@@ -497,10 +501,11 @@ export {
   getCellDataType,
   getUserFacingUnit,
   getStandardValue,
-  instantiateSelectedColumns,
   addMissingColumnsToVariations,
   removeObsoleteColumnsFromVariations,
   addMissingColumnDefinitions,
   removeObsoleteColumnDefinitions,
+  getMetadataColumnGroupChild,
+  getPropertyColumnGroupChild,
   REACTION_VARIATIONS_TAB_KEY
 };

--- a/db/migrate/20250304140809_add_metadata_to_reaction_variations.rb
+++ b/db/migrate/20250304140809_add_metadata_to_reaction_variations.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class AddMetadataToReactionVariations < ActiveRecord::Migration[6.1]
+  def up
+    Reaction.where.not('variations = ?', '[]').find_each do |reaction|
+      variations = reaction.variations
+      variations.each do |variation|
+        variation['metadata'] ||= {}
+        
+        if variation['notes']
+           variation['metadata']['notes'] = variation.delete('notes')
+        end
+        if variation['analyses']
+           variation['metadata']['analyses'] = variation.delete('analyses')
+        end
+      end
+      reaction.update_column(:variations, variations)
+    end
+  end
+
+  def down
+    Reaction.where.not('variations = ?', '[]').find_each do |reaction|
+      variations = reaction.variations
+      variations.each do |variation|
+        next unless variation['metadata']
+
+        variation['notes'] ||= variation['metadata'].delete('notes') || ''
+        variation['analyses'] ||= variation['metadata'].delete('analyses') || []
+        variation.delete('metadata')
+      end
+      reaction.update_column(:variations, variations)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_02_26_095051) do
+ActiveRecord::Schema.define(version: 2025_03_04_140809) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"

--- a/spec/factories/reactions.rb
+++ b/spec/factories/reactions.rb
@@ -96,8 +96,10 @@ FactoryBot.define do
 
           {
             id: i.to_s,
-            analyses: [],
-            notes: '',
+            metadata: {
+              analyses: [],
+              notes: '',
+            },
             properties: {
               duration: { unit: 'Hour(s)', value: '42' },
               temperature: { unit: '°C', value: '42' },

--- a/spec/javascripts/helper/reactionVariationsHelpers.js
+++ b/spec/javascripts/helper/reactionVariationsHelpers.js
@@ -11,6 +11,11 @@ import {
 async function setUpMaterial() {
   return SampleFactory.build('SampleFactory.water_100g');
 }
+
+function getSelectedColumns(materialIDs) {
+  return { ...materialIDs, properties: ['duration', 'temperature'], metadata: ['analyses', 'notes'] };
+}
+
 async function setUpReaction() {
   const reaction = await ReactionFactory.build('ReactionFactory.water+water=>water+water');
   reaction.starting_materials[0].reference = true;
@@ -24,7 +29,7 @@ async function setUpReaction() {
     variations.push(createVariationsRow(
       {
         materials,
-        materialIDs,
+        selectedColumns: getSelectedColumns(materialIDs),
         variations,
         durationValue: '',
         durationUnit: 'Hour(s)',
@@ -63,7 +68,7 @@ async function setUpGaseousReaction() {
     variations.push(createVariationsRow(
       {
         materials,
-        materialIDs,
+        selectedColumns: getSelectedColumns(materialIDs),
         variations,
         gasMode: true,
         vesselVolume: 10
@@ -93,5 +98,10 @@ function getColumnDefinitionsMaterialIDs(columnDefinitions, materialType) {
 }
 
 export {
-  setUpMaterial, setUpReaction, setUpGaseousReaction, getColumnGroupChild, getColumnDefinitionsMaterialIDs
+  setUpMaterial,
+  setUpReaction,
+  setUpGaseousReaction,
+  getColumnGroupChild,
+  getColumnDefinitionsMaterialIDs,
+  getSelectedColumns
 };

--- a/spec/javascripts/helper/reactionVariationsHelpers.js
+++ b/spec/javascripts/helper/reactionVariationsHelpers.js
@@ -16,11 +16,22 @@ async function setUpReaction() {
   reaction.starting_materials[0].reference = true;
   reaction.reactants = [await setUpMaterial()];
 
-  const materialIDs = getReactionMaterialsIDs(getReactionMaterials(reaction));
+  const materials = getReactionMaterials(reaction);
+  const materialIDs = getReactionMaterialsIDs(materials);
 
   const variations = [];
   for (let id = 0; id < 3; id++) {
-    variations.push(createVariationsRow(reaction, materialIDs, variations));
+    variations.push(createVariationsRow(
+      {
+        materials,
+        materialIDs,
+        variations,
+        durationValue: '',
+        durationUnit: 'Hour(s)',
+        temperatureValue: '',
+        temperatureUnit: '°C',
+      }
+    ));
   }
   reaction.variations = variations;
 
@@ -44,11 +55,20 @@ async function setUpGaseousReaction() {
   reaction.products[0].amount_unit = 'mol';
   reaction.products[0].amount_value = 1;
 
-  const materialIDs = getReactionMaterialsIDs(getReactionMaterials(reaction));
+  const materials = getReactionMaterials(reaction);
+  const materialIDs = getReactionMaterialsIDs(materials);
 
   const variations = [];
   for (let id = 0; id < 3; id++) {
-    variations.push(createVariationsRow(reaction, materialIDs, variations, true, 10));
+    variations.push(createVariationsRow(
+      {
+        materials,
+        materialIDs,
+        variations,
+        gasMode: true,
+        vesselVolume: 10
+      }
+    ));
   }
   reaction.variations = variations;
 

--- a/spec/javascripts/helper/reactionVariationsHelpers.js
+++ b/spec/javascripts/helper/reactionVariationsHelpers.js
@@ -3,6 +3,10 @@ import SampleFactory from 'factories/SampleFactory';
 import {
   createVariationsRow,
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
+import {
+  getReactionMaterials,
+  getReactionMaterialsIDs
+} from '../../../app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
 
 async function setUpMaterial() {
   return SampleFactory.build('SampleFactory.water_100g');
@@ -12,9 +16,11 @@ async function setUpReaction() {
   reaction.starting_materials[0].reference = true;
   reaction.reactants = [await setUpMaterial()];
 
+  const materialIDs = getReactionMaterialsIDs(getReactionMaterials(reaction));
+
   const variations = [];
   for (let id = 0; id < 3; id++) {
-    variations.push(createVariationsRow(reaction, variations));
+    variations.push(createVariationsRow(reaction, materialIDs, variations));
   }
   reaction.variations = variations;
 
@@ -38,9 +44,11 @@ async function setUpGaseousReaction() {
   reaction.products[0].amount_unit = 'mol';
   reaction.products[0].amount_value = 1;
 
+  const materialIDs = getReactionMaterialsIDs(getReactionMaterials(reaction));
+
   const variations = [];
   for (let id = 0; id < 3; id++) {
-    variations.push(createVariationsRow(reaction, variations, true, 10));
+    variations.push(createVariationsRow(reaction, materialIDs, variations, true, 10));
   }
   reaction.variations = variations;
 

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses.spec.js
@@ -28,30 +28,30 @@ describe('ReactionVariationsAnalyses', async () => {
     });
     it('when no update is necessary', async () => {
       let { variations } = reaction;
-      variations[0].analyses = [analysisFoo.id];
-      variations[1].analyses = [analysisBar.id];
+      variations[0].metadata.analyses = [analysisFoo.id];
+      variations[1].metadata.analyses = [analysisBar.id];
       expect(updateAnalyses(variations, getReactionAnalyses(reaction))).toEqual(variations);
     });
     it('when analysis is removed', async () => {
       let { variations } = reaction;
-      variations[0].analyses = [analysisFoo.id];
-      expect(updateAnalyses(variations, getReactionAnalyses(reaction))[0].analyses).toEqual([analysisFoo.id]);
+      variations[0].metadata.analyses = [analysisFoo.id];
+      expect(updateAnalyses(variations, getReactionAnalyses(reaction))[0].metadata.analyses).toEqual([analysisFoo.id]);
       reaction.container.children[0].children = reaction.container.children[0].children.filter((child) => child.id !== analysisFoo.id);
-      expect(updateAnalyses(variations, getReactionAnalyses(reaction))[0].analyses).toEqual([]);
+      expect(updateAnalyses(variations, getReactionAnalyses(reaction))[0].metadata.analyses).toEqual([]);
     });
     it('when analysis is marked as deleted', async () => {
       let { variations } = reaction;
-      variations[1].analyses = [analysisBar.id];
-      expect(updateAnalyses(variations, getReactionAnalyses(reaction))[1].analyses).toEqual([analysisBar.id]);
+      variations[1].metadata.analyses = [analysisBar.id];
+      expect(updateAnalyses(variations, getReactionAnalyses(reaction))[1].metadata.analyses).toEqual([analysisBar.id]);
       analysisBar.is_deleted = true;
-      expect(updateAnalyses(variations, getReactionAnalyses(reaction))[1].analyses).toEqual([]);
+      expect(updateAnalyses(variations, getReactionAnalyses(reaction))[1].metadata.analyses).toEqual([]);
     });
     it('when analysis is new', async () => {
       let { variations } = reaction;
-      variations[1].analyses = [analysisBar.id];
-      expect(updateAnalyses(variations, getReactionAnalyses(reaction))[1].analyses).toEqual([analysisBar.id]);
+      variations[1].metadata.analyses = [analysisBar.id];
+      expect(updateAnalyses(variations, getReactionAnalyses(reaction))[1].metadata.analyses).toEqual([analysisBar.id]);
       analysisBar.is_new = true;
-      expect(updateAnalyses(variations, getReactionAnalyses(reaction))[1].analyses).toEqual([]);
+      expect(updateAnalyses(variations, getReactionAnalyses(reaction))[1].metadata.analyses).toEqual([]);
     });
   });
 });

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.spec.js
@@ -36,7 +36,7 @@ describe('ReactionVariationsMaterials', () => {
     const reactionMaterials = getReactionMaterials(reaction);
     const columnDefinitions = Object.entries(reactionMaterials).map(([materialType, materials]) => ({
       groupId: materialType,
-      children: materials.map((material) => getMaterialColumnGroupChild(material, materialType, null, false))
+      children: materials.map((material) => getMaterialColumnGroupChild(material, materialType, false))
     }));
 
     const startingMaterialIDs = reactionMaterials.startingMaterials.map((material) => material.id);
@@ -136,7 +136,7 @@ describe('ReactionVariationsMaterials', () => {
     const reactionMaterials = getReactionMaterials(reaction);
     const columnDefinitions = Object.entries(reactionMaterials).map(([materialType, materials]) => ({
       groupId: materialType,
-      children: materials.map((material) => getMaterialColumnGroupChild(material, materialType, null, false))
+      children: materials.map((material) => getMaterialColumnGroupChild(material, materialType, false))
     }));
 
     Object.keys(materialTypes).forEach((materialType) => {

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.spec.js
@@ -1,8 +1,7 @@
 import expect from 'expect';
 import {
   getReactionMaterials, updateVariationsRowOnReferenceMaterialChange,
-  removeObsoleteMaterialsFromVariations, addMissingMaterialsToVariations,
-  updateColumnDefinitionsMaterials, updateVariationsRowOnCatalystMaterialChange,
+  removeObsoleteMaterialsFromVariations, updateVariationsRowOnCatalystMaterialChange,
   getMaterialColumnGroupChild, getReactionMaterialsIDs, updateColumnDefinitionsMaterialTypes,
   getReactionMaterialsGasTypes, updateVariationsGasTypes, cellIsEditable
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
@@ -30,23 +29,6 @@ describe('ReactionVariationsMaterials', () => {
     updatedVariations
       .forEach((variation) => {
         expect(Object.keys(variation.products)).toEqual(updatedProductIDs);
-      });
-  });
-  it('adds missing materials', async () => {
-    const reaction = await setUpReaction();
-    const material = await setUpMaterial();
-    const startingMaterialIDs = reaction.starting_materials.map((startingMaterial) => startingMaterial.id);
-    reaction.variations.forEach((variation) => {
-      expect(Object.keys(variation.startingMaterials)).toEqual(startingMaterialIDs);
-    });
-
-    reaction.starting_materials.push(material);
-    const updatedStartingMaterialIDs = reaction.starting_materials.map((startingMaterial) => startingMaterial.id);
-    const currentMaterials = getReactionMaterials(reaction);
-    const updatedVariations = addMissingMaterialsToVariations(reaction.variations, currentMaterials, false);
-    updatedVariations
-      .forEach((variation) => {
-        expect(Object.keys(variation.startingMaterials)).toEqual(updatedStartingMaterialIDs);
       });
   });
   it('updates yield when product mass changes', async () => {
@@ -87,25 +69,6 @@ describe('ReactionVariationsMaterials', () => {
       oldValue: reactant,
       newValue: Number(-42).toString()
     }).mass.value).toBe(0);
-  });
-  it('removes obsolete materials from column definitions', async () => {
-    const reaction = await setUpReaction();
-    const reactionMaterials = getReactionMaterials(reaction);
-    const columnDefinitions = Object.entries(reactionMaterials).map(([materialType, materials]) => ({
-      groupId: materialType,
-      children: materials.map((material) => getMaterialColumnGroupChild(material, materialType, null, false))
-    }));
-
-    const startingMaterialIDs = reactionMaterials.startingMaterials.map((material) => material.id);
-    expect(getColumnDefinitionsMaterialIDs(columnDefinitions, 'startingMaterials')).toEqual(startingMaterialIDs);
-
-    reactionMaterials.startingMaterials.pop();
-    const updatedStartingMaterialIDs = reactionMaterials.startingMaterials.map((material) => material.id);
-    const updatedColumnDefinitions = updateColumnDefinitionsMaterials(columnDefinitions, reactionMaterials, null, false);
-    expect(getColumnDefinitionsMaterialIDs(
-      updatedColumnDefinitions,
-      'startingMaterials'
-    )).toEqual(updatedStartingMaterialIDs);
   });
   it('retrieves reaction material IDs', async () => {
     const reaction = await setUpReaction();

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.spec.js
@@ -24,8 +24,8 @@ describe('ReactionVariationsMaterials', () => {
 
     reaction.products.pop();
     const updatedProductIDs = reaction.products.map((product) => product.id);
-    const currentMaterials = getReactionMaterials(reaction);
-    const updatedVariations = removeObsoleteMaterialsFromVariations(reaction.variations, currentMaterials);
+    const materialIDs = getReactionMaterialsIDs(getReactionMaterials(reaction));
+    const updatedVariations = removeObsoleteMaterialsFromVariations(reaction.variations, materialIDs);
     updatedVariations
       .forEach((variation) => {
         expect(Object.keys(variation.products)).toEqual(updatedProductIDs);

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.spec.js
@@ -3,7 +3,7 @@ import {
   getReactionMaterials, updateVariationsRowOnReferenceMaterialChange,
   removeObsoleteMaterialsFromVariations, removeObsoleteMaterialsFromColumnDefinitions,
   updateVariationsRowOnCatalystMaterialChange, getMaterialColumnGroupChild, getReactionMaterialsIDs,
-  updateColumnDefinitionsMaterialTypes, getReactionMaterialsGasTypes, updateVariationsGasTypes, cellIsEditable
+  resetColumnDefinitionsMaterials, getReactionMaterialsGasTypes, updateVariationsGasTypes, cellIsEditable
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
 import {
   EquivalentParser
@@ -157,7 +157,7 @@ describe('ReactionVariationsMaterials', () => {
       });
     });
 
-    const updatedColumnDefinitions = updateColumnDefinitionsMaterialTypes(
+    const updatedColumnDefinitions = resetColumnDefinitionsMaterials(
       columnDefinitions,
       reactionMaterials,
       getReactionMaterialsIDs(reactionMaterials),

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.spec.js
@@ -1,11 +1,18 @@
 import expect from 'expect';
 import {
-  convertUnit, createVariationsRow, copyVariationsRow, updateVariationsRow, updateColumnDefinitions
+  convertUnit, createVariationsRow, copyVariationsRow, updateVariationsRow, updateColumnDefinitions,
+  removeObsoleteColumnsFromVariations, removeObsoleteColumnDefinitions, addMissingColumnDefinitions,
+  addMissingColumnsToVariations
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
 import {
   getReactionMaterials, getMaterialColumnGroupChild, getReactionMaterialsIDs
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
-import { setUpReaction, getColumnGroupChild } from 'helper/reactionVariationsHelpers';
+import {
+  setUpReaction,
+  getColumnGroupChild,
+  getSelectedColumns,
+  getColumnDefinitionsMaterialIDs
+} from 'helper/reactionVariationsHelpers';
 
 describe('ReactionVariationsUtils', () => {
   it('converts units', () => {
@@ -30,7 +37,7 @@ describe('ReactionVariationsUtils', () => {
     const row = createVariationsRow(
       {
         materials,
-        materialIDs,
+        selectedColumns: getSelectedColumns(materialIDs),
         variations: reaction.variations,
         durationValue: '',
         durationUnit: 'Hour(s)',
@@ -46,8 +53,8 @@ describe('ReactionVariationsUtils', () => {
     );
     const reactant = Object.values(row.reactants)[0];
     expect(row.id).toBe(4);
-    expect(row.analyses).toEqual([]);
-    expect(row.notes).toEqual('');
+    expect(row.metadata.analyses).toEqual([]);
+    expect(row.metadata.notes).toEqual('');
     expect(row.properties).toEqual({
       temperature: { value: '', unit: '°C' },
       duration: { value: NaN, unit: 'Second(s)' },
@@ -56,15 +63,98 @@ describe('ReactionVariationsUtils', () => {
     expect(nonReferenceStartingMaterial.equivalent.value).toBe(1);
     expect(reactant.equivalent.value).toBe(1);
   });
+  it('adds missing columns to variations', async () => {
+    const reaction = await setUpReaction();
+    const { variations } = reaction;
+
+    let updatedVariations = removeObsoleteColumnsFromVariations(variations, { properties: [], metadata: [] });
+
+    updatedVariations = addMissingColumnsToVariations({
+      materials: {},
+      selectedColumns: { properties: ['temperature', 'duration'], metadata: ['notes', 'analyses'] },
+      variations: updatedVariations,
+      durationValue: 42,
+      durationUnit: 'Second(s)',
+      temperatureValue: 42,
+      temperatureUnit: '°C',
+    });
+
+    expect(updatedVariations[0].properties.duration.value).toBe(42);
+    expect(updatedVariations[0].properties.temperature.value).toBe(42);
+    expect(updatedVariations[0].metadata.notes).toBe('');
+    expect(Array.isArray(updatedVariations[0].metadata.analyses));
+    expect(updatedVariations[0].metadata.analyses.length === 0);
+  });
+  it('removes obsolete materials from variations', async () => {
+    const reaction = await setUpReaction();
+    const productIDs = reaction.products.map((product) => product.id);
+    reaction.variations.forEach((variation) => {
+      expect(Object.keys(variation.products)).toEqual(productIDs);
+    });
+
+    reaction.products.pop();
+    const updatedProductIDs = reaction.products.map((product) => product.id);
+    const materialIDs = getReactionMaterialsIDs(getReactionMaterials(reaction));
+    const updatedVariations = removeObsoleteColumnsFromVariations(reaction.variations, materialIDs);
+    updatedVariations
+      .forEach((variation) => {
+        expect(Object.keys(variation.products)).toEqual(updatedProductIDs);
+      });
+  });
+  it('adds missing column definitions', async () => {
+    const columnDefinitions = [
+      {
+        groupId: 'metadata',
+        children: []
+      },
+      {
+        groupId: 'properties',
+        children: []
+      },
+    ];
+
+    const columns = { properties: ['temperature', 'duration'], metadata: ['notes', 'analyses'] };
+    const updatedColumnDefinitions = addMissingColumnDefinitions(columnDefinitions, columns, {}, false);
+
+    const metadataChildren = updatedColumnDefinitions.find((entry) => entry.groupId === 'metadata').children;
+    expect(metadataChildren.some((child) => child.field === 'metadata.analyses'));
+    expect(metadataChildren.some((child) => child.field === 'metadata.notes'));
+
+    const propertiesChildren = updatedColumnDefinitions.find((entry) => entry.groupId === 'properties').children;
+    expect(propertiesChildren.some((child) => child.field === 'properties.temperature'));
+    expect(propertiesChildren.some((child) => child.field === 'properties.duration'));
+  });
+  it('removes obsolete materials from column definitions', async () => {
+    const reaction = await setUpReaction();
+    const reactionMaterials = getReactionMaterials(reaction);
+    const columnDefinitions = Object.entries(reactionMaterials).map(([materialType, materials]) => ({
+      groupId: materialType,
+      children: materials.map((material) => getMaterialColumnGroupChild(material, materialType, false))
+    }));
+
+    const startingMaterialIDs = reactionMaterials.startingMaterials.map((material) => material.id);
+    expect(getColumnDefinitionsMaterialIDs(columnDefinitions, 'startingMaterials')).toEqual(startingMaterialIDs);
+
+    reactionMaterials.startingMaterials.pop();
+    const updatedStartingMaterialIDs = reactionMaterials.startingMaterials.map((material) => material.id);
+    const updatedColumnDefinitions = removeObsoleteColumnDefinitions(
+      columnDefinitions,
+      getReactionMaterialsIDs(reactionMaterials)
+    );
+    expect(getColumnDefinitionsMaterialIDs(
+      updatedColumnDefinitions,
+      'startingMaterials'
+    )).toEqual(updatedStartingMaterialIDs);
+  });
   it('copies a row in the variations table', async () => {
     const reaction = await setUpReaction();
     const row = reaction.variations[0];
-    row.analyses = [42];
-    row.notes = 'foo bar baz';
+    row.metadata.analyses = [42];
+    row.metadata.notes = 'foo bar baz';
     const copiedRow = copyVariationsRow(row, reaction.variations);
     expect(copiedRow.id).toBeGreaterThan(row.id);
-    expect(copiedRow.analyses).toEqual([]);
-    expect(copiedRow.notes).toEqual('');
+    expect(copiedRow.metadata.analyses).toEqual([]);
+    expect(copiedRow.metadata.notes).toEqual('');
   });
   it('updates a row in the variations table', async () => {
     const reaction = await setUpReaction();

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.spec.js
@@ -94,7 +94,7 @@ describe('ReactionVariationsUtils', () => {
     const field = `startingMaterials.${reactionMaterials.startingMaterials[0].id}`;
     const columnDefinitions = Object.entries(reactionMaterials).map(([materialType, materials]) => ({
       groupId: materialType,
-      children: materials.map((material) => getMaterialColumnGroupChild(material, materialType, null, false))
+      children: materials.map((material) => getMaterialColumnGroupChild(material, materialType, false))
     }));
     expect(getColumnGroupChild(columnDefinitions, 'startingMaterials', field).cellDataType).toBe('material');
     const updatedColumnDefinitions = updateColumnDefinitions(

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.spec.js
@@ -2,7 +2,7 @@ import expect from 'expect';
 import {
   convertUnit, createVariationsRow, copyVariationsRow, updateVariationsRow, updateColumnDefinitions,
   removeObsoleteColumnsFromVariations, removeObsoleteColumnDefinitions, addMissingColumnDefinitions,
-  addMissingColumnsToVariations
+  addMissingColumnsToVariations, getVariationsColumns
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
 import {
   getReactionMaterials, getMaterialColumnGroupChild, getReactionMaterialsIDs
@@ -194,5 +194,19 @@ describe('ReactionVariationsUtils', () => {
       'equivalent'
     );
     expect(getColumnGroupChild(updatedColumnDefinitions, 'startingMaterials', field).cellDataType).toBe('equivalent');
+  });
+  it('gets column names from variations table', async () => {
+    const reaction = await setUpReaction();
+    const reactionMaterialsIDs = getReactionMaterialsIDs(getReactionMaterials(reaction));
+    const variationsColumns = getVariationsColumns(reaction.variations);
+
+    expect(variationsColumns.startingMaterials).toEqual(reactionMaterialsIDs.startingMaterials);
+    expect(variationsColumns.properties).toEqual(expect.arrayContaining(['duration', 'temperature']));
+    expect(variationsColumns.metadata).toEqual(expect.arrayContaining(['notes', 'analyses']));
+
+    const emptyVariationsColumns = getVariationsColumns([]);
+    expect(emptyVariationsColumns.startingMaterials).toEqual([]);
+    expect(emptyVariationsColumns.properties).toEqual([]);
+    expect(emptyVariationsColumns.metadata).toEqual([]);
   });
 });

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.spec.js
@@ -23,10 +23,21 @@ describe('ReactionVariationsUtils', () => {
 
     expect(Object.keys(reaction.variations[0].products).length).toBe(2);
 
-    const materialIDs = getReactionMaterialsIDs(getReactionMaterials(reaction));
+    const materials = getReactionMaterials(reaction);
+    const materialIDs = getReactionMaterialsIDs(materials);
     materialIDs.products.pop();
 
-    const row = createVariationsRow(reaction, materialIDs, reaction.variations);
+    const row = createVariationsRow(
+      {
+        materials,
+        materialIDs,
+        variations: reaction.variations,
+        durationValue: '',
+        durationUnit: 'Hour(s)',
+        temperatureValue: '',
+        temperatureUnit: '°C'
+      }
+    );
 
     expect(Object.keys(row.products).length).toBe(1);
 

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.spec.js
@@ -3,7 +3,7 @@ import {
   convertUnit, createVariationsRow, copyVariationsRow, updateVariationsRow, updateColumnDefinitions
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
 import {
-  getReactionMaterials, getMaterialColumnGroupChild
+  getReactionMaterials, getMaterialColumnGroupChild, getReactionMaterialsIDs
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
 import { setUpReaction, getColumnGroupChild } from 'helper/reactionVariationsHelpers';
 
@@ -18,9 +18,18 @@ describe('ReactionVariationsUtils', () => {
     expect(convertUnit(1, 'Second(s)', 'Minute(s)')).toBeCloseTo(0.0167, 0.00001);
     expect(convertUnit(1, 'Minute(s)', 'Second(s)')).toBe(60);
   });
-  it('creates a row in the variations table', async () => {
+  it('creates a row in the variations table with selected materials', async () => {
     const reaction = await setUpReaction();
-    const row = createVariationsRow(reaction, reaction.variations);
+
+    expect(Object.keys(reaction.variations[0].products).length).toBe(2);
+
+    const materialIDs = getReactionMaterialsIDs(getReactionMaterials(reaction));
+    materialIDs.products.pop();
+
+    const row = createVariationsRow(reaction, materialIDs, reaction.variations);
+
+    expect(Object.keys(row.products).length).toBe(1);
+
     const nonReferenceStartingMaterial = Object.values(row.startingMaterials).find(
       (material) => !material.aux.isReference
     );
@@ -32,7 +41,7 @@ describe('ReactionVariationsUtils', () => {
       temperature: { value: '', unit: '°C' },
       duration: { value: NaN, unit: 'Second(s)' },
     });
-    expect(Object.values(row.products).map((product) => product.yield.value)).toEqual([100, 100]);
+    expect(Object.values(row.products).map((product) => product.yield.value)).toEqual([100]);
     expect(nonReferenceStartingMaterial.equivalent.value).toBe(1);
     expect(reactant.equivalent.value).toBe(1);
   });


### PR DESCRIPTION
This PR addresses #2296.

Columns can be selected via the blue "Select columns" button

![button](https://github.com/user-attachments/assets/38f8d536-41a6-4bc3-ac3c-e721f35e2a9f)

which opens a modal for column selection.

![modal](https://github.com/user-attachments/assets/6949b40e-4684-4480-9723-5b83b2ae0ab1)

Note that the column selection gets reset once the reaction details tab is re-mounted.
This will be fixed with an upcoming PR, which aims to persist the table layout (addressing #2363).

The corresponding documentation is over at https://www.chemotion.net/docs/eln/ui/details#variations-tab.