### PR TITLE
feat: labimotion 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'kaminari-grape'
 # gem 'ketcherails', git: 'https://github.com/complat/ketcher-rails.git', branch: 'upgrade-to-rails-6'
 gem 'ketcherails', git: 'https://github.com/complat/ketcher-rails.git', ref: 'd4ae864a0e2d9e853eac8e4fc4ce7e3ab8174f80'
 
-gem 'labimotion', '2.0.0.rc8'
+gem 'labimotion', '2.0.0'
 gem 'logidze'
 
 gem 'mimemagic', '0.3.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -425,7 +425,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    labimotion (2.0.0.rc8)
+    labimotion (2.0.0)
       rails (~> 6.1.7)
     language_server-protocol (3.17.0.3)
     latex-decode (0.4.0)
@@ -912,7 +912,7 @@ DEPENDENCIES
   kaminari
   kaminari-grape
   ketcherails!
-  labimotion (= 2.0.0.rc8)
+  labimotion (= 2.0.0)
   launchy
   listen
   logidze

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "antd": "^5.17.2",
     "aviator": "v0.6.1",
     "base-64": "^0.1.0",
-    "chem-generic-ui": "2.0.0-rc18",
+    "chem-generic-ui": "2.0.0",
     "citation-js": "0.6.8",
     "classnames": "^2.2.5",
     "commonmark": "^0.28.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5097,10 +5097,10 @@ cheerio@^1.0.0-rc.3:
     parse5-htmlparser2-tree-adapter "^6.0.1"
     tslib "^2.2.0"
 
-chem-generic-ui@2.0.0-rc18:
-  version "2.0.0-rc18"
-  resolved "https://registry.yarnpkg.com/chem-generic-ui/-/chem-generic-ui-2.0.0-rc18.tgz#e9f551b674f7e5893722e59a3c0099ce171a955a"
-  integrity sha512-Ulu4GwlrhGyfQNA3kprgbioj5BxHxQVp2iK6BuZ+Y8NeUD/jGpO3oOL2wGoP6u14bgQlZH0I/atYgkMPGMFzNg==
+chem-generic-ui@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chem-generic-ui/-/chem-generic-ui-2.0.0.tgz#145d10f20cf43e09a2f8df0602a9a6bb933cbc90"
+  integrity sha512-LslAxqmg+Emfk7XkSljfyrNwxXWFsm59wnMB4Kt4m4SFV9Gg5e3Lfak3A5v/FRSJ+vhBDO4NIvaZQMX3+dbHnA==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.5.2"
     "@fortawesome/free-regular-svg-icons" "^6.5.2"


### PR DESCRIPTION
LabIMotion Version 2.0.0 Release (RC to Final Release)
- Upgraded LabIMotion from 2.0.0.rc8 to 2.0.0.
- Upgraded chem-generic-ui from 2.0.0-rc18 to 2.0.0.
