### PR TITLE
fix(UI): make element detail tabs and header sticky 

### DIFF
--- a/app/assets/stylesheets/global-styles/utilities/detail-card.scss
+++ b/app/assets/stylesheets/global-styles/utilities/detail-card.scss
@@ -1,15 +1,30 @@
 .detail-card {
-  @extend .border-0;
+  @extend .d-flex;
+  @extend .flex-column;
 
-  > .card {
-    &-header {
-      @extend .surface-tab__header;
-      @extend .state-border;
-    }
-    &-body {
+  @extend .border-0;
+  @extend .h-100;
+
+  & > .card-header {
+    @extend .surface-tab__header;
+    @extend .state-border;
+  }
+
+  &.detail-card--unsaved > .card-header {
+    @extend .border-warning;
+  }
+
+  & > &__scroll-container {
+    @extend .flex-grow-1;
+    @extend .h-0;
+    @extend .overflow-y-auto;
+    @extend .pt-1;
+
+    > .card-body {
       @extend .p-0;
     }
-    &-footer {
+
+    .card-footer {
       @extend .surface-tab__header;
       @extend .border-0;
       @extend .d-flex;
@@ -17,10 +32,6 @@
       @extend .align-items-center;
       @extend .gap-2;
     }
-  }
-
-  &.detail-card--unsaved > .card-header {
-    @extend .border-warning;
   }
 }
 

--- a/app/javascript/src/apps/mydb/elements/details/DetailCard.js
+++ b/app/javascript/src/apps/mydb/elements/details/DetailCard.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cs from 'classnames';
+import { Card } from 'react-bootstrap';
+
+export default function DetailCard({
+  children, isPendingToSave, header, footer
+}) {
+  const className = cs(
+    'detail-card',
+    { 'detail-card--unsaved': isPendingToSave }
+  );
+
+  return (
+    <Card className={className}>
+      <Card.Header>{header}</Card.Header>
+      <div className="detail-card__scroll-container">
+        <Card.Body>
+          {children}
+        </Card.Body>
+        {footer && <Card.Footer>{footer}</Card.Footer>}
+      </div>
+    </Card>
+  );
+}
+
+DetailCard.propTypes = {
+  children: PropTypes.node.isRequired,
+  isPendingToSave: PropTypes.bool,
+  header: PropTypes.node.isRequired,
+  footer: PropTypes.node
+};
+
+DetailCard.defaultProps = {
+  isPendingToSave: false,
+  footer: null
+};

--- a/app/javascript/src/apps/mydb/elements/details/GraphContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/GraphContainer.js
@@ -72,28 +72,30 @@ export default class GraphContainer extends React.Component {
     });
   }
 
+  header() {
+    return (
+      <div className="d-flex align-items-baseline justify-content-between">
+        <div>
+          <i className="fa fa-area-chart me-1" />
+          Graph
+        </div>
+        <Button
+          key="closeBtn"
+          onClick={this.onClose}
+          variant="danger"
+          size="xxsm"
+        >
+          <i className="fa fa-times" />
+        </Button>
+      </div>
+    );
+  }
+
   render() {
     const { selectedComputedProps } = this.state;
 
     return (
-      <DetailCard
-        header={(
-          <div className="d-flex align-items-baseline justify-content-between">
-            <div>
-              <i className="fa fa-area-chart me-1" />
-              Graph
-            </div>
-            <Button
-              key="closeBtn"
-              onClick={this.onClose}
-              variant="danger"
-              size="xxsm"
-            >
-              <i className="fa fa-times" />
-            </Button>
-          </div>
-        )}
-      >
+      <DetailCard header={this.header()}>
         <ComputedPropsGraphContainer
           show
           style={{ overflowY: 'auto', maxHeight: 'calc(100vh - 303px)' }}

--- a/app/javascript/src/apps/mydb/elements/details/GraphContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/GraphContainer.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Card } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
+import DetailCard from 'src/apps/mydb/elements/details/DetailCard';
 import ReportActions from 'src/stores/alt/actions/ReportActions';
 import DetailActions from 'src/stores/alt/actions/DetailActions';
 import UIStore from 'src/stores/alt/stores/UIStore';
@@ -75,29 +76,30 @@ export default class GraphContainer extends React.Component {
     const { selectedComputedProps } = this.state;
 
     return (
-      <Card>
-        <Card.Header className="text-bg-primary d-flex align-items-baseline justify-content-between">
-          <div>
-            <i className="fa fa-area-chart me-1" />
-            Graph
+      <DetailCard
+        header={(
+          <div className="d-flex align-items-baseline justify-content-between">
+            <div>
+              <i className="fa fa-area-chart me-1" />
+              Graph
+            </div>
+            <Button
+              key="closeBtn"
+              onClick={this.onClose}
+              variant="danger"
+              size="xxsm"
+            >
+              <i className="fa fa-times" />
+            </Button>
           </div>
-          <Button
-            key="closeBtn"
-            onClick={this.onClose}
-            variant="danger"
-            size="xxsm"
-          >
-            <i className="fa fa-times" />
-          </Button>
-        </Card.Header>
-        <Card.Body>
-          <ComputedPropsGraphContainer
-            show
-            style={{ overflowY: 'auto', maxHeight: 'calc(100vh - 303px)' }}
-            graphData={selectedComputedProps}
-          />
-        </Card.Body>
-      </Card>
+        )}
+      >
+        <ComputedPropsGraphContainer
+          show
+          style={{ overflowY: 'auto', maxHeight: 'calc(100vh - 303px)' }}
+          graphData={selectedComputedProps}
+        />
+      </DetailCard>
     );
   }
 }

--- a/app/javascript/src/apps/mydb/elements/details/LiteratureDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/LiteratureDetails.js
@@ -344,17 +344,36 @@ export default class LiteratureDetails extends Component {
     );
   }
 
+  literatureHeader() {
+    const { currentCollection } = this.state;
+    const label = currentCollection?.label || null;
+    return (
+      <div className="d-flex justify-content-between">
+        <span>
+          <i className="fa fa-book me-1" />
+          Literature Management for collection '{label}'
+        </span>
+        <Button
+          key="closeBtn"
+          onClick={this.onClose}
+          variant="danger"
+          size="xxsm"
+        >
+          <i className="fa fa-times" />
+        </Button>
+      </div>
+    );
+  }
+
   render() {
     const {
       sampleRefs,
       reactionRefs,
       selectedRefs,
       sortedIds,
-      currentCollection,
       literature
     } = this.state;
     const { currentUser } = UserStore.getState();
-    const label = currentCollection ? currentCollection.label : null;
     let contentSamples = '';
     sampleRefs.forEach((citation) => {
       contentSamples = `${contentSamples}\n${literatureContent(citation, true)}`;
@@ -375,24 +394,7 @@ export default class LiteratureDetails extends Component {
     });
 
     return (
-      <DetailCard
-        header={(
-          <div className="d-flex justify-content-between">
-            <span>
-              <i className="fa fa-book me-1" />
-              Literature Management for collection '{label}'
-            </span>
-            <Button
-              key="closeBtn"
-              onClick={this.onClose}
-              variant="danger"
-              size="xxsm"
-            >
-              <i className="fa fa-times" />
-            </Button>
-          </div>
-        )}
-      >
+      <DetailCard header={this.literatureHeader()}>
         <Accordion>
           <Accordion.Item eventKey="2">
             <Accordion.Header>

--- a/app/javascript/src/apps/mydb/elements/details/LiteratureDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/LiteratureDetails.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
   Accordion,
-  Card,
   Table,
   Button,
   ListGroup,
@@ -25,6 +24,7 @@ import {
   LiteralType,
   literatureContent
 } from 'src/apps/mydb/elements/details/literature/LiteratureCommon';
+import DetailCard from 'src/apps/mydb/elements/details/DetailCard';
 import Literature from 'src/models/Literature';
 import LiteratureMap from 'src/models/LiteratureMap';
 import LiteraturesFetcher from 'src/fetchers/LiteraturesFetcher';
@@ -375,126 +375,127 @@ export default class LiteratureDetails extends Component {
     });
 
     return (
-      <Card>
-        <Card.Header className="text-bg-primary d-flex justify-content-between">
-          <span>
-            <i className="fa fa-book me-1" />
-            Literature Management for collection '{label}'
-          </span>
-          <Button
-            key="closeBtn"
-            onClick={this.onClose}
-            variant="danger"
-            size="xxsm"
-          >
-            <i className="fa fa-times" />
-          </Button>
-        </Card.Header>
-        <Card.Body>
-          <Accordion>
-            <Accordion.Item eventKey="2">
-              <Accordion.Header>
-                {this.renderSectionHeader('References for samples', contentSamples)}
-              </Accordion.Header>
-              <Accordion.Body>
-                {sampleRefs.map((lit) => (
-                  <Row key={`sampleRef-${lit.id}`} className="mb-3">
-                    <Col xs={1}><ElementTypeLink literature={lit} type="sample" /></Col>
-                    <Col xs={11}><Citation literature={lit} /></Col>
-                  </Row>
-                ))}
-              </Accordion.Body>
-            </Accordion.Item>
+      <DetailCard
+        header={(
+          <div className="d-flex justify-content-between">
+            <span>
+              <i className="fa fa-book me-1" />
+              Literature Management for collection '{label}'
+            </span>
+            <Button
+              key="closeBtn"
+              onClick={this.onClose}
+              variant="danger"
+              size="xxsm"
+            >
+              <i className="fa fa-times" />
+            </Button>
+          </div>
+        )}
+      >
+        <Accordion>
+          <Accordion.Item eventKey="2">
+            <Accordion.Header>
+              {this.renderSectionHeader('References for samples', contentSamples)}
+            </Accordion.Header>
+            <Accordion.Body>
+              {sampleRefs.map((lit) => (
+                <Row key={`sampleRef-${lit.id}`} className="mb-3">
+                  <Col xs={1}><ElementTypeLink literature={lit} type="sample" /></Col>
+                  <Col xs={11}><Citation literature={lit} /></Col>
+                </Row>
+              ))}
+            </Accordion.Body>
+          </Accordion.Item>
 
-            <Accordion.Item eventKey="3">
-              <Accordion.Header>
-                {this.renderSectionHeader('References for reactions', contentReactions)}
-              </Accordion.Header>
-              <Accordion.Body>
-                {reactionRefs.map((lit) => (
-                  <Row key={`reactionRef-${lit.id}`} className="mb-3">
-                    <Col xs={1}><ElementTypeLink literature={lit} type="reaction" /></Col>
-                    <Col xs={11}><Citation literature={lit} /></Col>
-                  </Row>
-                ))}
-              </Accordion.Body>
-            </Accordion.Item>
+          <Accordion.Item eventKey="3">
+            <Accordion.Header>
+              {this.renderSectionHeader('References for reactions', contentReactions)}
+            </Accordion.Header>
+            <Accordion.Body>
+              {reactionRefs.map((lit) => (
+                <Row key={`reactionRef-${lit.id}`} className="mb-3">
+                  <Col xs={1}><ElementTypeLink literature={lit} type="reaction" /></Col>
+                  <Col xs={11}><Citation literature={lit} /></Col>
+                </Row>
+              ))}
+            </Accordion.Body>
+          </Accordion.Item>
 
-            <Accordion.Item eventKey="4">
-              <Accordion.Header>
-                {this.renderSectionHeader('References for selected elements', contentElements)}
-              </Accordion.Header>
-              <Accordion.Body>
-                <ListGroup>
-                  <ListGroupItem>
-                    <Row>
-                      <Col md={8} style={{ paddingRight: 0 }}>
-                        <LiteratureInput
-                          handleInputChange={this.handleInputChange}
-                          literature={literature}
-                          field="doi"
-                          placeholder="DOI: 10.... or  http://dx.doi.org/10... or 10. ..."
-                        />
-                      </Col>
-                      <Col md={3} style={{ paddingRight: 0 }}>
-                        <LiteralType
-                          handleInputChange={this.handleInputChange}
-                          disabled={false}
-                          val={literature.litype}
-                        />
-                      </Col>
-                      <Col md={1} style={{ paddingRight: 0 }}>
-                        <Button
-                          variant="success"
-                          size="sm"
-                          style={{ marginTop: 2 }}
-                          onClick={this.fetchDOIMetadata}
-                          title="fetch metadata for this doi and add citation to selection"
-                          disabled={!doiValid(literature.doi)}
-                        >
-                          <i className="fa fa-plus" />
-                        </Button>
-                      </Col>
-                      <Col md={12} style={{ paddingRight: 0 }}>
-                        <Citation literature={literature} />
-                      </Col>
-                      <Col md={7} style={{ paddingRight: 0 }}>
-                        <LiteratureInput
-                          handleInputChange={this.handleInputChange}
-                          literature={literature}
-                          field="title"
-                          placeholder="Title..."
-                        />
-                      </Col>
-                      <Col md={4} style={{ paddingRight: 0 }}>
-                        <LiteratureInput
-                          handleInputChange={this.handleInputChange}
-                          literature={literature}
-                          field="url"
-                          placeholder="URL..."
-                        />
-                      </Col>
-                      <Col md={1}>
-                        <AddButton
-                          onLiteratureAdd={this.handleLiteratureAdd}
-                          literature={literature}
-                          title="add citation to selection"
-                        />
-                      </Col>
-                    </Row>
-                  </ListGroupItem>
-                </ListGroup>
-                <CitationTable
-                  rows={selectedRefs}
-                  sortedIds={sortedIds}
-                  removeCitation={this.handleLiteratureRemove}
-                  userId={currentUser.id}
-                />
-              </Accordion.Body>
-            </Accordion.Item>
-          </Accordion>
-        </Card.Body>
-      </Card>
+          <Accordion.Item eventKey="4">
+            <Accordion.Header>
+              {this.renderSectionHeader('References for selected elements', contentElements)}
+            </Accordion.Header>
+            <Accordion.Body>
+              <ListGroup>
+                <ListGroupItem>
+                  <Row>
+                    <Col md={8} style={{ paddingRight: 0 }}>
+                      <LiteratureInput
+                        handleInputChange={this.handleInputChange}
+                        literature={literature}
+                        field="doi"
+                        placeholder="DOI: 10.... or  http://dx.doi.org/10... or 10. ..."
+                      />
+                    </Col>
+                    <Col md={3} style={{ paddingRight: 0 }}>
+                      <LiteralType
+                        handleInputChange={this.handleInputChange}
+                        disabled={false}
+                        val={literature.litype}
+                      />
+                    </Col>
+                    <Col md={1} style={{ paddingRight: 0 }}>
+                      <Button
+                        variant="success"
+                        size="sm"
+                        style={{ marginTop: 2 }}
+                        onClick={this.fetchDOIMetadata}
+                        title="fetch metadata for this doi and add citation to selection"
+                        disabled={!doiValid(literature.doi)}
+                      >
+                        <i className="fa fa-plus" />
+                      </Button>
+                    </Col>
+                    <Col md={12} style={{ paddingRight: 0 }}>
+                      <Citation literature={literature} />
+                    </Col>
+                    <Col md={7} style={{ paddingRight: 0 }}>
+                      <LiteratureInput
+                        handleInputChange={this.handleInputChange}
+                        literature={literature}
+                        field="title"
+                        placeholder="Title..."
+                      />
+                    </Col>
+                    <Col md={4} style={{ paddingRight: 0 }}>
+                      <LiteratureInput
+                        handleInputChange={this.handleInputChange}
+                        literature={literature}
+                        field="url"
+                        placeholder="URL..."
+                      />
+                    </Col>
+                    <Col md={1}>
+                      <AddButton
+                        onLiteratureAdd={this.handleLiteratureAdd}
+                        literature={literature}
+                        title="add citation to selection"
+                      />
+                    </Col>
+                  </Row>
+                </ListGroupItem>
+              </ListGroup>
+              <CitationTable
+                rows={selectedRefs}
+                sortedIds={sortedIds}
+                removeCitation={this.handleLiteratureRemove}
+                userId={currentUser.id}
+              />
+            </Accordion.Body>
+          </Accordion.Item>
+        </Accordion>
+      </DetailCard>
     );
   }
 }

--- a/app/javascript/src/apps/mydb/elements/details/cellLines/CellLineDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/CellLineDetails.js
@@ -10,9 +10,9 @@ import UserStore from 'src/stores/alt/stores/UserStore';
 import CollectionUtils from 'src/models/collection/CollectionUtils';
 
 import {
-  ButtonToolbar, Button, Card,
-  Tabs, Tab, OverlayTrigger, Tooltip
+  Button, Tabs, Tab, OverlayTrigger, Tooltip
 } from 'react-bootstrap';
+import DetailCard from 'src/apps/mydb/elements/details/DetailCard';
 import GeneralProperties from 'src/apps/mydb/elements/details/cellLines/propertiesTab/GeneralProperties';
 import AnalysesContainer from 'src/apps/mydb/elements/details/cellLines/analysesTab/AnalysesContainer';
 import DetailsTabLiteratures from 'src/apps/mydb/elements/details/literature/DetailsTabLiteratures';
@@ -179,42 +179,41 @@ class CellLineDetails extends React.Component {
     const { readOnly } = this.state;
     const { activeTab } = this.state;
     return (
-      <Card className="detail-card">
-        <Card.Header>
-          {this.renderHeaderContent()}
-        </Card.Header>
-        <Card.Body>
-          <div className="tabs-container--with-borders">
-            <Tabs activeKey={activeTab} onSelect={(event) => this.handleTabChange(event)} id="cell-line-details-tab">
-              <Tab eventKey="tab1" title="Properties" key="tab1">
-                <GeneralProperties
-                  item={cellLineItem}
-                  readOnly={readOnly}
-                />
-              </Tab>
-              <Tab eventKey="tab2" title="Analyses" key="tab2">
-                <AnalysesContainer
-                  item={cellLineItem}
-                  readOnly={readOnly}
-                />
-              </Tab>
-              <Tab eventKey="tab3" title="References" key="tab3" disabled={cellLineItem.is_new}>
-                <DetailsTabLiteratures
-                  readOnly={readOnly}
-                  element={cellLineItem}
-                  literatures={cellLineItem.is_new ? cellLineItem.literatures : null}
-                />
-              </Tab>
-            </Tabs>
-          </div>
-        </Card.Body>
-        <Card.Footer className="d-flex justify-content-between">
-          <Button variant="primary" onClick={() => { this.handleClose(cellLineItem); }}>
-            Close
-          </Button>
-          {this.renderSubmitButton()}
-        </Card.Footer>
-      </Card>
+      <DetailCard
+        header={this.renderHeaderContent()}
+        footer={(
+          <>
+            <Button variant="primary" onClick={() => { this.handleClose(cellLineItem); }}>
+              Close
+            </Button>
+            {this.renderSubmitButton()}
+          </>
+        )}
+      >
+        <div className="tabs-container--with-borders">
+          <Tabs activeKey={activeTab} onSelect={(event) => this.handleTabChange(event)} id="cell-line-details-tab">
+            <Tab eventKey="tab1" title="Properties" key="tab1">
+              <GeneralProperties
+                item={cellLineItem}
+                readOnly={readOnly}
+              />
+            </Tab>
+            <Tab eventKey="tab2" title="Analyses" key="tab2">
+              <AnalysesContainer
+                item={cellLineItem}
+                readOnly={readOnly}
+              />
+            </Tab>
+            <Tab eventKey="tab3" title="References" key="tab3" disabled={cellLineItem.is_new}>
+              <DetailsTabLiteratures
+                readOnly={readOnly}
+                element={cellLineItem}
+                literatures={cellLineItem.is_new ? cellLineItem.literatures : null}
+              />
+            </Tab>
+          </Tabs>
+        </div>
+      </DetailCard>
     );
   }
 }

--- a/app/javascript/src/apps/mydb/elements/details/cellLines/CellLineDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/CellLineDetails.js
@@ -94,6 +94,19 @@ class CellLineDetails extends React.Component {
     );
   }
 
+  renderFooterContent() {
+    const { cellLineItem } = this.props;
+
+    return (
+      <>
+        <Button variant="primary" onClick={() => { this.handleClose(cellLineItem); }}>
+          Close
+        </Button>
+        {this.renderSubmitButton()}
+      </>
+    );
+  }
+
   renderSaveButton(closeAfterClick = false) {
     const { cellLineItem } = this.props;
     const { cellLineDetailsStore } = this.context;
@@ -181,14 +194,7 @@ class CellLineDetails extends React.Component {
     return (
       <DetailCard
         header={this.renderHeaderContent()}
-        footer={(
-          <>
-            <Button variant="primary" onClick={() => { this.handleClose(cellLineItem); }}>
-              Close
-            </Button>
-            {this.renderSubmitButton()}
-          </>
-        )}
+        footer={this.renderFooterContent()}
       >
         <div className="tabs-container--with-borders">
           <Tabs activeKey={activeTab} onSelect={(event) => this.handleTabChange(event)} id="cell-line-details-tab">

--- a/app/javascript/src/apps/mydb/elements/details/computeTasks/ComputeTaskContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/computeTasks/ComputeTaskContainer.js
@@ -64,26 +64,28 @@ export default class ComputeTaskContainer extends React.Component {
   }
   /* eslint-enable class-methods-use-this */
 
+  computeTaskHeader() {
+    return (
+      <div className="d-flex align-items-baseline justify-content-between">
+        Task
+        <Button
+          key="closeBtn"
+          onClick={this.onClose}
+          variant="danger"
+          size="xxsm"
+          className="ms-auto"
+        >
+          <i className="fa fa-times" />
+        </Button>
+      </div>
+    );
+  }
+
   render() {
     const { tasks } = this.state;
 
     return (
-      <DetailCard
-        header={(
-          <div className="d-flex align-items-baseline justify-content-between">
-            Task
-            <Button
-              key="closeBtn"
-              onClick={this.onClose}
-              variant="danger"
-              size="xxsm"
-              className="ms-auto"
-            >
-              <i className="fa fa-times" />
-            </Button>
-          </div>
-        )}
-      >
+      <DetailCard header={this.computeTaskHeader()}>
         <Table striped condensed hover>
           <thead>
             <tr>

--- a/app/javascript/src/apps/mydb/elements/details/computeTasks/ComputeTaskContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/computeTasks/ComputeTaskContainer.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Table, Card } from 'react-bootstrap';
+import { Button, Table } from 'react-bootstrap';
+
+import DetailCard from 'src/apps/mydb/elements/details/DetailCard';
 
 import ComputeTaskActions from 'src/stores/alt/actions/ComputeTaskActions';
 import DetailActions from 'src/stores/alt/actions/DetailActions';
@@ -66,43 +68,44 @@ export default class ComputeTaskContainer extends React.Component {
     const { tasks } = this.state;
 
     return (
-      <Card className="detail-card">
-        <Card.Header className="d-flex align-items-baseline justify-content-between">
-          Task
-          <Button
-            key="closeBtn"
-            onClick={this.onClose}
-            variant="danger"
-            size="xxsm"
-            className="ms-auto"
-          >
-            <i className="fa fa-times" />
-          </Button>
-        </Card.Header>
-        <Card.Body>
-          <Table striped condensed hover>
-            <thead>
-              <tr>
-                <th className="text-center">Sample</th>
-                <th className="text-center">Status</th>
-                <th className="text-center">Updated at</th>
-                <th className="text-center">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {tasks.map((task) => (
-                <ComputeTask
-                  key={task.id}
-                  task={task}
-                  checkState={this.checkState}
-                  revokeTask={this.revokeTask}
-                  deleteTask={this.deleteTask}
-                />
-              ))}
-            </tbody>
-          </Table>
-        </Card.Body>
-      </Card>
+      <DetailCard
+        header={(
+          <div className="d-flex align-items-baseline justify-content-between">
+            Task
+            <Button
+              key="closeBtn"
+              onClick={this.onClose}
+              variant="danger"
+              size="xxsm"
+              className="ms-auto"
+            >
+              <i className="fa fa-times" />
+            </Button>
+          </div>
+        )}
+      >
+        <Table striped condensed hover>
+          <thead>
+            <tr>
+              <th className="text-center">Sample</th>
+              <th className="text-center">Status</th>
+              <th className="text-center">Updated at</th>
+              <th className="text-center">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tasks.map((task) => (
+              <ComputeTask
+                key={task.id}
+                task={task}
+                checkState={this.checkState}
+                revokeTask={this.revokeTask}
+                deleteTask={this.deleteTask}
+              />
+            ))}
+          </tbody>
+        </Table>
+      </DetailCard>
     );
   }
 }

--- a/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/DeviceDescriptionDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/DeviceDescriptionDetails.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useContext } from 'react';
 import {
-  Button, Tabs, Tab, Tooltip, OverlayTrigger, Card
+  Button, Tabs, Tab, Tooltip, OverlayTrigger
 } from 'react-bootstrap';
 
 import PropertiesForm from './propertiesTab/PropertiesForm';
@@ -18,6 +18,7 @@ import { commentActivation } from 'src/utilities/CommentHelper';
 import MatrixCheck from 'src/components/common/MatrixCheck';
 import ConfirmClose from 'src/components/common/ConfirmClose';
 import PrintCodeButton from 'src/components/common/PrintCodeButton';
+import DetailCard from 'src/apps/mydb/elements/details/DetailCard';
 import ElementDetailSortTab from 'src/apps/mydb/elements/details/ElementDetailSortTab';
 import OpenCalendarButton from 'src/components/calendar/OpenCalendarButton';
 import CopyElementModal from 'src/components/common/CopyElementModal';
@@ -192,39 +193,39 @@ const DeviceDescriptionDetails = () => {
   }
 
   return (
-    <Card className={"detail-card" + (deviceDescription.isPendingToSave ? " detail-card--unsaved" : "")}>
-      <Card.Header>
-        {deviceDescriptionHeader()}
-      </Card.Header>
-      <Card.Body>
-        <div className="tabs-container--with-borders">
-          <ElementDetailSortTab
-            type="device_description"
-            availableTabs={Object.keys(tabContentComponents)}
-            tabTitles={tabTitles}
-            onTabPositionChanged={onTabPositionChanged}
-          />
-          <Tabs
-            activeKey={deviceDescriptionsStore.active_tab_key}
-            onSelect={key => handleTabChange(key)}
-            id="deviceDescriptionDetailsTab"
-            unmountOnExit
-          >
-            {tabContents}
-          </Tabs>
-        </div>
-        <CommentModal element={deviceDescription} />
-      </Card.Body>
-      <Card.Footer>
-        <Button variant="primary" onClick={() => DetailActions.close(deviceDescription)}>
-          Close
-        </Button>
-        <Button variant="warning" disabled={!deviceDescriptionIsValid()} onClick={() => handleSubmit()}>
-          {submitLabel}
-        </Button>
-        {downloadAnalysisButton()}
-      </Card.Footer>
-    </Card>
+    <DetailCard
+      isPendingToSave={deviceDescription.isPendingToSave}
+      header={deviceDescriptionHeader()}
+      footer={(
+        <>
+          <Button variant="primary" onClick={() => DetailActions.close(deviceDescription)}>
+            Close
+          </Button>
+          <Button variant="warning" disabled={!deviceDescriptionIsValid()} onClick={() => handleSubmit()}>
+            {submitLabel}
+          </Button>
+          {downloadAnalysisButton()}
+        </>
+      )}
+    >
+      <div className="tabs-container--with-borders">
+        <ElementDetailSortTab
+          type="device_description"
+          availableTabs={Object.keys(tabContentComponents)}
+          tabTitles={tabTitles}
+          onTabPositionChanged={onTabPositionChanged}
+        />
+        <Tabs
+          activeKey={deviceDescriptionsStore.active_tab_key}
+          onSelect={key => handleTabChange(key)}
+          id="deviceDescriptionDetailsTab"
+          unmountOnExit
+        >
+          {tabContents}
+        </Tabs>
+      </div>
+      <CommentModal element={deviceDescription} />
+    </DetailCard>
   );
 }
 

--- a/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/DeviceDescriptionDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/DeviceDescriptionDetails.js
@@ -192,21 +192,23 @@ const DeviceDescriptionDetails = () => {
     );
   }
 
+  const deviceDescriptionFooter = () => (
+    <>
+      <Button variant="primary" onClick={() => DetailActions.close(deviceDescription)}>
+        Close
+      </Button>
+      <Button variant="warning" disabled={!deviceDescriptionIsValid()} onClick={() => handleSubmit()}>
+        {submitLabel}
+      </Button>
+      {downloadAnalysisButton()}
+    </>
+  );
+
   return (
     <DetailCard
       isPendingToSave={deviceDescription.isPendingToSave}
       header={deviceDescriptionHeader()}
-      footer={(
-        <>
-          <Button variant="primary" onClick={() => DetailActions.close(deviceDescription)}>
-            Close
-          </Button>
-          <Button variant="warning" disabled={!deviceDescriptionIsValid()} onClick={() => handleSubmit()}>
-            {submitLabel}
-          </Button>
-          {downloadAnalysisButton()}
-        </>
-      )}
+      footer={deviceDescriptionFooter()}
     >
       <div className="tabs-container--with-borders">
         <ElementDetailSortTab

--- a/app/javascript/src/apps/mydb/elements/details/formats/FormatComponent.js
+++ b/app/javascript/src/apps/mydb/elements/details/formats/FormatComponent.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Card, Button } from 'react-bootstrap';
 import QuillViewer from 'src/components/QuillViewer';
+import DetailCard from 'src/apps/mydb/elements/details/DetailCard';
 
 const tryParse = function TryParseToJson(obj) {
   if (typeof obj === 'object') return obj;
@@ -105,20 +106,14 @@ FormatComponentHeader.propTypes = {
 const FormatComponent = ({
   list, isPendingToSave, onSave, onFormat, onClose
 }) => (
-  <Card className={"detail-card" + (isPendingToSave ? " detail-card--unsaved" : "")}>
-    <Card.Header>
-      <FormatComponentHeader
-        onSave={onSave}
-        onFormat={onFormat}
-        onClose={onClose}
-      />
-    </Card.Header>
-    <Card.Body className="d-flex flex-column gap-3">
-      {list.map((el, idx) => (
-        <ElementAnalyses key={el.id} element={el} idx={idx} />
-      ))}
-    </Card.Body>
-  </Card>
+  <DetailCard
+    isPendingToSave={isPendingToSave}
+    header={<FormatComponentHeader onSave={onSave} onFormat={onFormat} onClose={onClose} />}
+  >
+    {list.map((el, idx) => (
+      <ElementAnalyses key={el.id} element={el} idx={idx} />
+    ))}
+  </DetailCard>
 );
 
 FormatComponent.propTypes = {

--- a/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -435,6 +435,29 @@ export default class ReactionDetails extends Component {
     );
   }
 
+  reactionFooter() {
+    const submitLabel = (reaction && reaction.isNew) ? 'Create' : 'Save';
+
+    return (
+      <>
+        <Button variant="primary" onClick={() => DetailActions.close(reaction)}>
+          Close
+        </Button>
+        <Button
+          id="submit-reaction-btn"
+          variant="warning"
+          onClick={() => this.handleSubmit()}
+          disabled={!permitOn(reaction) || !this.reactionIsValid()}
+        >
+          {submitLabel}
+        </Button>
+        {reaction && !reaction.isNew && (
+          <ExportSamplesButton type="reaction" id={reaction.id} />
+        )}
+      </>
+    );
+  }
+
   updateReactionSvg() {
     const { reaction } = this.state;
     const materialsSvgPaths = {
@@ -601,31 +624,13 @@ export default class ReactionDetails extends Component {
       if (tabContent) { tabContents.push(tabContent); }
     });
 
-    const submitLabel = (reaction && reaction.isNew) ? 'Create' : 'Save';
-    const exportButton = (reaction && reaction.isNew) ? null : <ExportSamplesButton type="reaction" id={reaction.id} />;
-
     const currentTab = (activeTab !== 0 && activeTab) || visible[0];
 
     return (
       <DetailCard
         isPendingToSave={reaction.isPendingToSave}
         header={this.reactionHeader(reaction)}
-        footer={(
-          <>
-            <Button variant="primary" onClick={() => DetailActions.close(reaction)}>
-              Close
-            </Button>
-            <Button
-              id="submit-reaction-btn"
-              variant="warning"
-              onClick={() => this.handleSubmit()}
-              disabled={!permitOn(reaction) || !this.reactionIsValid()}
-            >
-              {submitLabel}
-            </Button>
-            {exportButton}
-          </>
-        )}
+        footer={this.reactionFooter()}
       >
         {this.reactionSVG(reaction)}
         {this.state.sfn && <ScifinderSearch el={reaction} />}

--- a/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -5,16 +5,18 @@ import React, { Component } from 'react';
 import Aviator from 'aviator';
 import PropTypes from 'prop-types';
 import {
-  Button, Tabs, Tab, OverlayTrigger, Tooltip, Card, ButtonToolbar, ButtonGroup
+  Button, Tabs, Tab, OverlayTrigger, Tooltip, ButtonToolbar, ButtonGroup
 } from 'react-bootstrap';
 import SvgFileZoomPan from 'react-svg-file-zoom-pan-latest';
 import { findIndex, isEmpty } from 'lodash';
+
 import ElementCollectionLabels from 'src/apps/mydb/elements/labels/ElementCollectionLabels';
 import ElementResearchPlanLabels from 'src/apps/mydb/elements/labels/ElementResearchPlanLabels';
 import ElementAnalysesLabels from 'src/apps/mydb/elements/labels/ElementAnalysesLabels';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
 import DetailActions from 'src/stores/alt/actions/DetailActions';
 import LoadingActions from 'src/stores/alt/actions/LoadingActions';
+import DetailCard from 'src/apps/mydb/elements/details/DetailCard';
 import ReactionVariations from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations';
 import {
   REACTION_VARIATIONS_TAB_KEY
@@ -605,46 +607,46 @@ export default class ReactionDetails extends Component {
     const currentTab = (activeTab !== 0 && activeTab) || visible[0];
 
     return (
-      <Card className={`detail-card${reaction.isPendingToSave ? ' detail-card--unsaved' : ''}`}>
-        <Card.Header>
-          {this.reactionHeader(reaction)}
-        </Card.Header>
-        <Card.Body>
-          {this.reactionSVG(reaction)}
-          {this.state.sfn && <ScifinderSearch el={reaction} />}
-          <div className="tabs-container--with-borders">
-            <ElementDetailSortTab
-              type="reaction"
-              availableTabs={Object.keys(tabContentsMap)}
-              onTabPositionChanged={this.onTabPositionChanged}
-            />
-            <Tabs
-              mountOnEnter
-              activeKey={currentTab}
-              onSelect={this.handleSelect}
-              id="reaction-detail-tab"
-              unmountOnExit
+      <DetailCard
+        isPendingToSave={reaction.isPendingToSave}
+        header={this.reactionHeader(reaction)}
+        footer={(
+          <>
+            <Button variant="primary" onClick={() => DetailActions.close(reaction)}>
+              Close
+            </Button>
+            <Button
+              id="submit-reaction-btn"
+              variant="warning"
+              onClick={() => this.handleSubmit()}
+              disabled={!permitOn(reaction) || !this.reactionIsValid()}
             >
-              {tabContents}
-            </Tabs>
-            <CommentModal element={reaction} />
-          </div>
-        </Card.Body>
-        <Card.Footer>
-          <Button variant="primary" onClick={() => DetailActions.close(reaction)}>
-            Close
-          </Button>
-          <Button
-            id="submit-reaction-btn"
-            variant="warning"
-            onClick={() => this.handleSubmit()}
-            disabled={!permitOn(reaction) || !this.reactionIsValid()}
+              {submitLabel}
+            </Button>
+            {exportButton}
+          </>
+        )}
+      >
+        {this.reactionSVG(reaction)}
+        {this.state.sfn && <ScifinderSearch el={reaction} />}
+        <div className="tabs-container--with-borders">
+          <ElementDetailSortTab
+            type="reaction"
+            availableTabs={Object.keys(tabContentsMap)}
+            onTabPositionChanged={this.onTabPositionChanged}
+          />
+          <Tabs
+            mountOnEnter
+            activeKey={currentTab}
+            onSelect={this.handleSelect}
+            id="reaction-detail-tab"
+            unmountOnExit
           >
-            {submitLabel}
-          </Button>
-          {exportButton}
-        </Card.Footer>
-      </Card>
+            {tabContents}
+          </Tabs>
+          <CommentModal element={reaction} />
+        </div>
+      </DetailCard>
     );
   }
 }

--- a/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -436,6 +436,7 @@ export default class ReactionDetails extends Component {
   }
 
   reactionFooter() {
+    const { reaction } = this.state;
     const submitLabel = (reaction && reaction.isNew) ? 'Create' : 'Save';
 
     return (

--- a/app/javascript/src/apps/mydb/elements/details/reports/ReportContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/reports/ReportContainer.js
@@ -94,7 +94,7 @@ export default class ReportContainer extends Component {
     }
   }
 
-  reportHeader() {
+  reportHeader(report) {
     return (
       <div className='d-flex align-items-center justify-content-between'>
         Report Generation
@@ -135,7 +135,7 @@ export default class ReportContainer extends Component {
     const { report } = this.props;
     return (
       <DetailCard
-        header={this.reportHeader()}
+        header={this.reportHeader(report)}
       >
         {alertTemplateNotFound && (
           <Alert variant="warning">

--- a/app/javascript/src/apps/mydb/elements/details/reports/ReportContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/reports/ReportContainer.js
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
 import {
-  Alert, Badge, Card, Tabs, Tab
+  Alert, Badge, Tabs, Tab
 } from 'react-bootstrap';
 import LoadingActions from 'src/stores/alt/actions/LoadingActions';
 import ReportActions from 'src/stores/alt/actions/ReportActions';
 import ReportStore from 'src/stores/alt/stores/ReportStore';
 import UIStore from 'src/stores/alt/stores/UIStore';
+import DetailCard from 'src/apps/mydb/elements/details/DetailCard';
 import Setting from 'src/apps/mydb/elements/details/reports/Setting';
 import Previews from 'src/apps/mydb/elements/details/reports/Previews';
 import Orders from 'src/apps/mydb/elements/details/reports/Orders';
@@ -116,81 +117,82 @@ export default class ReportContainer extends Component {
 
     const { report } = this.props;
     return (
-      <Card className="detail-card">
-        <Card.Header className='d-flex align-items-center justify-content-between'>
-          Report Generation
-          <div className="d-flex gap-1">
-            <ResetBtn key="resetBtn" />
-            <GenerateReportBtn
-              key="generateReportBtn"
-              allState={this.state}
-              updateQueue={this.updateQueue}
-            />
-            <CloseBtn key="closeBtn" report={report} />
+      <DetailCard
+        header={(
+          <div className='d-flex align-items-center justify-content-between'>
+            Report Generation
+            <div className="d-flex gap-1">
+              <ResetBtn key="resetBtn" />
+              <GenerateReportBtn
+                key="generateReportBtn"
+                allState={this.state}
+                updateQueue={this.updateQueue}
+              />
+              <CloseBtn key="closeBtn" report={report} />
+            </div>
           </div>
-        </Card.Header>
-        <Card.Body>
-          {alertTemplateNotFound && (
-            <Alert variant="warning">
-              Report Template not found. Set to Standard. Please check your config settings.
-            </Alert>
-          )}
-          <div className="tabs-container--with-borders">
-            <Tabs
-              activeKey={activeKey}
-              onSelect={this.selectTab}
-              id="report-tabs"
-            >
-              <Tab eventKey={0} title="Config">
-                <Config
-                  imgFormat={imgFormat}
-                  fileName={fileName}
-                  fileDescription={fileDescription}
-                  configs={configs}
-                  checkedAllConfigs={checkedAllConfigs}
-                  template={template}
-                  handleTemplateChanged={this.handleTemplateChanged}
-                  options={templateOpts}
-                />
-              </Tab>
-              <Tab eventKey={1} title="Setting">
-                <Setting
-                  template={template}
-                  splSettings={splSettings}
-                  checkedAllSplSettings={checkedAllSplSettings}
-                  rxnSettings={rxnSettings}
-                  checkedAllRxnSettings={checkedAllRxnSettings}
-                  siRxnSettings={siRxnSettings}
-                  checkedAllSiRxnSettings={checkedAllSiRxnSettings}
-                />
-              </Tab>
+        )}
+      >
+        {alertTemplateNotFound && (
+          <Alert variant="warning">
+            Report Template not found. Set to Standard. Please check your config settings.
+          </Alert>
+        )}
+        <div className="tabs-container--with-borders">
+          <Tabs
+            activeKey={activeKey}
+            onSelect={this.selectTab}
+            id="report-tabs"
+          >
+            <Tab eventKey={0} title="Config">
+              <Config
+                imgFormat={imgFormat}
+                fileName={fileName}
+                fileDescription={fileDescription}
+                configs={configs}
+                checkedAllConfigs={checkedAllConfigs}
+                template={template}
+                handleTemplateChanged={this.handleTemplateChanged}
+                options={templateOpts}
+              />
+            </Tab>
+            <Tab eventKey={1} title="Setting">
+              <Setting
+                template={template}
+                splSettings={splSettings}
+                checkedAllSplSettings={checkedAllSplSettings}
+                rxnSettings={rxnSettings}
+                checkedAllRxnSettings={checkedAllRxnSettings}
+                siRxnSettings={siRxnSettings}
+                checkedAllSiRxnSettings={checkedAllSiRxnSettings}
+              />
+            </Tab>
 
-              <Tab eventKey={2} title="Order">
-                <Orders selectedObjs={selectedObjs} template={template} />
-              </Tab>
-              <Tab eventKey={3} title="Label">
-                <Serials selMolSerials={selMolSerials} template={template} />
-              </Tab>
-              <Tab eventKey={4} title="Preview">
-                <Previews
-                  previewObjs={previewObjs}
-                  splSettings={splSettings}
-                  rxnSettings={rxnSettings}
-                  siRxnSettings={siRxnSettings}
-                  configs={configs}
-                  template={template}
-                  molSerials={selMolSerials}
-                  prdAtts={prdAtts}
-                  attThumbNails={attThumbNails}
-                />
-              </Tab>
-              <Tab eventKey={5} title={this.archivesTitle()}>
-                <Archives archives={archives} />
-              </Tab>
-            </Tabs>
-          </div>
-        </Card.Body>
-      </Card>
+            <Tab eventKey={2} title="Order">
+              <Orders selectedObjs={selectedObjs} template={template} />
+            </Tab>
+            <Tab eventKey={3} title="Label">
+              <Serials selMolSerials={selMolSerials} template={template} />
+            </Tab>
+            <Tab eventKey={4} title="Preview">
+              <Previews
+                previewObjs={previewObjs}
+                splSettings={splSettings}
+                rxnSettings={rxnSettings}
+                siRxnSettings={siRxnSettings}
+                configs={configs}
+                template={template}
+                molSerials={selMolSerials}
+                prdAtts={prdAtts}
+                attThumbNails={attThumbNails}
+              />
+            </Tab>
+            <Tab eventKey={5} title={this.archivesTitle()}>
+              <Archives archives={archives} />
+            </Tab>
+          </Tabs>
+        </div>
+      </DetailCard>
     );
   }
 }

--- a/app/javascript/src/apps/mydb/elements/details/reports/ReportContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/reports/ReportContainer.js
@@ -94,6 +94,23 @@ export default class ReportContainer extends Component {
     }
   }
 
+  reportHeader() {
+    return (
+      <div className='d-flex align-items-center justify-content-between'>
+        Report Generation
+        <div className="d-flex gap-1">
+          <ResetBtn key="resetBtn" />
+          <GenerateReportBtn
+            key="generateReportBtn"
+            allState={this.state}
+            updateQueue={this.updateQueue}
+          />
+          <CloseBtn key="closeBtn" report={report} />
+        </div>
+      </div>
+    );
+  }
+
   render() {
     const {
       splSettings, checkedAllSplSettings, archives, activeKey,
@@ -118,20 +135,7 @@ export default class ReportContainer extends Component {
     const { report } = this.props;
     return (
       <DetailCard
-        header={(
-          <div className='d-flex align-items-center justify-content-between'>
-            Report Generation
-            <div className="d-flex gap-1">
-              <ResetBtn key="resetBtn" />
-              <GenerateReportBtn
-                key="generateReportBtn"
-                allState={this.state}
-                updateQueue={this.updateQueue}
-              />
-              <CloseBtn key="closeBtn" report={report} />
-            </div>
-          </div>
-        )}
+        header={this.reportHeader()}
       >
         {alertTemplateNotFound && (
           <Alert variant="warning">

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
@@ -3,7 +3,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
-  ButtonToolbar, Button, Tooltip, OverlayTrigger, Tabs, Tab, Dropdown, ButtonGroup, Card
+  ButtonToolbar, Button, Tooltip, OverlayTrigger, Tabs, Tab, Dropdown, ButtonGroup
 } from 'react-bootstrap';
 import { unionBy, findIndex } from 'lodash';
 import Immutable from 'immutable';
@@ -29,6 +29,7 @@ import ResearchPlanDetailsName from
   'src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsName';
 import ResearchPlanDetailsContainers from
   'src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers';
+import DetailCard from 'src/apps/mydb/elements/details/DetailCard';
 import ElementDetailSortTab from 'src/apps/mydb/elements/details/ElementDetailSortTab';
 import { addSegmentTabs } from 'src/components/generic/SegmentDetails';
 import PrivateNoteElement from 'src/apps/mydb/elements/details/PrivateNoteElement';
@@ -487,37 +488,35 @@ export default class ResearchPlanDetails extends Component {
     );
 
     return (
-      <Card.Header className={`text-bg-${researchPlan.isPendingToSave ? 'info' : 'primary'}`}>
-        <div className="d-flex align-items-center justify-content-between">
-          <div className="d-flex align-items-center gap-2">
-            <OverlayTrigger placement="bottom" overlay={<Tooltip id="rpDates">{titleTooltip}</Tooltip>}>
-              <span>
-                <i className="fa fa-file-text-o" />
-                <span className="mx-1">{researchPlan.name}</span>
-              </span>
-            </OverlayTrigger>
-            <ShowUserLabels element={researchPlan} />
-            <ElementCollectionLabels element={researchPlan} placement="right" />
-            <HeaderCommentSection element={researchPlan} />
-          </div>
-          <div className="d-flex align-items-center gap-1 flex-row-reverse">
-            <ConfirmClose el={researchPlan} />
-            <OverlayTrigger placement="bottom" overlay={<Tooltip id="saveresearch_plan">Save Research Plan</Tooltip>}>
-              <Button
-                variant="warning"
-                size="xxsm"
-                onClick={() => this.handleSubmit()}
-                style={{ display: (researchPlan.changed || false) ? '' : 'none' }}
-              >
-                <i className="fa fa-floppy-o" aria-hidden="true" />
-              </Button>
-            </OverlayTrigger>
-            {!researchPlan.isNew
-              && <OpenCalendarButton isPanelHeader eventableId={researchPlan.id} eventableType="ResearchPlan" />}
-            {copyBtn}
-          </div>
+      <div className="d-flex align-items-center justify-content-between">
+        <div className="d-flex align-items-center gap-2">
+          <OverlayTrigger placement="bottom" overlay={<Tooltip id="rpDates">{titleTooltip}</Tooltip>}>
+            <span>
+              <i className="fa fa-file-text-o" />
+              <span className="mx-1">{researchPlan.name}</span>
+            </span>
+          </OverlayTrigger>
+          <ShowUserLabels element={researchPlan} />
+          <ElementCollectionLabels element={researchPlan} placement="right" />
+          <HeaderCommentSection element={researchPlan} />
         </div>
-      </Card.Header>
+        <div className="d-flex align-items-center gap-1 flex-row-reverse">
+          <ConfirmClose el={researchPlan} />
+          <OverlayTrigger placement="bottom" overlay={<Tooltip id="saveresearch_plan">Save Research Plan</Tooltip>}>
+            <Button
+              variant="warning"
+              size="xxsm"
+              onClick={() => this.handleSubmit()}
+              style={{ display: (researchPlan.changed || false) ? '' : 'none' }}
+            >
+              <i className="fa fa-floppy-o" aria-hidden="true" />
+            </Button>
+          </OverlayTrigger>
+          {!researchPlan.isNew
+            && <OpenCalendarButton isPanelHeader eventableId={researchPlan.id} eventableType="ResearchPlan" />}
+          {copyBtn}
+        </div>
+      </div>
     );
   }
 
@@ -609,38 +608,43 @@ export default class ResearchPlanDetails extends Component {
     const activeTab = (this.state.activeTab !== 0 && this.state.activeTab) || visible[0];
 
     return (
-      <Card className="detail-card">
-        {this.renderPanelHeading(researchPlan)}
-        <Card.Body>
-          <div className="tabs-container--with-borders">
-            <ElementDetailSortTab
-              type="research_plan"
-              availableTabs={Object.keys(tabContentsMap)}
-              onTabPositionChanged={this.onTabPositionChanged}
-            />
-            <Tabs
-              mountOnEnter
-              unmountOnExit
-              activeKey={activeTab}
-              onSelect={(key) => this.handleSelect(key)}
-              id="screen-detail-tab"
+      <DetailCard
+        isPendingToSave={researchPlan.isPendingToSave}
+        header={this.renderPanelHeading(researchPlan)}
+        footer={(
+          <>
+            <Button
+              variant="primary"
+              onClick={() => DetailActions.close(researchPlan)}
             >
-              {tabContents}
-            </Tabs>
-          </div>
-          <CommentModal element={researchPlan} />
-        </Card.Body>
-        <Card.Footer>
-          <Button variant="primary" onClick={() => DetailActions.close(researchPlan)}>Close</Button>
-          {
-            (researchPlan.changed || researchPlan.is_copy) && (
+              Close
+            </Button>
+            {(researchPlan.changed || researchPlan.is_copy) && (
               <Button variant="warning" onClick={() => this.handleSubmit()}>
                 {researchPlan.isNew ? 'Create' : 'Save'}
               </Button>
-            )
-          }
-        </Card.Footer>
-      </Card>
+            )}
+          </>
+        )}
+      >
+        <div className="tabs-container--with-borders">
+          <ElementDetailSortTab
+            type="research_plan"
+            availableTabs={Object.keys(tabContentsMap)}
+            onTabPositionChanged={this.onTabPositionChanged}
+          />
+          <Tabs
+            mountOnEnter
+            unmountOnExit
+            activeKey={activeTab}
+            onSelect={(key) => this.handleSelect(key)}
+            id="screen-detail-tab"
+          >
+            {tabContents}
+          </Tabs>
+        </div>
+        <CommentModal element={researchPlan} />
+      </DetailCard>
     );
   }
 }

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
@@ -520,6 +520,26 @@ export default class ResearchPlanDetails extends Component {
     );
   }
 
+  renderPanelFooter() {
+    const { researchPlan } = this.state;
+
+    return (
+      <>
+        <Button
+          variant="primary"
+          onClick={() => DetailActions.close(researchPlan)}
+        >
+          Close
+        </Button>
+        {(researchPlan.changed || researchPlan.is_copy) && (
+          <Button variant="warning" onClick={() => this.handleSubmit()}>
+            {researchPlan.isNew ? 'Create' : 'Save'}
+          </Button>
+        )}
+      </>
+    );
+  }
+
   render() {
     const { researchPlan, visible } = this.state;
 
@@ -611,21 +631,7 @@ export default class ResearchPlanDetails extends Component {
       <DetailCard
         isPendingToSave={researchPlan.isPendingToSave}
         header={this.renderPanelHeading(researchPlan)}
-        footer={(
-          <>
-            <Button
-              variant="primary"
-              onClick={() => DetailActions.close(researchPlan)}
-            >
-              Close
-            </Button>
-            {(researchPlan.changed || researchPlan.is_copy) && (
-              <Button variant="warning" onClick={() => this.handleSubmit()}>
-                {researchPlan.isNew ? 'Create' : 'Save'}
-              </Button>
-            )}
-          </>
-        )}
+        footer={this.renderPanelFooter()}
       >
         <div className="tabs-container--with-borders">
           <ElementDetailSortTab

--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -1007,33 +1007,88 @@ export default class SampleDetails extends React.Component {
 
     const inventoryLabel = sample.inventory_sample && sample.inventory_label ? sample.inventory_label : null;
 
+    const { pageMessage } = this.state;
+    const messageBlock = (pageMessage
+      && (pageMessage.error.length > 0 || pageMessage.warning.length > 0)) ? (
+        <Alert variant="warning" style={{ marginBottom: 'unset', padding: '5px', marginTop: '10px' }}>
+          <strong>Structure Alert</strong>
+          <Button
+            size="sm"
+            variant="outline-warning"
+            style={{ float: 'right' }}
+            onClick={() => this.setState({ pageMessage: null })}
+          >
+            Close Alert
+          </Button>
+          {
+          pageMessage.error.map((m) => (
+            <div key={uuid.v1()}>{m}</div>
+          ))
+        }
+          {
+          pageMessage.warning.map((m) => (
+            <div key={uuid.v1()}>{m}</div>
+          ))
+        }
+        </Alert>
+      ) : null;
+
+    // warning message for redirection
+    const redirectWarningBlock = this.state.showRedirectWarning ? (
+      <Alert variant="warning" className="d-flex flex-column gap-2 mt-2 mb-0 p-2">
+        <div>
+          <strong>Notice:</strong>
+          <p className="mb-1">
+            You are viewing the original sample that was used to create this component. Some of its attributes may have
+            changed now.
+          </p>
+          <p className="mb-0">
+            Any updates you make here will apply only to the original sample, not to any component generated from it.
+            However, changes on this sample may affect other dependant entities.
+          </p>
+        </div>
+        <div className="align-self-end">
+          <Button
+            size="sm"
+            variant="outline-warning"
+            onClick={() => this.setState({ showRedirectWarning: false })}
+          >
+            Close Alert
+          </Button>
+        </div>
+      </Alert>
+    ) : null;
 
     return (
-      <div className="d-flex align-items-center flex-wrap">
-        <div className="d-flex align-items-center flex-wrap flex-grow-1 gap-2">
-          <OverlayTrigger placement="bottom" overlay={<Tooltip id="sampleDates">{titleTooltip}</Tooltip>}>
-            <span className="flex-shrink-0">
-              <i className="icon-sample me-1" />
-              {inventoryLabel || sample.title()}
-            </span>
-          </OverlayTrigger>
-          <ShowUserLabels element={sample} />
-          <ElementAnalysesLabels element={sample} key={`${sample.id}_analyses`} />
-          {!sample.isNew && <ElementCollectionLabels element={sample} key={sample.id} placement="right" />}
-          <ElementReactionLabels element={sample} key={`${sample.id}_reactions`} />
-          <PubchemLabels element={sample} />
-          <HeaderCommentSection element={sample} />
-          {sample.isNew && !sample.isMixture() && <FastInput fnHandle={this.handleFastInput} />}
+      <>
+        <div className="d-flex align-items-center flex-wrap">
+          <div className="d-flex align-items-center flex-wrap flex-grow-1 gap-2">
+            <OverlayTrigger placement="bottom" overlay={<Tooltip id="sampleDates">{titleTooltip}</Tooltip>}>
+              <span className="flex-shrink-0">
+                <i className="icon-sample me-1" />
+                {inventoryLabel || sample.title()}
+              </span>
+            </OverlayTrigger>
+            <ShowUserLabels element={sample} />
+            <ElementAnalysesLabels element={sample} key={`${sample.id}_analyses`} />
+            {!sample.isNew && <ElementCollectionLabels element={sample} key={sample.id} placement="right" />}
+            <ElementReactionLabels element={sample} key={`${sample.id}_reactions`} />
+            <PubchemLabels element={sample} />
+            <HeaderCommentSection element={sample} />
+            {sample.isNew && !sample.isMixture() && <FastInput fnHandle={this.handleFastInput} />}
+          </div>
+          <div className="d-flex align-items-center gap-2">
+            {decoupleCb}
+            {inventorySample}
+            {!sample.isNew && <OpenCalendarButton isPanelHeader eventableId={sample.id} eventableType="Sample" />}
+            <PrintCodeButton element={sample} />
+            {copyBtn}
+            {this.saveAndCloseSample(sample, saveBtnDisplay)}
+          </div>
         </div>
-        <div className="d-flex align-items-center gap-2">
-          {decoupleCb}
-          {inventorySample}
-          {!sample.isNew && <OpenCalendarButton isPanelHeader eventableId={sample.id} eventableType="Sample" />}
-          <PrintCodeButton element={sample} />
-          {copyBtn}
-          {this.saveAndCloseSample(sample, saveBtnDisplay)}
-        </div>
-      </div>
+        {messageBlock}
+        {redirectWarningBlock}
+      </>
     );
   }
 
@@ -1425,58 +1480,6 @@ export default class SampleDetails extends React.Component {
       }
     });
 
-    const { pageMessage } = this.state;
-    const messageBlock = (pageMessage
-      && (pageMessage.error.length > 0 || pageMessage.warning.length > 0)) ? (
-        <Alert variant="warning" style={{ marginBottom: 'unset', padding: '5px', marginTop: '10px' }}>
-          <strong>Structure Alert</strong>
-          <Button
-            size="sm"
-            variant="outline-warning"
-            style={{ float: 'right' }}
-            onClick={() => this.setState({ pageMessage: null })}
-          >
-            Close Alert
-          </Button>
-          {
-          pageMessage.error.map((m) => (
-            <div key={uuid.v1()}>{m}</div>
-          ))
-        }
-          {
-          pageMessage.warning.map((m) => (
-            <div key={uuid.v1()}>{m}</div>
-          ))
-        }
-        </Alert>
-      ) : null;
-
-    // warning message for redirection
-    const redirectWarningBlock = this.state.showRedirectWarning ? (
-      <Alert variant="warning" className="d-flex flex-column gap-2 mt-2 mb-0 p-2">
-        <div>
-          <strong>Notice:</strong>
-          <p className="mb-1">
-            You are viewing the original sample that was used to create this component. Some of its attributes may have
-            changed now.
-          </p>
-          <p className="mb-0">
-            Any updates you make here will apply only to the original sample, not to any component generated from it.
-            However, changes on this sample may affect other dependant entities.
-          </p>
-        </div>
-        <div className="align-self-end">
-          <Button
-            size="sm"
-            variant="outline-warning"
-            onClick={() => this.setState({ showRedirectWarning: false })}
-          >
-            Close Alert
-          </Button>
-        </div>
-      </Alert>
-    ) : null;
-
     const activeTab = (this.state.activeTab !== 0 && stb.indexOf(this.state.activeTab) > -1
       && this.state.activeTab) || visible.get(0);
 
@@ -1485,13 +1488,7 @@ export default class SampleDetails extends React.Component {
     return (
       <DetailCard
         isPendingToSave={pendingToSave}
-        header={(
-          <>
-            {this.sampleHeader(sample)}
-            {redirectWarningBlock}
-            {messageBlock}
-          </>
-        )}
+        header={this.sampleHeader(sample)}
         footer={this.sampleFooter()}
       >
         {this.sampleInfo(sample)}

--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -6,8 +6,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Button, InputGroup, ListGroupItem, Tabs, Tab, Row, Col,
-  Tooltip, OverlayTrigger, Modal, Alert, Card, Form,
-  Accordion
+  Tooltip, OverlayTrigger, Modal, Alert, Form,
+  Accordion, Container
 } from 'react-bootstrap';
 import SVG from 'react-inlinesvg';
 import { CreatableSelect } from 'src/components/common/Select';
@@ -30,6 +30,7 @@ import ElementAnalysesLabels from 'src/apps/mydb/elements/labels/ElementAnalyses
 import PubchemLabels from 'src/components/pubchem/PubchemLabels';
 import PubchemLcss from 'src/components/pubchem/PubchemLcss';
 import ElementReactionLabels from 'src/apps/mydb/elements/labels/ElementReactionLabels';
+import DetailCard from 'src/apps/mydb/elements/details/DetailCard';
 import SampleDetailsContainers from 'src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainers';
 
 import StructureEditorModal from 'src/components/structureEditor/StructureEditorModal';
@@ -1006,6 +1007,7 @@ export default class SampleDetails extends React.Component {
 
     const inventoryLabel = sample.inventory_sample && sample.inventory_label ? sample.inventory_label : null;
 
+
     return (
       <div className="d-flex align-items-center flex-wrap">
         <div className="d-flex align-items-center flex-wrap flex-grow-1 gap-2">
@@ -1055,22 +1057,24 @@ export default class SampleDetails extends React.Component {
       ? <PubchemLcss cid={pubchemCid} informArray={pubchemLcss} /> : null;
 
     return (
-      <Row className='mb-4'>
-        <Col md={4}>
-          <h4><SampleName sample={sample} /></h4>
-          {!isMixture && (
-            <>
-              <h5>{this.sampleAverageMW(sample)}</h5>
-              <h5>{this.sampleExactMW(sample)}</h5>
-            </>
-          )}
-          {sample.isNew || isMixture ? null : <h6>{this.moleculeCas()}</h6>}
-          {lcssSign}
-        </Col>
-        <Col md={8} className="position-relative">
-          {this.svgOrLoading(sample)}
-        </Col>
-      </Row>
+      <Container>
+        <Row className="mb-4">
+          <Col md={4}>
+            <h4><SampleName sample={sample} /></h4>
+            {!isMixture && (
+              <>
+                <h5>{this.sampleAverageMW(sample)}</h5>
+                <h5>{this.sampleExactMW(sample)}</h5>
+              </>
+            )}
+            {sample.isNew || isMixture ? null : <h6>{this.moleculeCas()}</h6>}
+            {lcssSign}
+          </Col>
+          <Col md={8} className="position-relative">
+            {this.svgOrLoading(sample)}
+          </Col>
+        </Row>
+      </Container>
     );
   }
 
@@ -1479,41 +1483,41 @@ export default class SampleDetails extends React.Component {
     const pendingToSave = sample.isPendingToSave || isChemicalEdited;
 
     return (
-      <Card className={`detail-card${pendingToSave ? ' detail-card--unsaved' : ''}`}>
-        <Card.Header>
-          {this.sampleHeader(sample)}
-          {redirectWarningBlock}
-          {messageBlock}
-        </Card.Header>
-        <Card.Body>
-          {this.sampleInfo(sample)}
-          {this.state.sfn && <ScifinderSearch el={sample} />}
-          <div className="tabs-container--with-borders">
-            <ElementDetailSortTab
-              type="sample"
-              availableTabs={Object.keys(tabContentsMap)}
-              tabTitles={tabTitlesMap}
-              onTabPositionChanged={this.onTabPositionChanged}
-              addInventoryTab={sample.inventory_sample}
-            />
-            <Tabs
-              mountOnEnter
-              unmountOnExit
-              activeKey={activeTab}
-              onSelect={this.handleSelect}
-              id="SampleDetailsXTab"
-            >
-              {tabContents}
-            </Tabs>
-          </div>
-          {this.structureEditorModal(sample)}
-          {this.renderMolfileModal()}
-          <CommentModal element={sample} />
-        </Card.Body>
-        <Card.Footer>
-          {this.sampleFooter()}
-        </Card.Footer>
-      </Card>
+      <DetailCard
+        isPendingToSave={pendingToSave}
+        header={(
+          <>
+            {this.sampleHeader(sample)}
+            {redirectWarningBlock}
+            {messageBlock}
+          </>
+        )}
+        footer={this.sampleFooter()}
+      >
+        {this.sampleInfo(sample)}
+        {this.state.sfn && <ScifinderSearch el={sample} />}
+        <div className="tabs-container--with-borders">
+          <ElementDetailSortTab
+            type="sample"
+            availableTabs={Object.keys(tabContentsMap)}
+            tabTitles={tabTitlesMap}
+            onTabPositionChanged={this.onTabPositionChanged}
+            addInventoryTab={sample.inventory_sample}
+          />
+          <Tabs
+            mountOnEnter
+            unmountOnExit
+            activeKey={activeTab}
+            onSelect={this.handleSelect}
+            id="SampleDetailsXTab"
+          >
+            {tabContents}
+          </Tabs>
+        </div>
+        {this.structureEditorModal(sample)}
+        {this.renderMolfileModal()}
+        <CommentModal element={sample} />
+      </DetailCard>
     );
   }
 }

--- a/app/javascript/src/apps/mydb/elements/details/screens/ScreenDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/ScreenDetails.js
@@ -226,6 +226,26 @@ export default class ScreenDetails extends Component {
     );
   }
 
+  screenFooter() {
+    const { screen } = this.state;
+    const submitLabel = screen.isNew ? 'Create' : 'Save';
+
+    return (
+      <>
+        <Button variant="primary" onClick={() => DetailActions.close(screen)}>
+          Close
+        </Button>
+        <Button
+          id="submit-screen-btn"
+          variant="warning"
+          onClick={() => this.handleSubmit()}
+        >
+          {submitLabel}
+        </Button>
+      </>
+    );
+  }
+
   propertiesFields(screen) {
     const {
       wellplates, name, collaborator, result, conditions, requirements, description
@@ -355,7 +375,6 @@ export default class ScreenDetails extends Component {
 
   render() {
     const { screen, visible } = this.state;
-    const submitLabel = screen.isNew ? 'Create' : 'Save';
 
     const tabContentsMap = {
       properties: (
@@ -434,20 +453,7 @@ export default class ScreenDetails extends Component {
       <DetailCard
         isPendingToSave={screen.isPendingToSave}
         header={this.screenHeader(screen)}
-        footer={(
-          <>
-            <Button variant="primary" onClick={() => DetailActions.close(screen)}>
-              Close
-            </Button>
-            <Button
-              id="submit-screen-btn"
-              variant="warning"
-              onClick={() => this.handleSubmit()}
-            >
-              {submitLabel}
-            </Button>
-          </>
-        )}
+        footer={this.screenFooter()}
       >
         <ResearchplanFlowDisplay
           initialData={screen.componentGraphData}

--- a/app/javascript/src/apps/mydb/elements/details/screens/ScreenDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/ScreenDetails.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Form, Card, Row, Col, ButtonToolbar, Button,
+  Form, Row, Col, Button,
   Tooltip, OverlayTrigger, Tabs, Tab
 } from 'react-bootstrap';
 import { unionBy, findIndex } from 'lodash';
@@ -11,6 +11,7 @@ import ConfirmClose from 'src/components/common/ConfirmClose';
 import DetailActions from 'src/stores/alt/actions/DetailActions';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
 import ElementCollectionLabels from 'src/apps/mydb/elements/labels/ElementCollectionLabels';
+import DetailCard from 'src/apps/mydb/elements/details/DetailCard';
 import ElementDetailSortTab from 'src/apps/mydb/elements/details/ElementDetailSortTab';
 import LoadingActions from 'src/stores/alt/actions/LoadingActions';
 import PrintCodeButton from 'src/components/common/PrintCodeButton';
@@ -430,47 +431,47 @@ export default class ScreenDetails extends Component {
     };
 
     return (
-      <Card className={`detail-card${screen.isPendingToSave ? ' detail-card--unsaved' : ''}`}>
-        <Card.Header>
-          {this.screenHeader(screen)}
-        </Card.Header>
-        <Card.Body>
-          <ResearchplanFlowDisplay
-            initialData={screen.componentGraphData}
-            researchplans={screen.research_plans}
-            flowConfiguration={flowConfiguration}
-          />
-          <div className="tabs-container--with-borders">
-            <ElementDetailSortTab
-              type="screen"
-              availableTabs={Object.keys(tabContentsMap)}
-              onTabPositionChanged={this.onTabPositionChanged}
-            />
-            <Tabs
-              mountOnEnter
-              unmountOnExit
-              activeKey={activeTab}
-              onSelect={(key) => this.handleSelect(key)}
-              id="screen-detail-tab"
+      <DetailCard
+        isPendingToSave={screen.isPendingToSave}
+        header={this.screenHeader(screen)}
+        footer={(
+          <>
+            <Button variant="primary" onClick={() => DetailActions.close(screen)}>
+              Close
+            </Button>
+            <Button
+              id="submit-screen-btn"
+              variant="warning"
+              onClick={() => this.handleSubmit()}
             >
-              {tabContents}
-            </Tabs>
-          </div>
-          <CommentModal element={screen} />
-        </Card.Body>
-        <Card.Footer>
-          <Button variant="primary" onClick={() => DetailActions.close(screen)}>
-            Close
-          </Button>
-          <Button
-            id="submit-screen-btn"
-            variant="warning"
-            onClick={() => this.handleSubmit()}
+              {submitLabel}
+            </Button>
+          </>
+        )}
+      >
+        <ResearchplanFlowDisplay
+          initialData={screen.componentGraphData}
+          researchplans={screen.research_plans}
+          flowConfiguration={flowConfiguration}
+        />
+        <div className="tabs-container--with-borders">
+          <ElementDetailSortTab
+            type="screen"
+            availableTabs={Object.keys(tabContentsMap)}
+            onTabPositionChanged={this.onTabPositionChanged}
+          />
+          <Tabs
+            mountOnEnter
+            unmountOnExit
+            activeKey={activeTab}
+            onSelect={(key) => this.handleSelect(key)}
+            id="screen-detail-tab"
           >
-            {submitLabel}
-          </Button>
-        </Card.Footer>
-      </Card>
+            {tabContents}
+          </Tabs>
+        </div>
+        <CommentModal element={screen} />
+      </DetailCard>
     );
   }
 }

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
@@ -277,14 +277,36 @@ export default class WellplateDetails extends Component {
     );
   }
 
+  wellplateFooter() {
+    const { wellplate } = this.state;
+
+    return (
+      <>
+        <Button variant="primary" onClick={() => DetailActions.close(wellplate)}>Close</Button>
+        {wellplate.changed && (
+          <Button variant="warning" onClick={() => this.handleSubmit()}>
+            {wellplate.isNew ? 'Create' : 'Save'}
+          </Button>
+        )}
+
+        {wellplate && !wellplate.isNew && (
+          <ExportSamplesButton type="wellplate" id={wellplate.id} />
+        )}
+
+        <Button
+          variant="primary"
+          onClick={() => this.handlePrint()}
+          disabled={wellplate.width > 12}
+        >
+          Print Wells
+        </Button>
+      </>
+    );
+  }
 
   render() {
     const { wellplate, showWellplate, visible } = this.state;
-    const printButtonDisabled = wellplate.width > 12;
     const readoutTitles = wellplate.readout_titles;
-    const exportButton = (wellplate && wellplate.isNew)
-      ? null : <ExportSamplesButton type="wellplate" id={wellplate.id} />;
-
     const tabContentsMap = {
       designer: (
         <Tab eventKey="designer" title="Designer" key={`designer_${wellplate.id}`}>
@@ -401,26 +423,7 @@ export default class WellplateDetails extends Component {
       <DetailCard
         isPendingToSave={wellplate.isPendingToSave}
         header={this.wellplateHeader(wellplate)}
-        footer={(
-          <>
-            <Button variant="primary" onClick={() => DetailActions.close(wellplate)}>Close</Button>
-            {
-              wellplate.changed && (
-                <Button variant="warning" onClick={() => this.handleSubmit()}>
-                  {wellplate.isNew ? 'Create' : 'Save'}
-                </Button>
-              )
-            }
-            {exportButton}
-            <Button
-              variant="primary"
-              onClick={() => this.handlePrint()}
-              disabled={printButtonDisabled}
-            >
-              Print Wells
-            </Button>
-          </>
-        )}
+        footer={this.wellplateFooter()}
       >
         <div className="tabs-container--with-borders">
           <ElementDetailSortTab

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
@@ -28,6 +28,7 @@ import UIActions from 'src/stores/alt/actions/UIActions';
 import UserStore from 'src/stores/alt/stores/UserStore';
 import MatrixCheck from 'src/components/common/MatrixCheck';
 import ConfirmClose from 'src/components/common/ConfirmClose';
+import DetailCard from 'src/apps/mydb/elements/details/DetailCard';
 import ExportSamplesButton from 'src/apps/mydb/elements/details/ExportSamplesButton';
 import ElementDetailSortTab from 'src/apps/mydb/elements/details/ElementDetailSortTab';
 import { addSegmentTabs } from 'src/components/generic/SegmentDetails';
@@ -397,46 +398,48 @@ export default class WellplateDetails extends Component {
     const activeTab = (this.state.activeTab !== 0 && this.state.activeTab) || visible[0];
 
     return (
-      <Card className={`detail-card${wellplate.isPendingToSave ? ' detail-card--unsaved' : ''}`}>
-        <Card.Header>{this.wellplateHeader(wellplate)}</Card.Header>
-        <Card.Body>
-          <div className="tabs-container--with-borders">
-            <ElementDetailSortTab
-              type="wellplate"
-              availableTabs={Object.keys(tabContentsMap)}
-              onTabPositionChanged={this.onTabPositionChanged}
-            />
-            <Tabs
-              mountOnEnter
-              unmountOnExit
-              activeKey={activeTab}
-              onSelect={(event) => this.handleTabChange(event)}
-              id="wellplateDetailsTab"
+      <DetailCard
+        isPendingToSave={wellplate.isPendingToSave}
+        header={this.wellplateHeader(wellplate)}
+        footer={(
+          <>
+            <Button variant="primary" onClick={() => DetailActions.close(wellplate)}>Close</Button>
+            {
+              wellplate.changed && (
+                <Button variant="warning" onClick={() => this.handleSubmit()}>
+                  {wellplate.isNew ? 'Create' : 'Save'}
+                </Button>
+              )
+            }
+            {exportButton}
+            <Button
+              variant="primary"
+              onClick={() => this.handlePrint()}
+              disabled={printButtonDisabled}
             >
-              {tabContents}
-            </Tabs>
-          </div>
-        </Card.Body>
-        <Card.Footer>
-          <Button variant="primary" onClick={() => DetailActions.close(wellplate)}>Close</Button>
-          {
-            wellplate.changed && (
-              <Button variant="warning" onClick={() => this.handleSubmit()}>
-                {wellplate.isNew ? 'Create' : 'Save'}
-              </Button>
-            )
-          }
-          {exportButton}
-          <Button
-            variant="primary"
-            onClick={() => this.handlePrint()}
-            disabled={printButtonDisabled}
+              Print Wells
+            </Button>
+          </>
+        )}
+      >
+        <div className="tabs-container--with-borders">
+          <ElementDetailSortTab
+            type="wellplate"
+            availableTabs={Object.keys(tabContentsMap)}
+            onTabPositionChanged={this.onTabPositionChanged}
+          />
+          <Tabs
+            mountOnEnter
+            unmountOnExit
+            activeKey={activeTab}
+            onSelect={(event) => this.handleTabChange(event)}
+            id="wellplateDetailsTab"
           >
-            Print Wells
-          </Button>
+            {tabContents}
+          </Tabs>
           <CommentModal element={wellplate} />
-        </Card.Footer>
-      </Card>
+        </div>
+      </DetailCard>
     );
   }
 }

--- a/app/javascript/src/components/generic/GenericElDetails.js
+++ b/app/javascript/src/components/generic/GenericElDetails.js
@@ -5,8 +5,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
   Button,
-  ButtonToolbar,
-  Card,
   ListGroupItem,
   Tabs,
   Tab,
@@ -36,6 +34,7 @@ import GenericAttachments from 'src/components/generic/GenericAttachments';
 import { SegmentTabs } from 'src/components/generic/SegmentDetails';
 import OpenCalendarButton from 'src/components/calendar/OpenCalendarButton';
 import ElementCollectionLabels from 'src/apps/mydb/elements/labels/ElementCollectionLabels';
+import DetailCard from 'src/apps/mydb/elements/details/DetailCard';
 import ElementDetailSortTab from 'src/apps/mydb/elements/details/ElementDetailSortTab';
 import { EditUserLabels, ShowUserLabels } from 'src/components/UserLabels';
 
@@ -506,44 +505,42 @@ export default class GenericElDetails extends Component {
       activeTab = tabKeyContentList[0];
     }
     return (
-      <Card
-        className={`detail-card${
-          genericEl.isPendingToSave ? ' detail-card--unsaved' : ''
-        }`}
-      >
-        <Card.Header>{this.header(genericEl)}</Card.Header>
-        <Card.Body>
-          <div className="tabs-container--with-borders">
-            <ElementDetailSortTab
-              type={genericEl.type}
-              availableTabs={Object.keys(tabContents)}
-              onTabPositionChanged={this.onTabPositionChanged}
-            />
-            <Tabs
-              activeKey={activeTab}
-              onSelect={(key) => this.handleSelect(key, genericEl.type)}
-              id="GenericElementDetailsXTab"
+      <DetailCard
+        isPendingToSave={genericEl.isPendingToSave}
+        header={this.header(genericEl)}
+        footer={(
+          <>
+            <Button
+              variant="secondary"
+              onClick={() => DetailActions.close(genericEl, true)}
             >
-              {tabContentList}
-            </Tabs>
-          </div>
-        </Card.Body>
-        <Card.Footer>
-          <Button
-            variant="secondary"
-            onClick={() => DetailActions.close(genericEl, true)}
+              Close
+            </Button>
+            <Button
+              variant="warning"
+              onClick={() => this.handleSubmit()}
+              style={saveBtnDisplay}
+            >
+              {submitLabel}
+            </Button>
+          </>
+        )}
+      >
+        <div className="tabs-container--with-borders">
+          <ElementDetailSortTab
+            type={genericEl.type}
+            availableTabs={Object.keys(tabContents)}
+            onTabPositionChanged={this.onTabPositionChanged}
+          />
+          <Tabs
+            activeKey={activeTab}
+            onSelect={(key) => this.handleSelect(key, genericEl.type)}
+            id="GenericElementDetailsXTab"
           >
-            Close
-          </Button>
-          <Button
-            variant="warning"
-            onClick={() => this.handleSubmit()}
-            style={saveBtnDisplay}
-          >
-            {submitLabel}
-          </Button>
-        </Card.Footer>
-      </Card>
+            {tabContentList}
+          </Tabs>
+        </div>
+      </DetailCard>
     );
   }
 }

--- a/app/javascript/src/components/generic/GenericElDetails.js
+++ b/app/javascript/src/components/generic/GenericElDetails.js
@@ -470,12 +470,32 @@ export default class GenericElDetails extends Component {
     );
   }
 
+  footer() {
+    const { genericEl } = this.state;
+    const showSaveButton = genericEl && (genericEl.isNew || (genericEl.can_update && genericEl.changed));
+
+    return (
+      <>
+        <Button
+          variant="secondary"
+          onClick={() => DetailActions.close(genericEl, true)}
+        >
+          Close
+        </Button>
+        {showSaveButton && (
+          <Button
+            variant="warning"
+            onClick={() => this.handleSubmit()}
+          >
+            {genericEl.isNew ? 'Create' : 'Save'}
+          </Button>
+        )}
+      </>
+    );
+  }
+
   render() {
     const { genericEl, visible } = this.state;
-    const submitLabel = genericEl && genericEl.isNew ? 'Create' : 'Save';
-    // eslint-disable-next-line max-len
-    const saveBtnDisplay = (genericEl?.isNew || (genericEl?.can_update && genericEl?.changed)) ? { display: '' } : { display: 'none' };
-
     /**
      *  tabContents is a object containing all (visible) segment tabs
      */
@@ -508,23 +528,7 @@ export default class GenericElDetails extends Component {
       <DetailCard
         isPendingToSave={genericEl.isPendingToSave}
         header={this.header(genericEl)}
-        footer={(
-          <>
-            <Button
-              variant="secondary"
-              onClick={() => DetailActions.close(genericEl, true)}
-            >
-              Close
-            </Button>
-            <Button
-              variant="warning"
-              onClick={() => this.handleSubmit()}
-              style={saveBtnDisplay}
-            >
-              {submitLabel}
-            </Button>
-          </>
-        )}
+        footer={this.footer()}
       >
         <div className="tabs-container--with-borders">
           <ElementDetailSortTab

--- a/app/javascript/src/components/metadata/MetadataContainer.js
+++ b/app/javascript/src/components/metadata/MetadataContainer.js
@@ -1,12 +1,14 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Card, Tabs, Tab } from 'react-bootstrap';
+import { Tabs, Tab } from 'react-bootstrap';
 import UIActions from 'src/stores/alt/actions/UIActions';
 import Metadata from 'src/models/Metadata';
 import UIStore from 'src/stores/alt/stores/UIStore';
 import DetailActions from 'src/stores/alt/actions/DetailActions';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
 import LoadingActions from 'src/stores/alt/actions/LoadingActions';
+
+import DetailCard from 'src/apps/mydb/elements/details/DetailCard';
 
 import MetadataHeader from 'src/components/metadata/MetadataHeader';
 import MetadataGeneral from 'src/components/metadata/MetadataGeneral';
@@ -85,16 +87,17 @@ export default class MetadataContainer extends Component {
     const saveBtnDisplay = !!metadata.isEdited;
 
     return (
-      <Card className="detail-card">
-        <Card.Header>
+      <DetailCard
+        header={(
           <MetadataHeader
             title={title}
             saveBtnDisplay={saveBtnDisplay}
             onSave={this.handleSave}
             onClose={this.handleClose}
           />
-        </Card.Header>
-        <Card.Body className="tabs-container--with-borders">
+        )}
+      >
+        <div className="tabs-container--with-borders">
           <Tabs
             id="metadata-tabs"
             activeKey={this.state.activeTab}
@@ -157,8 +160,8 @@ export default class MetadataContainer extends Component {
               />
             </Tab>
           </Tabs>
-        </Card.Body>
-      </Card>
+        </div>
+      </DetailCard>
     );
   }
 }


### PR DESCRIPTION
This patch introduces a common DetailCard component for shared styling.

Before this change the whole right-side detail view scrolled on
overflow, including tabs and headers. With this change the tab bar and
detail view headers stay fixed and only individual detail view contents
scroll on overflow.

Before

https://github.com/user-attachments/assets/ab57a3d3-3d2a-445a-ac9c-d4b938b4b8a8

After

https://github.com/user-attachments/assets/8db88aff-1079-423d-8590-b2364e4ccf3e
