### PR TITLE
chore(service): bump spectra-app and ketcher2 requirements

### DIFF
--- a/.service-dependencies
+++ b/.service-dependencies
@@ -1,6 +1,6 @@
 #syntax=v1
 CONVERTER=ComPlat/chemotion-converter-app@1.4.0
 KETCHER=ptrxyz/chemotion-ketchersvc@main
-SPECTRA=ComPlat/chem-spectra-app@v1.2.5
+SPECTRA=ComPlat/chem-spectra-app@v1.2.6
 NMRIUMWRAPPER=NFDI4Chem/nmrium-react-wrapper@v0.8.0
-KETCHER2=epam/ketcher@v2.28.0
+KETCHER2=epam/ketcher@v3.0.3


### PR DESCRIPTION
- spectra-app to [1.2.6](https://github.com/ComPlat/chem-spectra-app/releases/tag/v1.2.6)
- ketcher2 to [3.0.3](https://github.com/epam/ketcher/releases/tag/v3.0.3)


