### PR TITLE
fix: use molecule ID instead of inchikey for names molecule api endpoint

### DIFF
--- a/app/api/chemotion/molecule_api.rb
+++ b/app/api/chemotion/molecule_api.rb
@@ -220,14 +220,14 @@ module Chemotion
 
       desc 'return names of the molecule'
       params do
-        requires :inchikey, type: String, desc: 'Molecule inchikey'
+        requires :id, type: String, desc: 'Molecule id'
         optional :new_name, type: String, desc: 'New molecule_name'
       end
       get :names do
-        inchikey = params[:inchikey]
+        id = params[:id]
         new_name = params[:new_name]
 
-        mol = Molecule.find_by(inchikey: inchikey)
+        mol = Molecule.find_by(id: id)
         return [] if mol.blank?
 
         user_id = current_user.id

--- a/app/javascript/src/fetchers/MoleculesFetcher.js
+++ b/app/javascript/src/fetchers/MoleculesFetcher.js
@@ -42,12 +42,12 @@ export default class MoleculesFetcher {
       .catch(errorMessage => console.log(errorMessage));
   }
 
-  static updateNames(inchikey, newMolName = '') {
-    return fetch(`/api/v1/molecules/names?inchikey=${inchikey}` +
-      `&new_name=${escape(newMolName)}`, {
+  static updateNames(id, newMolName = '') {
+    return fetch(`/api/v1/molecules/names?id=${id}`
+      + `&new_name=${escape(newMolName)}`, {
       credentials: 'same-origin',
-    }).then(response => response.json()).then(json => json.molecules)
-      .catch(errorMessage => console.log(errorMessage));
+    }).then((response) => response.json()).then((json) => json.molecules)
+      .catch((errorMessage) => console.log(errorMessage));
   }
 
   static computePropsFromSmiles(sampleId) {

--- a/app/javascript/src/stores/alt/actions/DetailActions.js
+++ b/app/javascript/src/stores/alt/actions/DetailActions.js
@@ -32,14 +32,14 @@ class DetailActions {
   }
 
   updateMoleculeNames(sample, newMolName = '') {
-    const inchikey = sample.molecule.inchikey;
-    if (!inchikey) { return null; }
+    const id = sample.molecule.id;
+    if (!id) { return null; }
 
     return (dispatch) => {
       MoleculesFetcher
-        .updateNames(inchikey, newMolName)
+        .updateNames(id, newMolName)
         .then((result) => {
-          const mn = result.find(r => r.name === newMolName);
+          const mn = result.find((r) => r.name === newMolName);
           if (mn) sample.molecule_name = { label: mn.name, value: mn.id };
           sample.molecule_names = result;
           dispatch(sample);

--- a/spec/api/molecule_api_spec.rb
+++ b/spec/api/molecule_api_spec.rb
@@ -90,7 +90,7 @@ M  END"
       let(:m) { create(:molecule) }
 
       it 'returns molecule_names hash' do
-        get "/api/v1/molecules/names?inchikey=#{m.inchikey}"
+        get "/api/v1/molecules/names?id=#{m.id}"
         mns = JSON.parse(response.body)['molecules'].map { |m| m['label'] }
         expect(mns).to include(m.sum_formular)
       end


### PR DESCRIPTION
**Problem**:
- The molecule names API endpoint was using inchikey as the lookup parameter, which is not unique anymore

**Solution**:
- Changed API parameter in MoleculeAPI names endpoint from 'inchikey' to 'id'
- Updated client-side code in MoleculesFetcher and DetailActions to match this change
- Updated tests to use id parameter in API requests

refs: #2444 
_____________________________________________________________________________________________

- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [x] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
