### PR TITLE
feat: enhance import process with discarded attachments of research_plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,7 +131,7 @@
 
 
 /public/zip/*
-/public/failed_reports/*
+/public/import_logs/*
 !/public/zip/.keep
 
 /public/udm/*

--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@
 
 
 /public/zip/*
+/public/failed_reports/*
 !/public/zip/.keep
 
 /public/udm/*

--- a/app/jobs/import_collections_job.rb
+++ b/app/jobs/import_collections_job.rb
@@ -4,25 +4,39 @@ class ImportCollectionsJob < ApplicationJob
   queue_as :import_collections
 
   after_perform do |job|
-    begin
+    data_args = {
+      col_labels: '',
+      operation: 'import',
+      expires_at: nil,
+    }
+
+    if @discarded_info
+      data_args[:discarded_count] = @discarded_info[:count]
+      data_args[:report_path] = @discarded_info[:report_path]
+    end
+
+    if @success
       Message.create_msg_notification(
         channel_subject: Channel::COLLECTION_ZIP,
         message_from: @user_id,
-        data_args: { col_labels: '', operation: 'import', expires_at: nil },
-        autoDismiss: 5
-      ) if @success
-    rescue StandardError => e
-      Delayed::Worker.logger.error e
+        data_args: data_args,
+        url: @discarded_info&.dig(:report_path),
+        autoDismiss: 10,
+      )
     end
+  rescue StandardError => e
+    Delayed::Worker.logger.error e
   end
 
   def perform(att, current_user_id)
     @user_id = current_user_id
     @success = true
+
     begin
       import = Import::ImportCollections.new(att, current_user_id)
       import.extract
       import.import!
+      @discarded_info = import.discarded_attachments_info
     rescue => e
       Delayed::Worker.logger.error e
       Message.create_msg_notification(


### PR DESCRIPTION
- Added functionality to track and report discarded attachments from research_plans during the collection import process
- Introduced a new method to generate a report for discarded attachments
- Updated the import job to include details about discarded attachments in the notification message