### PR TITLE
fix: reaction variations optional field access

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses.js
@@ -21,14 +21,15 @@ function updateAnalyses(variations, allReactionAnalyses) {
   const updatedVariations = cloneDeep(variations);
   updatedVariations.forEach((row) => {
     // eslint-disable-next-line no-param-reassign
-    row.metadata.analyses = row.metadata.analyses.filter((id) => analysesIDs.includes(id));
+    const analyses = row.metadata.analyses || [];
+    row.metadata.analyses = analyses.filter((id) => analysesIDs.includes(id));
   });
 
   return updatedVariations;
 }
 
 function getAnalysesOverlay({ data: row, context }) {
-  const { analyses: analysesIDs } = row;
+  const { analyses: analysesIDs = [] } = row.metadata;
   const { allReactionAnalyses } = context;
 
   return allReactionAnalyses.filter((analysis) => analysesIDs.includes(analysis.id));
@@ -61,7 +62,9 @@ AnalysisOverlay.propTypes = {
 
 function AnalysisVariationLink({ reaction, analysisID }) {
   const { variations } = cloneDeep(reaction);
-  const linkedVariations = variations.filter((row) => row.metadata.analyses.includes(analysisID)) ?? [];
+  const linkedVariations = variations.filter(
+    (row) => row.metadata.analyses && row.metadata.analyses.includes(analysisID)
+  ) ?? [];
 
   if (linkedVariations.length === 0) {
     return null;

--- a/lib/reporter/docx/detail_reaction.rb
+++ b/lib/reporter/docx/detail_reaction.rb
@@ -55,15 +55,21 @@ module Reporter
       def variations
         obj.variations.map do |var|
           {
-            'temperature' => "#{var[:properties][:temperature][:value]} #{var[:properties][:temperature][:unit]}",
-            'duration' => "#{var[:properties][:duration][:value]} #{var[:properties][:duration][:unit]}",
+            'temperature' => variation_property(var, :temperature),
+            'duration' => variation_property(var, :duration),
             'startingMaterials' => variation_materials(var, :startingMaterials),
             'reactants' => variation_materials(var, :reactants),
             'solvents' => variation_materials(var, :solvents),
             'products' => variation_materials(var, :products),
-            'notes' => var[:notes],
-          }
+            'notes' => var[:metadata]&.dig(:notes),
+          }.compact
         end
+      end
+
+      def variation_property(var, property)
+        value = var[:properties]&.dig(property, :value)
+        unit = var[:properties]&.dig(property, :unit)
+        "#{value} #{unit}" if value && unit
       end
 
       def variation_materials(variation, type)


### PR DESCRIPTION
Prior to this PR, all sub-fields under `metadata` and `properties` were assumed to be present.
This PR fixes this incorrect assumption by treating all sub-fields under `metadata` and `properties` as optional.