### PR TITLE
style(variation): badge only visible if variations present

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses.js
@@ -6,7 +6,10 @@ import {
 import cloneDeep from 'lodash/cloneDeep';
 import Reaction from 'src/models/Reaction';
 import UIActions from 'src/stores/alt/actions/UIActions';
-import { getVariationsRowName } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
+import {
+  getVariationsRowName,
+  REACTION_VARIATIONS_TAB_KEY,
+} from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
 
 function getReactionAnalyses(reaction) {
   const reactionCopy = cloneDeep(reaction);
@@ -66,15 +69,17 @@ function AnalysisVariationLink({ reaction, analysisID }) {
     (row) => row.metadata.analyses && row.metadata.analyses.includes(analysisID)
   ) ?? [];
 
-  if (linkedVariations.length === 0) {
+  const count = linkedVariations.length;
+
+  if (count === 0) {
     return null;
   }
   return (
     <Badge
       bg="info"
-      onClick={() => UIActions.selectTab({ type: 'reaction', tabKey: 'variations' })}
+      onClick={() => UIActions.selectTab({ type: 'reaction', tabKey: REACTION_VARIATIONS_TAB_KEY })}
     >
-      {`Linked to ${linkedVariations.length} variation(s)`}
+      {`Linked to ${count} variation${count > 1 ? 's' : ''}`}
       {' '}
       <i className="fa fa-external-link" />
     </Badge>

--- a/app/javascript/src/apps/mydb/elements/list/reaction/ReactionVariations.js
+++ b/app/javascript/src/apps/mydb/elements/list/reaction/ReactionVariations.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import { Badge } from 'react-bootstrap';
 
 function ReactionVariations({ element }) {
-  if (element.type !== 'reaction' || !element.variations) {
+  if (element.type !== 'reaction' || !element.variations || element.variations.length === 0) {
     return null;
   }
 
   return (
     <Badge bg="info">
-      {`${element.variations.length} variation(s)`}
+      {`${element.variations.length} variation${element.variations.length > 1 ? 's' : ''}`}
     </Badge>
   );
 }


### PR DESCRIPTION
- avoid cluttering list items if no variations is available

## Before
![image](https://github.com/user-attachments/assets/c36c9ecc-cdc4-425f-924a-06238beeec6e)

## After
![image](https://github.com/user-attachments/assets/c6393a93-b19a-4138-a637-151e5a9933e4)


- also fix navigating from an analysis linked to a reaction  in the analyses-tab to the variations-tab