### PR TITLE
feat: show multiple quantities per reaction variation material

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -19,8 +19,8 @@ import {
   getReactionAnalyses, updateAnalyses
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses';
 import {
-  updateVariationsAux, getReactionMaterials, getReactionMaterialsIDs,
-  removeObsoleteMaterialColumns, resetColumnDefinitionsMaterials, getReactionMaterialsHashes
+  updateVariationsOnAuxChange, getReactionMaterials, getReactionMaterialsIDs,
+  removeObsoleteMaterialColumns, updateColumnDefinitionsMaterialsOnAuxChange, getReactionMaterialsHashes
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
 import { ColumnSelection } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents';
 import columnDefinitionsReducer
@@ -105,21 +105,22 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
     let updatedColumnDefinitions = removeObsoleteColumnDefinitions(columnDefinitions, updatedSelectedColumns);
 
     /*
-    Update the materials' non-editable quantities according to the "Scheme" tab.
+    Update column definitions to account for potential changes in the corresponding materials' gas type.
     */
-    updatedReactionVariations = updateVariationsAux(
+    updatedColumnDefinitions = updateColumnDefinitionsMaterialsOnAuxChange(
+      updatedColumnDefinitions,
+      reactionMaterials,
+      gasMode
+    );
+
+    /*
+    Update materials in response to changes in non-editable quantities from the "Scheme" tab.
+    */
+    updatedReactionVariations = updateVariationsOnAuxChange(
       updatedReactionVariations,
       reactionMaterials,
       gasMode,
       vesselVolume
-    );
-
-    // Reset materials' column definitions to account for potential changes in their gas type.
-    updatedColumnDefinitions = resetColumnDefinitionsMaterials(
-      updatedColumnDefinitions,
-      reactionMaterials,
-      updatedSelectedColumns,
-      gasMode
     );
 
     setColumnDefinitions(
@@ -359,7 +360,7 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
           rowData={reactionVariations}
           rowDragEntireRow
           rowDragManaged
-          headerHeight={70}
+          headerHeight={110}
           columnDefs={columnDefinitions}
           suppressPropertyNamesCheck
           defaultColDef={defaultColumnDefinitions}
@@ -388,6 +389,7 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
           onGridPreDestroyed={(event) => persistGridState(reaction.id, event)}
           onStateUpdated={(event) => persistGridState(reaction.id, event)}
           onFirstDataRendered={() => gridRef.current.api.autoSizeAllColumns()}
+          onComponentStateChanged={() => gridRef.current.api.autoSizeAllColumns()}
         />
       </div>
     </div>

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -13,7 +13,7 @@ import Reaction from 'src/models/Reaction';
 import {
   createVariationsRow, copyVariationsRow, updateVariationsRow, getVariationsColumns, materialTypes,
   addMissingColumnsToVariations, removeObsoleteColumnsFromVariations, getColumnDefinitions,
-  removeObsoleteColumnDefinitions, getInitialGridState, persistGridState, cellDataTypes
+  removeObsoleteColumnDefinitions, getInitialGridState, getInitialEntryDefinitions, persistTableLayout, cellDataTypes
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
 import {
   getReactionAnalyses, updateAnalyses
@@ -50,7 +50,12 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
   const { userText: temperatureValue = null, valueUnit: temperatureUnit = 'None' } = reaction.temperature ?? {};
   const vesselVolume = GasPhaseReactionStore.getState().reactionVesselSizeValue;
   const [selectedColumns, setSelectedColumns] = useState(getVariationsColumns(reactionVariations));
-  const initialColumnDefinitions = useMemo(() => getColumnDefinitions(selectedColumns, reactionMaterials, gasMode), []);
+  const initialColumnDefinitions = useMemo(() => getColumnDefinitions(
+    selectedColumns,
+    reactionMaterials,
+    gasMode,
+    getInitialEntryDefinitions(reaction.id)
+  ), []);
   const [columnDefinitions, setColumnDefinitions] = useReducer(columnDefinitionsReducer, initialColumnDefinitions);
   const initialGridState = useMemo(() => getInitialGridState(reaction.id), []);
 
@@ -386,8 +391,8 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
           onCellEditRequest={updateRow}
           onCellValueChanged={(event) => fitColumnToContent(event)}
           onColumnHeaderClicked={(event) => fitColumnToContent(event)}
-          onGridPreDestroyed={(event) => persistGridState(reaction.id, event)}
-          onStateUpdated={(event) => persistGridState(reaction.id, event)}
+          onGridPreDestroyed={(event) => persistTableLayout(reaction.id, event, columnDefinitions)}
+          onStateUpdated={(event) => persistTableLayout(reaction.id, event, columnDefinitions)}
           onFirstDataRendered={() => gridRef.current.api.autoSizeAllColumns()}
           onComponentStateChanged={() => gridRef.current.api.autoSizeAllColumns()}
         />

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -13,7 +13,7 @@ import Reaction from 'src/models/Reaction';
 import {
   createVariationsRow, copyVariationsRow, updateVariationsRow, getVariationsColumns, materialTypes,
   addMissingColumnsToVariations, removeObsoleteColumnsFromVariations, getColumnDefinitions,
-  removeObsoleteColumnDefinitions, getInitialGridState, persistGridState
+  removeObsoleteColumnDefinitions, getInitialGridState, persistGridState, cellDataTypes
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
 import {
   getReactionAnalyses, updateAnalyses
@@ -22,12 +22,7 @@ import {
   updateVariationsAux, getReactionMaterials, getReactionMaterialsIDs,
   removeObsoleteMaterialColumns, resetColumnDefinitionsMaterials, getReactionMaterialsHashes
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
-import {
-  PropertyFormatter, PropertyParser,
-  MaterialFormatter, MaterialParser,
-  EquivalentParser, GasParser, FeedstockParser,
-  ColumnSelection
-} from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents';
+import { ColumnSelection } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents';
 import columnDefinitionsReducer
   from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsReducers';
 import GasPhaseReactionStore from 'src/stores/alt/stores/GasPhaseReactionStore';
@@ -58,44 +53,6 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
   const initialColumnDefinitions = useMemo(() => getColumnDefinitions(selectedColumns, reactionMaterials, gasMode), []);
   const [columnDefinitions, setColumnDefinitions] = useReducer(columnDefinitionsReducer, initialColumnDefinitions);
   const initialGridState = useMemo(() => getInitialGridState(reaction.id), []);
-
-  const dataTypeDefinitions = {
-    property: {
-      extendsDataType: 'object',
-      baseDataType: 'object',
-      valueFormatter: PropertyFormatter,
-      valueParser: PropertyParser,
-    },
-    material: {
-      extendsDataType: 'object',
-      baseDataType: 'object',
-      valueFormatter: MaterialFormatter,
-      valueParser: MaterialParser,
-    },
-    equivalent: {
-      extendsDataType: 'object',
-      baseDataType: 'object',
-      valueFormatter: (params) => parseFloat(Number(params.value.equivalent.value).toPrecision(4)),
-      valueParser: EquivalentParser,
-    },
-    yield: {
-      extendsDataType: 'object',
-      baseDataType: 'object',
-      valueFormatter: (params) => parseFloat(Number(params.value.yield.value).toPrecision(4)),
-    },
-    gas: {
-      extendsDataType: 'object',
-      baseDataType: 'object',
-      valueFormatter: MaterialFormatter,
-      valueParser: GasParser,
-    },
-    feedstock: {
-      extendsDataType: 'object',
-      baseDataType: 'object',
-      valueFormatter: MaterialFormatter,
-      valueParser: FeedstockParser,
-    },
-  };
 
   const defaultColumnDefinitions = {
     editable: true,
@@ -406,7 +363,7 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
           columnDefs={columnDefinitions}
           suppressPropertyNamesCheck
           defaultColDef={defaultColumnDefinitions}
-          dataTypeDefinitions={dataTypeDefinitions}
+          dataTypeDefinitions={cellDataTypes}
           tooltipShowDelay={0}
           domLayout="autoHeight"
           maintainColumnOrder

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -387,6 +387,7 @@ export default function ReactionVariations({ reaction, onReactionChange, isActiv
           onColumnHeaderClicked={(event) => fitColumnToContent(event)}
           onGridPreDestroyed={(event) => persistGridState(reaction.id, event)}
           onStateUpdated={(event) => persistGridState(reaction.id, event)}
+          onFirstDataRendered={() => gridRef.current.api.autoSizeAllColumns()}
         />
       </div>
     </div>

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.js
@@ -1,9 +1,10 @@
 import { get, cloneDeep } from 'lodash';
 import {
-  materialTypes, getStandardUnits, getCellDataType, updateColumnDefinitions, getStandardValue, convertUnit
+  materialTypes, getStandardUnits, getCellDataType, getStandardValue, convertUnit,
+  getEntryDefs, getCurrentEntry
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
 import {
-  MaterialOverlay, MenuHeader
+  MaterialOverlay, MaterialRenderer, MenuHeader
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents';
 import { calculateTON, calculateFeedstockMoles } from 'src/utilities/UnitsConversion';
 
@@ -162,7 +163,7 @@ function getMaterialEntries(materialType, gasType) {
 }
 
 function cellIsEditable(params) {
-  const entry = params.colDef.entryDefs.currentEntry;
+  const entry = getCurrentEntry(params.colDef.entryDefs);
   const cellData = get(params.data, params.colDef.field);
   const { isReference, gasType, materialType } = cellData.aux;
 
@@ -226,7 +227,7 @@ function getMaterialData(material, materialType, gasMode = false, vesselVolume =
   return materialData;
 }
 
-function updateVariationsAux(variations, materials, gasMode, vesselVolume) {
+function updateVariationsOnAuxChange(variations, materials, gasMode, vesselVolume) {
   const updatedVariations = cloneDeep(variations);
   updatedVariations.forEach((row) => {
     Object.keys(materialTypes).forEach((materialType) => {
@@ -234,7 +235,17 @@ function updateVariationsAux(variations, materials, gasMode, vesselVolume) {
         if (!Object.prototype.hasOwnProperty.call(row[materialType], material.id.toString())) {
           return;
         }
-        row[materialType][material.id].aux = getMaterialAux(material, materialType, gasMode, vesselVolume);
+        if (row[materialType][material.id].aux.gasType !== getMaterialGasType(material, gasMode)) {
+          // Re-instantiate the entire material data because we need another set of entries if gas type changes.
+          row[materialType][material.id] = getMaterialData(
+            material,
+            materialType,
+            gasMode,
+            vesselVolume
+          );
+        } else {
+          row[materialType][material.id].aux = getMaterialAux(material, materialType, gasMode, vesselVolume);
+        }
       });
     });
   });
@@ -259,11 +270,10 @@ function getMaterialColumnGroupChild(material, materialType, gasMode) {
 
   const gasType = getMaterialGasType(materialCopy, gasMode);
 
-  const entries = getMaterialEntries(
+  const entryDefs = getEntryDefs(getMaterialEntries(
     materialType,
     gasType
-  );
-  const entry = entries[0];
+  ));
 
   let names = new Set([`ID: ${materialCopy.id}`]);
   ['external_label', 'name', 'short_label', 'molecule_formula', 'molecule_iupac_name'].forEach((name) => {
@@ -277,34 +287,38 @@ function getMaterialColumnGroupChild(material, materialType, gasMode) {
     field: `${materialType}.${materialCopy.id}`, // Must be unique.
     tooltipField: `${materialType}.${materialCopy.id}`,
     tooltipComponent: MaterialOverlay,
-    entryDefs: {
-      currentEntry: entry,
-      displayUnit: getStandardUnits(entry)[0],
-      availableEntries: entries
-    },
+    entryDefs,
     editable: (params) => cellIsEditable(params),
-    cellDataType: getCellDataType(entry, gasType),
+    cellDataType: getCellDataType(getCurrentEntry(entryDefs), gasType),
     headerComponent: MenuHeader,
     headerComponentParams: {
       names,
       gasType,
     },
+    cellRenderer: MaterialRenderer
   };
 }
 
-function resetColumnDefinitionsMaterials(columnDefinitions, materials, selectedColumns, gasMode) {
-  return Object.entries(materials).reduce((updatedDefinitions, [materialType, materialsOfType]) => {
-    const updatedMaterials = materialsOfType
-      .filter((material) => selectedColumns[materialType].includes(material.id.toString()))
-      .map((material) => getMaterialColumnGroupChild(material, materialType, gasMode));
+function updateColumnDefinitionsMaterialsOnAuxChange(columnDefinitions, materials, gasMode) {
+  const materialTypeKeys = Object.keys(materialTypes);
+  const updatedColumnDefinitions = cloneDeep(columnDefinitions);
 
-    return updateColumnDefinitions(
-      updatedDefinitions,
-      materialType,
-      'children',
-      updatedMaterials
-    );
-  }, cloneDeep(columnDefinitions));
+  return updatedColumnDefinitions.map((parent) => {
+    if (parent.groupId && materialTypeKeys.includes(parent.groupId) && parent.children) {
+      parent.children = parent.children.map((child) => {
+        const [materialType, materialId] = child.field.split('.');
+        const material = materials[materialType].find((m) => m.id.toString() === materialId);
+        const gasType = getMaterialGasType(material, gasMode);
+
+        if (gasType !== child.headerComponentParams.gasType) {
+          return getMaterialColumnGroupChild(material, materialType, gasMode);
+        }
+
+        return child;
+      });
+    }
+    return parent;
+  });
 }
 
 function removeObsoleteMaterialColumns(materials, columns) {
@@ -385,13 +399,13 @@ export {
   getReactionMaterialsIDs,
   getReactionMaterialsHashes,
   getMaterialData,
-  resetColumnDefinitionsMaterials,
+  updateColumnDefinitionsMaterialsOnAuxChange,
   updateVariationsRowOnReferenceMaterialChange,
   updateVariationsRowOnCatalystMaterialChange,
   updateVariationsRowOnFeedstockMaterialChange,
   computeDerivedQuantitiesVariationsRow,
   removeObsoleteMaterialColumns,
-  updateVariationsAux,
+  updateVariationsOnAuxChange,
   getReferenceMaterial,
   getCatalystMaterial,
   getFeedstockMaterial,

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.js
@@ -265,12 +265,12 @@ function getReactionMaterialsHashes(materials, gasMode, vesselVolume) {
   );
 }
 
-function getMaterialColumnGroupChild(material, materialType, gasMode) {
+function getMaterialColumnGroupChild(material, materialType, gasMode, externalEntryDefs = undefined) {
   const materialCopy = cloneDeep(material);
 
   const gasType = getMaterialGasType(materialCopy, gasMode);
 
-  const entryDefs = getEntryDefs(getMaterialEntries(
+  const entryDefs = externalEntryDefs || getEntryDefs(getMaterialEntries(
     materialType,
     gasType
   ));

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsReducers.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsReducers.js
@@ -1,6 +1,6 @@
 import {
   getCellDataType, updateColumnDefinitions, addMissingColumnDefinitions, removeObsoleteColumnDefinitions,
-  getColumnDefinitions
+  getColumnDefinitions, getCurrentEntry
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
 
 export default function columnDefinitionsReducer(columnDefinitions, action) {
@@ -29,7 +29,7 @@ export default function columnDefinitionsReducer(columnDefinitions, action) {
         updatedColumnDefinitions,
         action.field,
         'cellDataType',
-        getCellDataType(action.entryDefs.currentEntry, action.gasType)
+        getCellDataType(getCurrentEntry(action.entryDefs), action.gasType)
       );
       return updatedColumnDefinitions;
     }

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.js
@@ -10,6 +10,9 @@ import {
   AnalysesCellRenderer, AnalysesCellEditor, getAnalysesOverlay, AnalysisOverlay
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses';
 import {
+  PropertyFormatter, PropertyParser,
+  MaterialFormatter, MaterialParser,
+  EquivalentParser, GasParser, FeedstockParser,
   NoteCellRenderer, NoteCellEditor, MenuHeader, RowToolsCellRenderer
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents';
 import UserStore from 'src/stores/alt/stores/UserStore';
@@ -26,6 +29,43 @@ const materialTypes = {
   reactants: { label: 'Reactants', reactionAttributeName: 'reactants' },
   products: { label: 'Products', reactionAttributeName: 'products' },
   solvents: { label: 'Solvents', reactionAttributeName: 'solvents' }
+};
+const cellDataTypes = {
+  property: {
+    extendsDataType: 'object',
+    baseDataType: 'object',
+    valueFormatter: PropertyFormatter,
+    valueParser: PropertyParser,
+  },
+  material: {
+    extendsDataType: 'object',
+    baseDataType: 'object',
+    valueFormatter: MaterialFormatter,
+    valueParser: MaterialParser,
+  },
+  equivalent: {
+    extendsDataType: 'object',
+    baseDataType: 'object',
+    valueFormatter: (params) => parseFloat(Number(params.value.equivalent.value).toPrecision(4)),
+    valueParser: EquivalentParser,
+  },
+  yield: {
+    extendsDataType: 'object',
+    baseDataType: 'object',
+    valueFormatter: (params) => parseFloat(Number(params.value.yield.value).toPrecision(4)),
+  },
+  gas: {
+    extendsDataType: 'object',
+    baseDataType: 'object',
+    valueFormatter: MaterialFormatter,
+    valueParser: GasParser,
+  },
+  feedstock: {
+    extendsDataType: 'object',
+    baseDataType: 'object',
+    valueFormatter: MaterialFormatter,
+    valueParser: FeedstockParser,
+  },
 };
 
 function convertUnit(value, fromUnit, toUnit) {
@@ -558,6 +598,7 @@ export {
   getStandardUnits,
   convertUnit,
   materialTypes,
+  cellDataTypes,
   getVariationsRowName,
   getVariationsColumns,
   createVariationsRow,

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.js
@@ -212,6 +212,26 @@ function getCellDataType(entry, gasType = 'off') {
   }
 }
 
+function getEntryDefs(entries) {
+  return entries.reduce((defs, entry) => {
+    defs[entry] = {
+      isMain: entry === entries[0],
+      isSelected: entry === entries[0],
+      displayUnit: getStandardUnits(entry)[0]
+    };
+    return defs;
+  }, {});
+}
+
+function getCurrentEntry(entryDefs) {
+  return Object.keys(entryDefs).find((key) => entryDefs[key].isMain) || null;
+}
+
+function getUserFacingEntryName(entry) {
+  // E.g., 'turnoverNumber' -> 'turnover number'
+  return entry.split(/(?=[A-Z])/).join(' ').toLowerCase();
+}
+
 function getVariationsRowName(reactionLabel, variationsRowId) {
   return `${reactionLabel}-${variationsRowId}`;
 }
@@ -393,11 +413,7 @@ function getPropertyColumnGroupChild(propertyType, gasMode) {
       return {
         field: 'properties.temperature',
         cellDataType: getCellDataType('temperature'),
-        entryDefs: {
-          currentEntry: 'temperature',
-          displayUnit: getStandardUnits('temperature')[0],
-          availableEntries: ['temperature']
-        },
+        entryDefs: getEntryDefs(['temperature']),
         headerComponent: MenuHeader,
         headerComponentParams: {
           names: ['T'],
@@ -408,11 +424,7 @@ function getPropertyColumnGroupChild(propertyType, gasMode) {
         field: 'properties.duration',
         cellDataType: getCellDataType('duration'),
         editable: !gasMode,
-        entryDefs: {
-          currentEntry: 'duration',
-          displayUnit: getStandardUnits('duration')[0],
-          availableEntries: ['duration']
-        },
+        entryDefs: getEntryDefs(['duration']),
         headerComponent: MenuHeader,
         headerComponentParams: {
           names: ['t'],
@@ -617,5 +629,8 @@ export {
   getPropertyColumnGroupChild,
   REACTION_VARIATIONS_TAB_KEY,
   getInitialGridState,
-  persistGridState
+  persistGridState,
+  getEntryDefs,
+  getCurrentEntry,
+  getUserFacingEntryName
 };

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils.js
@@ -407,13 +407,13 @@ function removeObsoleteColumnsFromVariations(variations, selectedColumns) {
   return updatedVariations;
 }
 
-function getPropertyColumnGroupChild(propertyType, gasMode) {
+function getPropertyColumnGroupChild(propertyType, gasMode, externalEntryDefs = undefined) {
   switch (propertyType) {
     case 'temperature':
       return {
         field: 'properties.temperature',
         cellDataType: getCellDataType('temperature'),
-        entryDefs: getEntryDefs(['temperature']),
+        entryDefs: externalEntryDefs || getEntryDefs(['temperature']),
         headerComponent: MenuHeader,
         headerComponentParams: {
           names: ['T'],
@@ -424,7 +424,7 @@ function getPropertyColumnGroupChild(propertyType, gasMode) {
         field: 'properties.duration',
         cellDataType: getCellDataType('duration'),
         editable: !gasMode,
-        entryDefs: getEntryDefs(['duration']),
+        entryDefs: externalEntryDefs || getEntryDefs(['duration']),
         headerComponent: MenuHeader,
         headerComponentParams: {
           names: ['t'],
@@ -531,7 +531,7 @@ function updateColumnDefinitions(columnDefinitions, field, property, newValue) {
   return updatedColumnDefinitions;
 }
 
-function getColumnDefinitions(selectedColumns, materials, gasMode) {
+function getColumnDefinitions(selectedColumns, materials, gasMode, externalEntryDefs = {}) {
   return [
     {
       headerName: 'Tools',
@@ -552,7 +552,9 @@ function getColumnDefinitions(selectedColumns, materials, gasMode) {
       headerName: 'Properties',
       groupId: 'properties',
       marryChildren: true,
-      children: selectedColumns.properties.map((entry) => getPropertyColumnGroupChild(entry, gasMode))
+      children: selectedColumns.properties.map(
+        (entry) => getPropertyColumnGroupChild(entry, gasMode, externalEntryDefs[`properties.${entry}`])
+      )
     },
   ].concat(
     Object.entries(materialTypes).map(([materialType, { label }]) => ({
@@ -565,7 +567,8 @@ function getColumnDefinitions(selectedColumns, materials, gasMode) {
         (materialID) => getMaterialColumnGroupChild(
           materials[materialType].find((material) => material.id.toString() === materialID),
           materialType,
-          gasMode
+          gasMode,
+          externalEntryDefs[`${materialType}.${materialID}`]
         )
       )
     }))
@@ -584,20 +587,42 @@ function getVariationsColumns(variations) {
   return { ...materialColumns, properties: propertyColumns, metadata: metadataColumns };
 }
 
-function getGridStateId(id) {
+function getGridStateId(reactionId) {
   const { currentUser } = UserStore.getState();
-  return `user${currentUser.id}-reaction${id}-reactionVariationsGridState`;
+  return `user${currentUser.id}-reaction${reactionId}-reactionVariationsGridState`;
 }
 
-function getInitialGridState(id) {
-  const gridState = JSON.parse(localStorage.getItem(getGridStateId(id)));
-
-  return gridState;
+function getEntryDefinitionsId(reactionId) {
+  const { currentUser } = UserStore.getState();
+  return `user${currentUser.id}-reaction${reactionId}-reactionVariationsEntryDefinitions`;
 }
 
-const persistGridState = (id, event) => {
+function getInitialGridState(reactionId) {
+  return JSON.parse(localStorage.getItem(getGridStateId(reactionId))) || {};
+}
+
+function getInitialEntryDefinitions(reactionId) {
+  return JSON.parse(localStorage.getItem(getEntryDefinitionsId(reactionId))) || {};
+}
+
+const persistTableLayout = (reactionId, event, columnDefinitions) => {
   const { state: gridState } = event;
-  localStorage.setItem(getGridStateId(id), JSON.stringify(gridState));
+  localStorage.setItem(getGridStateId(reactionId), JSON.stringify(gridState));
+
+  const entryDefs = {};
+  function extractEntryDefs(items) {
+    items.forEach((item) => {
+      if (item.field) {
+        entryDefs[item.field] = item.entryDefs || {};
+      }
+      if (item.children && Array.isArray(item.children)) {
+        extractEntryDefs(item.children);
+      }
+    });
+  }
+  extractEntryDefs(columnDefinitions);
+
+  localStorage.setItem(getEntryDefinitionsId(reactionId), JSON.stringify(entryDefs));
 };
 
 export {
@@ -629,7 +654,8 @@ export {
   getPropertyColumnGroupChild,
   REACTION_VARIATIONS_TAB_KEY,
   getInitialGridState,
-  persistGridState,
+  getInitialEntryDefinitions,
+  persistTableLayout,
   getEntryDefs,
   getCurrentEntry,
   getUserFacingEntryName

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents.spec.js
@@ -1,4 +1,5 @@
 import expect from 'expect';
+import { getEntryDefs } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
 import {
   EquivalentParser, PropertyFormatter, PropertyParser, MaterialFormatter, MaterialParser, FeedstockParser, GasParser
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents';
@@ -8,13 +9,15 @@ describe('ReactionVariationsComponents', async () => {
   describe('FormatterComponents', () => {
     it('PropertyFormatter returns number string with correct precision', () => {
       const cellData = { value: 1.2345, unit: 'Second(s)' };
-      const colDef = { entryDefs: { displayUnit: 'Minute(s)' } };
+      const colDef = { entryDefs: getEntryDefs(['duration']) };
+      colDef.entryDefs.duration.displayUnit = 'Minute(s)';
 
       expect(PropertyFormatter({ value: cellData, colDef })).toEqual(0.02057);
     });
     it('MaterialFormatter returns number string with correct precision', () => {
       const cellData = { amount: { value: 1.2345, unit: 'mol' } };
-      const colDef = { entryDefs: { currentEntry: 'amount', displayUnit: 'mmol' } };
+      const colDef = { entryDefs: getEntryDefs(['amount']) };
+      colDef.entryDefs.amount.displayUnit = 'mmol';
 
       expect(MaterialFormatter({ value: cellData, colDef })).toEqual(1235);
     });
@@ -45,7 +48,9 @@ describe('ReactionVariationsComponents', async () => {
   describe('PropertyParser', async () => {
     it('rejects negative value for duration', () => {
       const cellData = { value: 120, unit: 'Second(s)' };
-      const colDef = { entryDefs: { currentEntry: 'duration', displayUnit: 'Minute(s)' } };
+      const colDef = { entryDefs: getEntryDefs(['duration']) };
+      colDef.entryDefs.duration.displayUnit = 'Minute(s)';
+
       const newValue = '-1';
       const updatedCellData = PropertyParser({ oldValue: cellData, newValue, colDef });
 
@@ -53,7 +58,8 @@ describe('ReactionVariationsComponents', async () => {
     });
     it('accepts negative value for temperature', () => {
       const cellData = { value: 120, unit: '°C' };
-      const colDef = { entryDefs: { currentEntry: 'temperature', displayUnit: 'K' } };
+      const colDef = { entryDefs: getEntryDefs(['temperature']) };
+      colDef.entryDefs.temperature.displayUnit = 'K';
       const newValue = '-1';
       const updatedCellData = PropertyParser({ oldValue: cellData, newValue, colDef });
 
@@ -71,7 +77,8 @@ describe('ReactionVariationsComponents', async () => {
       context = { reactionHasPolymers: false };
     });
     it('rejects negative value', () => {
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'amount', displayUnit: 'mmol' } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['amount']) };
+      colDef.entryDefs.amount.displayUnit = 'mmol';
       const updatedCellData = MaterialParser({
         data: variationsRow, oldValue: cellData, newValue: '-1', colDef, context
       });
@@ -79,7 +86,8 @@ describe('ReactionVariationsComponents', async () => {
       expect(updatedCellData.amount.value).toEqual(0);
     });
     it('adapts mass when updating amount', () => {
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'amount', displayUnit: 'mmol' } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['amount']) };
+      colDef.entryDefs.amount.displayUnit = 'mmol';
 
       expect(cellData.mass.value).toBe(100);
 
@@ -90,7 +98,8 @@ describe('ReactionVariationsComponents', async () => {
       expect(updatedCellData.mass.value).toBeCloseTo(0.756);
     });
     it('adapts amount when updating mass', () => {
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'mass', displayUnit: 'g' } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['mass']) };
+      colDef.entryDefs.mass.displayUnit = 'g';
 
       expect(cellData.amount.value).toBeCloseTo(5.55);
 
@@ -101,7 +110,8 @@ describe('ReactionVariationsComponents', async () => {
       expect(updatedCellData.amount.value).toBeCloseTo(2.33);
     });
     it("adapts non-reference materials' equivalent when updating mass", async () => {
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'mass', displayUnit: 'g' } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['mass']) };
+      colDef.entryDefs.mass.displayUnit = 'g';
 
       const updatedCellData = MaterialParser({
         data: variationsRow, oldValue: cellData, newValue: `${cellData.mass.value * 2}`, colDef, context
@@ -111,7 +121,8 @@ describe('ReactionVariationsComponents', async () => {
     });
     it("adapts non-reference materials' yield when updating mass", async () => {
       cellData = Object.values(variationsRow.products)[0];
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'mass', displayUnit: 'g' } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['mass']) };
+      colDef.entryDefs.mass.displayUnit = 'g';
 
       const updatedCellData = MaterialParser({
         data: variationsRow, oldValue: cellData, newValue: `${cellData.mass.value * 0.1}`, colDef, context
@@ -120,7 +131,8 @@ describe('ReactionVariationsComponents', async () => {
       expect(updatedCellData.yield.value).toBeLessThan(cellData.yield.value);
     });
     it('adapts volume when updating mass', async () => {
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'mass', displayUnit: 'g' } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['mass']) };
+      colDef.entryDefs.mass.displayUnit = 'g';
       cellData.volume.value = 3;
       cellData.aux.molarity = 5;
 
@@ -131,7 +143,8 @@ describe('ReactionVariationsComponents', async () => {
       expect(updatedCellData.volume.value).toBeCloseTo(0.466);
     });
     it('adapts volume when updating amount', async () => {
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'amount', displayUnit: 'mmol' } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['amount']) };
+      colDef.entryDefs.amount.displayUnit = 'mmol';
       cellData.volume.value = 3;
       cellData.aux.molarity = 5;
 
@@ -142,7 +155,8 @@ describe('ReactionVariationsComponents', async () => {
       expect(updatedCellData.volume.value).toBeCloseTo(0.008);
     });
     it('adapts mass when updating volume', async () => {
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'volume', displayUnit: 'ml' } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['volume']) };
+      colDef.entryDefs.volume.displayUnit = 'ml';
       cellData.aux.molarity = 5;
 
       expect(cellData.mass.value).toBe(100);
@@ -154,7 +168,8 @@ describe('ReactionVariationsComponents', async () => {
       expect(updatedCellData.mass.value).toBeCloseTo(3.78);
     });
     it('adapts amount when updating volume', async () => {
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'volume', displayUnit: 'ml' } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['volume']) };
+      colDef.entryDefs.volume.displayUnit = 'ml';
       cellData.aux.molarity = 5;
 
       expect(cellData.amount.value).toBeCloseTo(5.55);
@@ -166,7 +181,8 @@ describe('ReactionVariationsComponents', async () => {
       expect(updatedCellData.amount.value).toBeCloseTo(0.21);
     });
     it('adapts equivalent when updating volume', async () => {
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'volume', displayUnit: 'ml' } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['volume']) };
+      colDef.entryDefs.volume.displayUnit = 'ml';
       cellData.aux.molarity = 5;
 
       expect(cellData.equivalent.value).toBe(1);
@@ -179,7 +195,8 @@ describe('ReactionVariationsComponents', async () => {
     });
     it('adapts yield when updating volume', async () => {
       cellData = Object.values(variationsRow.products)[0];
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'volume', displayUnit: 'ml' } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['volume']) };
+      colDef.entryDefs.volume.displayUnit = 'ml';
       cellData.aux.molarity = 5;
 
       expect(cellData.yield.value).toBe(100);
@@ -202,7 +219,7 @@ describe('ReactionVariationsComponents', async () => {
       context = { reactionHasPolymers: false };
     });
     it('rejects negative value', () => {
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'equivalent', displayUnit: null } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['equivalent']) };
       const updatedCellData = FeedstockParser({
         data: variationsRow, oldValue: cellData, newValue: '-1', colDef, context
       });
@@ -210,7 +227,7 @@ describe('ReactionVariationsComponents', async () => {
       expect(updatedCellData.equivalent.value).toEqual(0);
     });
     it('adapts nothing when updating equivalent', () => {
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'equivalent', displayUnit: null } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['equivalent']) };
 
       const updatedCellData = FeedstockParser({
         data: variationsRow, oldValue: cellData, newValue: `${cellData.equivalent.value * 2}`, colDef, context
@@ -222,7 +239,8 @@ describe('ReactionVariationsComponents', async () => {
       expect(updatedCellData.volume.value).toBe(cellData.volume.value);
     });
     it('adapts other entries when updating volume', () => {
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'volume', displayUnit: 'l' } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['volume']) };
+      colDef.entryDefs.volume.displayUnit = 'l';
 
       const updatedCellData = FeedstockParser({
         data: variationsRow, oldValue: cellData, newValue: `${cellData.volume.value * 2}`, colDef, context
@@ -234,7 +252,8 @@ describe('ReactionVariationsComponents', async () => {
       expect(updatedCellData.equivalent.value).toBeGreaterThan(cellData.equivalent.value);
     });
     it('adapts other entries when updating amount', () => {
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'amount', displayUnit: 'mol' } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['amount']) };
+      colDef.entryDefs.amount.displayUnit = 'mol';
 
       const updatedCellData = FeedstockParser({
         data: variationsRow, oldValue: cellData, newValue: `${cellData.amount.value * 2}`, colDef, context
@@ -257,7 +276,8 @@ describe('ReactionVariationsComponents', async () => {
       context = { reactionHasPolymers: false };
     });
     it('rejects negative value', () => {
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'duration', displayUnit: 'Hour(s)' } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['duration']) };
+      colDef.entryDefs.duration.displayUnit = 'Hours(s)';
       const updatedCellData = GasParser({
         data: variationsRow, oldValue: cellData, newValue: '-1', colDef, context
       });
@@ -265,7 +285,8 @@ describe('ReactionVariationsComponents', async () => {
       expect(updatedCellData.duration.value).toEqual(0);
     });
     it('adapts only turnover frequency when updating duration', () => {
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'duration', displayUnit: 'Hour(s)' } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['duration']) };
+      colDef.entryDefs.duration.displayUnit = 'Hour(s)';
 
       const updatedCellData = GasParser({
         data: variationsRow, oldValue: cellData, newValue: '2', colDef, context
@@ -279,7 +300,8 @@ describe('ReactionVariationsComponents', async () => {
       expect(updatedCellData.turnoverFrequency.value).toBeLessThan(cellData.turnoverFrequency.value);
     });
     it('adapts other entries when updating concentration', () => {
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'concentration', displayUnit: 'ppm' } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['concentration']) };
+      colDef.entryDefs.concentration.displayUnit = 'ppm';
 
       const updatedCellData = GasParser({
         data: variationsRow, oldValue: cellData, newValue: `${cellData.concentration.value * 2}`, colDef, context
@@ -293,7 +315,8 @@ describe('ReactionVariationsComponents', async () => {
       expect(updatedCellData.turnoverFrequency.value).not.toBe(cellData.turnoverFrequency.value);
     });
     it('adapts other entries when updating temperature', () => {
-      const colDef = { field: 'foo.bar', entryDefs: { currentEntry: 'temperature', displayUnit: 'K' } };
+      const colDef = { field: 'foo.bar', entryDefs: getEntryDefs(['temperature']) };
+      colDef.entryDefs.temperature.displayUnit = 'K';
 
       const updatedCellData = GasParser({
         data: variationsRow, oldValue: cellData, newValue: `${cellData.temperature.value / 2}`, colDef, context

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials.spec.js
@@ -2,7 +2,7 @@ import expect from 'expect';
 import {
   getReactionMaterials, updateVariationsRowOnReferenceMaterialChange, removeObsoleteMaterialColumns,
   updateVariationsRowOnCatalystMaterialChange, getMaterialColumnGroupChild, getReactionMaterialsIDs,
-  resetColumnDefinitionsMaterials, updateVariationsAux, cellIsEditable, getReactionMaterialsHashes
+  updateColumnDefinitionsMaterialsOnAuxChange, updateVariationsOnAuxChange, cellIsEditable, getReactionMaterialsHashes
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsMaterials';
 import {
   EquivalentParser
@@ -11,8 +11,7 @@ import {
   setUpReaction, setUpGaseousReaction, getColumnDefinitionsMaterialIDs, getColumnGroupChild
 } from 'helper/reactionVariationsHelpers';
 import {
-  materialTypes,
-
+  materialTypes, getCurrentEntry, getEntryDefs,
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsUtils';
 import { cloneDeep } from 'lodash';
 
@@ -84,7 +83,7 @@ describe('ReactionVariationsMaterials', () => {
     updatedMaterials.reactants[0].gas_type = 'catalyst';
     updatedMaterials.products[0].gas_type = 'off';
 
-    const updatedVariations = updateVariationsAux(reaction.variations, updatedMaterials, false, null);
+    const updatedVariations = updateVariationsOnAuxChange(reaction.variations, updatedMaterials, false, null);
 
     const variationsRow = reaction.variations[0];
     const updatedVariationsRow = updatedVariations[0];
@@ -129,10 +128,9 @@ describe('ReactionVariationsMaterials', () => {
       });
     });
 
-    const updatedColumnDefinitions = resetColumnDefinitionsMaterials(
+    const updatedColumnDefinitions = updateColumnDefinitionsMaterialsOnAuxChange(
       columnDefinitions,
       reactionMaterials,
-      getReactionMaterialsIDs(reactionMaterials),
       true
     );
 
@@ -143,8 +141,9 @@ describe('ReactionVariationsMaterials', () => {
       `products.${productIDs[0]}`
     );
     expect(productColumnDefinition.cellDataType).toBe('gas');
-    expect(productColumnDefinition.entryDefs.currentEntry).toBe('duration');
-    expect(productColumnDefinition.entryDefs.displayUnit).toBe('Second(s)');
+    const currentEntry = getCurrentEntry(productColumnDefinition.entryDefs);
+    expect(currentEntry).toBe('duration');
+    expect(productColumnDefinition.entryDefs[currentEntry].displayUnit).toBe('Second(s)');
 
     const reactantIDs = getColumnDefinitionsMaterialIDs(updatedColumnDefinitions, 'reactants');
     const reactantColumnDefinition = getColumnGroupChild(
@@ -153,17 +152,12 @@ describe('ReactionVariationsMaterials', () => {
       `reactants.${reactantIDs[0]}`
     );
     expect(reactantColumnDefinition.cellDataType).toBe('feedstock');
-    const { currentEntry } = reactantColumnDefinition.entryDefs;
-
-    expect(currentEntry).toBe('mass');
+    expect(getCurrentEntry(reactantColumnDefinition.entryDefs)).toBe('mass');
   });
   it('determines cell editability based on entry', async () => {
     const colDef = {
       field: 'foo',
-      entryDefs: {
-        currentEntry: 'equivalent',
-        displayUnit: null
-      }
+      entryDefs: getEntryDefs(['equivalent'])
     };
     const data = {
       foo: {


### PR DESCRIPTION
This PR addressed #2578.

Columns in the variations table now have an "Entries" button

<img width="85%" alt="multi_column_materials" src="https://github.com/user-attachments/assets/ba6bfd55-bcd0-4522-8799-8c74e4fef37e" />

that opens a modal for entry configuration

<img width="85%" alt="entry_selection_modal" src="https://github.com/user-attachments/assets/1e36f666-bd8c-4e41-8263-2193a081d055" />

Note that only one of the displayed entries is editable, the one that's selected as "Main entry".


