### PR TITLE
fix: arg parsing to query pubchem by cid

### DIFF
--- a/lib/pub_chem.rb
+++ b/lib/pub_chem.rb
@@ -124,7 +124,7 @@ module PubChem
   def self.get_cas_from_cid(cid)
     return [] if cid.blank?
 
-    cid = cid.split(/\s+|,/).compact_blank.last
+    cid = cid.to_s.split(/\s+|,/).compact_blank.last
     options = { timeout: 10, headers: { 'Content-Type' => 'text/json' } }
     page = "https://#{PUBCHEM_HOST}/rest/pug_view/data/compound/#{cid}/XML?heading=CAS"
     resp = HTTParty.get(page, options)

--- a/spec/lib/pub_chem_spec.rb
+++ b/spec/lib/pub_chem_spec.rb
@@ -15,7 +15,23 @@ RSpec.describe 'PubChem' do
 
       target = []
       result = PubChem.most_occurance(target)
-      expect(result).to eq nil
+      expect(result).to be_nil
+    end
+  end
+
+  describe '.get_cas_from_cid' do
+    it 'builds the correct URL' do
+      expected_url = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug_view/data/compound/123456/XML?heading=CAS'
+      expected_body = '<Value><StringWithMarkup><String>123-45-6</String></StringWithMarkup></Value>'
+      allow(HTTParty).to(
+        receive(:get).with(expected_url, anything)
+                     .and_return(instance_double(HTTParty::Response, success?: true, body: expected_body)),
+      )
+
+      [123_456, '123456', ' 1234 , 12345 ,123456 ', "1 \n \n 1234 \n 12345 \n 123456"].each do |cid|
+        result = PubChem.get_cas_from_cid(cid)
+        expect(result).to eq ['123-45-6']
+      end
     end
   end
 end


### PR DESCRIPTION
#2447 introduce parsing of multiline cid  to build the proper url. However the cid, if coming from the db, is likely to be integer 

Allow parsing of cid as integer

refs: #2447


