### PR TITLE
fix(UI): correctly display yield field when conversion rate is null

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
@@ -129,11 +129,7 @@ export default class ReactionDetailsScheme extends Component {
   }
 
   switchYield = (shouldDisplayYield) => {
-    if (shouldDisplayYield) {
-      this.setState({ displayYieldField: true });
-    } else {
-      this.setState({ displayYieldField: false });
-    }
+    this.setState({ displayYieldField: !!shouldDisplayYield });
   };
 
   handleOnConditionSelect(eventKey) {

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
@@ -1147,7 +1147,7 @@ export default class ReactionDetailsScheme extends Component {
       const allHaveNoConversion = reaction.products.every(
         (material) => !(material.conversion_rate && material.conversion_rate !== 0)
       );
-      this.switchYield(!!allHaveNoConversion);
+      this.switchYield(allHaveNoConversion);
     }
 
     const headReactants = reaction.starting_materials.length ?? 0;

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
@@ -129,8 +129,11 @@ export default class ReactionDetailsScheme extends Component {
   }
 
   switchYield = (shouldDisplayYield) => {
-    const { displayYieldField } = this.state;
-    this.setState({ displayYieldField: shouldDisplayYield ?? !displayYieldField });
+    if (shouldDisplayYield) {
+      this.setState({ displayYieldField: true });
+    } else {
+      this.setState({ displayYieldField: false });
+    }
   };
 
   handleOnConditionSelect(eventKey) {
@@ -1142,11 +1145,9 @@ export default class ReactionDetailsScheme extends Component {
 
     if (displayYieldField === null) {
       const allHaveNoConversion = reaction.products.every(
-        (material) => material.conversion_rate && material.conversion_rate !== 0
+        (material) => !(material.conversion_rate && material.conversion_rate !== 0)
       );
-      if (allHaveNoConversion) {
-        this.switchYield(!allHaveNoConversion);
-      }
+      this.switchYield(!!allHaveNoConversion);
     }
 
     const headReactants = reaction.starting_materials.length ?? 0;


### PR DESCRIPTION
**Problem/Bug:**

- The yield field was not displaying correctly on new reactions when no conversion rate was assigned.
- The original implementation used a conditional operator ([shouldDisplayYield ?? !displayYieldField](vscode-file://vscode-app/c:/Users/49172/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)) that caused ambiguous state toggling.
The condition checking for conversion rates in products was incorrectly negated, resulting in an incorrect boolean value for yield display.

**Fix:**

- Refactored the [switchYield](vscode-file://vscode-app/c:/Users/49172/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) function to use explicit if...else statements so that the state is set deterministically:
  - If [shouldDisplayYield](vscode-file://vscode-app/c:/Users/49172/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) is truthy, the [displayYieldField](vscode-file://vscode-app/c:/Users/49172/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) state is set to true.
  - Otherwise, it is set to false.
- Improved the condition in [ReactionDetailsScheme](vscode-file://vscode-app/c:/Users/49172/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) that checks the conversion rates of reaction products by using the proper negation, thus correctly determining if all products have no conversion rate.

_______________________________________________________________________________________________________________
- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
