### PR TITLE
fix(db): de-type deleted user-device

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -538,6 +538,9 @@ class Group < User
   end
 end
 
+class DeviceDeprecated < User
+end
+
 # rubocop: enable Metrics/ClassLength, Metrics/CyclomaticComplexity
 # rubocop: enable Metrics/AbcSize
 # rubocop: enable Metrics/PerceivedComplexity

--- a/db/migrate/20250422105404_detype_obsolet_users.rb
+++ b/db/migrate/20250422105404_detype_obsolet_users.rb
@@ -1,0 +1,12 @@
+class DetypeObsoletUsers < ActiveRecord::Migration[6.1]
+  class User < ActiveRecord::Base
+    self.inheritance_column = nil
+    self.table_name = 'users'
+  end
+
+  # Operating on soft-deleted records causes issues if those with type `Device`
+  # since Device < User has been deprecated and refactor to its own table.
+  def up
+    User.where(type: 'Device').update_all(type:  'DeviceDeprecated') }
+  end
+end

--- a/db/migrate/20250422105404_detype_obsolet_users.rb
+++ b/db/migrate/20250422105404_detype_obsolet_users.rb
@@ -7,6 +7,6 @@ class DetypeObsoletUsers < ActiveRecord::Migration[6.1]
   # Operating on soft-deleted records causes issues if those with type `Device`
   # since Device < User has been deprecated and refactor to its own table.
   def up
-    User.where(type: 'Device').update_all(type:  'DeviceDeprecated') }
+    User.where(type: 'Device').update_all(type:  'DeviceDeprecated')
   end
 end


### PR DESCRIPTION
to avoid history serialization error since Device is not a User anymore

```
ActiveRecord::SubclassNotFound
Invalid single-table inheritance type: Device is not a subclass of User
```

refs: #1736, #2068


