### PR TITLE
perf: add indices to improve sample serialization

### DIFF
--- a/app/api/chemotion/collection_api.rb
+++ b/app/api/chemotion/collection_api.rb
@@ -92,7 +92,7 @@ module Chemotion
 
       build_tree = Proc.new do |collects, delete_empty_root|
         col_tree = []
-        collects.collect{ |obj| col_tree.push(obj) if obj['ancestry'] == '/' }
+        collects.collect { |obj| col_tree.push(obj) if obj['ancestry'] == '/' }
         get_child.call(col_tree,collects)
         col_tree.select! { |col| col[:children].count > 0 } if delete_empty_root
         Entities::CollectionRootEntity.represent(col_tree, serializable: true, root: :collections)

--- a/app/api/chemotion/ols_terms_api.rb
+++ b/app/api/chemotion/ols_terms_api.rb
@@ -30,7 +30,7 @@ module Chemotion
       end
 
       get 'root' do
-        list = OlsTerm.where(owl_name: params[:name], is_enabled: true, ancestry: nil)
+        list = OlsTerm.where(owl_name: params[:name], is_enabled: true, ancestry: '/')
 
         present list, with: Entities::OlsTermEntity, root: :ols_terms
       end

--- a/app/api/entities/sample_entity.rb
+++ b/app/api/entities/sample_entity.rb
@@ -127,7 +127,7 @@ module Entities
     end
 
     def parent_id
-      object.parent&.id
+      object.parent_id
     end
 
     def type

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -23,7 +23,7 @@
 #  key             :string(500)
 #  storage         :string(20)       default("tmp")
 #  thumb           :boolean          default(FALSE)
-#  version         :string
+#  version         :string           default("/"), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  attachable_id   :integer
@@ -32,6 +32,7 @@
 #
 #  index_attachments_on_attachable_type_and_attachable_id  (attachable_type,attachable_id)
 #  index_attachments_on_identifier                         (identifier) UNIQUE
+#  index_attachments_on_version                            (version) WHERE (deleted_at IS NULL)
 #
 
 class Attachment < ApplicationRecord
@@ -44,7 +45,7 @@ class Attachment < ApplicationRecord
 
   attr_accessor :file_data, :file_path, :thumb_path, :thumb_data, :duplicated, :transferred
 
-  has_ancestry ancestry_column: :version
+  has_ancestry ancestry_column: :version, orphan_strategy: :adopt
 
   validate :check_file_size
 

--- a/app/models/cellline_sample.rb
+++ b/app/models/cellline_sample.rb
@@ -6,7 +6,7 @@
 #
 #  id                   :bigint           not null, primary key
 #  amount               :bigint
-#  ancestry             :string
+#  ancestry             :string           default("/"), not null
 #  contamination        :string
 #  deleted_at           :datetime
 #  description          :string
@@ -22,11 +22,11 @@
 #
 # Indexes
 #
-#  index_cellline_samples_on_ancestry  (ancestry)
+#  index_cellline_samples_on_ancestry  (ancestry) WHERE (deleted_at IS NULL)
 #
 class CelllineSample < ApplicationRecord
   acts_as_paranoid
-  has_ancestry
+  has_ancestry orphan_strategy: :adopt
 
   include ElementUIStateScopes
   include Taggable

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -7,7 +7,7 @@
 # Table name: collections
 #
 #  id                             :integer          not null, primary key
-#  ancestry                       :string
+#  ancestry                       :string           default("/"), not null
 #  celllinesample_detail_level    :integer          default(10)
 #  deleted_at                     :datetime
 #  devicedescription_detail_level :integer          default(10)
@@ -32,7 +32,7 @@
 #
 # Indexes
 #
-#  index_collections_on_ancestry      (ancestry)
+#  index_collections_on_ancestry      (ancestry) WHERE (deleted_at IS NULL)
 #  index_collections_on_deleted_at    (deleted_at)
 #  index_collections_on_inventory_id  (inventory_id)
 #  index_collections_on_user_id       (user_id)

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -21,6 +21,7 @@
 # Indexes
 #
 #  index_containers_on_containable  (containable_type,containable_id)
+#  index_containers_on_parent_id    (parent_id) WHERE (deleted_at IS NULL)
 #
 
 class Container < ApplicationRecord

--- a/app/models/device_description.rb
+++ b/app/models/device_description.rb
@@ -7,7 +7,7 @@
 #  id                                   :bigint           not null, primary key
 #  access_comments                      :string
 #  access_options                       :string
-#  ancestry                             :string
+#  ancestry                             :string           default("/"), not null
 #  application_name                     :string
 #  application_version                  :string
 #  building                             :string
@@ -62,7 +62,7 @@
 #
 # Indexes
 #
-#  index_device_descriptions_on_ancestry   (ancestry)
+#  index_device_descriptions_on_ancestry   (ancestry) WHERE (deleted_at IS NULL)
 #  index_device_descriptions_on_device_id  (device_id)
 #
 class DeviceDescription < ApplicationRecord

--- a/app/models/ols_term.rb
+++ b/app/models/ols_term.rb
@@ -3,7 +3,7 @@
 # Table name: ols_terms
 #
 #  id               :integer          not null, primary key
-#  ancestry         :string
+#  ancestry         :string           default("/"), not null
 #  desc             :string
 #  is_enabled       :boolean          default(TRUE)
 #  label            :string
@@ -125,7 +125,7 @@ class OlsTerm < ApplicationRecord
         OlsTerm.where(owl_name: owl_name).find_each do |o|
           next if (root = o.root) == o
           next if root.root == root
-          new_a = root.ancestry + '/' + o.ancestry
+          new_a = root.ancestry + o.ancestry
           o.update_columns(ancestry: new_a)
           count += 1
         end
@@ -170,7 +170,7 @@ class OlsTerm < ApplicationRecord
         if ancestor.ancestry.nil?
           new_a = ancestor.id.to_s
         else
-          new_a = ancestor.ancestry + '/' + ancestor.id.to_s
+          new_a = ancestor.ancestry + ancestor.id.to_s + '/'
         end
         o.update_columns(ancestry: new_a)
       end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -5,7 +5,7 @@
 # Table name: samples
 #
 #  id                  :integer          not null, primary key
-#  ancestry            :string
+#  ancestry            :string           default("/"), not null
 #  boiling_point       :numrange
 #  created_by          :integer
 #  decoupled           :boolean          default(FALSE), not null
@@ -51,6 +51,7 @@
 #
 # Indexes
 #
+#  index_samples_on_ancestry          (ancestry) WHERE (deleted_at IS NULL)
 #  index_samples_on_deleted_at        (deleted_at)
 #  index_samples_on_identifier        (identifier)
 #  index_samples_on_inventory_sample  (inventory_sample)

--- a/app/usecases/sharing/take_ownership.rb
+++ b/app/usecases/sharing/take_ownership.rb
@@ -27,7 +27,7 @@ module Usecases
               user_id: previous_owner_id,
               shared_by_id: new_owner_id,
               is_locked: true,
-              is_shared: true,
+              is_shared: true
             }
 
             sc = SyncCollectionsUser.find_by(collection_id: c.id, user_id: @params[:current_user_id])
@@ -50,7 +50,7 @@ module Usecases
                   user_id: sc.user_id,
                   shared_by_id: new_owner_id,
                   is_locked: true,
-                  is_shared: true,
+                  is_shared: true
                 }
                 rca = Collection.find_or_create_by(root_collection_attrs)
                 sc.update(shared_by_id: new_owner_id, fake_ancestry: rca.id.to_s)
@@ -60,7 +60,7 @@ module Usecases
 
           user = User.find_by(id: new_owner_id)
           col = Collection.find_by(id: rsc.collection_id)
-          Message.create_msg_notification(
+          message = Message.create_msg_notification(
             channel_subject: Channel::COLLECTION_TAKE_OWNERSHIP,
             data_args: { new_owner: user.name, collection_name: col.label },
             message_from: new_owner_id, message_to: [o_owner_id]
@@ -77,27 +77,19 @@ module Usecases
 
           owner = User.find(c.shared_by_id)
           owner_collections = owner.collections
-          owner_sample_collections = owner_collections.includes(:samples).where('samples.id IN (?)',
-                                                                                sample_ids).references(:samples)
-          owner_reaction_collections = owner_collections.includes(:reactions).where('reactions.id IN (?)',
-                                                                                    reaction_ids).references(:reacions)
-          owner_wellplate_collections = owner_collections.includes(:wellplates).where('wellplates.id IN (?)',
-                                                                                      wellplate_ids).references(:wellplates)
-          owner_screen_collections = owner_collections.includes(:screens).where('screens.id IN (?)',
-                                                                                screen_ids).references(:screens)
+          owner_sample_collections = owner_collections.includes(:samples).where('samples.id IN (?)', sample_ids).references(:samples)
+          owner_reaction_collections = owner_collections.includes(:reactions).where('reactions.id IN (?)', reaction_ids).references(:reacions)
+          owner_wellplate_collections = owner_collections.includes(:wellplates).where('wellplates.id IN (?)', wellplate_ids).references(:wellplates)
+          owner_screen_collections = owner_collections.includes(:screens).where('screens.id IN (?)', screen_ids).references(:screens)
 
           ActiveRecord::Base.transaction do
             c.update(is_shared: false, parent: nil, shared_by_id: nil)
 
             # delete all associations of former_owner to elements included in c
-            CollectionsSample.where('sample_id IN (?) AND collection_id IN (?)', sample_ids,
-                                    owner_sample_collections.pluck(:id)).delete_all
-            CollectionsReaction.where('reaction_id IN (?) AND collection_id IN (?)', reaction_ids,
-                                      owner_reaction_collections.pluck(:id)).delete_all
-            CollectionsWellplate.where('wellplate_id IN (?) AND collection_id IN (?)', wellplate_ids,
-                                       owner_wellplate_collections.pluck(:id)).delete_all
-            CollectionsScreen.where('screen_id IN (?) AND collection_id IN (?)', screen_ids,
-                                    owner_screen_collections.pluck(:id)).delete_all
+            CollectionsSample.where('sample_id IN (?) AND collection_id IN (?)', sample_ids, owner_sample_collections.pluck(:id)).delete_all
+            CollectionsReaction.where('reaction_id IN (?) AND collection_id IN (?)', reaction_ids, owner_reaction_collections.pluck(:id)).delete_all
+            CollectionsWellplate.where('wellplate_id IN (?) AND collection_id IN (?)', wellplate_ids, owner_wellplate_collections.pluck(:id)).delete_all
+            CollectionsScreen.where('screen_id IN (?) AND collection_id IN (?)', screen_ids, owner_screen_collections.pluck(:id)).delete_all
           end
         end
       end

--- a/config/initializers/ancestry.rb
+++ b/config/initializers/ancestry.rb
@@ -1,0 +1,3 @@
+Ancestry.default_ancestry_format = :materialized_path2
+Ancestry.default_update_strategy = :sql
+# Ancestry.default_orphan_strategy = :adopt # NB: not implemented yet

--- a/db/migrate/20250616122740_add_index_on_ancestry_to_samples.rb
+++ b/db/migrate/20250616122740_add_index_on_ancestry_to_samples.rb
@@ -1,0 +1,7 @@
+class AddIndexOnAncestryToSamples < ActiveRecord::Migration[6.1]
+  def change
+    add_index :samples, :ancestry, unique: false, where: "deleted_at IS NULL"
+  rescue StandardError => e
+    Rails.logger.error "An error occurred while adding index on ancestry: #{e.message}"
+  end
+end

--- a/db/migrate/20250616123935_add_index_on_parent_id_to_containers.rb
+++ b/db/migrate/20250616123935_add_index_on_parent_id_to_containers.rb
@@ -1,0 +1,7 @@
+class AddIndexOnParentIdToContainers < ActiveRecord::Migration[6.1]
+  def change
+    add_index :containers, :parent_id, unique: false, where: "deleted_at IS NULL"
+  rescue StandardError => e
+    Rails.logger.error "An error occurred while adding the index: #{e.message}"
+  end
+end

--- a/db/migrate/20250701121906_remove_ancestry_indices.rb
+++ b/db/migrate/20250701121906_remove_ancestry_indices.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class RemoveAncestryIndices < ActiveRecord::Migration[6.1]
+  def change
+    # rubocop:disable Layout/SpaceInsidePercentLiteralDelimiters, Layout/SpaceInsideArrayPercentLiteral
+    tables_with_ancestry = [
+      # [ :table_name         :column_name :index_name                            ],
+      %w[ collections         ancestry      index_collections_on_ancestry         ],
+      %w[ attachments         version       index_attachments_on_version          ],
+      %w[ samples             ancestry      index_samples_on_ancestry             ],
+      %w[ cellline_samples    ancestry      index_cellline_samples_on_ancestry    ],
+      %w[ device_descriptions ancestry      index_device_descriptions_on_ancestry ],
+      %w[ ols_terms           ancestry      index_ols_terms_on_ancestry           ],
+    ]
+    # rubocop:enable Layout/SpaceInsidePercentLiteralDelimiters, Layout/SpaceInsideArrayPercentLiteral
+
+    tables_with_ancestry.each do |table_name, column_name, index_name|
+      reversible do |dir|
+        dir.up do
+          remove_index(table_name, [column_name]) if index_exists?(table_name, [column_name])
+          remove_index(table_name, name: index_name) if index_exists?(table_name, name: index_name)
+        end
+        dir.down do
+          add_index(table_name, [column_name], name: index_name) unless index_exists?(table_name, [column_name])
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20250701121907_migrate_ancestry_to_materialyzed_path2.rb
+++ b/db/migrate/20250701121907_migrate_ancestry_to_materialyzed_path2.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class MigrateAncestryToMaterialyzedPath2 < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  #
+  # models with has_ancestry
+  # ANCESTRY_MODELS = [
+  #  # [ :table_name         :column_name :index_name                            ],
+  #  %w[ collections         ancestry      index_collections_on_ancestry         ],
+  #  %w[ attachments         version       index_attachments_on_version          ],
+  #  %w[ samples             ancestry      index_samples_on_ancestry             ],
+  #  %w[ cellline_samples    ancestry      index_cellline_samples_on_ancestry    ],
+  #  %w[ device_descriptions ancestry      index_device_descriptions_on_ancestry ],
+  #  %w[ ols_terms           ancestry      index_ols_terms_on_ancestry           ],
+  # ].freeze
+  ANCESTRY_MODELS = [
+    Collection, Attachment, Sample, CelllineSample, DeviceDescription, OlsTerm
+  ].freeze
+  def change
+    reversible do |dir|
+      ANCESTRY_MODELS.each do |model|
+        table_name = model.table_name
+        column_name = model.ancestry_column
+        dir.up do
+          execute <<~SQL.squish
+            UPDATE #{table_name}
+            SET #{column_name} = '/' || trim(both '/' FROM #{column_name}) || '/'
+            WHERE #{column_name} IS NOT NULL;
+          SQL
+
+          execute <<~SQL.squish
+            UPDATE #{table_name}
+            SET #{column_name} = '/'
+            WHERE #{column_name} IS NULL;
+          SQL
+
+          change_table table_name do |t|
+            t.change column_name, :string, default: '/', null: false, collation: 'C'
+          end
+        end
+
+        dir.down do
+          change_table table_name do |t|
+            t.change column_name, :string, default: nil, null: true, collation: nil
+          end
+          execute <<~SQL.squish
+            UPDATE #{table_name}
+            SET #{column_name} = NULL
+            WHERE #{column_name} = '/';
+          SQL
+
+          execute <<~SQL.squish
+            UPDATE #{table_name}
+            SET #{column_name} = trim(both '/' FROM #{column_name})
+            WHERE #{column_name} IS NOT NULL;
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20250701121908_add_ancestry_indices.rb
+++ b/db/migrate/20250701121908_add_ancestry_indices.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class AddAncestryIndices < ActiveRecord::Migration[6.1]
+  # rubocop:disable Layout/SpaceInsidePercentLiteralDelimiters, Layout/SpaceInsideArrayPercentLiteral
+  ANCESTRY_MODELS = [
+    # [ :table_name         :column_name :index_name                            ],
+    %w[ collections         ancestry      index_collections_on_ancestry         ],
+    %w[ attachments         version       index_attachments_on_version          ],
+    %w[ samples             ancestry      index_samples_on_ancestry             ],
+    %w[ cellline_samples    ancestry      index_cellline_samples_on_ancestry    ],
+    %w[ device_descriptions ancestry      index_device_descriptions_on_ancestry ],
+    %w[ ols_terms           ancestry      index_ols_terms_on_ancestry           ],
+  ].freeze
+  # rubocop:enable Layout/SpaceInsidePercentLiteralDelimiters, Layout/SpaceInsideArrayPercentLiteral
+
+  def up
+    ANCESTRY_MODELS.each do |table_name, column_name, index_name|
+      if column_exists?(table_name, :deleted_at)
+        add_index table_name, column_name, opclass: :varchar_pattern_ops, unique: false, name: index_name,
+                                         where: 'deleted_at IS NULL'
+      else
+        add_index table_name, column_name, opclass: :varchar_pattern_ops, unique: false, name: index_name
+      end
+    end
+  end
+
+  def down
+    ANCESTRY_MODELS.each do |table_name, _column_name, index_name|
+      remove_index table_name, name: index_name if index_exists?(table_name, name: index_name)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_06_16_123935) do
+ActiveRecord::Schema.define(version: 2025_07_01_121908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -60,7 +60,7 @@ ActiveRecord::Schema.define(version: 2025_06_16_123935) do
     t.string "storage", limit: 20, default: "tmp"
     t.integer "created_by", null: false
     t.integer "created_for"
-    t.string "version"
+    t.string "version", default: "/", null: false, collation: "C"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "content_type"
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 2025_06_16_123935) do
     t.string "created_by_type"
     t.index ["attachable_type", "attachable_id"], name: "index_attachments_on_attachable_type_and_attachable_id"
     t.index ["identifier"], name: "index_attachments_on_identifier", unique: true
+    t.index ["version"], name: "index_attachments_on_version", opclass: :varchar_pattern_ops, where: "(deleted_at IS NULL)"
   end
 
   create_table "authentication_keys", id: :serial, force: :cascade do |t|
@@ -152,8 +153,8 @@ ActiveRecord::Schema.define(version: 2025_06_16_123935) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "short_label"
-    t.string "ancestry"
-    t.index ["ancestry"], name: "index_cellline_samples_on_ancestry"
+    t.string "ancestry", default: "/", null: false, collation: "C"
+    t.index ["ancestry"], name: "index_cellline_samples_on_ancestry", opclass: :varchar_pattern_ops, where: "(deleted_at IS NULL)"
   end
 
   create_table "channels", id: :serial, force: :cascade do |t|
@@ -185,7 +186,7 @@ ActiveRecord::Schema.define(version: 2025_06_16_123935) do
 
   create_table "collections", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
-    t.string "ancestry"
+    t.string "ancestry", default: "/", null: false, collation: "C"
     t.text "label", null: false
     t.integer "shared_by_id"
     t.boolean "is_shared", default: false
@@ -206,7 +207,7 @@ ActiveRecord::Schema.define(version: 2025_06_16_123935) do
     t.integer "celllinesample_detail_level", default: 10
     t.bigint "inventory_id"
     t.integer "devicedescription_detail_level", default: 10
-    t.index ["ancestry"], name: "index_collections_on_ancestry"
+    t.index ["ancestry"], name: "index_collections_on_ancestry", opclass: :varchar_pattern_ops, where: "(deleted_at IS NULL)"
     t.index ["deleted_at"], name: "index_collections_on_deleted_at"
     t.index ["inventory_id"], name: "index_collections_on_inventory_id"
     t.index ["user_id"], name: "index_collections_on_user_id"
@@ -461,7 +462,7 @@ ActiveRecord::Schema.define(version: 2025_06_16_123935) do
   create_table "device_descriptions", force: :cascade do |t|
     t.string "access_comments"
     t.string "access_options"
-    t.string "ancestry"
+    t.string "ancestry", default: "/", null: false, collation: "C"
     t.string "application_name"
     t.string "application_version"
     t.string "building"
@@ -513,7 +514,7 @@ ActiveRecord::Schema.define(version: 2025_06_16_123935) do
     t.string "vendor_company_name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["ancestry"], name: "index_device_descriptions_on_ancestry"
+    t.index ["ancestry"], name: "index_device_descriptions_on_ancestry", opclass: :varchar_pattern_ops, where: "(deleted_at IS NULL)"
     t.index ["device_id"], name: "index_device_descriptions_on_device_id"
   end
 
@@ -996,7 +997,7 @@ ActiveRecord::Schema.define(version: 2025_06_16_123935) do
   create_table "ols_terms", id: :serial, force: :cascade do |t|
     t.string "owl_name"
     t.string "term_id"
-    t.string "ancestry"
+    t.string "ancestry", default: "/", null: false, collation: "C"
     t.string "ancestry_term_id"
     t.string "label"
     t.string "synonym"
@@ -1006,7 +1007,7 @@ ActiveRecord::Schema.define(version: 2025_06_16_123935) do
     t.boolean "is_enabled", default: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["ancestry"], name: "index_ols_terms_on_ancestry"
+    t.index ["ancestry"], name: "index_ols_terms_on_ancestry", opclass: :varchar_pattern_ops
     t.index ["owl_name", "term_id"], name: "index_ols_terms_on_owl_name_and_term_id", unique: true
   end
 
@@ -1277,7 +1278,7 @@ ActiveRecord::Schema.define(version: 2025_06_16_123935) do
     t.string "impurities", default: ""
     t.string "location", default: ""
     t.boolean "is_top_secret", default: false
-    t.string "ancestry"
+    t.string "ancestry", default: "/", null: false, collation: "C"
     t.string "external_label", default: ""
     t.integer "created_by"
     t.string "short_label"
@@ -1308,7 +1309,7 @@ ActiveRecord::Schema.define(version: 2025_06_16_123935) do
     t.string "sample_type", default: "Micromolecule"
     t.jsonb "sample_details"
     t.jsonb "log_data"
-    t.index ["ancestry"], name: "index_samples_on_ancestry", where: "(deleted_at IS NULL)"
+    t.index ["ancestry"], name: "index_samples_on_ancestry", opclass: :varchar_pattern_ops, where: "(deleted_at IS NULL)"
     t.index ["deleted_at"], name: "index_samples_on_deleted_at"
     t.index ["identifier"], name: "index_samples_on_identifier"
     t.index ["inventory_sample"], name: "index_samples_on_inventory_sample"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_05_15_141514) do
+ActiveRecord::Schema.define(version: 2025_06_16_123935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -375,6 +375,7 @@ ActiveRecord::Schema.define(version: 2025_05_15_141514) do
     t.text "plain_text_content"
     t.jsonb "log_data"
     t.index ["containable_type", "containable_id"], name: "index_containers_on_containable"
+    t.index ["parent_id"], name: "index_containers_on_parent_id", where: "(deleted_at IS NULL)"
   end
 
   create_table "dataset_klasses", id: :serial, force: :cascade do |t|
@@ -1307,6 +1308,7 @@ ActiveRecord::Schema.define(version: 2025_05_15_141514) do
     t.string "sample_type", default: "Micromolecule"
     t.jsonb "sample_details"
     t.jsonb "log_data"
+    t.index ["ancestry"], name: "index_samples_on_ancestry", where: "(deleted_at IS NULL)"
     t.index ["deleted_at"], name: "index_samples_on_deleted_at"
     t.index ["identifier"], name: "index_samples_on_identifier"
     t.index ["inventory_sample"], name: "index_samples_on_inventory_sample"

--- a/db/seeds/development/00_persons.seed.rb
+++ b/db/seeds/development/00_persons.seed.rb
@@ -17,7 +17,7 @@ Person.find_each do |u|
   collection = Collection.create(
     user_id: u.id,
     label: "project #{u.name_abbreviation}-#{Faker::Color.color_name}"
-    # ancestry: nil,
+    # ancestry: '/',
     # position:
   )
   ca =  Collection.find_by(user: u, label: 'All', is_locked: true)
@@ -41,7 +41,7 @@ Person.find_each do |u|
       impurities: "",
       location:  Faker::Commerce.department,
       is_top_secret: false,
-      ancestry: nil,
+      ancestry: '/',
       external_label: "#{u.name_abbreviation}-#{Faker::Name.first_name}",
       created_by: u.id,
       density: rand(0..1.0).round(3),
@@ -153,7 +153,7 @@ Person.find_each do |u|
                                          show_yield: true)
 
     reaction_svg = composer.compose_reaction_svg
-    
+
     attributes = {
       name: Faker::Book.title,
       short_label: Faker::Book.title,

--- a/spec/api/collection_api_spec.rb
+++ b/spec/api/collection_api_spec.rb
@@ -28,10 +28,10 @@ describe Chemotion::CollectionAPI do
 
     let!(:c2) do
       create(:collection, user: u2, shared_by_id: user.id, is_shared: true, permission_level: 2,
-                          ancestry: root_u.id.to_s)
+                          parent: root_u)
     end
     let!(:c3)   { create(:collection, user: user, is_shared: false) }
-    let!(:c4)   { create(:collection, user: user, shared_by_id: u2.id, is_shared: true, ancestry: root_u2.id.to_s) }
+    let!(:c4)   { create(:collection, user: user, shared_by_id: u2.id, is_shared: true, parent: root_u2) }
     let!(:c5)   { create(:collection, shared_by_id: u2.id, is_shared: true) }
     # - - - - sync collection
     let!(:owner) { create(:user) }
@@ -174,7 +174,7 @@ describe Chemotion::CollectionAPI do
           create(
             :collection, user: user, is_shared: true,
                          shared_by_id: p2.id, is_locked: false,
-                         ancestry: root_g.id.to_s
+                         parent: root_g
           )
         end
 

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -26,7 +26,7 @@
 #  key             :string(500)
 #  storage         :string(20)       default("tmp")
 #  thumb           :boolean          default(FALSE)
-#  version         :string
+#  version         :string           default("/"), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  attachable_id   :integer
@@ -35,6 +35,7 @@
 #
 #  index_attachments_on_attachable_type_and_attachable_id  (attachable_type,attachable_id)
 #  index_attachments_on_identifier                         (identifier) UNIQUE
+#  index_attachments_on_version                            (version) WHERE (deleted_at IS NULL)
 #
 require 'rails_helper'
 

--- a/spec/models/cellline_sample_spec.rb
+++ b/spec/models/cellline_sample_spec.rb
@@ -6,7 +6,7 @@
 #
 #  id                   :bigint           not null, primary key
 #  amount               :bigint
-#  ancestry             :string
+#  ancestry             :string           default("/"), not null
 #  contamination        :string
 #  deleted_at           :datetime
 #  description          :string
@@ -22,7 +22,7 @@
 #
 # Indexes
 #
-#  index_cellline_samples_on_ancestry  (ancestry)
+#  index_cellline_samples_on_ancestry  (ancestry) WHERE (deleted_at IS NULL)
 #
 require 'rails_helper'
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -5,7 +5,7 @@
 # Table name: collections
 #
 #  id                             :integer          not null, primary key
-#  ancestry                       :string
+#  ancestry                       :string           default("/"), not null
 #  celllinesample_detail_level    :integer          default(10)
 #  deleted_at                     :datetime
 #  devicedescription_detail_level :integer          default(10)
@@ -30,7 +30,7 @@
 #
 # Indexes
 #
-#  index_collections_on_ancestry      (ancestry)
+#  index_collections_on_ancestry      (ancestry) WHERE (deleted_at IS NULL)
 #  index_collections_on_deleted_at    (deleted_at)
 #  index_collections_on_inventory_id  (inventory_id)
 #  index_collections_on_user_id       (user_id)

--- a/spec/models/container_spec.rb
+++ b/spec/models/container_spec.rb
@@ -21,6 +21,7 @@
 # Indexes
 #
 #  index_containers_on_containable  (containable_type,containable_id)
+#  index_containers_on_parent_id    (parent_id) WHERE (deleted_at IS NULL)
 #
 require 'rails_helper'
 

--- a/spec/models/device_description_spec.rb
+++ b/spec/models/device_description_spec.rb
@@ -7,7 +7,7 @@
 #  id                                   :bigint           not null, primary key
 #  access_comments                      :string
 #  access_options                       :string
-#  ancestry                             :string
+#  ancestry                             :string           default("/"), not null
 #  application_name                     :string
 #  application_version                  :string
 #  building                             :string
@@ -62,7 +62,7 @@
 #
 # Indexes
 #
-#  index_device_descriptions_on_ancestry   (ancestry)
+#  index_device_descriptions_on_ancestry   (ancestry) WHERE (deleted_at IS NULL)
 #  index_device_descriptions_on_device_id  (device_id)
 #
 require 'rails_helper'

--- a/spec/models/sample_spec.rb
+++ b/spec/models/sample_spec.rb
@@ -5,7 +5,7 @@
 # Table name: samples
 #
 #  id                  :integer          not null, primary key
-#  ancestry            :string
+#  ancestry            :string           default("/"), not null
 #  boiling_point       :numrange
 #  created_by          :integer
 #  decoupled           :boolean          default(FALSE), not null
@@ -51,6 +51,7 @@
 #
 # Indexes
 #
+#  index_samples_on_ancestry          (ancestry) WHERE (deleted_at IS NULL)
 #  index_samples_on_deleted_at        (deleted_at)
 #  index_samples_on_identifier        (identifier)
 #  index_samples_on_inventory_sample  (inventory_sample)


### PR DESCRIPTION
- add index on samples.ancestry (SampleEntity => children_count)
- add index on containers.parent_id: this improve drastically the serialization of container as ContainerEntity is self recurring on object.children

- call sample parent_id from ancestry directly to avoid another query


- upgrade ancestry path to materialized_path2

