### PR TITLE
fix: css for image and svg in history tracker

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,6 +26,7 @@
 @import "components/SearchResult";
 @import "components/QuillEditor";
 @import "components/QuillViewer";
+@import "components/svg_with_popver";
 
 @import "legacy/miscellaneous";
 @import "legacy/AttachmentContainer";

--- a/app/assets/stylesheets/global-styles/package-mods/react-svg-file-zoom-pan.scss
+++ b/app/assets/stylesheets/global-styles/package-mods/react-svg-file-zoom-pan.scss
@@ -1,3 +1,7 @@
 .svg-file-zoom-pan > svg {
   min-height: 250px;
 }
+
+.svg-file-zoom-pan-container > .svg-file-zoom-pan > svg {
+  min-width: 30vw;
+}

--- a/app/javascript/src/apps/mydb/elements/details/VersionsTableFields.js
+++ b/app/javascript/src/apps/mydb/elements/details/VersionsTableFields.js
@@ -78,9 +78,9 @@ function VersionsTableFields(props) {
       hasPop
       previewObject={{
         txtOnly: '',
-        isSVG: true,
+        isSVG: input.endsWith('.svg'),
         src: input,
-        className: 'image-with-full-width',
+        className: input.endsWith('.svg') ? 'molecule ' : 'image-with-full-width',
       }}
       popObject={{
         title,

--- a/app/javascript/src/components/common/SvgWithPopover.js
+++ b/app/javascript/src/components/common/SvgWithPopover.js
@@ -17,7 +17,7 @@ export default class SvgWithPopover extends Component {
         {
           popObject.title && <Popover.Header as="h3">{popObject.title}</Popover.Header>
         }
-        <Popover.Body>
+        <Popover.Body className="svg-file-zoom-pan-container">
           {
             previewObject.isSVG
             ? 
@@ -40,7 +40,7 @@ export default class SvgWithPopover extends Component {
       previewObj = (
         previewObject.isSVG
           ? <SVG src={previewObject.src} className={previewObject.className || 'molecule'} key={previewObject.src} />
-          : <img src={previewObject.src} alt="" />
+          : <img src={previewObject.src} className={previewObject.className} alt="" />
       );
     }
 


### PR DESCRIPTION
- ensure min-width for popover svg in list (regres from #2443)
- fix missing image css import
- ensure css class is passed to SvgWithPopover preview <img>
- history image preview: check src filename ext to infer which css class to use in SvgWithPopover

Notes: SvgWithPopOver could handle the mime type of the src instead of
  having to pass additional props like isSvg or conditional default css class

refs: #2068, #2443


