### PR TITLE
feat: make creatableselects editable across all elements

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/cellLines/propertiesTab/CellLineName.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/propertiesTab/CellLineName.js
@@ -12,7 +12,8 @@ export default class CellLineName extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      nameSuggestions: []
+      nameSuggestions: [],
+      cellLineNameInputValue: props.name || ''
     };
   }
 
@@ -22,6 +23,15 @@ export default class CellLineName extends React.Component {
       .then((data) => {
         this.setState({ nameSuggestions: data });
       });
+  }
+
+  componentDidUpdate(prevProps) {
+    // Sync cellLineNameInputValue when name prop changes
+    if (prevProps.name !== this.props.name) {
+      this.setState({
+        cellLineNameInputValue: this.props.name || ''
+      });
+    }
   }
 
   static renderNameSuggestion(name, src) {
@@ -38,7 +48,7 @@ export default class CellLineName extends React.Component {
 
   render() {
     const { cellLineDetailsStore } = this.context;
-    const { nameSuggestions } = this.state;
+    const { nameSuggestions, cellLineNameInputValue } = this.state;
     const { id, name, readOnly } = this.props;
 
     if (readOnly) {
@@ -65,28 +75,36 @@ export default class CellLineName extends React.Component {
         <Col sm={9}>
           <CreatableSelect
             className={className}
+            isClearable
+            isInputEditable
+            inputValue={this.state.cellLineNameInputValue}
             onChange={(e) => {
-              if (typeof e.value === 'number') {
-                const currentEntry = nameSuggestions.filter((x) => x.value === e.value);
+              const value = e ? e.value : '';
+              this.setState({ cellLineNameInputValue: value });
+              if (typeof value === 'number') {
+                const currentEntry = nameSuggestions.filter((x) => x.value === value);
                 if (currentEntry.length > 0) {
                   cellLineDetailsStore.changeCellLineName(id, currentEntry[0].name);
-                  CellLinesFetcher.getCellLineMaterialById(e.value)
+                  CellLinesFetcher.getCellLineMaterialById(value)
                     .then((result) => {
                       cellLineDetailsStore.setMaterialProperties(id, result);
                     });
                 }
               } else {
-                cellLineDetailsStore.changeCellLineName(id, e.value);
+                cellLineDetailsStore.changeCellLineName(id, value);
               }
             }}
-            onInputChange={(e, action) => {
-              if (action.action === 'input-change') {
+            onInputChange={(e, { action }) => {
+              if (action === 'input-change') {
+                this.setState({ cellLineNameInputValue: e });
                 cellLineDetailsStore.changeCellLineName(id, e);
               }
             }}
             options={nameSuggestions}
-            placeholder="enter new cell line name or choose from existing ones "
+            placeholder="Enter new cell line name or choose from existing ones "
             defaultInputValue={name}
+            allowCreateWhileLoading
+            formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
           />
         </Col>
       </Form.Group>

--- a/app/javascript/src/apps/mydb/elements/details/cellLines/propertiesTab/GeneralProperties.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/propertiesTab/GeneralProperties.js
@@ -115,15 +115,13 @@ class GeneralProperties extends React.Component {
         onChange={() => {}}
       />
     ) : (
-      <CreatableSelect
+      <Select
+        name="unit"
         className={styleClassUnit}
+        value={options.find(({ value }) => value === item.unit)}
         onChange={(e) => { cellLineDetailsStore.changeUnit(item.id, e.value); }}
-        onInputChange={(e, action) => {
-          if (action.action === 'input-change') { cellLineDetailsStore.changeUnit(item.id, e); }
-        }}
         options={options}
-        placeholder="choose/enter unit"
-        defaultInputValue={item.unit}
+        placeholder="choose unit"
       />
     );
 

--- a/app/javascript/src/apps/userSettings/Affiliations.js
+++ b/app/javascript/src/apps/userSettings/Affiliations.js
@@ -15,6 +15,7 @@ function Affiliations({ show, onHide }) {
   const [inputError, setInputError] = useState({});
   const [errorMsg, setErrorMsg] = useState('');
   const [showConfirmIndex, setShowConfirmIndex] = useState(null);
+  const [inputValues, setInputValues] = useState({});
 
   const currentEntries = affiliations.filter((entry) => entry.current);
 
@@ -265,6 +266,9 @@ function Affiliations({ show, onHide }) {
                     : (
                       <CreatableSelect
                         disabled={item.disabled}
+                        isClearable
+                        isInputEditable
+                        inputValue={inputValues[`${index}_country`] || item.country || ''}
                         placeholder="Select or enter a new option"
                         options={countryOptions}
                         onCreateOption={(newValue) => {
@@ -273,7 +277,19 @@ function Affiliations({ show, onHide }) {
                           onChangeHandler(index, 'country', newValue);
                         }}
                         value={countryOptions.find((option) => option.value === item.country) || null}
-                        onChange={(choice) => onChangeHandler(index, 'country', !choice ? '' : choice.value)}
+                        onChange={(choice) => {
+                          const value = choice ? choice.value : '';
+                          setInputValues(prev => ({ ...prev, [`${index}_country`]: value }));
+                          onChangeHandler(index, 'country', value);
+                        }}
+                        onInputChange={(inputValue, { action }) => {
+                          if (action === 'input-change') {
+                            setInputValues(prev => ({ ...prev, [`${index}_country`]: inputValue }));
+                            onChangeHandler(index, 'country', inputValue);
+                          }
+                        }}
+                        allowCreateWhileLoading
+                        formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
                       />
                     )}
                 </td>
@@ -283,6 +299,9 @@ function Affiliations({ show, onHide }) {
                       <>
                         <CreatableSelect
                           disabled={item.disabled}
+                          isClearable
+                          isInputEditable
+                          inputValue={inputValues[`${index}_organization`] || item.organization || ''}
                           placeholder="Select or enter a new option"
                           className={inputError[index] && inputError[index].organization ? 'is-invalid' : ''}
                           options={orgOptions}
@@ -292,7 +311,19 @@ function Affiliations({ show, onHide }) {
                             setOrgOptions((prev) => [...prev, newOption]);
                             onChangeHandler(index, 'organization', newValue);
                           }}
-                          onChange={(choice) => onChangeHandler(index, 'organization', !choice ? '' : choice.value)}
+                          onChange={(choice) => {
+                            const value = choice ? choice.value : '';
+                            setInputValues(prev => ({ ...prev, [`${index}_organization`]: value }));
+                            onChangeHandler(index, 'organization', value);
+                          }}
+                          onInputChange={(inputValue, { action }) => {
+                            if (action === 'input-change') {
+                              setInputValues(prev => ({ ...prev, [`${index}_organization`]: inputValue }));
+                              onChangeHandler(index, 'organization', inputValue);
+                            }
+                          }}
+                          allowCreateWhileLoading
+                          formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
                         />
                         {inputError[index] && inputError[index].organization && (
                           <div className="invalid-feedback">Organization is required</div>
@@ -305,6 +336,9 @@ function Affiliations({ show, onHide }) {
                     : (
                       <CreatableSelect
                         disabled={item.disabled}
+                        isClearable
+                        isInputEditable
+                        inputValue={inputValues[`${index}_department`] || item.department || ''}
                         placeholder="Select or enter a new option"
                         options={deptOptions}
                         value={deptOptions.find((option) => option.value === item.department) || null}
@@ -313,7 +347,19 @@ function Affiliations({ show, onHide }) {
                           setDeptOptions((prev) => [...prev, newOption]);
                           onChangeHandler(index, 'department', newValue);
                         }}
-                        onChange={(choice) => onChangeHandler(index, 'department', !choice ? '' : choice.value)}
+                        onChange={(choice) => {
+                          const value = choice ? choice.value : '';
+                          setInputValues(prev => ({ ...prev, [`${index}_department`]: value }));
+                          onChangeHandler(index, 'department', value);
+                        }}
+                        onInputChange={(inputValue, { action }) => {
+                          if (action === 'input-change') {
+                            setInputValues(prev => ({ ...prev, [`${index}_department`]: inputValue }));
+                            onChangeHandler(index, 'department', inputValue);
+                          }
+                        }}
+                        allowCreateWhileLoading
+                        formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
                       />
                     )}
                 </td>
@@ -323,6 +369,9 @@ function Affiliations({ show, onHide }) {
                       <CreatableSelect
                         placeholder="Select or enter a new option"
                         disabled={item.disabled}
+                        isClearable
+                        isInputEditable
+                        inputValue={inputValues[`${index}_group`] || item.group || ''}
                         value={groupOptions.find((option) => option.value === item.group) || null}
                         options={groupOptions}
                         onCreateOption={(newValue) => {
@@ -330,7 +379,19 @@ function Affiliations({ show, onHide }) {
                           setGroupOptions((prev) => [...prev, newOption]);
                           onChangeHandler(index, 'group', newValue);
                         }}
-                        onChange={(choice) => onChangeHandler(index, 'group', !choice ? '' : choice.value)}
+                        onChange={(choice) => {
+                          const value = choice ? choice.value : '';
+                          setInputValues(prev => ({ ...prev, [`${index}_group`]: value }));
+                          onChangeHandler(index, 'group', value);
+                        }}
+                        onInputChange={(inputValue, { action }) => {
+                          if (action === 'input-change') {
+                            setInputValues(prev => ({ ...prev, [`${index}_group`]: inputValue }));
+                            onChangeHandler(index, 'group', inputValue);
+                          }
+                        }}
+                        allowCreateWhileLoading
+                        formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
                       />
                     )}
                 </td>

--- a/app/javascript/src/components/common/Select.js
+++ b/app/javascript/src/components/common/Select.js
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
-import RSelect from 'react-select';
+import RSelect, { components } from 'react-select';
 import RAsyncSelect from 'react-select/async';
 import RCreatableSelect from 'react-select/creatable';
 import cs from 'classnames';
@@ -13,12 +13,19 @@ import cs from 'classnames';
 
 const baseClassName = 'chemotion-select';
 
+// Custom Input component that keeps the input visible for editing selected values
+const EditableInput = (props) => (
+  <components.Input {...props} isHidden={false} />
+);
+
 function buildWrappedComponent(name, BaseComponent) {
   const component = forwardRef(({
     minWidth,
     maxHeight,
     className,
     styles = {},
+    components: customComponents = {},
+    isInputEditable = false,
     ...props
   }, ref) => {
     const styleDefaults = {
@@ -53,6 +60,12 @@ function buildWrappedComponent(name, BaseComponent) {
       )
     };
 
+    // Merge custom components with editable input if needed
+    const mergedComponents = {
+      ...customComponents,
+      ...(isInputEditable && { Input: EditableInput }),
+    };
+
     return (
       <BaseComponent
         {...props}
@@ -66,6 +79,7 @@ function buildWrappedComponent(name, BaseComponent) {
         menuPlacement="auto"
         unstyled
         styles={stylesWithOverrides}
+        components={mergedComponents}
       />
     );
   });
@@ -75,11 +89,13 @@ function buildWrappedComponent(name, BaseComponent) {
     ...BaseComponent.propTypes,
     minWidth: PropTypes.string,
     maxHeight: PropTypes.string,
+    isInputEditable: PropTypes.bool,
   };
   component.defaultProps = {
     ...BaseComponent.defaultProps,
     minWidth: null,
     maxHeight: null,
+    isInputEditable: false,
   };
 
   return component;

--- a/app/javascript/src/components/container/ContainerDatasetModalContent.js
+++ b/app/javascript/src/components/container/ContainerDatasetModalContent.js
@@ -52,6 +52,7 @@ export class ContainerDatasetModalContent extends Component {
     this.state = {
       datasetContainer,
       instruments: [],
+      instrumentInputValue: '',
       timeoutReference: null,
       attachmentEditor: false,
       extension: null,
@@ -85,8 +86,10 @@ export class ContainerDatasetModalContent extends Component {
 
   componentDidMount() {
     this.editorInitial();
+    const { datasetContainer } = this.state;
     this.setState({
-      attachmentGroups: this.classifyAttachments(this.props.datasetContainer.attachments)
+      attachmentGroups: this.classifyAttachments(this.props.datasetContainer.attachments),
+      instrumentInputValue: datasetContainer?.extended_metadata?.instrument || ''
     });
   }
 
@@ -95,6 +98,13 @@ export class ContainerDatasetModalContent extends Component {
     const { attachments } = this.props.datasetContainer;
 
     const prevAttachments = [...attachments];
+
+    // Sync instrumentInputValue when datasetContainer.extended_metadata.instrument changes
+    if (prevProps.datasetContainer?.extended_metadata?.instrument !== this.props.datasetContainer?.extended_metadata?.instrument) {
+      this.setState({
+        instrumentInputValue: this.props.datasetContainer?.extended_metadata?.instrument || ''
+      });
+    }
 
     if (prevMessages.length !== newMessages.length) {
       this.setState({
@@ -339,6 +349,7 @@ export class ContainerDatasetModalContent extends Component {
     this.setState({
       value: '',
       instruments: [],
+      instrumentInputValue: '',
     });
     datasetContainer.extended_metadata.instrument = '';
   }
@@ -600,22 +611,18 @@ export class ContainerDatasetModalContent extends Component {
             <Form.Label>Instrument</Form.Label>
             <CreatableSelect
               isClearable
+              isInputEditable
               className="w-100"
-              value={
-                datasetContainer?.extended_metadata?.instrument
-                  ? {
-                    label: datasetContainer.extended_metadata.instrument,
-                    value: datasetContainer.extended_metadata.instrument
-                  }
-                  : null
-              }
+              inputValue={this.state.instrumentInputValue}
               isDisabled={readOnly || disabled}
               onChange={(selectedOption) => {
                 const value = selectedOption ? selectedOption.value : '';
+                this.setState({ instrumentInputValue: value });
                 this.handleInstrumentValueChange({ target: { value } }, this.doneInstrumentTyping);
               }}
               onInputChange={(inputValue, { action }) => {
                 if (action === 'input-change') {
+                  this.setState({ instrumentInputValue: inputValue });
                   this.handleInstrumentValueChange({ target: { value: inputValue } }, this.doneInstrumentTyping);
                 }
               }}
@@ -624,6 +631,8 @@ export class ContainerDatasetModalContent extends Component {
                 value: item.name,
               }))}
               placeholder="Enter or select an instrument"
+              allowCreateWhileLoading
+              formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
             />
           </Form.Group>
         </div>


### PR DESCRIPTION
**Description**

This PR standardizes and enables editable (creatable) select inputs across the application for a consistent user experience.

For example, as it was in v1.9, the user can select a molecule name for a sample and edit the value and save it. Same for a dataset instrument. 

**Key changes:**

- Updated all relevant CreatableSelect and Select components to support input editing, clearing, and creation of new options.
- Unified props usage (isClearable, isInputEditable, inputValue, onInputChange, allowCreateWhileLoading, formatCreateLabel) across SampleForm, CellLineName, GeneralProperties, Affiliations, ComputedPropsGraphContainer, and SampleDetails.
- Improved state management and value matching for selects to ensure correct display and editing.
- Fixed issues where selected values were not editable or labels were not displayed correctly.
- Enhanced user experience by allowing direct editing and creating select options everywhere needed.

------------------------------


