### PR TITLE
fix: missing SVG path with Barcode PDFs

### DIFF
--- a/app/pdfs/code_pdf.rb
+++ b/app/pdfs/code_pdf.rb
@@ -185,8 +185,11 @@ class CodePdf < Prawn::Document
   # @param elements [Array] The elements to get the data from.
   # @return [Array<String, String, String>] An array containing the width, height and URL of the SVG image.
   def image_data_getter
+    dummy_file = 'images/wild_card/no_image_180.svg' # Dummy file path
     element = elements.first
     full_svg_path = element.send(:full_svg_path)
+    full_svg_path = Rails.public_path.join(dummy_file).to_s if full_svg_path.nil? || !File.exist?(full_svg_path)
+
     doc = Nokogiri::XML(File.read(full_svg_path))
     # Extract the width and height attributes from the SVG element
     svg_width = doc.at_css('svg')['width']


### PR DESCRIPTION
Resolves: [sentry#867](https://complat-sentry-internal.ibcs.kit.edu/organizations/complat/issues/867)

SVG reader fall back to dummy svg when element full_svg_path is invalid or nil.


----------------------------


- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
