### PR TITLE
fix(UI):  purification selection in Reaction - function length typo

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsPurification.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsPurification.js
@@ -30,7 +30,7 @@ export default class ReactionDetailsPurification extends Component {
   }
 
   handlePurificationChange(selected) {
-    if (selected.lenth == 0) {
+    if (selected.length == 0) {
       return this.handleMultiselectChange('purification', []);
     }
 


### PR DESCRIPTION
Description:

When we deleted some selected purification items in reaction, it was crashing now it has been fixed. There was a typo error in handlePurificationChange function. 

---------------------------------
- [ ] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
