### PR TITLE
fix: drag inbox file item on analysis having no dataset

### DIFF
--- a/app/javascript/src/components/container/ContainerDatasets.js
+++ b/app/javascript/src/components/container/ContainerDatasets.js
@@ -134,7 +134,7 @@ export default class ContainerDatasets extends Component {
                   />
                 </div>
               ))}
-              <div key="attachmentdropzone" className="list-group-item disabled" >
+              <div key="attachmentdropzone" className="list-group-item" >
                 <AttachmentDropzone
                   handleAddWithAttachments={(attachments) => this.handleAddWithAttachments(attachments)}
                 />
@@ -162,7 +162,7 @@ export default class ContainerDatasets extends Component {
         <div className="border rounded p-2 mb-2">
           <p>There are currently no Datasets.</p>
           <div className="list-group">
-            <div key="attachmentdropzone" className="list-group-item disabled">
+            <div key="attachmentdropzone" className="list-group-item">
               <AttachmentDropzone
                 handleAddWithAttachments={(attachments) => this.handleAddWithAttachments(attachments)}
               />


### PR DESCRIPTION
Description:

When dragging attachments from the inbox, we previously had to create a dataset and drop items on it. The field as a whole was disabled. Now, you can drop attachments on the dataset even if it's empty. 

---------------------------------
- [ ] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
