### PR TITLE
Only strip last extension in fname_wo_ext to preserve internal dots

### DIFF
--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -503,8 +503,11 @@ module AttachmentJcampProcess
 
   def fname_wo_ext(target)
     parts = target.filename_parts
-    ending = parts.length == 2 || parts.length == 3 ? -2 : -3
-    parts[0..ending].join('_')
+    if parts.length >= 2
+      parts[0..-2].join('.')
+    else
+      parts[0]
+    end
   end
 
   def delete_related_imgs(img_att)


### PR DESCRIPTION
## What
Update `fname_wo_ext` so that it only removes the very last file extension, leaving any other dots in the original filename intact.

## Why
Previously, filenames with multiple dots (e.g. `raman_jcamp.2.jdx`) had all extensions stripped, causing the base name of generated images (`.peak.png`) to match the source and be deleted by `delete_related_imgs`. This change prevents unintended deletion of freshly generated spectrum images.

## How
Replace the old logic with:

```ruby
def fname_wo_ext(target)
  parts = target.filename_parts
  if parts.length >= 2
    parts[0..-2].join('.')
  else
    parts[0]
  end
end
```
## Impact
Generated images for multi-dot filenames will now remain in place as expected.

Closes #2580