### PR TITLE
update state for import samples to collection button

### DIFF
--- a/app/javascript/src/components/contextActions/ExportImportButton.js
+++ b/app/javascript/src/components/contextActions/ExportImportButton.js
@@ -45,7 +45,8 @@ function ExportImportButton() {
       || (is_shared === true && permission_level < PermissionConst.ImportElements)
     );
 
-    setIsDisabled({ isDisabled: newIsDisabled });
+
+    setIsDisabled(newIsDisabled);
   };
 
   useEffect(() => {


### PR DESCRIPTION
**PR Description:**

**Problem:** The import samples to collection button in the ExportImportButton component did not reflect the state based on the current collection's permissions, leading to incorrect enabling/disabling behavior.

**Fix:** Updated the state management logic in the onUIStoreChange function to ensure the button is enabled or disabled based on the collection's label, is_locked, is_shared, and permission_level.

----------------------------------------------------------------------------------
- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [x] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
