### PR TITLE
fix: remove unnecessary min-width from svg style

### DIFF
--- a/app/assets/stylesheets/global-styles/package-mods/react-svg-file-zoom-pan.scss
+++ b/app/assets/stylesheets/global-styles/package-mods/react-svg-file-zoom-pan.scss
@@ -1,4 +1,3 @@
 .svg-file-zoom-pan > svg {
   min-height: 250px;
-  min-width: 30vw;
 }


### PR DESCRIPTION
Removed :

`min-width: 30vw`

from .svg-file-zoom-pan > svg to fix layout issue in Chemspectra.

Before: 
![image](https://github.com/user-attachments/assets/98403f0a-9ee7-4e38-86b9-70fe7c2dfd0d)

After: 
![image](https://github.com/user-attachments/assets/0698a62b-11fc-469d-b443-88ce581a83d0)
