### PR TITLE
feat: inventory label reset

### DIFF
--- a/app/api/chemotion/inventory_api.rb
+++ b/app/api/chemotion/inventory_api.rb
@@ -13,10 +13,6 @@ module Chemotion
         end
         put do
           collection_ids = params[:collection_ids]
-          unless params[:prefix].present? && params[:name].present? &&
-                 params[:counter].present? && collection_ids.present?
-            error!({ error: 'Missing required parameters' }, 400)
-          end
           begin
             Inventory.create_or_update_inventory_label(
               params[:prefix],

--- a/app/javascript/src/apps/mydb/collections/CollectionSubtree.js
+++ b/app/javascript/src/apps/mydb/collections/CollectionSubtree.js
@@ -155,7 +155,7 @@ export default class CollectionSubtree extends React.Component {
           {root.inventory_prefix && (
             <OverlayTrigger
               placement="top"
-              overlay={<Tooltip id="collection_inventory_label">Inventory Label</Tooltip>}
+              overlay={<Tooltip id="collection_inventory_label">Prefix of Inventory Label</Tooltip>}
             >
               <Badge bg="secondary">{root.inventory_prefix}</Badge>
             </OverlayTrigger>

--- a/app/javascript/src/apps/settings/InventoryLabelSettings.js
+++ b/app/javascript/src/apps/settings/InventoryLabelSettings.js
@@ -99,9 +99,19 @@ function InventoryLabelSettings() {
   const updateInventoryLabelsArray = (collectionIds, updatedCollectionInventories) => {
     if (!updatedCollectionInventories?.inventory_collections) return;
 
-    setInventoryLabels(updatedCollectionInventories.inventory_collections);
-    const optionsArray = assignOptions(updatedCollectionInventories.inventory_collections);
+    const updatedInventories = updatedCollectionInventories.inventory_collections;
+    setInventoryLabels(updatedInventories);
+    const optionsArray = assignOptions(updatedInventories);
     setOptions(optionsArray);
+
+    // Keep only the valid collection IDs in the selection
+    const validCollectionIds = collectionIds.filter((id) => optionsArray.some((group) => {
+      if (group.children) {
+        return group.children.some((child) => child.value === id);
+      }
+      return group.value === id;
+    }));
+    setSelectedValue(validCollectionIds);
   };
 
   const findCollectionIds = (selectedOptions) => {
@@ -218,11 +228,6 @@ function InventoryLabelSettings() {
   const handleResetInventoryLabel = () => {
     setResetSpinner(true);
     const collectionIds = collectCollectionIds(selectedCollections);
-    if (collectionIds.length === 0) {
-      setErrorMessage('Please select collection(s) to reset');
-      setResetSpinner(false);
-      return;
-    }
 
     InventoryFetcher.updateInventoryLabel({
       prefix: null,
@@ -235,7 +240,7 @@ function InventoryLabelSettings() {
       } else {
         setPrefixValue('');
         setNameValue('');
-        setCounterValue(0);
+        setCounterValue('');
         setSelectedValue([]);
         updateInventoryLabelsArray(collectionIds, result, true);
       }
@@ -247,7 +252,14 @@ function InventoryLabelSettings() {
   };
 
   const handleResetConfirmation = () => {
-    setShowResetConfirmation(true);
+    const collectionIds = collectCollectionIds(selectedCollections);
+
+    if (collectionIds.length === 0) {
+      setErrorMessage('Please select collection(s) to reset');
+      setResetSpinner(false);
+    } else {
+      setShowResetConfirmation(true);
+    }
   };
 
   const handleResetCancel = () => {
@@ -306,7 +318,7 @@ function InventoryLabelSettings() {
         </Row>
         <Row className="mb-3">
           <Col xs={{ offset: 3 }}>
-            <b>Next sample inventory label will be:</b>
+            <b>Next sample inventory label will be: </b>
             {nextInventoryLabel}
           </Col>
         </Row>

--- a/app/javascript/src/apps/settings/InventoryLabelSettings.js
+++ b/app/javascript/src/apps/settings/InventoryLabelSettings.js
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import TreeSelect from 'antd/lib/tree-select';
 import {
-  Alert, Button, Card, Row, Col, Form
+  Alert, Button, Card, Row, Col, Form, Modal, OverlayTrigger, Tooltip
 } from 'react-bootstrap';
 import InventoryFetcher from 'src/fetchers/InventoryFetcher';
 import { find } from 'lodash';
@@ -18,6 +18,7 @@ function InventoryLabelSettings() {
   const [updateSpinner, setUpdateSpinner] = useState(false);
   const [resetSpinner, setResetSpinner] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
+  const [showResetConfirmation, setShowResetConfirmation] = useState(false);
 
   const assignOptions = (inventoryCollections) => {
     const assignedOptions = [];
@@ -245,6 +246,19 @@ function InventoryLabelSettings() {
     });
   };
 
+  const handleResetConfirmation = () => {
+    setShowResetConfirmation(true);
+  };
+
+  const handleResetCancel = () => {
+    setShowResetConfirmation(false);
+  };
+
+  const handleResetConfirm = () => {
+    setShowResetConfirmation(false);
+    handleResetInventoryLabel();
+  };
+
   return (
     <Card>
       <Card.Header>Sample Inventory Label</Card.Header>
@@ -298,33 +312,42 @@ function InventoryLabelSettings() {
         </Row>
         <Row>
           <Col xs={12} className="d-flex justify-content-end pe-5">
-            <div className="d-flex gap-2" style={{ width: '450px' }}>
+            <div className="d-flex gap-2" style={{ width: '600px' }}>
               <Button
                 variant="primary"
                 onClick={() => { updateUserSettings(); }}
-                style={{ width: '155px' }}
+                style={{ width: '180px' }}
                 disabled={resetSpinner}
               >
                 {updateSpinner
                   ? (
                     <i className="fa fa-spinner fa-pulse" aria-hidden="true" />
                   ) : (
-                    'Update user settings'
+                    'Update Inventory Label'
                   )}
               </Button>
-              <Button
-                variant="secondary"
-                onClick={() => { handleResetInventoryLabel(); }}
-                style={{ minWidth: '155px' }}
-                disabled={updateSpinner}
+              <OverlayTrigger
+                placement="top"
+                overlay={(
+                  <Tooltip>
+                    Reset the inventory label settings (prefix, name, counter) for selected collections
+                  </Tooltip>
+                )}
               >
-                {resetSpinner
-                  ? (
-                    <i className="fa fa-spinner fa-pulse" aria-hidden="true" />
-                  ) : (
-                    'Reset inventory label'
-                  )}
-              </Button>
+                <Button
+                  variant="danger"
+                  onClick={handleResetConfirmation}
+                  style={{ minWidth: '180px' }}
+                  disabled={updateSpinner}
+                >
+                  {resetSpinner
+                    ? (
+                      <i className="fa fa-spinner fa-pulse" aria-hidden="true" />
+                    ) : (
+                      'Reset inventory label'
+                    )}
+                </Button>
+              </OverlayTrigger>
             </div>
           </Col>
         </Row>
@@ -338,6 +361,24 @@ function InventoryLabelSettings() {
           </Row>
         )}
       </Card.Body>
+
+      <Modal show={showResetConfirmation} onHide={handleResetCancel}>
+        <Modal.Header closeButton>
+          <Modal.Title>Confirm Reset</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          You are about to delete the inventory label for selected collection(s).
+          Are you sure you want to delete the assigned prefix, name and counter?
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={handleResetCancel}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={handleResetConfirm}>
+            Yes, Reset
+          </Button>
+        </Modal.Footer>
+      </Modal>
     </Card>
   );
 }

--- a/db/migrate/20240319000000_allow_nullable_inventory_fields.rb
+++ b/db/migrate/20240319000000_allow_nullable_inventory_fields.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AllowNullableInventoryFields < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :inventories, :prefix, true
+    change_column_null :inventories, :name, true
+  end
+end 

--- a/db/migrate/20240319000000_allow_nullable_inventory_fields.rb
+++ b/db/migrate/20240319000000_allow_nullable_inventory_fields.rb
@@ -5,4 +5,4 @@ class AllowNullableInventoryFields < ActiveRecord::Migration[6.1]
     change_column_null :inventories, :prefix, true
     change_column_null :inventories, :name, true
   end
-end 
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -708,8 +708,8 @@ ActiveRecord::Schema.define(version: 2025_02_18_161800) do
   end
 
   create_table "inventories", force: :cascade do |t|
-    t.string "prefix", null: false
-    t.string "name", null: false
+    t.string "prefix"
+    t.string "name"
     t.integer "counter", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
- Allow resetting inventory labels
- Handle null values appropriately
- Update UI to reflect reset state

refactor: Improve collection selection handling
- Fix group selection behavior
- Clean up selection logic



- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
