### PR TITLE
fix: prevent attachment serialization errors when thumbnail previews cannot be retrieved

### DIFF
--- a/app/api/entities/attachment_entity.rb
+++ b/app/api/entities/attachment_entity.rb
@@ -8,6 +8,9 @@ module Entities
 
     def thumbnail
       object.thumb ? Base64.encode64(object.read_thumbnail) : nil
+    rescue StandardError => e
+      Rails.logger.error("Error generating thumbnail for attachment #{object.id}: #{e.message}")
+      nil
     end
   end
 end


### PR DESCRIPTION
so that navigation  (opening element is not impeded)