### PR TITLE
fix: prevent null cas search and show instrument modal on top of Gene…

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/samples/FastInput.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/FastInput.js
@@ -65,6 +65,7 @@ function FastInput(props) {
 
   const searchString = (e) => {
     const input = value;
+    if (!input) return;
     if (e.key === 'Enter' || e.type === 'click') {
       const getCas = validateCas(input, false);
       if (getCas !== 'smile') {

--- a/app/javascript/src/components/container/ContainerDatasetModalContent.js
+++ b/app/javascript/src/components/container/ContainerDatasetModalContent.js
@@ -699,7 +699,10 @@ export class ContainerDatasetModalContent extends Component {
               rootClose
               onHide={() => this.abortAutoSelection()}
             >
-              <ListGroup className="mt-0 w-100 overflow-auto" style={{ maxHeight: '200px' }}>
+              <ListGroup
+                className="mt-0 w-100 overflow-auto rounded-3 shadow-lg"
+                style={{ maxHeight: '200px', zIndex: 1 }}
+              >
                 {this.renderInstruments()}
               </ListGroup>
             </Overlay>


### PR DESCRIPTION
### Description

This PR fixes two issues:
- Added null check for input before calling validateCas while smile search in sample
- Ensured instrument modal shows on top of GenericDSDetails 

refs: #2511
