### PR TITLE
fix: disabled drag-and-drop handle for list samples and molecules to reaction scheme

### DIFF
--- a/app/javascript/src/apps/mydb/elements/list/ElementsTableSampleEntries.js
+++ b/app/javascript/src/apps/mydb/elements/list/ElementsTableSampleEntries.js
@@ -61,15 +61,21 @@ const isCurrEleDropType = (sourceType, targetType) => {
   return sourceType && targetType && targets[sourceType].includes(targetType);
 };
 
-const dragColumn = (element, sourceType, targetType) => (
-  <td className="text-center align-middle">
-    <ElementContainer
-      key={element.id}
-      sourceType={isCurrEleDropType(sourceType, targetType) ? sourceType : ''}
-      element={element}
-    />
-  </td>
-);
+const dragColumn = (element, sourceType, targetType) => {
+  if (!targetType) {
+    targetType = ElementStore.getState()?.currentElement?.type || null;
+  }
+
+  return (
+    <td className="text-center align-middle">
+      <ElementContainer
+        key={element.id}
+        sourceType={isCurrEleDropType(sourceType, targetType) ? sourceType : ''}
+        element={element}
+      />
+    </td>
+  );
+};
 
 function TopSecretIcon({ element }) {
   if (element.type === 'sample' && element.is_top_secret === true) {


### PR DESCRIPTION
try to get the currently opened element and its type from the element store,
in case the targetType has not be defined and passed to the component (due to race condition as when loading the whole page) 

