### PR TITLE
fix: sample SVG solid support bead not visible

### DIFF
--- a/lib/chemotion/sanitizer.rb
+++ b/lib/chemotion/sanitizer.rb
@@ -82,7 +82,7 @@ module Chemotion
     end
 
     def map_defs_ids
-      @current_node.xpath('svg:defs//*[@id]', svg_namespace).each do |element|
+      @current_node.xpath('svg:defs//svg:g[@id]', svg_namespace).each do |element|
         # Check if the element has an id attribute or skip if it has a unique id ending
         # (from SecureRandom.hex(4))
         next if !element['id'] || element['id'].match?(/_[0-9a-f]{8}$/)


### PR DESCRIPTION
ket1 solid support bead use <defs><radialGradient> that are references with `fill="url(...)`
re-mapping of index from b52a14704 does not cover this and break the references

this PR changes the selector to only re-index <g> descendants of <defs>

refs: #2483