### PR TITLE
fix: messaging user for incoming files from datacollector device

### DIFF
--- a/app/jobs/message_incoming_data_job.rb
+++ b/app/jobs/message_incoming_data_job.rb
@@ -4,7 +4,32 @@ class MessageIncomingDataJob < ApplicationJob
     Message.create_msg_notification(
       channel_subject: Channel::INBOX_ARRIVALS_TO_ME,
       data_args: { device_name: sender_name },
-      message_from: from, message_to: [to]
+      message_from: correspondent(from),
+      message_to: [correspondent(to)],
     )
+  end
+
+  private
+
+  # Find a user id for the message
+  # since Message only accepts user id as sender and receiver but
+  # here the sender is likely to be a Device.
+  # If it is a User, return the ID
+  # If it is a Device, return the ID of the first group it belongs to
+  # or the ID of the first Admin if it does not belong to any group
+  # If it is an Integer, return the Integer.
+  # @param arg [User, Device, Integer]
+  # @return [Integer]
+  def correspondent(arg)
+    case arg
+    when User
+      arg.id
+    when Device
+      arg.groups.any? ? arg.groups.first.id : Admin.first.id
+    when Integer
+      arg
+    else
+      raise ArgumentError, "Invalid argument type: #{arg.class}"
+    end
   end
 end

--- a/lib/datacollector/correspondence.rb
+++ b/lib/datacollector/correspondence.rb
@@ -123,7 +123,7 @@ module Datacollector
     # @param queue [String] The queue name
     def schedule_notification(queue)
       MessageIncomingDataJob.set(queue: queue, wait: 3.minutes).perform_later(
-        sender_container.name, sender.id, recipient.id
+        sender_container.name, sender, recipient
       )
     end
   end


### PR DESCRIPTION
when creating a notification on incoming datacollector file
handle sender type 
to ensure it is from a user

if sender is
- [User] -> user
- [Device] -> try to default to a device user group
else use the first [Admin]


refs: #1736