### PR TITLE
style(js): absolut path in test

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "expect": "^24.7.1",
     "jsdom-global": "^3.0.2",
     "mocha": "^11",
+    "module-alias": "^2.2.3",
     "nyc": "^15.1.0",
     "process": "^0.11.10",
     "react-refresh": "^0.12.0",
@@ -172,5 +173,9 @@
   },
   "packageManager": "yarn@1.22.22",
   "private": true,
-  "version": "0.1.0"
+  "_moduleAliases": {
+    "@src": "./app/javascript/src",
+    "@tests": "./spec/javascripts"
+  },
+  "version": "2.0.0-rc1"
 }

--- a/spec/javascripts/actions/ReportActions.spec.js
+++ b/spec/javascripts/actions/ReportActions.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import expect from 'expect'
-import ReportActions from '../../../app/javascript/src/stores/alt/actions/ReportActions'
+import ReportActions from '@src/stores/alt/actions/ReportActions'
 Object.assign = require('object-assign')
 
 describe('ReportActions', () => {

--- a/spec/javascripts/common/common.spec.js
+++ b/spec/javascripts/common/common.spec.js
@@ -3,7 +3,7 @@ import expect from 'expect';
 import { configure, shallow } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
-import SpinnerPencilIcon from '../../../app/javascript/src/components/common/SpinnerPencilIcon';
+import SpinnerPencilIcon from '@src/components/common/SpinnerPencilIcon';
 
 configure({ adapter: new Adapter() });
 

--- a/spec/javascripts/factories/AttachmentFactory.js
+++ b/spec/javascripts/factories/AttachmentFactory.js
@@ -1,6 +1,6 @@
 import { factory } from '@eflexsystems/factory-bot';
-import Attachment from 'src/models/Attachment';
-import Element from 'src/models/Element';
+import Attachment from '@src/models/Attachment';
+import Element from '@src/models/Element';
 
 export default class AttachmentFactory {
   static instance = undefined;

--- a/spec/javascripts/factories/AttachmentNotificationFactory.js
+++ b/spec/javascripts/factories/AttachmentNotificationFactory.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-unresolved,no-underscore-dangle */
 import { factory } from '@eflexsystems/factory-bot';
-import AttachmentFactory from 'factories/AttachmentFactory';
-import AttachmentNotification from 'factories/models/AttachmentNotification';
+import AttachmentFactory from '@tests/factories/AttachmentFactory';
+import AttachmentNotification from '@tests/factories/models/AttachmentNotification';
 
 export default class AttachmentNotificationFactory {
   static instance = undefined;

--- a/spec/javascripts/factories/CellLineFactory.js
+++ b/spec/javascripts/factories/CellLineFactory.js
@@ -1,5 +1,5 @@
 import { factory } from '@eflexsystems/factory-bot';
-import CellLine from 'src/models/cellLine/CellLine';
+import CellLine from '@src/models/cellLine/CellLine';
 
 export default class CellLineFactory {
   static instance = undefined;

--- a/spec/javascripts/factories/ChemicalFactory.js
+++ b/spec/javascripts/factories/ChemicalFactory.js
@@ -1,4 +1,4 @@
-import Chemical from 'src/models/Chemical';
+import Chemical from '@src/models/Chemical';
 
 class ChemicalFactory {
   static createChemical(chemicalData = [{ }], cas = null) {

--- a/spec/javascripts/factories/ContainerFactory.js
+++ b/spec/javascripts/factories/ContainerFactory.js
@@ -1,6 +1,6 @@
 import { factory } from '@eflexsystems/factory-bot';
-import Container from "src/models/Container";
-import AttachmentFactory from "factories/AttachmentFactory";
+import Container from "@src/models/Container";
+import AttachmentFactory from "@tests/factories/AttachmentFactory";
 
 export default class ContainerFactory {
   static instance = undefined;

--- a/spec/javascripts/factories/ReactionFactory.js
+++ b/spec/javascripts/factories/ReactionFactory.js
@@ -1,6 +1,6 @@
 import { factory } from '@eflexsystems/factory-bot';
-import Reaction from 'src/models/Reaction';
-import SampleFactory from "factories/SampleFactory";
+import Reaction from '@src/models/Reaction';
+import SampleFactory from "@tests/factories/SampleFactory";
 
 export default class ReactionFactory {
     static instance = undefined;

--- a/spec/javascripts/factories/ResearchPlanFactory.js
+++ b/spec/javascripts/factories/ResearchPlanFactory.js
@@ -1,7 +1,7 @@
 import { factory } from '@eflexsystems/factory-bot';
-import ResearchPlan from "src/models/ResearchPlan";
-import Container from "src/models/Container";
-import AttachmentFactory from "factories/AttachmentFactory";
+import ResearchPlan from "@src/models/ResearchPlan";
+import Container from "@src/models/Container";
+import AttachmentFactory from "@tests/factories/AttachmentFactory";
 
 export default class ResearchPlanFactory {
   static instance = undefined;

--- a/spec/javascripts/factories/SampleFactory.js
+++ b/spec/javascripts/factories/SampleFactory.js
@@ -1,6 +1,6 @@
 import { factory } from '@eflexsystems/factory-bot';
-import Sample from 'src/models/Sample';
-import Molecule from 'src/models/Molecule';
+import Sample from '@src/models/Sample';
+import Molecule from '@src/models/Molecule';
 
 export default class SampleFactory {
     static instance = undefined;

--- a/spec/javascripts/helper/reactionVariationsHelpers.js
+++ b/spec/javascripts/helper/reactionVariationsHelpers.js
@@ -1,8 +1,8 @@
-import ReactionFactory from 'factories/ReactionFactory';
-import SampleFactory from 'factories/SampleFactory';
+import ReactionFactory from '@tests/factories/ReactionFactory';
+import SampleFactory from '@tests/factories/SampleFactory';
 import {
   createVariationsRow,
-} from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
+} from '@src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
 
 async function setUpMaterial() {
   return SampleFactory.build('SampleFactory.water_100g');

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.spec.js
@@ -8,10 +8,10 @@ import {
 
 import { Button } from 'react-bootstrap';
 
-import ReactionDetailsContainers from 'src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers';
-import AccordionHeaderWithButtons from 'src/components/common/AccordionHeaderWithButtons';
-import Reaction from 'src/models/Reaction';
-import Container from 'src/models/Container';
+import ReactionDetailsContainers from '@src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers';
+import AccordionHeaderWithButtons from '@src/components/common/AccordionHeaderWithButtons';
+import Reaction from '@src/models/Reaction';
+import Container from '@src/models/Container';
 
 Enzyme.configure({ adapter: new Adapter() });
 

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses.spec.js
@@ -1,8 +1,8 @@
 import expect from 'expect';
-import Container from 'src/models/Container';
+import Container from '@src/models/Container';
 import {
   updateAnalyses, getReactionAnalyses
-} from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses';
+} from '@src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses';
 import { setUpReaction } from 'helper/reactionVariationsHelpers';
 
 function buildAnalysis(name) {

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import {
   EquivalentParser, PropertyFormatter, PropertyParser, MaterialFormatter, MaterialParser, FeedstockParser, GasParser
-} from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents';
+} from '@src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents';
 import { setUpReaction, setUpGaseousReaction } from 'helper/reactionVariationsHelpers';
 
 describe('ReactionVariationsComponents', async () => {

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.spec.js
@@ -5,14 +5,14 @@ import {
   updateColumnDefinitionsMaterials, updateVariationsRowOnCatalystMaterialChange,
   getMaterialColumnGroupChild, getReactionMaterialsIDs, updateColumnDefinitionsMaterialTypes,
   getReactionMaterialsGasTypes, updateVariationsGasTypes, cellIsEditable
-} from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
+} from '@src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
 import {
   EquivalentParser
-} from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents';
+} from '@src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents';
 import {
   setUpMaterial, setUpReaction, setUpGaseousReaction, getColumnDefinitionsMaterialIDs, getColumnGroupChild
 } from 'helper/reactionVariationsHelpers';
-import { materialTypes } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
+import { materialTypes } from '@src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
 import { cloneDeep } from 'lodash';
 
 describe('ReactionVariationsMaterials', () => {

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.spec.js
@@ -1,10 +1,10 @@
 import expect from 'expect';
 import {
   convertUnit, createVariationsRow, copyVariationsRow, updateVariationsRow, updateColumnDefinitions
-} from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
+} from '@src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
 import {
   getReactionMaterials, getMaterialColumnGroupChild
-} from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
+} from '@src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
 import { setUpReaction, getColumnGroupChild } from 'helper/reactionVariationsHelpers';
 
 describe('ReactionVariationsUtils', () => {

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ImageAnnotationEditButton.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ImageAnnotationEditButton.spec.js
@@ -5,8 +5,8 @@ import expect from 'expect';
 import { configure, shallow } from 'enzyme';
 import { spy } from 'sinon';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
-import ImageAnnotationEditButton from 'src/apps/mydb/elements/details/researchPlans/ImageAnnotationEditButton';
-import Attachment from 'src/models/Attachment';
+import ImageAnnotationEditButton from '@src/apps/mydb/elements/details/researchPlans/ImageAnnotationEditButton';
+import Attachment from '@src/models/Attachment';
 
 import { Button } from 'react-bootstrap';
 

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ImageAttachmentFilter.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ImageAttachmentFilter.spec.js
@@ -1,9 +1,9 @@
 import expect from 'expect';
 import Enzyme from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
-import ResearchPlan from 'src/models/ResearchPlan';
-import Attachment from 'src/models/Attachment';
-import ImageAttachmentFilter from 'src/utilities/ImageAttachmentFilter';
+import ResearchPlan from '@src/models/ResearchPlan';
+import Attachment from '@src/models/Attachment';
+import ImageAttachmentFilter from '@src/utilities/ImageAttachmentFilter';
 
 Enzyme.configure({ adapter: new Adapter() });
 

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ImageFileDropHandler.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ImageFileDropHandler.spec.js
@@ -1,9 +1,9 @@
 import expect from 'expect';
 import Enzyme from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
-import ResearchPlan from 'src/models/ResearchPlan';
-import Attachment from 'src/models/Attachment';
-import ImageFileDropHandler from 'src/apps/mydb/elements/details/researchPlans/researchPlanTab/ImageFileDropHandler';
+import ResearchPlan from '@src/models/ResearchPlan';
+import Attachment from '@src/models/Attachment';
+import ImageFileDropHandler from '@src/apps/mydb/elements/details/researchPlans/researchPlanTab/ImageFileDropHandler';
 
 Enzyme.configure({ adapter: new Adapter() });
 

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.spec.js
@@ -7,18 +7,18 @@ import { configure, shallow } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import sinon from 'sinon';
 
-import ResearchPlanFactory from 'factories/ResearchPlanFactory';
-import AttachmentFactory from 'factories/AttachmentFactory';
+import ResearchPlanFactory from '@tests/factories/ResearchPlanFactory';
+import AttachmentFactory from '@tests/factories/AttachmentFactory';
 // although not used import of ElementStore needed to initialize
 // the ResearchPlanDetails.js component. It must be executed before
 // the import of ResearchPlanDetails. Beware of the linter which
 // may put it at the end of the imports !!!
 
 // eslint-disable-next-line no-unused-vars
-import ElementStore from 'src/stores/alt/stores/ElementStore';
+import ElementStore from '@src/stores/alt/stores/ElementStore';
 
-import ResearchPlanDetails from 'src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails';
-import CommentActions from 'src/stores/alt/actions/CommentActions';
+import ResearchPlanDetails from '@src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails';
+import CommentActions from '@src/stores/alt/actions/CommentActions';
 
 configure({ adapter: new Adapter() });
 

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetailsFieldImage.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetailsFieldImage.spec.js
@@ -4,9 +4,9 @@ import React from 'react';
 import expect from 'expect';
 import Enzyme, { shallow } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
-import ResearchPlanDetailsFieldImage from 'src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsFieldImage';
-import ResearchPlan from 'src/models/ResearchPlan';
-import AttachmentFetcher from 'src/fetchers/AttachmentFetcher';
+import ResearchPlanDetailsFieldImage from '@src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsFieldImage';
+import ResearchPlan from '@src/models/ResearchPlan';
+import AttachmentFetcher from '@src/fetchers/AttachmentFetcher';
 import sinon from 'sinon';
 
 Enzyme.configure({ adapter: new Adapter() });

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.spec.js
@@ -8,12 +8,12 @@ import {
 
 import { Button } from 'react-bootstrap';
 
-import Container from 'src/models/Container';
-import ResearchPlan from 'src/models/ResearchPlan';
-import AccordionHeaderWithButtons from 'src/components/common/AccordionHeaderWithButtons';
+import Container from '@src/models/Container';
+import ResearchPlan from '@src/models/ResearchPlan';
+import AccordionHeaderWithButtons from '@src/components/common/AccordionHeaderWithButtons';
 
 import ResearchPlanDetailsContainers
-  from 'src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers';
+  from '@src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers';
 
 Enzyme.configure({ adapter: new Adapter() });
 

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.spec.js
@@ -6,13 +6,13 @@ import { configure, mount } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import sinon from 'sinon';
 
-import AttachmentFetcher from 'src/fetchers/AttachmentFetcher';
-import ResearchPlanFactory from 'factories/ResearchPlanFactory';
+import AttachmentFetcher from '@src/fetchers/AttachmentFetcher';
+import ResearchPlanFactory from '@tests/factories/ResearchPlanFactory';
 // eslint-disable-next-line no-unused-vars
 
-import EditorFetcher from 'src/fetchers/EditorFetcher';
+import EditorFetcher from '@src/fetchers/EditorFetcher';
 import ResearchPlanDetailsAttachments from
-  'src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments';
+  '@src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments';
 
 configure({ adapter: new Adapter() });
 

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.spec.js
@@ -9,10 +9,10 @@ import {
 
 import {
   AnalysesHeader
-} from 'src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux';
+} from '@src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux';
 
-import Container from 'src/models/Container';
-import Sample from 'src/models/Sample';
+import Container from '@src/models/Container';
+import Sample from '@src/models/Sample';
 
 configure({ adapter: new Adapter() });
 

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/samples/propertiesTab/SampleSolventGroup.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/samples/propertiesTab/SampleSolventGroup.spec.js
@@ -4,8 +4,8 @@ import expect from 'expect';
 import { configure, shallow } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { SampleSolventGroup, SolventDetails }
-  from 'src/apps/mydb/elements/details/samples/propertiesTab/SampleSolventGroup';
-import SampleFactory from 'factories/SampleFactory';
+  from '@src/apps/mydb/elements/details/samples/propertiesTab/SampleSolventGroup';
+import SampleFactory from '@tests/factories/SampleFactory';
 
 import {
   describe, it

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal.spec.js
@@ -8,9 +8,9 @@ import {
 import sinon, { spy } from 'sinon';
 import { configure, shallow, mount } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
-import CustomSizeModal from 'src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal';
-import wellplate2x3EmptyJson from 'fixture/wellplates/wellplate_2_3_empty';
-import Wellplate from 'src/models/Wellplate';
+import CustomSizeModal from '@src/apps/mydb/elements/details/wellplates/propertiesTab/CustomSizeModal';
+import wellplate2x3EmptyJson from '@tests/fixture/wellplates/wellplate_2_3_empty';
+import Wellplate from '@src/models/Wellplate';
 
 configure({ adapter: new Adapter() });
 

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateProperties.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateProperties.spec.js
@@ -5,9 +5,9 @@ import expect from 'expect';
 import { configure, shallow } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
-import Wellplate from 'src/models/Wellplate';
+import Wellplate from '@src/models/Wellplate';
 
-import WellplateProperties from 'src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateProperties';
+import WellplateProperties from '@src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateProperties';
 
 // Empty function placeholder for required props
 function emptyFunc() {}

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.spec.js
@@ -7,10 +7,10 @@ import {
 } from 'mocha';
 import { configure, shallow } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
-import WellplateSizeDropdown from 'src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown';
-import wellplate2x3EmptyJson from 'fixture/wellplates/wellplate_2_3_empty';
-import wellplate8x12EmptyJson from 'fixture/wellplates/wellplate_8_12_empty';
-import Wellplate from 'src/models/Wellplate';
+import WellplateSizeDropdown from '@src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown';
+import wellplate2x3EmptyJson from '@tests/fixture/wellplates/wellplate_2_3_empty';
+import wellplate8x12EmptyJson from '@tests/fixture/wellplates/wellplate_8_12_empty';
+import Wellplate from '@src/models/Wellplate';
 
 configure({ adapter: new Adapter() });
 

--- a/spec/javascripts/packs/src/components/AnalysisCommentBoxComponent.spec.js
+++ b/spec/javascripts/packs/src/components/AnalysisCommentBoxComponent.spec.js
@@ -5,7 +5,7 @@ import { Form } from 'react-bootstrap';
 import { describe, it } from 'mocha';
 import expect from 'expect';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
-import { CommentBox } from 'src/components/common/AnalysisCommentBoxComponent';
+import { CommentBox } from '@src/components/common/AnalysisCommentBoxComponent';
 
 configure({ adapter: new Adapter() });
 

--- a/spec/javascripts/packs/src/components/ChemSpectraLayouts.spec.js
+++ b/spec/javascripts/packs/src/components/ChemSpectraLayouts.spec.js
@@ -7,8 +7,8 @@ import {
 import assert from 'assert';
 import sinon from 'sinon';
 import expect from 'expect';
-import ChemSpectraFetcher from 'src/fetchers/ChemSpectraFetcher';
-import ChemSpectraLayouts from 'src/apps/admin/ChemSpectraLayouts';
+import ChemSpectraFetcher from '@src/fetchers/ChemSpectraFetcher';
+import ChemSpectraLayouts from '@src/apps/admin/ChemSpectraLayouts';
 
 configure({ adapter: new Adapter() });
 

--- a/spec/javascripts/packs/src/components/ChemicalTab.spec.js
+++ b/spec/javascripts/packs/src/components/ChemicalTab.spec.js
@@ -7,10 +7,10 @@ import sinon from 'sinon';
 import {
   describe, it, beforeEach, afterEach
 } from 'mocha';
-import ElementStore from 'src/stores/alt/stores/ElementStore';
-import ChemicalTab from 'src/components/ChemicalTab';
-import Sample from 'src/models/Sample';
-import Chemical from 'src/models/Chemical';
+import ElementStore from '@src/stores/alt/stores/ElementStore';
+import ChemicalTab from '@src/components/ChemicalTab';
+import Sample from '@src/models/Sample';
+import Chemical from '@src/models/Chemical';
 
 const createChemical = (chemicalData = [{}], cas = null) => {
   const chemical = new Chemical();

--- a/spec/javascripts/packs/src/components/OlsComponent.spec.js
+++ b/spec/javascripts/packs/src/components/OlsComponent.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { configure, shallow } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import expect from 'expect';
-import OlsTreeSelect from 'src/components/OlsComponent';
+import OlsTreeSelect from '@src/components/OlsComponent';
 import {
   describe, it
 } from 'mocha';

--- a/spec/javascripts/packs/src/components/common/ToggleButton.spec.js
+++ b/spec/javascripts/packs/src/components/common/ToggleButton.spec.js
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import {
   describe, it, beforeEach, afterEach
 } from 'mocha';
-import ToggleButton from 'src/components/common/ToggleButton';
+import ToggleButton from '@src/components/common/ToggleButton';
 
 configure({ adapter: new Adapter() });
 

--- a/spec/javascripts/packs/src/fetchers/BaseFetcher.spec.js
+++ b/spec/javascripts/packs/src/fetchers/BaseFetcher.spec.js
@@ -1,8 +1,8 @@
 /* global describe, it */
 
 import expect from 'expect';
-import ContainerFactory from 'factories/ContainerFactory';
-import BaseFetcher from 'src/fetchers/BaseFetcher';
+import ContainerFactory from '@tests/factories/ContainerFactory';
+import BaseFetcher from '@src/fetchers/BaseFetcher';
 
 describe('BaseFetcher', () => {
   describe('.getAttachments()', () => {

--- a/spec/javascripts/packs/src/fetchers/ChemSpectraFetcher.spec.js
+++ b/spec/javascripts/packs/src/fetchers/ChemSpectraFetcher.spec.js
@@ -1,4 +1,4 @@
-import ChemSpectraFetcher from 'src/fetchers/ChemSpectraFetcher';
+import ChemSpectraFetcher from '@src/fetchers/ChemSpectraFetcher';
 import { describe, it, beforeEach, afterEach } from 'mocha';
 import 'whatwg-fetch';
 import expect from 'expect';

--- a/spec/javascripts/packs/src/fetchers/ChemicalFetcher.spec.js
+++ b/spec/javascripts/packs/src/fetchers/ChemicalFetcher.spec.js
@@ -1,4 +1,4 @@
-import ChemicalFetcher from 'src/fetchers/ChemicalFetcher';
+import ChemicalFetcher from '@src/fetchers/ChemicalFetcher';
 import expect from 'expect';
 import sinon from 'sinon';
 import {

--- a/spec/javascripts/packs/src/fetchers/InventoryFetcher.spec.js
+++ b/spec/javascripts/packs/src/fetchers/InventoryFetcher.spec.js
@@ -1,4 +1,4 @@
-import InventoryFetcher from 'src/fetchers/InventoryFetcher';
+import InventoryFetcher from '@src/fetchers/InventoryFetcher';
 import expect from 'expect';
 import sinon from 'sinon';
 import {

--- a/spec/javascripts/packs/src/models/Chemical.spec.js
+++ b/spec/javascripts/packs/src/models/Chemical.spec.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-unresolved
-import ChemicalFactory from 'factories/ChemicalFactory';
-import Chemical from 'src/models/Chemical';
+import ChemicalFactory from '@tests/factories/ChemicalFactory';
+import Chemical from '@src/models/Chemical';
 import expect from 'expect';
 import {
   describe, it

--- a/spec/javascripts/packs/src/models/Container.spec.js
+++ b/spec/javascripts/packs/src/models/Container.spec.js
@@ -1,5 +1,5 @@
-import Container from 'src/models/Container';
-import ContainerFactory from 'factories/ContainerFactory';
+import Container from '@src/models/Container';
+import ContainerFactory from '@tests/factories/ContainerFactory';
 import expect from 'expect';
 
 import {

--- a/spec/javascripts/packs/src/models/Reaction.spec.js
+++ b/spec/javascripts/packs/src/models/Reaction.spec.js
@@ -1,4 +1,4 @@
-import ReactionFactory from 'factories/ReactionFactory';
+import ReactionFactory from '@tests/factories/ReactionFactory';
 import expect from 'expect';
 
 describe('Reaction', async () => {

--- a/spec/javascripts/packs/src/models/ResearchPlan.spec.js
+++ b/spec/javascripts/packs/src/models/ResearchPlan.spec.js
@@ -1,5 +1,5 @@
-import Attachment from 'src/models/Attachment';
-import ResearchPlan from 'src/models/ResearchPlan';
+import Attachment from '@src/models/Attachment';
+import ResearchPlan from '@src/models/ResearchPlan';
 import expect from 'expect';
 import {
   describe, it

--- a/spec/javascripts/packs/src/models/Sample.spec.js
+++ b/spec/javascripts/packs/src/models/Sample.spec.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import SampleFactory from "factories/SampleFactory";
+import SampleFactory from "@tests/factories/SampleFactory";
 
 describe('Sample', async () => {
     const referenceSample = await SampleFactory.build("SampleFactory.water_100g")

--- a/spec/javascripts/packs/src/models/Wellplate.spec.js
+++ b/spec/javascripts/packs/src/models/Wellplate.spec.js
@@ -3,10 +3,10 @@ import expect from 'expect';
 import {
   describe, it
 } from 'mocha';
-import Wellplate from '../../../../../app/javascript/src/models/Wellplate';
-import wellplate2x3EmptyJson from '../../../fixture/wellplates/wellplate_2_3_empty';
-import wellplate8x12EmptyJson from '../../../fixture/wellplates/wellplate_8_12_empty';
-import wellplate2x2fromServer from '../../../fixture/wellplates/wellplate_2_2_from_server';
+import Wellplate from '@src/models/Wellplate';
+import wellplate2x3EmptyJson from '@tests/fixture/wellplates/wellplate_2_3_empty';
+import wellplate8x12EmptyJson from '@tests/fixture/wellplates/wellplate_8_12_empty';
+import wellplate2x2fromServer from '@tests/fixture/wellplates/wellplate_2_2_from_server';
 
 describe('Wellplate', () => {
   const sampleMock = {};

--- a/spec/javascripts/packs/src/models/cellLine/CellLine.spec.js
+++ b/spec/javascripts/packs/src/models/cellLine/CellLine.spec.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import CellLine from '../../../../../../app/javascript/src/models/cellLine/CellLine';
+import CellLine from '@src/models/cellLine/CellLine';
 
 describe('CellLine', async () => {
   describe('createEmpty()', () => {

--- a/spec/javascripts/packs/src/models/cellLine/CellLineGroup.spec.js
+++ b/spec/javascripts/packs/src/models/cellLine/CellLineGroup.spec.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import CellLineFactory from 'factories/CellLineFactory';
-import CellLineGroup from '../../../../../../app/javascript/src/models/cellLine/CellLineGroup';
+import CellLineFactory from '@tests/factories/CellLineFactory';
+import CellLineGroup from '@src/models/cellLine/CellLineGroup';
 
 describe('CellLineGroup', async () => {
   describe('buildFromElements()', async () => {

--- a/spec/javascripts/packs/src/models/collection/CollectionUtils.spec.js
+++ b/spec/javascripts/packs/src/models/collection/CollectionUtils.spec.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-unresolved
-import CollectionUtils from 'src/models/collection/CollectionUtils';
+import CollectionUtils from '@src/models/collection/CollectionUtils';
 import expect from 'expect';
 import {
   describe, it

--- a/spec/javascripts/packs/src/utilities/SpectraHelper.spec.js
+++ b/spec/javascripts/packs/src/utilities/SpectraHelper.spec.js
@@ -7,10 +7,10 @@ import {
   isNMRKind, BuildSpcInfosForNMRDisplayer,
   JcampIds, BuildSpcInfos, cleaningNMRiumData,
   inlineNotation,
-} from 'src/utilities/SpectraHelper';
-import Sample from 'src/models/Sample';
-import Container from 'src/models/Container';
-import { chmosFixture } from '../../../fixture/chmos';
+} from '@src/utilities/SpectraHelper';
+import Sample from '@src/models/Sample';
+import Container from '@src/models/Container';
+import { chmosFixture } from '@tests/fixture/chmos';
 
 describe('SpectraHelper', () => {
   describe('.isNMRKind()', () => {

--- a/spec/javascripts/report/CheckBoxList.spec.js
+++ b/spec/javascripts/report/CheckBoxList.spec.js
@@ -6,7 +6,7 @@ import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
 
 import sinon from 'sinon'
-import CheckBoxList from '../../../app/javascript/src/components/common/CheckBoxList'
+import CheckBoxList from '@src/components/common/CheckBoxList'
 
 Enzyme.configure({ adapter: new Adapter() });
 

--- a/spec/javascripts/setup.js
+++ b/spec/javascripts/setup.js
@@ -1,3 +1,4 @@
+require('module-alias/register');
 require('@babel/register')();
 require('jsdom-global')();
 

--- a/spec/javascripts/stores/ReportStore.spec.js
+++ b/spec/javascripts/stores/ReportStore.spec.js
@@ -1,8 +1,8 @@
 import expect from 'expect'
-import { originalState } from '../fixture/report'
-import alt from '../../../app/javascript/src/stores/alt/alt'
-import ReportActions from '../../../app/javascript/src/stores/alt/actions/ReportActions'
-import ReportStore from '../../../app/javascript/src/stores/alt/stores/ReportStore'
+import { originalState } from '@tests/fixture/report'
+import alt from '@src/stores/alt/alt'
+import ReportActions from '@src/stores/alt/actions/ReportActions'
+import ReportStore from '@src/stores/alt/stores/ReportStore'
 
 describe('ReportStore', () => {
   beforeEach(() => {

--- a/spec/javascripts/stores/mobx/AttachmentNotificationStore.spec.js
+++ b/spec/javascripts/stores/mobx/AttachmentNotificationStore.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-unresolved,no-undef */
 import expect from 'expect';
-import { AttachmentNotificationStore } from 'src/stores/mobx/AttachmentNotificationStore';
-import AttachmentNotificationFactory from 'factories/AttachmentNotificationFactory';
+import { AttachmentNotificationStore } from '@src/stores/mobx/AttachmentNotificationStore';
+import AttachmentNotificationFactory from '@tests/factories/AttachmentNotificationFactory';
 
 describe('AttachmentNotificationStore', async () => {
   const message1 = await AttachmentNotificationFactory.build('AttachmentNotificationFactory.new');

--- a/spec/javascripts/stores/mobx/CellLineDetailsStore.spec.js
+++ b/spec/javascripts/stores/mobx/CellLineDetailsStore.spec.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { CellLineDetailsStore } from 'src/stores/mobx/CellLineDetailsStore';
-import CellLineFactory from 'factories/CellLineFactory';
+import { CellLineDetailsStore } from '@src/stores/mobx/CellLineDetailsStore';
+import CellLineFactory from '@tests/factories/CellLineFactory';
 
 const newMaterialProperties = {
   biosafety_level: 'S2',

--- a/spec/javascripts/utils/CasValidation.spec.js
+++ b/spec/javascripts/utils/CasValidation.spec.js
@@ -4,7 +4,7 @@ import {
   addHyphensToCas,
   checkCasDigit,
   validateCas
-} from '../../../app/javascript/src/utilities/CasValidation';
+} from '@src/utilities/CasValidation';
 
 describe('CasValidation', () => {
   describe('addHyphensToCas', () => {

--- a/spec/javascripts/utils/DeltaMarkdownConverter.spec.js
+++ b/spec/javascripts/utils/DeltaMarkdownConverter.spec.js
@@ -3,7 +3,7 @@ import Delta from 'quill-delta';
 
 import {
   deltaToMarkdown, markdownToDelta
-} from '../../../app/javascript/src/utilities/deltaMarkdownConverter';
+} from '@src/utilities/deltaMarkdownConverter';
 
 describe('Delta to Markdown converter', () => {
   it('should convert inline characters', () => {

--- a/spec/javascripts/utils/DndConst.js
+++ b/spec/javascripts/utils/DndConst.js
@@ -3,7 +3,7 @@ import expect from 'expect';
 import {
   DragDropItemTypes,
   targetContainerDataField
-} from 'src/utilities/DndConst';
+} from '@src/utilities/DndConst';
 
 const fakeMonitor = (dataType) => ({ getItemType: () => (DragDropItemTypes[dataType]) });
 

--- a/spec/javascripts/utils/ElementUtils.spec.js
+++ b/spec/javascripts/utils/ElementUtils.spec.js
@@ -4,14 +4,14 @@ import expect from 'expect';
 
 import {
   searchAndReplace
-} from '../../../app/javascript/src/utilities/markdownUtils';
+} from '@src/utilities/markdownUtils';
 import {
   sampleAnalysesFormatPattern, commonFormatPattern, hNmrCheckMsg, cNmrCheckMsg, rfValueFormat
-} from '../../../app/javascript/src/utilities/ElementUtils';
-import { contentToText } from '../../../app/javascript/src/utilities/quillFormat';
-import { nmrData1H } from '../fixture/nmr1H';
-import { nmrData13C } from '../fixture/nmr13C';
-import { rfValues } from '../fixture/rfvalue';
+} from '@src/utilities/ElementUtils';
+import { contentToText } from '@src/utilities/quillFormat';
+import { nmrData1H } from '@tests/fixture/nmr1H';
+import { nmrData13C } from '@tests/fixture/nmr13C';
+import { rfValues } from '@tests/fixture/rfvalue';
 
 describe('RF Value formating', () => {
   Object.keys(rfValues).map(k => (

--- a/spec/javascripts/utils/FetcherHelper.spec.js
+++ b/spec/javascripts/utils/FetcherHelper.spec.js
@@ -4,7 +4,7 @@ import base64 from 'base-64';
 
 import {
     parseBase64ToArrayBuffer
-} from '../../../app/javascript/src/utilities/FetcherHelper';
+} from '@src/utilities/FetcherHelper';
 
 describe('parseBase64ToArrayBuffer', () => {
   it('return array buffer', () => {

--- a/spec/javascripts/utils/MathUtils.spec.js
+++ b/spec/javascripts/utils/MathUtils.spec.js
@@ -2,7 +2,7 @@ import expect from 'expect';
 
 import {
   fixDigit, validDigit, correctPrefix, parseNumericString,
-} from '../../../app/javascript/src/utilities/MathUtils';
+} from '@src/utilities/MathUtils';
 
 describe('fixDigit', () => {
   it('return number with correct precisons', () => {

--- a/spec/javascripts/utils/NumericInputUnit.spec.js
+++ b/spec/javascripts/utils/NumericInputUnit.spec.js
@@ -5,7 +5,7 @@ import Enzyme, { shallow } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import expect from 'expect';
 import sinon from 'sinon';
-import NumericInputUnit from '../../../app/javascript/src/apps/mydb/elements/details/NumericInputUnit';
+import NumericInputUnit from '@src/apps/mydb/elements/details/NumericInputUnit';
 
 Enzyme.configure({ adapter: new Adapter() });
 

--- a/spec/javascripts/utils/UnitConversion.spec.js
+++ b/spec/javascripts/utils/UnitConversion.spec.js
@@ -17,7 +17,7 @@ import {
   calculateTONPerTimeValue,
   determineTONFrequencyValue,
   convertTurnoverFrequency,
-} from '../../../app/javascript/src/utilities/UnitsConversion';
+} from '@src/utilities/UnitsConversion';
 
 describe('Testing React Utility Functions', () => {
   const TEMPERATURE_UNITS = {

--- a/spec/javascripts/utils/quillFormat.spec.js
+++ b/spec/javascripts/utils/quillFormat.spec.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import { keepSupSub } from '../../../app/javascript/src/utilities/quillFormat';
+import { keepSupSub } from '@src/utilities/quillFormat';
 
 describe('keepSupSub', () => {
   it('does nothing special if empty ops', () => {

--- a/spec/javascripts/utils/textHelper.spec.js
+++ b/spec/javascripts/utils/textHelper.spec.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import { capitalizeWords } from 'src/utilities/textHelper';
+import { capitalizeWords } from '@src/utilities/textHelper';
 
 describe('capitalizeWords', () => {
   it('should capitalize the first letter of words in a string', () => {

--- a/spec/javascripts/utils/timezoneHelper.spec.js
+++ b/spec/javascripts/utils/timezoneHelper.spec.js
@@ -5,7 +5,7 @@ import {
   parseDate,
   formatDate,
   formatTimeStampsOfElement
-} from 'src/utilities/timezoneHelper';
+} from '@src/utilities/timezoneHelper';
 
 describe('parseDate', () => {
   it('should return a valid moment instance when date is iso8601', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10402,6 +10402,11 @@ mocha@^11:
     yargs-parser "^21.1.1"
     yargs-unparser "^2.0.0"
 
+module-alias@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.2.3.tgz#ec2e85c68973bda6ab71ce7c93b763ec96053221"
+  integrity sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==
+
 moment-precise-range-plugin@^1.2.4, moment-precise-range-plugin@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/moment-precise-range-plugin/-/moment-precise-range-plugin-1.3.0.tgz#60ac075fdfd14689f6d102af751d171a80b4ab60"


### PR DESCRIPTION
add module-alias and configure path aliases

style(js): rewrite relative imports to absolute alias path in tests
to prepare for 1:1 folder-structure replication with src folder
and ensure no path conflict

- (../app/javascript)/src to @src/

- (../)factories to @tests/factories

- (../)fixture to @tests/fixture