### PR TITLE
fix: Sanitize SVG glyph IDs and references on Ket2 svgs

### DIFF
--- a/app/javascript/src/components/structureEditor/StructureEditorModal.js
+++ b/app/javascript/src/components/structureEditor/StructureEditorModal.js
@@ -23,7 +23,7 @@ import KetcherEditor from 'src/components/structureEditor/KetcherEditor';
 import loadScripts from 'src/components/structureEditor/loadScripts';
 import CommonTemplatesList from 'src/components/ketcher-templates/CommonTemplatesList';
 import CommonTemplatesFetcher from 'src/fetchers/CommonTemplateFetcher';
-import transformSvgIdsAndReferences from 'src/utilities/SvgUtils';
+import { transformSvgIdsAndReferences } from 'src/utilities/SvgUtils';
 
 const notifyError = (message) => {
   NotificationActions.add({

--- a/app/javascript/src/utilities/SvgUtils.js
+++ b/app/javascript/src/utilities/SvgUtils.js
@@ -1,17 +1,14 @@
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 
-// modify svg id, replace at instances - append a uuid with already existing glyph id eg: Glyph-0-1_####-####-####-####
 const transformSvgIdsAndReferences = async (svgText) => {
-  let svg = svgText;
-  const idMap = {};
   const parser = new DOMParser();
   const xmlDoc = parser.parseFromString(svgText, 'image/svg+xml');
-
   const defs = xmlDoc.querySelector('defs');
   if (!defs) return svgText;
+
+  const idMap = {};
   const elementsWithId = defs.querySelectorAll('[id]');
 
-  // Step 1: Collect all IDs and assign unique suffixes
   elementsWithId.forEach((el) => {
     const originalId = el.getAttribute('id');
     const uniqueId = `${originalId}_${uuid()}`;
@@ -19,14 +16,15 @@ const transformSvgIdsAndReferences = async (svgText) => {
     el.setAttribute('id', uniqueId);
   });
 
-  // Step 2: Replace all IDs and references
+  let svg = svgText;
   Object.entries(idMap).forEach(([originalId, uniqueId]) => {
     const idRegex = new RegExp(`id="${originalId}"`, 'g');
     const hrefRegex = new RegExp(`xlink:href="#${originalId}"`, 'g');
-    svg = svgText
+    svg = svg
       .replace(idRegex, `id="${uniqueId}"`)
       .replace(hrefRegex, `xlink:href="#${uniqueId}"`);
   });
+
   return svg;
 };
 

--- a/app/javascript/src/utilities/SvgUtils.js
+++ b/app/javascript/src/utilities/SvgUtils.js
@@ -1,0 +1,33 @@
+import uuid from 'uuid';
+
+// modify svg id, replace at instances - append a uuid with already existing glyph id eg: Glyph-0-1_####-####-####-####
+const transformSvgIdsAndReferences = async (svgText) => {
+  let svg = svgText;
+  const idMap = {};
+  const parser = new DOMParser();
+  const xmlDoc = parser.parseFromString(svgText, 'image/svg+xml');
+
+  const defs = xmlDoc.querySelector('defs');
+  if (!defs) return svgText;
+  const elementsWithId = defs.querySelectorAll('[id]');
+
+  // Step 1: Collect all IDs and assign unique suffixes
+  elementsWithId.forEach((el) => {
+    const originalId = el.getAttribute('id');
+    const uniqueId = `${originalId}_${uuid()}`;
+    idMap[originalId] = uniqueId;
+    el.setAttribute('id', uniqueId);
+  });
+
+  // Step 2: Replace all IDs and references
+  Object.entries(idMap).forEach(([originalId, uniqueId]) => {
+    const idRegex = new RegExp(`id="${originalId}"`, 'g');
+    const hrefRegex = new RegExp(`xlink:href="#${originalId}"`, 'g');
+    svg = svgText
+      .replace(idRegex, `id="${uniqueId}"`)
+      .replace(hrefRegex, `xlink:href="#${uniqueId}"`);
+  });
+  return svg;
+};
+
+export default transformSvgIdsAndReferences;

--- a/app/javascript/src/utilities/SvgUtils.js
+++ b/app/javascript/src/utilities/SvgUtils.js
@@ -1,17 +1,24 @@
-import { v4 as uuid } from 'uuid';
+const mappedIdPattern = /glyph-\d+-\d+_[0-9a-f]{8}/;
+
+function generateSuffix4() {
+  return Math.floor(Math.random() * 0x100000000).toString(16).padStart(8, '0');
+}
 
 const transformSvgIdsAndReferences = async (svgText) => {
   const parser = new DOMParser();
   const xmlDoc = parser.parseFromString(svgText, 'image/svg+xml');
   const defs = xmlDoc.querySelector('defs');
-  if (!defs) return svgText;
 
+  if (!defs) return svgText;
   const idMap = {};
   const elementsWithId = defs.querySelectorAll('[id]');
 
+  const uniqueSuffix = generateSuffix4();
+
   elementsWithId.forEach((el) => {
     const originalId = el.getAttribute('id');
-    const uniqueId = `${originalId}_${uuid()}`;
+    if (mappedIdPattern.test(originalId)) return svgText;
+    const uniqueId = `${originalId}_${uniqueSuffix}`;
     idMap[originalId] = uniqueId;
     el.setAttribute('id', uniqueId);
   });
@@ -28,4 +35,4 @@ const transformSvgIdsAndReferences = async (svgText) => {
   return svg;
 };
 
-export default transformSvgIdsAndReferences;
+export { transformSvgIdsAndReferences, mappedIdPattern };

--- a/app/javascript/src/utilities/UserTemplatesHelpers.js
+++ b/app/javascript/src/utilities/UserTemplatesHelpers.js
@@ -50,12 +50,13 @@ const updateUserTemplateDetails = async (oldValue, newValue) => {
 
 const onEventListen = async (event) => {
   let { newValue, oldValue } = event;
-  if (newValue.length && oldValue.length) {
+  const bothArrayHaveItems = Array.isArray(newValue) && newValue.length && Array.isArray(oldValue) && oldValue.length;
+  if (bothArrayHaveItems) {
     newValue = JSON.parse(newValue);
     oldValue = JSON.parse(oldValue);
     if (event.key === key) { // matching key && deleteAllowed
       if (newValue.length > oldValue.length) { // when a new template is added
-        let newItem = newValue[newValue.length - 1];
+        const newItem = newValue[newValue.length - 1];
         createAddAttachmentidToNewUserTemplate(newValue, newItem);
       } else if (newValue.length < oldValue.length) { // when a template is deleted
         const listOfLocalid = newValue.map((item) => item.props.path);

--- a/spec/fixtures/svg/defMutationAlreadyProcessed.svg
+++ b/spec/fixtures/svg/defMutationAlreadyProcessed.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="21" viewBox="0 0 30.0 21.0" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<g>
+<g id="glyph-0-100_4cc45a84">
+<path d="M 1.21875 "></path>
+</g>
+<g id="glyph-0-69_4cc45a84">
+<path d="M 3.7187"></path>
+</g>
+<g id="glyph-0-66_4cc45a84">
+<path d="M 8.35937"></path>
+</g>
+<g id="glyph-0-22_4cc45a84">
+<path d="M 6.40625 "></path>
+</g>
+</g>
+</defs>
+<g fill="#000000" fill-opacity="1">
+<use xlink:href="#glyph-0-1_111111" x="2.832031" y="13.15625"></use>
+</g>
+<g fill="#000000" fill-opacity="1">
+<use xlink:href="#glyph-0-2_111111" x="10.105469" y="13.15625"></use>
+</g>
+<g fill="#000000" fill-opacity="1">
+<use xlink:href="#glyph-0-3_111111" x="19.210938" y="16.996094"></use>
+</g>
+</svg>

--- a/spec/fixtures/svg/defMutationEmptyDefs.svg
+++ b/spec/fixtures/svg/defMutationEmptyDefs.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="21" viewBox="0 0 30.0 21.0" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+</defs>
+<g fill="#000000" fill-opacity="1">
+<use xlink:href="#glyph-0-1" x="2.832031" y="13.15625"></use>
+</g>
+<g fill="#000000" fill-opacity="1">
+<use xlink:href="#glyph-0-2" x="10.105469" y="13.15625"></use>
+</g>
+<g fill="#000000" fill-opacity="1">
+<use xlink:href="#glyph-0-3" x="19.210938" y="16.996094"></use>
+</g>
+</svg>

--- a/spec/fixtures/svg/defMutationNoIds.svg
+++ b/spec/fixtures/svg/defMutationNoIds.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="21" viewBox="0 0 30.0 21.0" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<g>
+<g>
+<path d="M 1.21875 "></path>
+</g>
+<g>
+<path d="M 3.7187"></path>
+</g>
+<g>
+<path d="M 8.35937"></path>
+</g>
+<g>
+<path d="M 6.40625 "></path>
+</g>
+</g>
+</defs>
+</svg>

--- a/spec/fixtures/svg/defMutationWithId.svg
+++ b/spec/fixtures/svg/defMutationWithId.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="21" viewBox="0 0 30.0 21.0" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<g>
+<g id="glyph-0-0">
+<path d="M 1.21875 "></path>
+</g>
+<g id="glyph-0-1">
+<path d="M 3.7187"></path>
+</g>
+<g id="glyph-0-2">
+<path d="M 8.35937"></path>
+</g>
+<g id="glyph-0-3">
+<path d="M 6.40625 "></path>
+</g>
+</g>
+</defs>
+<g fill="#000000" fill-opacity="1">
+<use xlink:href="#glyph-0-1" x="2.832031" y="13.15625"></use>
+</g>
+<g fill="#000000" fill-opacity="1">
+<use xlink:href="#glyph-0-2" x="10.105469" y="13.15625"></use>
+</g>
+<g fill="#000000" fill-opacity="1">
+<use xlink:href="#glyph-0-3" x="19.210938" y="16.996094"></use>
+</g>
+</svg>

--- a/spec/fixtures/svg/defMutationWithUse.svg
+++ b/spec/fixtures/svg/defMutationWithUse.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="21" viewBox="0 0 30.0 21.0" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<g>
+<g id="glyph-0-100">
+<path d="M 1.21875 "></path>
+</g>
+<g id="glyph-0-69">
+<path d="M 3.7187"></path>
+</g>
+<g id="glyph-0-66">
+<path d="M 8.35937"></path>
+</g>
+<g id="glyph-0-22">
+<path d="M 6.40625 "></path>
+</g>
+</g>
+</defs>
+<g fill="#000000" fill-opacity="1">
+<use xlink:href="#glyph-0-1" x="2.832031" y="13.15625"></use>
+</g>
+<g fill="#000000" fill-opacity="1">
+<use xlink:href="#glyph-0-2" x="10.105469" y="13.15625"></use>
+</g>
+<g fill="#000000" fill-opacity="1">
+<use xlink:href="#glyph-0-3" x="19.210938" y="16.996094"></use>
+</g>
+</svg>

--- a/spec/javascripts/utils/svg.specs.js
+++ b/spec/javascripts/utils/svg.specs.js
@@ -1,0 +1,53 @@
+/* eslint-disable no-undef */
+import expect from 'expect';
+import { JSDOM } from 'jsdom';
+import fs from 'fs';
+import transformSvgIdsAndReferences from 'src/utilities/SvgUtils';
+
+global.DOMParser = new JSDOM().window.DOMParser;
+const modifiedIdPattern = /glyph-\d+-\d+_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+const originalIdPatter = /glyph-\d+-\d/;
+const loadFixture = (name) => fs.readFileSync(`spec/fixtures/svg/${name}.svg`, 'utf-8');
+
+describe('SVG id & reference mutations', () => {
+  it('should append UUID to IDs in <defs> and match with pattern', async () => {
+    const svgFile = loadFixture('defMutationWithId');
+    const updatedSvg = await transformSvgIdsAndReferences(svgFile);
+    const allIds = new Set();
+
+    // Extract all id="..." values
+    Array.from(updatedSvg.matchAll(/id="([^"]+)"/g)).forEach((match) => {
+      const id = match[1];
+      expect(id).toMatch(modifiedIdPattern);
+      allIds.add(id);
+    });
+
+    // Extract all xlink:href or href references
+    Array.from(updatedSvg.matchAll(/<use[^>]+(?:xlink:)?href="#([^"]+)"/g)).forEach((match) => {
+      const refId = match[1];
+      expect(refId).toMatch(modifiedIdPattern);
+      expect(allIds.has(refId)).toBe(true);
+    });
+  });
+
+  it('should return the same svg when there are no ids', async () => {
+    const svgFile = loadFixture('defMutationNoIds');
+    const updatedSvg = await transformSvgIdsAndReferences(svgFile);
+    expect(updatedSvg).toEqual(svgFile);
+  });
+
+  it('should return the same svg when there are no defs', async () => {
+    const svgFile = loadFixture('defMutationEmptyDefs');
+    const updatedSvg = await transformSvgIdsAndReferences(svgFile);
+    expect(updatedSvg).toEqual(svgFile);
+  });
+
+  it('should not modify any id in use when defs are empty', async () => {
+    const svgFile = loadFixture('defMutationWithUse');
+    const updatedSvg = await transformSvgIdsAndReferences(svgFile);
+    Array.from(updatedSvg.matchAll(/<use[^>]+(?:xlink:)?href="#([^"]+)"/g)).forEach((match) => {
+      const refId = match[1];
+      expect(refId).toMatch(originalIdPatter);
+    });
+  });
+});


### PR DESCRIPTION
PR resolves a part of Issue: [#2277 ]( https://github.com/ComPlat/chemotion_ELN/issues/2277)
#### How?
On saving Ketcher2 svg content modify svg defined Glyph id and their references. 

#### Why?
Modify Id would help avoid conflict in glyph id used in other reactions/svgs, specially with reactions.

#### How can be tested?
On saving a reaction while using Ket2. The svg should have modified defined glyph ids.
Before: glyph-0-0
After: glyph-0-3_e15e902f

---------------------------------


- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
