### PR TITLE
fix: persist coefficient value on material change in reaction scheme

### DIFF
--- a/app/javascript/src/models/Reaction.js
+++ b/app/javascript/src/models/Reaction.js
@@ -812,6 +812,7 @@ export default class Reaction extends Element {
           mat.reference = group[index].reference;
           mat.gas_type = group[index].gas_type;
           mat.gas_phase_data = group[index].gas_phase_data;
+          mat.coefficient = group[index].coefficient;
           mat.updateChecksum();
           group[index] = mat;
           break;


### PR DESCRIPTION
**Description**

When updating a sample that is part of a reaction, the coefficient value was being lost due to it not being carried over from the original sample. This fix ensures the existing coefficient is retained by extracting it from the reaction's current material and reapplying it to the updated sample before refreshing the reaction state.

-------------------------------------------

- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
