### PR TITLE
fix: Limit maximum SampleTaskInbox height

### DIFF
--- a/app/assets/stylesheets/global-styles/utilities/sizing.scss
+++ b/app/assets/stylesheets/global-styles/utilities/sizing.scss
@@ -13,3 +13,7 @@
 .vh-80 {
   height: 80vh;
 }
+
+.max-vh-60 {
+  max-height: 60vh;
+}

--- a/app/javascript/src/components/sampleTaskInbox/SampleTaskInbox.js
+++ b/app/javascript/src/components/sampleTaskInbox/SampleTaskInbox.js
@@ -124,7 +124,7 @@ const SampleTaskInbox = ({}) => {
             </Modal.Title>
           </Modal.Header>
 
-          <Modal.Body>
+          <Modal.Body className="max-vh-60">
             {openSampleTasks()}
           </Modal.Body>
 


### PR DESCRIPTION
to keep draggable modal content in the viewport and prevent offscreen un-interactable content
