### PR TITLE
fix(ui): improve unit switch behavior for reaction scheme gase phase inputs

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
@@ -324,19 +324,36 @@ class Material extends Component {
     const readOnly = this.isFieldReadOnly(field);
 
     const updateValue = this.getFormattedValue(value);
+    const message = 'Unit switch only active with valid values';
+    const noSwitchUnits = ['ppm', 'TON'];
+
+    const inputComponent = (
+      <NumeralInputWithUnitsCompo
+        size="sm"
+        precision={4}
+        variant="success"
+        value={updateValue}
+        disabled={readOnly}
+        onMetricsChange={(e) => this.gasFieldsUnitsChanged(e, field)}
+        onChange={(e) => this.handleGasFieldsChange(field, e, value)}
+        unit={unit}
+      />
+    );
 
     return (
       <td colSpan={colSpan} style={style}>
-        <NumeralInputWithUnitsCompo
-          size="sm"
-          precision={4}
-          variant="success"
-          value={updateValue}
-          disabled={readOnly}
-          onMetricsChange={(e) => this.gasFieldsUnitsChanged(e, field)}
-          onChange={(e) => this.handleGasFieldsChange(field, e, value)}
-          unit={unit}
-        />
+        <div>
+          {(value === 'n.d' || !value) && !noSwitchUnits.includes(unit) ? (
+            <OverlayTrigger
+              placement="top"
+              overlay={<Tooltip id={`${field}-tooltip`}>{message}</Tooltip>}
+            >
+              <div>{inputComponent}</div>
+            </OverlayTrigger>
+          ) : (
+            <div>{inputComponent}</div>
+          )}
+        </div>
       </td>
     );
   }


### PR DESCRIPTION
Problem:
- Switching units for gas products input fields in the gaseous reaction scheme is not available with invalid values
- This was causing unnecessary UI clutter and potentially confusing users

Solution:
- Modified the `gaseousInputFields` function to only show tooltips when:
  1. The value is not defined (null, undefined, or 'n.d')
  2. The unit is not in the list of non-switchable units (ppm, TON): Some fields like 'ppm' and 'TON' should not show unit switch tooltips at all
- Added a clear message "Unit switch only active with valid values" to guide users
- Extracted the input component to avoid code duplication

Changes:
- Added `noSwitchUnits` array to identify units that don't support switching
- Updated tooltip display logic to check both value existence and unit type
___________________________________________________________________________
- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
