### PR TITLE
fix: import functionality for chemicals

### DIFF
--- a/app/javascript/src/components/contextActions/ExportImportButton.js
+++ b/app/javascript/src/components/contextActions/ExportImportButton.js
@@ -14,8 +14,7 @@ import ModalImportCollection from 'src/components/contextActions/ModalImportColl
 import { elementShowOrNew } from 'src/utilities/routesUtils';
 
 const importSampleFunction = (updateModalProps, importAsChemical) => {
-  // caution: title is used in ModalImport.js, if you change it here, you need to change it there too
-  const title = importAsChemical ? 'Import chemicals from file' : 'Import samples from file';
+  const title = 'Import samples from file';
   const component = ModalImport;
   const action = ElementActions.importSamplesFromFile;
   const listSharedCollections = false;
@@ -144,13 +143,6 @@ function ExportImportButton({ isDisabled, updateModalProps, customClass }) {
           title="Import from spreadsheet or sdf"
         >
           Import samples to collection
-        </Dropdown.Item>
-        <Dropdown.Item
-          onClick={() => importSampleFunction(updateModalProps, true)}
-          disabled={isDisabled}
-          title="Import chemicals from spreadsheet"
-        >
-          Import chemicals to collection
         </Dropdown.Item>
         <Dropdown.Divider />
         <Dropdown.Item

--- a/app/javascript/src/components/contextActions/ExportImportButton.js
+++ b/app/javascript/src/components/contextActions/ExportImportButton.js
@@ -14,6 +14,7 @@ import ModalImportCollection from 'src/components/contextActions/ModalImportColl
 import { elementShowOrNew } from 'src/utilities/routesUtils';
 
 const importSampleFunction = (updateModalProps, importAsChemical) => {
+  // caution: title is used in ModalImport.js, if you change it here, you need to change it there too
   const title = importAsChemical ? 'Import chemicals from file' : 'Import samples from file';
   const component = ModalImport;
   const action = ElementActions.importSamplesFromFile;

--- a/app/javascript/src/components/contextActions/ModalImport.js
+++ b/app/javascript/src/components/contextActions/ModalImport.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, ButtonToolbar } from 'react-bootstrap';
+import { Button, ButtonToolbar, Form } from 'react-bootstrap';
 import Dropzone from 'react-dropzone';
 import UIStore from 'src/stores/alt/stores/UIStore';
 
@@ -9,15 +9,16 @@ export default class ModalImport extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      file: null
+      file: null,
+      importAsChemical: false
     };
   }
 
   handleClick() {
     const { onHide, action } = this.props;
-    const { file } = this.state;
+    const { file, importAsChemical } = this.state;
     const uiState = UIStore.getState();
-    const importSampleAs = uiState.modalParams.title === 'Import chemicals from file' ? 'chemical' : 'sample';
+    const importSampleAs = importAsChemical ? 'chemical' : 'sample';
     const params = {
       file,
       currentCollectionId: uiState.currentCollection.id,
@@ -47,7 +48,7 @@ export default class ModalImport extends React.Component {
   }
 
   dropzoneOrfilePreview() {
-    const { file } = this.state;
+    const { file, importAsChemical } = this.state;
     if (file) {
       return (
         <div className="d-flex justify-content-between">
@@ -57,8 +58,9 @@ export default class ModalImport extends React.Component {
           </Button>
         </div>
       );
-    } else {
-      return (
+    }
+    return (
+      <>
         <Dropzone
           onDrop={attachment_file => this.handleFileDrop(attachment_file)}
           style={{ height: 50, width: '100%', border: '3px dashed lightgray' }}
@@ -67,8 +69,17 @@ export default class ModalImport extends React.Component {
             Drop File, or Click to Select.
           </div>
         </Dropzone>
-      );
-    }
+        <div style={{ paddingTop: 12 }}>
+          <Form.Check
+            type="checkbox"
+            onChange={() => this.setState((prevState) => ({ importAsChemical: !prevState.importAsChemical }))}
+            label="Import as a chemical inventory"
+            checked={importAsChemical}
+            className="me-2"
+          />
+        </div>
+      </>
+    );
   }
 
   isDisabled() {

--- a/app/javascript/src/components/contextActions/ModalImport.js
+++ b/app/javascript/src/components/contextActions/ModalImport.js
@@ -17,7 +17,7 @@ export default class ModalImport extends React.Component {
     const { onHide, action } = this.props;
     const { file } = this.state;
     const uiState = UIStore.getState();
-    const importSampleAs = uiState.modalParams.title === 'Import Chemicals from File' ? 'chemical' : 'sample';
+    const importSampleAs = uiState.modalParams.title === 'Import chemicals from file' ? 'chemical' : 'sample';
     const params = {
       file,
       currentCollectionId: uiState.currentCollection.id,


### PR DESCRIPTION
**Problem Description**
- The import functionality for chemicals is malfunctioning, resulting in files designated as chemicals being incorrectly processed as samples. Additionally, there is a mismatch between the title parameter in `ExportImportButton.js` and its expected usage in `ModalImport.js`.

**Proposed Solution**
- Delete the Option of "import chemicals to collections" from the header bar in `ExportImportButton.js`.
- Introduce checkbox into the import module `ModalImport.js`  to allow selection between importing as a chemical or a sample.
--------------------------------------------------------------------------------------------------------------------------------
- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [x] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
