### PR TITLE
fix: don't render variations of new, unsaved reaction

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -44,6 +44,14 @@ const persistGridState = (id, event) => {
 };
 
 export default function ReactionVariations({ reaction, onReactionChange, isActive }) {
+  if (reaction.isNew) {
+    return (
+      <Alert variant="info">
+        Save the reaction to enable the variations tab.
+      </Alert>
+    );
+  }
+
   const gridRef = useRef(null);
   const reactionVariations = reaction.variations;
   const reactionHasPolymers = reaction.hasPolymers();
@@ -377,14 +385,6 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
       </Button>
     </OverlayTrigger>
   );
-
-  if (reaction.isNew) {
-    return (
-      <Alert variant="info">
-        Save the reaction to enable the variations tab.
-      </Alert>
-    );
-  }
 
   const fitColumnToContent = (event) => {
     const { column } = event;


### PR DESCRIPTION
This PR prevents rendering the variations of new reactions that have not been saved yet.
It is an amendment of the fix in #2265.
The amendment is merely moving up the guard to prevent any logic from executing that relies on the integrity of the sample IDs in the variations of new, unsaved reactions (see #2265 for details).