### PR TITLE
fix(UI): Allow weighing task inbox to be toggled from sidebar

### DIFF
--- a/app/javascript/src/components/sampleTaskInbox/SampleTaskSidebarButton.js
+++ b/app/javascript/src/components/sampleTaskInbox/SampleTaskSidebarButton.js
@@ -13,7 +13,7 @@ function SampleTaskNavigationElement({ isCollapsed }) {
     <SidebarButton
       label="Weighing Tasks"
       icon="fa-image"
-      onClick={sampleTasksStore.showSampleTaskInbox}
+      onClick={sampleTasksStore.toggleSampleTaskInbox}
       badgeCount={sampleTasksStore.openSampleTaskCount}
       showLabel={false}
       isCollapsed={isCollapsed}

--- a/app/javascript/src/stores/mobx/SampleTasksStore.jsx
+++ b/app/javascript/src/stores/mobx/SampleTasksStore.jsx
@@ -36,8 +36,8 @@ export const SampleTasksStore = types
       self.sample_tasks.clear();
       result.forEach(entry => self.sample_tasks.set(entry.id, SampleTask.create({ ...entry })));
     }),
-    showSampleTaskInbox() {
-      self.inbox_visible = true;
+    toggleSampleTaskInbox() {
+      self.inbox_visible = !self.inbox_visible;
     },
     hideSampleTaskInbox() {
       self.inbox_visible = false;


### PR DESCRIPTION
Before this change, the weighing task sidebar button would only open the inbox. Now it toggles it.