### PR TITLE
fix: stick add-analysis button to the top when scrolling

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/AnalysesContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/AnalysesContainer.js
@@ -192,7 +192,7 @@ class AnalysesContainer extends Component {
     const { currentElement } = ElementStore.getState();
     return (
       <div className="analysis-container">
-        <div className="d-flex justify-content-between mb-3">
+        <div className="d-flex justify-content-between mb-3 sticky-top bg-white p-2 border-bottom">
           {this.renderModeButton()}
           <ButtonToolbar className="gap-2">
             <CommentButton toggleCommentBox={this.toggleCommentBox} size="xsm" disable={false} />

--- a/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/OntologiesList.js
+++ b/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/OntologiesList.js
@@ -273,7 +273,7 @@ const OntologiesList = ({ store, element }) => {
 
   return (
     <>
-      <div className="d-flex justify-content-between mb-3" key={`${store.key_prefix}-${element['name']}`}>
+      <div className="d-flex justify-content-between mb-3 sticky-top bg-white p-2 border-bottom" key={`${store.key_prefix}-${element['name']}`}>
         {ontologyModeButton()}
         {addOntologyButton()}
       </div>

--- a/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysesContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysesContainer.js
@@ -139,7 +139,7 @@ const AnalysesContainer = ({ readonly }) => {
       {
         containers.length > 0 ? (
           <div>
-            <div className="d-flex justify-content-between align-items-center mb-3">
+            <div className="d-flex justify-content-between align-items-center mb-3 sticky-top bg-white p-2 border-bottom">
               {modeButton()}
               <ButtonToolbar className="gap-2">
                 <CommentButton

--- a/app/javascript/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.js
@@ -340,7 +340,7 @@ export default class ReactionDetailsContainers extends Component {
       if (analyses_container.length === 1 && analyses_container[0].children.length > 0) {
         return (
           <div>
-            <div className="d-flex justify-content-between align-items-center mb-3">
+            <div className="d-flex justify-content-between align-items-center mb-3 sticky-top bg-white p-2 border-bottom">
               <span className="text-muted me-3 small" style={{ maxWidth: '60%' }}>
                 This tab can be used for reaction-related data (e.g., process control, in situ).
                 For sample data (e.g., characterization), use the sample analysis tab.

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
@@ -268,7 +268,7 @@ export default class ResearchPlanDetailsContainers extends Component {
       if (analysesContainer.length === 1 && analysesContainer[0].children.length > 0) {
         return (
           <div>
-            <div className="my-2 mx-3 d-flex justify-content-end">
+            <div className="my-2 mx-3 d-flex justify-content-end sticky-top bg-white p-2 border-bottom">
               <ButtonToolbar className="gap-1">
                 <div className="mt-2">
                   <CommentButton toggleCommentBox={this.toggleCommentBox} size="sm" />

--- a/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersCom.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersCom.js
@@ -49,7 +49,7 @@ function ReactionsDisplay({
 
   return (
     <div>
-      <div className="d-flex justify-content-between align-items-center mb-3">
+      <div className="d-flex justify-content-between align-items-center mb-3 sticky-top bg-white p-2 border-bottom">
         {AnalysisModeToggle(mode, handleToggleMode, isDisabled)}
         <ButtonToolbar className="gap-2">
           <CommentButton toggleCommentBox={toggleCommentBox} size="xsm" />

--- a/app/javascript/src/apps/mydb/elements/details/screens/analysesTab/ScreenDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/analysesTab/ScreenDetailsContainers.js
@@ -196,7 +196,7 @@ export default class ScreenDetailsContainers extends Component {
       if (this.analysesContainer.length == 1 && this.analysesContainer[0].children.length > 0) {
         return (
           <div>
-            <div className="mb-2 me-1 d-flex flex-row-reverse">
+            <div className="mb-2 me-1 d-flex flex-row-reverse sticky-top bg-white p-2 border-bottom">
               <ButtonToolbar className="gap-2">
                 <div className="mt-2">
                   <CommentButton toggleCommentBox={this.toggleCommentBox} size="xxsm" />

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/analysesTab/WellplateDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/analysesTab/WellplateDetailsContainers.js
@@ -160,7 +160,7 @@ export default class WellplateDetailsContainers extends Component {
 
     if (analyses_container.length != 1 || analyses_container[0].children.length == 0) {
       return (
-        <div className='d-flex justify-content-between align-items-center my-2 mx-3'>
+        <div className='d-flex justify-content-between align-items-center my-2 mx-3 sticky-top bg-white p-2 border-bottom'>
           <p className='m-0'>
             There are currently no Analyses.
           </p>
@@ -174,7 +174,7 @@ export default class WellplateDetailsContainers extends Component {
 
     return (
       <div>
-        <div className="d-flex justify-content-end my-2 mx-3">
+        <div className="d-flex justify-content-end my-2 mx-3 sticky-top bg-white p-2 border-bottom">
           <ButtonToolbar className="gap-2">
             <CommentButton toggleCommentBox={this.toggleCommentBox} size="xsm" />
             {this.addButton()}

--- a/app/javascript/src/components/generic/GenericElDetailsContainers.js
+++ b/app/javascript/src/components/generic/GenericElDetailsContainers.js
@@ -143,7 +143,7 @@ export default class GenericElDetailsContainers extends Component {
       if (analysesContainer.length === 1 && analysesContainer[0].children.length > 0) {
         return (
           <div>
-            <div className="mb-2 me-1 d-flex justify-content-end">
+            <div className="mb-2 me-1 d-flex justify-content-end sticky-top bg-white p-2 border-bottom">
               {this.addButton()}
             </div>
             <GenericContainerSet
@@ -161,14 +161,14 @@ export default class GenericElDetailsContainers extends Component {
         );
       }
       return (
-        <div className="d-flex align-items-center justify-content-between mb-2 mt-4 mx-3">
+        <div className="d-flex align-items-center justify-content-between mb-2 mt-4 mx-3 sticky-top bg-white p-2 border-bottom">
           <span className="ms-3"> There are currently no Analyses. </span>
           <div>{this.addButton()}</div>
         </div>
       );
     }
     return (
-      <div className="d-flex align-items-center justify-content-between mb-2 mt-4 mx-3">
+      <div className="d-flex align-items-center justify-content-between mb-2 mt-4 mx-3 sticky-top bg-white p-2 border-bottom">
         <span className="ms-3"> There are currently no Analyses. </span>
         <div>{this.addButton()}</div>
       </div>


### PR DESCRIPTION
Make Add Analysis, Add Comment, and Edit Mode buttons sticky at top of all elenemts.


