### PR TITLE
fix: rendering short label link in research plan table

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsFieldTableColumnNameModal.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsFieldTableColumnNameModal.js
@@ -1,13 +1,18 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Modal, ButtonToolbar, Button, Form } from 'react-bootstrap';
-
+import { COLUMN_ID_SHORT_LABEL_SAMPLE, COLUMN_ID_SHORT_LABEL_REACTION } from 'src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsFieldTableUtils';
 class ResearchPlanDetailsFieldTableColumnNameModal extends Component {
   constructor(props) {
     super(props);
+    const { columns, colId } = this.props;
     this.state = {
       columnNameValue: '',
-      columnNameError: ''
+      columnNameError: '',
+      linkSampleShortLabel: colId === COLUMN_ID_SHORT_LABEL_SAMPLE,
+      linkSampleShortLabelAvailable: !columns.some(col => col.colId !== colId && col.colId === COLUMN_ID_SHORT_LABEL_SAMPLE),
+      linkReactionShortLabel: colId === 'reaction',
+      linkReactionShortLabelAvailable: !columns.some(col => col.colId !== colId && col.colId === COLUMN_ID_SHORT_LABEL_REACTION),
     };
   }
 
@@ -95,7 +100,10 @@ ResearchPlanDetailsFieldTableColumnNameModal.propTypes = {
   columnName: PropTypes.string,
   onSubmit: PropTypes.func,
   onHide: PropTypes.func,
-  columns: PropTypes.array
+  columns: PropTypes.array,
+  colId: PropTypes.string,
 };
+
+
 
 export default ResearchPlanDetailsFieldTableColumnNameModal;

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsFieldTableUtils.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsFieldTableUtils.js
@@ -1,0 +1,8 @@
+/** String constant for matching column IDs used in the Research Plan Details Field Table */
+const COLUMN_ID_SHORT_LABEL_SAMPLE = 'sample';
+const COLUMN_ID_SHORT_LABEL_REACTION = 'reaction';
+
+export {
+  COLUMN_ID_SHORT_LABEL_SAMPLE,
+  COLUMN_ID_SHORT_LABEL_REACTION
+};


### PR DESCRIPTION
get renderShortLabel as a Ag-grid cellRenderer function to return a value 
in empty cells of `sample` or `reaction` columns

change header matcher to enable the renderShortLabel from `sample` to `Sample (short-label)` (respectively `reaction` ...)

use uuid for column ids unless  initiated with 'sample' or 'reaction'

TODO: selecting the renderer should not rely on the column header name

ref: #2437

