### PR TITLE
fix(UI): layout and event propagation in sample and reaction card

### DIFF
--- a/app/assets/stylesheets/components/QuillEditor.css
+++ b/app/assets/stylesheets/components/QuillEditor.css
@@ -32,7 +32,6 @@
   line-height: 1.42;
   height: 100%;
   outline: none;
-  overflow-y: auto;
   padding: 12px 15px;
   tab-size: 4;
   -moz-tab-size: 4;

--- a/app/assets/stylesheets/global-styles/bootstrap-mods.scss
+++ b/app/assets/stylesheets/global-styles/bootstrap-mods.scss
@@ -54,5 +54,3 @@
 .input-group {
   z-index: 0;
 }
-
-

--- a/app/assets/stylesheets/global-styles/bootstrap-mods.scss
+++ b/app/assets/stylesheets/global-styles/bootstrap-mods.scss
@@ -54,3 +54,9 @@
 .input-group {
   z-index: 0;
 }
+
+.min-h-200 {
+  min-height: 200px;
+}
+
+

--- a/app/assets/stylesheets/global-styles/bootstrap-mods.scss
+++ b/app/assets/stylesheets/global-styles/bootstrap-mods.scss
@@ -55,8 +55,4 @@
   z-index: 0;
 }
 
-.min-h-200 {
-  min-height: 200px;
-}
-
 

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
@@ -847,7 +847,7 @@ class Material extends Component {
 
   solventMaterial(props, className) {
     const { material, deleteMaterial, connectDragSource,
-      connectDropTarget, reaction } = props;
+      connectDropTarget, reaction, materialGroup } = props;
     const isTarget = material.amountType === 'target';
     const mw = material.molecule && material.molecule.molecular_weight;
     const drySolvTooltip = <Tooltip>Dry Solvent</Tooltip>;
@@ -889,18 +889,18 @@ class Material extends Component {
                 size="sm"
                 value={material.external_label}
                 placeholder={material.molecule.iupac_name}
-                onChange={event => this.handleExternalLabelChange(event)}
+                onChange={(event) => this.handleExternalLabelChange(event)}
               />
             </OverlayTrigger>
             <OverlayTrigger placement="bottom" overlay={refreshSvgTooltip}>
-                <Button
-                  disabled={!permitOn(reaction)}
-                  active
-                  onClick={e => this.handleExternalLabelCompleted(e)}
-                  size="sm"
-                >
-                  <i className="fa fa-refresh" />
-                </Button>
+              <Button
+                disabled={materialGroup === 'purification_solvents' || !permitOn(reaction)}
+                active
+                onClick={(e) => this.handleExternalLabelCompleted(e)}
+                size="sm"
+              >
+                <i className="fa fa-refresh" />
+              </Button>
             </OverlayTrigger>
           </InputGroup>
         </td>

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/MaterialCalculations.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/MaterialCalculations.js
@@ -57,60 +57,62 @@ export default class MaterialCalculations extends Component {
       paddingLeft: 2,
     };
 
-    return <tr>
-      <td className='pt-4 px-1'></td>
-      <td className='pt-4 px-1'></td>
-      <td className='pt-4 px-1'></td>
-      <td className='pt-4 px-1'><label>Adjusted: </label></td>
-      <td className='pt-4 px-1'>
-        <NumeralInputWithUnitsCompo
-          key={material.id}
-          value={material.adjusted_amount_g}
-          unit='g'
-          metricPrefix={metric}
-          metricPrefixes={metricPrefixes}
-          precision={5}
-          disabled
-          readOnly
-        />
-      </td>
+    return (
+      <tr>
+        <td className="pt-4 px-1" />
+        <td className="pt-4 px-1" />
+        <td className="pt-4 px-1" />
+        <td className="pt-4 px-1"><label>Adjusted: </label></td>
+        <td className="pt-4 px-1">
+          <NumeralInputWithUnitsCompo
+            key={material.id}
+            value={material.adjusted_amount_g}
+            unit='g'
+            metricPrefix={metric}
+            metricPrefixes={metricPrefixes}
+            precision={5}
+            disabled
+            readOnly
+          />
+        </td>
 
-      {this.materialVolume(material, inputsStyle)}
+        {this.materialVolume(material, inputsStyle)}
 
-      <td className='pt-4 px-1'>
-        <NumeralInputWithUnitsCompo
-          key={'adjusted_amount_mol' + material.id.toString()}
-          value={material.adjusted_amount_mol}
-          unit='mol'
-          metricPrefix={metricMol}
-          metricPrefixes={metricPrefixesMol}
-          precision={4}
-          disabled
-          readOnly
-        />
-      </td>
+        <td className="pt-4 px-1">
+          <NumeralInputWithUnitsCompo
+            key={'adjusted_amount_mol' + material.id.toString()}
+            value={material.adjusted_amount_mol}
+            unit="mol"
+            metricPrefix={metricMol}
+            metricPrefixes={metricPrefixesMol}
+            precision={4}
+            disabled
+            readOnly
+          />
+        </td>
 
-      <td className='pt-4 px-1'>
-        <NumeralInputWithUnitsCompo
-          key={'adjusted_loading' + material.id.toString()}
-          value={material.adjusted_loading}
-          unit='mmol/g'
-          metricPrefix='n'
-          metricPrefixes={['n']}
-          precision={3}
-          disabled
-          readOnly
-        />
-      </td>
+        <td className="pt-4 px-1">
+          <NumeralInputWithUnitsCompo
+            key={'adjusted_loading' + material.id.toString()}
+            value={material.adjusted_loading}
+            unit="mmol/g"
+            metricPrefix="n"
+            metricPrefixes={['n']}
+            precision={3}
+            disabled
+            readOnly
+          />
+        </td>
 
-      <td className='pt-4 px-1'>
-        <Form.Control
-          type="text"
-          value={`${((material.adjusted_equivalent || 0) * 100).toFixed(1)} %`}
-          disabled
-        />
-      </td>
-      <td></td>
-    </tr>
+        <td className="pt-4 px-1">
+          <Form.Control
+            type="text"
+            value={`${((material.adjusted_equivalent || 0) * 100).toFixed(1)} %`}
+            disabled
+          />
+        </td>
+        <td />
+      </tr>
+    );
   }
 }

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/MaterialGroup.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/MaterialGroup.js
@@ -305,9 +305,9 @@ function SolventsMaterialGroup({
         <col style={{ width: '22%' }} />
         <col style={{ width: '2%' }} />
         <col style={{ width: '2%' }} />
-        <col style={{ width: '15%' }} />
-        <col style={{ width: '15%' }} />
-        <col />
+        <col style={{ width: '22%' }} />
+        <col style={{ width: '14%' }} />
+        <col style={{ width: '14%' }} />
         <col style={{ width: '2%' }} />
       </colgroup>
       <thead>

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/MaterialGroup.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/MaterialGroup.js
@@ -300,6 +300,16 @@ function SolventsMaterialGroup({
 
   return (
     <Table borderless className="w-100">
+      <colgroup>
+        <col style={{ width: '4%' }} />
+        <col style={{ width: '22%' }} />
+        <col style={{ width: '2%' }} />
+        <col style={{ width: '2%' }} />
+        <col style={{ width: '15%' }} />
+        <col style={{ width: '15%' }} />
+        <col />
+        <col style={{ width: '2%' }} />
+      </colgroup>
       <thead>
         <tr>
           <th className="align-middle">{addSampleButton}</th>

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsPurification.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsPurification.js
@@ -103,7 +103,7 @@ export default class ReactionDetailsPurification extends Component {
     const { reaction, onInputChange, additionQuillRef } = this.props;
     return (
       <>
-        <Row className='mb-2'>
+        <Row className="mb-3">
           <Col sm={12}>
             <Form.Group>
               <Form.Label>Purification</Form.Label>
@@ -118,7 +118,7 @@ export default class ReactionDetailsPurification extends Component {
             </Form.Group>
           </Col>
         </Row>
-        <Row className='mb-2'>
+        <Row className="mb-2">
           <Col sm={12}>
             <Form.Label>Purification solvents</Form.Label>
             <MaterialGroupContainer
@@ -134,19 +134,20 @@ export default class ReactionDetailsPurification extends Component {
             />
           </Col>
         </Row>
-        <Row className='mb-3'>
+        <Row className="mb-3">
           <Col md={12}>
             <Form.Label>Additional information for publication and purification details</Form.Label>
             <div className="quill-resize">
               {
-                permitOn(reaction) ?
+                permitOn(reaction) ? (
                   <QuillEditor
                     ref={additionQuillRef}
                     value={reaction.observation}
                     height="100%"
                     disabled={!permitOn(reaction) || reaction.isMethodDisabled('observation')}
-                    onChange={event => onInputChange('observation', event)}
-                  /> : <QuillViewer value={reaction.observation} />
+                    onChange={(event) => onInputChange('observation', event)}
+                  />
+                ) : <QuillViewer value={reaction.observation} />
               }
             </div>
             <PrivateNoteElement element={reaction} disabled={!reaction.can_update} />

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsPurification.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsPurification.js
@@ -20,7 +20,6 @@ export default class ReactionDetailsPurification extends Component {
     this.handlePurificationChange = this.handlePurificationChange.bind(this);
     this.handleOnReactionChange = this.handleOnReactionChange.bind(this);
     this.handleOnSolventSelect = this.handleOnSolventSelect.bind(this);
-    this.handlePSolventChange = this.handlePSolventChange.bind(this);
     this.deletePSolvent = this.deletePSolvent.bind(this);
     this.dropPSolvent = this.dropPSolvent.bind(this);
   }
@@ -55,14 +54,6 @@ export default class ReactionDetailsPurification extends Component {
     } else {
       this.handleMultiselectChange('purification', selected);
     }
-  }
-
-  handlePSolventChange(changeEvent) {
-    const { sampleID, amount } = changeEvent;
-    const { reaction, onReactionChange } = this.props;
-    const updatedSample = reaction.sampleById(sampleID);
-    updatedSample.setAmount(amount);
-    onReactionChange(reaction);
   }
 
   deletePSolvent(material) {
@@ -100,7 +91,12 @@ export default class ReactionDetailsPurification extends Component {
   }
 
   render() {
-    const { reaction, onInputChange, additionQuillRef } = this.props;
+    const {
+      reaction,
+      onInputChange,
+      additionQuillRef,
+      onChange
+    } = this.props;
     return (
       <>
         <Row className="mb-3">
@@ -113,7 +109,7 @@ export default class ReactionDetailsPurification extends Component {
                 isDisabled={!permitOn(reaction) || reaction.isMethodDisabled('purification')}
                 options={purificationOptions}
                 onChange={this.handlePurificationChange}
-                value={purificationOptions.filter(({value}) => reaction.purification.includes(value))}
+                value={purificationOptions.filter(({ value }) => reaction.purification.includes(value))}
               />
             </Form.Group>
           </Col>
@@ -129,7 +125,7 @@ export default class ReactionDetailsPurification extends Component {
               deleteMaterial={this.deletePSolvent}
               dropSample={this.dropPSolvent}
               showLoadingColumn={!!reaction.hasPolymers()}
-              onChange={this.handlePSolventChange}
+              onChange={onChange}
               headIndex={0}
             />
           </Col>
@@ -162,12 +158,14 @@ ReactionDetailsPurification.propTypes = {
   reaction: PropTypes.object,
   onReactionChange: PropTypes.func,
   onInputChange: PropTypes.func,
-  additionQuillRef: PropTypes.object
+  additionQuillRef: PropTypes.object,
+  onChange: PropTypes.func,
 };
 
 ReactionDetailsPurification.defaultProps = {
   reaction: {},
   onReactionChange: () => {},
   onInputChange: () => {},
+  onChange: () => {},
   additionQuillRef: {}
 };

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsPurification.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsPurification.js
@@ -137,7 +137,7 @@ export default class ReactionDetailsPurification extends Component {
         <Row className="mb-3">
           <Col md={12}>
             <Form.Label>Additional information for publication and purification details</Form.Label>
-            <div className="quill-resize">
+            <div>
               {
                 permitOn(reaction) ? (
                   <QuillEditor

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
@@ -1284,7 +1284,7 @@ export default class ReactionDetailsScheme extends Component {
             {this.reactionVesselSize()}
           </Col>
         </Row>
-        <Row>
+        <Row className="mb-3">
           <Form.Group>
             <Form.Label>Description</Form.Label>
             <div>

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
@@ -1284,10 +1284,10 @@ export default class ReactionDetailsScheme extends Component {
             {this.reactionVesselSize()}
           </Col>
         </Row>
-        <Row className="mb-3">
+        <Row>
           <Form.Group>
             <Form.Label>Description</Form.Label>
-            <div className="quill-resize">
+            <div className="quill-resize d-flex flex-column min-h-200">
               {
                 permitOn(reaction)
                   ? (

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
@@ -1309,6 +1309,7 @@ export default class ReactionDetailsScheme extends Component {
           onReactionChange={(r) => this.onReactionChange(r)}
           onInputChange={(type, event) => this.props.onInputChange(type, event)}
           additionQuillRef={this.additionQuillRef}
+          onChange={(event) => this.handleMaterialsChange(event)}
         />
       </>
     );

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
@@ -1287,7 +1287,7 @@ export default class ReactionDetailsScheme extends Component {
         <Row>
           <Form.Group>
             <Form.Label>Description</Form.Label>
-            <div className="quill-resize d-flex flex-column min-h-200">
+            <div>
               {
                 permitOn(reaction)
                   ? (

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsFieldRichText.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsFieldRichText.js
@@ -11,7 +11,7 @@ export default class ResearchPlanDetailsFieldRichText extends Component {
     } = this.props;
 
     return (
-      <div className="quill-resize">
+      <div>
         <QuillEditor
           value={field.value}
           height="100%"

--- a/app/javascript/src/apps/mydb/elements/details/samples/FastInput.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/FastInput.js
@@ -82,28 +82,30 @@ function FastInput(props) {
   };
 
   return (
-    <OverlayTrigger
-      placement="top"
-      delayShow={500}
-      overlay={<Tooltip id="_fast_create_btn">Fast create by CAS RN (with dashes) or SMILES</Tooltip>}
-    >
-      <InputGroup size="xxsm" className="fast-input">
-        <Form.Control
-          id="_fast_create_btn_split"
-          type="text"
-          onChange={updateValue}
-          value={value}
-          onKeyPress={(e) => searchString(e)}
-          placeholder="fast create by CAS/Smiles ..."
-        />
-        <Button
-          variant="light"
-          onClick={(e) => searchString(e)}
-        >
-          <i className="fa fa-search" />
-        </Button>
-      </InputGroup>
-    </OverlayTrigger>
+    <div className="w-50">
+      <OverlayTrigger
+        placement="top"
+        delayShow={500}
+        overlay={<Tooltip id="_fast_create_btn">Fast create by CAS RN (with dashes) or SMILES</Tooltip>}
+      >
+        <InputGroup size="xxsm" className="fast-input">
+          <Form.Control
+            id="_fast_create_btn_split"
+            type="text"
+            onChange={updateValue}
+            value={value}
+            onKeyPress={(e) => searchString(e)}
+            placeholder="fast create by CAS/Smiles..."
+          />
+          <Button
+            variant="light"
+            onClick={(e) => searchString(e)}
+          >
+            <i className="fa fa-search" />
+          </Button>
+        </InputGroup>
+      </OverlayTrigger>
+    </div>
   );
 }
 

--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -965,7 +965,7 @@ export default class SampleDetails extends React.Component {
       <Form.Check
         type="checkbox"
         id="sample-inventory-header"
-        className="mx-3 sample-inventory-header"
+        className="mx-2 sample-inventory-header"
         checked={sample.inventory_sample}
         onChange={(e) => this.handleInventorySample(e)}
         label="Inventory"
@@ -976,7 +976,7 @@ export default class SampleDetails extends React.Component {
       <Form.Check
         type="checkbox"
         id="sample-header-decouple"
-        className="mx-3 sample-header-decouple"
+        className="mx-2 sample-header-decouple"
         checked={sample.decoupled}
         onChange={(e) => this.decoupleChanged(e)}
         label="Decoupled"
@@ -986,8 +986,8 @@ export default class SampleDetails extends React.Component {
     const inventoryLabel = sample.inventory_sample && sample.inventory_label ? sample.inventory_label : null;
 
     return (
-      <div className="d-flex align-items-center justify-content-between">
-        <div className="d-flex align-items-center flex-wrap gap-2">
+      <div className="d-flex align-items-center flex-wrap">
+        <div className="d-flex align-items-center flex-wrap flex-grow-1 gap-2">
           <OverlayTrigger placement="bottom" overlay={<Tooltip id="sampleDates">{titleTooltip}</Tooltip>}>
             <span className="flex-shrink-0">
               <i className="icon-sample me-1" />
@@ -1002,7 +1002,7 @@ export default class SampleDetails extends React.Component {
           <HeaderCommentSection element={sample} />
           {sample.isNew && <FastInput fnHandle={this.handleFastInput} />}
         </div>
-        <div className="d-flex align-items-center gap-1">
+        <div className="d-flex align-items-center gap-2">
           {decoupleCb}
           {inventorySample}
           {!sample.isNew && <OpenCalendarButton isPanelHeader eventableId={sample.id} eventableType="Sample" />}

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -255,7 +255,7 @@ export default class SampleForm extends React.Component {
             options={moleculeNames}
             onMenuOpen={() => this.openMolName(sample)}
             onChange={this.updateMolName}
-            isLoading={this.state.isMolNameLoading}
+            isLoading={isMolNameLoading}
             value={moleculeNames.find(({ value }) => value === mno?.value)}
             onCreateOption={this.addMolName}
             className="flex-grow-1"

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -239,6 +239,7 @@ export default class SampleForm extends React.Component {
 
   moleculeInput() {
     const { sample } = this.props;
+    const { isMolNameLoading } = this.state;
     const mnos = sample.molecule_names;
     const mno = sample.molecule_name;
     const newMolecule = !mno || sample._molecule.id !== mno.mid;
@@ -746,8 +747,6 @@ export default class SampleForm extends React.Component {
       <Form>
         <Row className="align-items-end mb-4">
           <Col>{this.moleculeInput()}</Col>
-        </Row>
-        <Row className="align-items-end mb-4">
           <Col>{this.textInput(sample, 'name', 'Sample name')}</Col>
           <Col>{this.stereoAbsInput()}</Col>
           <Col>{this.stereoRelInput()}</Col>

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -748,7 +748,7 @@ export default class SampleForm extends React.Component {
         <Row className="align-items-end mb-4">
           <Col>{this.moleculeInput()}</Col>
         </Row>
-        <Row>
+        <Row className="align-items-end mb-4">
           <Col>{this.textInput(sample, 'name', 'Sample name')}</Col>
           <Col>{this.stereoAbsInput()}</Col>
           <Col>{this.stereoRelInput()}</Col>

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -784,7 +784,7 @@ export default class SampleForm extends React.Component {
         )}
 
         <Row className="align-items-center g-2 mb-4">
-          <Col xs={6} className="d-flex align-items-end gap-2">
+          <Col xs={7} className="d-flex align-items-end gap-2">
             {this.infoButton()}
             {this.sampleAmount(sample)}
           </Col>

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -225,7 +225,7 @@ export default class SampleForm extends React.Component {
 
     return (
       <Form.Group>
-        <Form.Label>Stereo Rel</Form.Label>
+        <Form.Label>Stereo rel</Form.Label>
         <Select
           name="stereoRel"
           isDisabled={!sample.can_update}
@@ -747,6 +747,8 @@ export default class SampleForm extends React.Component {
       <Form>
         <Row className="align-items-end mb-4">
           <Col>{this.moleculeInput()}</Col>
+        </Row>
+        <Row>
           <Col>{this.textInput(sample, 'name', 'Sample name')}</Col>
           <Col>{this.stereoAbsInput()}</Col>
           <Col>{this.stereoRelInput()}</Col>

--- a/app/javascript/src/components/QuillEditor.js
+++ b/app/javascript/src/components/QuillEditor.js
@@ -348,6 +348,7 @@ export default class QuillEditor extends React.Component {
         <div
           ref={this.id}
           style={{ height: this.height }}
+          className="quill-resize"
         />
       </div>
     );

--- a/app/javascript/src/components/reactQuill/ReactQuill.js
+++ b/app/javascript/src/components/reactQuill/ReactQuill.js
@@ -424,7 +424,7 @@ export default class ReactQuill extends React.Component {
 
     return preserveWhitespace
       ? <pre {...properties} />
-      : <div {...properties} />;
+      : <div className="quill-resize" {...properties} />;
   }
 
   render() {


### PR DESCRIPTION
**UI Issues and Solutions - Detailed Implementation**
-----------------------------------------------------------

**Issue 1: QuillEditor Styling Inconsistencies**

Files Modified:
[QuillEditor.js]
[ReactQuill.js]
[ReactionDetailsScheme.js]
[ReactionDetailsPurification.js]
[ResearchPlanDetailsFieldRichText.js]

**Problem:** The quill-resize class was inconsistently applied across different components—sometimes on parent divs, sometimes missing entirely. This caused unpredictable rendering behavior with the rich text editors' inconsistent sizes.

**Solution:**
1. Moved the quill-resize class directly to the inner component in ReactQuill.js
2. Added the class to the div in QuillEditor.js
3. Removed unnecessary wrapper divs in multiple files
4. This ensures consistent styling hierarchy across all rich text editors

--------------------------------------------------------------------------------------------------------------------------------

**Issue 2: Layout and Spacing Inconsistencies**

Files Modified:
[FastInput.js]
[SampleDetails.js]
[SampleForm.js]

**Problem:** Components had inconsistent spacing and alignment, particularly in the Sample Details header and form elements. The FastInput component lacked proper width constraints.

**Solution:**
1. Wrapped FastInput in width-constrained container (w-50)
2. Improved flex layout in SampleDetails with better spacing classes
3. Fixed capitalization in SampleForm labels (e.g., "Stereo Rel" → "Stereo rel")
4. Modified spacing between form rows for better visual hierarchy
--------------------------------------------------------------------------------------------------------------------------------

**Issue 3: Table Column Width Problems**

Files Modified:
[MaterialGroup.js]
[MaterialCalculations.js]

**Problem:** The MaterialGroup tables had inconsistent column widths, causing layout shifts when data was added or changed.

**Solution:**
1. Added proper <colgroup> definitions with specific widths:
2. Improved formatting in MaterialCalculations.js with proper JSX structure
3. Standardized class names using double quotes instead of single quotes
--------------------------------------------------------------------------------------------------------------------------------

**Issue 4: Event Propagation Failure in Purification Solvents**

Files Modified:
ReactionDetailsPurification.js
ReactionDetailsScheme.js

**Problem:** Material changes weren't being properly synchronized between components due to custom event handlers not properly passing data up the component tree.

**Solution:**
1. Removed redundant handlePSolventChange method in ReactionDetailsPurification
2. Added proper onChange prop passing from parent component:
3. Updated PropTypes definitions to include the missing onChange property
4. This ensures changes to purification solvents are properly reflected throughout the component hierarchy
6. These coordinated changes across multiple files address specific UI issues while maintaining a consistent approach to styling, layout, and event handling throughout the application.

___________________________________________________________________________________________________________________________
- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
