### PR TITLE
Fix: Improve attachment upload and saving flow for elements (#2273)

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -190,8 +190,8 @@ export default class SampleDetails extends React.Component {
 
     const smileReadonly = !(
       (sample.isNew
-       && (typeof (sample.molfile) === 'undefined'
-        || (sample.molfile || '').length === 0)
+        && (typeof (sample.molfile) === 'undefined'
+          || (sample.molfile || '').length === 0)
       )
       || (typeof (sample.molfile) !== 'undefined' && sample.molecule.inchikey === 'DUMMY')
     );
@@ -221,9 +221,15 @@ export default class SampleDetails extends React.Component {
   }
 
   handleSampleChanged(sample, cb) {
+    console.log('handleSampleChanged', sample);
     this.setState({
       sample,
-    }, cb);
+    }, () => {
+      if (typeof cb === 'function') {
+        cb();
+      }
+      this.handleSubmit();
+    });
   }
 
   handleAmountChanged(amount) {
@@ -334,7 +340,6 @@ export default class SampleDetails extends React.Component {
 
   handleSubmit(closeView = false) {
     const { currentCollection } = UIStore.getState();
-    LoadingActions.start.defer();
     const { sample, validCas } = this.state;
     if (this.matchSelectedCollection(currentCollection) && sample.inventory_label !== undefined) {
       sample.collection_id = currentCollection.id;
@@ -346,6 +351,7 @@ export default class SampleDetails extends React.Component {
     if (!decoupleCheck(sample)) return;
     if (!rangeCheck('boiling_point', sample)) return;
     if (!rangeCheck('melting_point', sample)) return;
+    LoadingActions.start.defer();
     if (sample.belongTo && sample.belongTo.type === 'reaction') {
       const reaction = sample.belongTo;
       reaction.editedSample = sample;
@@ -825,7 +831,7 @@ export default class SampleDetails extends React.Component {
     const { sample, isCasLoading, validCas } = this.state;
     const { molecule, xref } = sample;
     const cas = xref?.cas ?? '';
-    let casArr = Array.isArray(molecule?.cas) ? molecule?.cas?.filter((el) => el !== null) : [];
+    const casArr = Array.isArray(molecule?.cas) ? molecule?.cas?.filter((el) => el !== null) : [];
     if (cas && !casArr.includes(cas)) {
       casArr.push(cas);
     }
@@ -907,38 +913,38 @@ export default class SampleDetails extends React.Component {
     const elementToSave = activeTab === 'inventory' ? 'Chemical' : 'Sample';
     const saveAndClose = (saveBtnDisplay
       && (
-      <OverlayTrigger
-        placement="bottom"
-        overlay={(
-          <Tooltip id="saveCloseSample">
-            {`Save and Close ${elementToSave}`}
-          </Tooltip>
-        )}
-      >
-        {this.saveButton(sampleUpdateCondition, floppyTag, timesTag, true)}
-      </OverlayTrigger>
+        <OverlayTrigger
+          placement="bottom"
+          overlay={(
+            <Tooltip id="saveCloseSample">
+              {`Save and Close ${elementToSave}`}
+            </Tooltip>
+          )}
+        >
+          {this.saveButton(sampleUpdateCondition, floppyTag, timesTag, true)}
+        </OverlayTrigger>
       )
     );
     const save = (saveBtnDisplay
       && (
-      <OverlayTrigger
-        placement="bottom"
-        overlay={(
-          <Tooltip id="saveSample">
-            {`Save ${elementToSave}`}
-          </Tooltip>
-        )}
-      >
-        {this.saveButton(sampleUpdateCondition, floppyTag)}
-      </OverlayTrigger>
+        <OverlayTrigger
+          placement="bottom"
+          overlay={(
+            <Tooltip id="saveSample">
+              {`Save ${elementToSave}`}
+            </Tooltip>
+          )}
+        >
+          {this.saveButton(sampleUpdateCondition, floppyTag)}
+        </OverlayTrigger>
       )
     );
 
     const saveForChemical = isChemicalTab && isChemicalEdited ? save : null;
     return (
       <>
-        { isChemicalTab ? saveForChemical : save}
-        { isChemicalTab ? null : saveAndClose }
+        {isChemicalTab ? saveForChemical : save}
+        {isChemicalTab ? null : saveAndClose}
         <ConfirmClose el={sample} />
       </>
     );
@@ -1383,27 +1389,27 @@ export default class SampleDetails extends React.Component {
     const { pageMessage } = this.state;
     const messageBlock = (pageMessage
       && (pageMessage.error.length > 0 || pageMessage.warning.length > 0)) ? (
-        <Alert variant="warning" style={{ marginBottom: 'unset', padding: '5px', marginTop: '10px' }}>
-          <strong>Structure Alert</strong>
-          <Button
-            size="sm"
-            variant="warning"
-            onClick={() => this.setState({ pageMessage: null })}
-          >
-            Close Alert
-          </Button>
-          {
+      <Alert variant="warning" style={{ marginBottom: 'unset', padding: '5px', marginTop: '10px' }}>
+        <strong>Structure Alert</strong>
+        <Button
+          size="sm"
+          variant="warning"
+          onClick={() => this.setState({ pageMessage: null })}
+        >
+          Close Alert
+        </Button>
+        {
           pageMessage.error.map((m) => (
             <div key={uuid.v1()}>{m}</div>
           ))
         }
-          {
+        {
           pageMessage.warning.map((m) => (
             <div key={uuid.v1()}>{m}</div>
           ))
         }
-        </Alert>
-      ) : null;
+      </Alert>
+    ) : null;
 
     const activeTab = (this.state.activeTab !== 0 && stb.indexOf(this.state.activeTab) > -1
       && this.state.activeTab) || visible.get(0);

--- a/app/javascript/src/components/container/ContainerDatasetModal.js
+++ b/app/javascript/src/components/container/ContainerDatasetModal.js
@@ -32,12 +32,10 @@ export default class ContainerDatasetModal extends Component {
   }
 
   handleSave() {
-    this.datasetInput.current.handleSave();
-    this.props.onChange({
-      ...this.props.datasetContainer,
-      ...this.datasetInput.current.state.datasetContainer,
-      name: this.state.localName
-    });
+    if (this.datasetInput.current) {
+      this.datasetInput.current.setLocalName(this.state.localName);
+      this.datasetInput.current.handleSave();
+    }
   }
 
   handleNameChange(newName) {
@@ -185,7 +183,7 @@ export default class ContainerDatasetModal extends Component {
               className="align-self-center ms-auto"
               onClick={this.handleSave}
             >
-              Keep Changes
+              Save Changes
             </Button>
           </Modal.Footer>
         </Modal>

--- a/app/javascript/src/components/container/ContainerDatasetModalContent.js
+++ b/app/javascript/src/components/container/ContainerDatasetModalContent.js
@@ -120,6 +120,15 @@ export class ContainerDatasetModalContent extends Component {
     }
   }
 
+  setLocalName(localName) {
+    this.setState((prevState) => ({
+      datasetContainer: {
+        ...prevState.datasetContainer,
+        name: localName,
+      }
+    }));
+  }
+
   // eslint-disable-next-line react/sort-comp
   updateAttachmentsFromContext = () => {
     const { datasetContainer } = this.props;
@@ -321,7 +330,7 @@ export class ContainerDatasetModalContent extends Component {
       if (attachment.aasm_state === 'queueing' && attachment.content_type === 'application/zip') {
         groups.BagitZip.push(attachment);
       } else if (attachment.aasm_state === 'image'
-          && (attachment.filename.includes('.combined')
+        && (attachment.filename.includes('.combined')
           || attachment.filename.includes('.new_combined'))) {
         groups.Combined.push(attachment);
       } else if (attachment.filename.includes('bagit')) {
@@ -560,9 +569,9 @@ export class ContainerDatasetModalContent extends Component {
                   extension,
                   attachmentEditor,
                   attachment.aasm_state === 'oo_editing' && new Date().getTime()
-                    < (new Date(attachment.updated_at).getTime() + 15 * 60 * 1000),
+                  < (new Date(attachment.updated_at).getTime() + 15 * 60 * 1000),
                   !attachmentEditor || attachment.aasm_state === 'oo_editing'
-                    || attachment.is_new || this.documentType(attachment.filename) === null,
+                  || attachment.is_new || this.documentType(attachment.filename) === null,
                   this.handleEdit
                 )}
                 {annotateButton(attachment, () => {
@@ -792,7 +801,7 @@ ContainerDatasetModalContent.defaultProps = {
   readOnly: false,
   attachments: [],
   kind: null,
-  onInstrumentChange: () => {},
+  onInstrumentChange: () => { },
 };
 
 export default observer(ContainerDatasetModalContent);

--- a/app/javascript/src/components/container/ContainerDatasets.js
+++ b/app/javascript/src/components/container/ContainerDatasets.js
@@ -43,7 +43,7 @@ export default class ContainerDatasets extends Component {
     container.children.push(datasetContainer);
 
     this.handleModalOpen(datasetContainer);
-    this.props.onChange(container);
+    // this.props.onChange(container);
   }
 
   handleAddWithAttachments(attachments) {

--- a/app/javascript/src/fetchers/AttachmentFetcher.js
+++ b/app/javascript/src/fetchers/AttachmentFetcher.js
@@ -734,4 +734,12 @@ export default class AttachmentFetcher {
 
     return promise;
   }
+
+  static async uploadNewAttachmentsForContainer(container) {
+    const files = this.getFileListfrom(container);
+    if (files.length > 0) {
+      const tasks = files.map((file) => this.uploadFile(file));
+      await Promise.all(tasks);
+    }
+  }
 }

--- a/app/javascript/src/fetchers/SamplesFetcher.js
+++ b/app/javascript/src/fetchers/SamplesFetcher.js
@@ -63,7 +63,6 @@ export default class SamplesFetcher {
   }
 
   static update(sample) {
-    const files = AttachmentFetcher.getFileListfrom(sample.container);
     const promise = () => fetch(`/api/v1/samples/${sample.id}`, {
       credentials: 'same-origin',
       method: 'put',
@@ -79,17 +78,11 @@ export default class SamplesFetcher {
         console.log(errorMessage);
       });
 
-    if (files.length > 0) {
-      const tasks = [];
-      files.forEach((file) => tasks.push(AttachmentFetcher.uploadFile(file).then()));
-      return Promise.all(tasks).then(() => promise());
-    }
-
-    return promise();
+    return AttachmentFetcher.uploadNewAttachmentsForContainer(sample.container)
+      .then(() => promise());
   }
 
   static create(sample) {
-    const files = AttachmentFetcher.getFileListfrom(sample.container);
     const promise = () => fetch('/api/v1/samples', {
       credentials: 'same-origin',
       method: 'post',
@@ -103,13 +96,7 @@ export default class SamplesFetcher {
         .then(() => this.fetchById(json.sample.id))).catch((errorMessage) => {
         console.log(errorMessage);
       });
-    if (files.length > 0) {
-      const tasks = [];
-      files.forEach((file) => tasks.push(AttachmentFetcher.uploadFile(file)));
-      return Promise.all(tasks).then(() => promise());
-    }
-
-    return promise();
+    return AttachmentFetcher.uploadNewAttachmentsForContainer(sample.container).then(() => promise());
   }
 
   static splitAsSubsamples(params) {
@@ -117,7 +104,7 @@ export default class SamplesFetcher {
       credentials: 'same-origin',
       method: 'POST',
       headers: {
-        'Accept': 'application/json',
+        Accept: 'application/json',
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({


### PR DESCRIPTION
**Description**

- Refactored the attachment upload and update flow across all element types (e.g., Samples, Reactions, DeviceDescriptions, etc.).
- Attachments are now automatically uploaded before saving the element (Sample, Reaction, DeviceDescription, etc.).
- No more need for manual Save sequence after uploading attachments.
- Improved the reliability of saving analyses immediately after file uploads.
---------------------------------------------------
- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
