### PR TITLE
fix(UI): notifications rendered out of modal when too many.

### DIFF
--- a/app/javascript/src/components/contextActions/NoticeButton.js
+++ b/app/javascript/src/components/contextActions/NoticeButton.js
@@ -389,7 +389,7 @@ export default class NoticeButton extends React.Component {
         <Modal.Header closeButton>
           <Modal.Title>Unread Notifications</Modal.Title>
         </Modal.Header>
-        <Modal.Body className="vh-70">
+        <Modal.Body className="vh-70 overflow-auto">
           {this.renderBody()}
         </Modal.Body>
         <Modal.Footer>


### PR DESCRIPTION
when too many notification items are there i.e. greater than the size of the window they render out of the modal. 

This UI issue has been fixed with this PR. 