### PR TITLE
fix: chemical export queries with select all samples

### DIFF
--- a/app/api/helpers/report_helpers.rb
+++ b/app/api/helpers/report_helpers.rb
@@ -284,8 +284,8 @@ module ReportHelpers
       selection = "s.id in (#{s_ids}) and"
     end
 
-    rest_of_selections = if columns[0].is_a?(Array)
-                           columns[0][0]
+    rest_of_selections = if columns.is_a?(Array)
+                           columns.join(', ')
                          else
                            columns
                          end
@@ -308,26 +308,46 @@ module ReportHelpers
     SQL
   end
 
-  def chemical_query(chemical_columns, sample_ids)
-    individual_queries = sample_ids.map do |s_id|
-      <<~SQL.squish
-        SELECT #{s_id} AS chemical_sample_id, #{chemical_columns}
-        FROM chemicals c
-        WHERE c.sample_id = #{s_id}
-      SQL
+  def chemical_query(chemical_columns, c_id, ids, checked_all)
+    s_ids = [ids].flatten.join(',')
+    return '' if !checked_all && s_ids.empty?
+
+    if checked_all
+      return '' unless c_id
+
+      collection_condition = "INNER JOIN collections_samples cs ON c.sample_id = cs.sample_id AND cs.deleted_at IS NULL AND cs.collection_id = #{c_id}"
+      order = 'c.sample_id ASC'
+      selection = if s_ids.empty?
+                    ''
+                  else
+                    "AND c.sample_id NOT IN (#{s_ids})"
+                  end
+    else
+      collection_condition = ''
+      order = "position(','||c.sample_id::text||',' in '(,#{s_ids},)')"
+      selection = "AND c.sample_id IN (#{s_ids})"
     end
-    individual_queries.join(' UNION ALL ')
+
+    <<~SQL.squish
+      SELECT c.sample_id AS chemical_sample_id, #{chemical_columns}
+      FROM chemicals c
+      #{collection_condition}
+      WHERE c.deleted_at IS NULL #{selection}
+      ORDER BY #{order}
+    SQL
   end
 
   def build_sql_sample_chemicals(columns, c_id, ids, checked_all)
-    sample_query = build_sql_sample_sample(columns[0].join(','), c_id, ids, checked_all)
+    sample_query = build_sql_sample_sample(columns[0], c_id, ids, checked_all)
     return nil if sample_query.blank?
 
-    chemical_query = chemical_query(columns[1].join(','), ids)
+    chemical_query_sql = chemical_query(columns[1].join(','), c_id, ids, checked_all)
+    return sample_query if chemical_query_sql.blank?
+
     <<~SQL.squish
-      SELECT *
+      SELECT sample_results.*, chemical_results.*
       FROM (#{sample_query}) AS sample_results
-      JOIN (#{chemical_query}) AS chemical_results
+      LEFT JOIN (#{chemical_query_sql}) AS chemical_results
       ON sample_results.s_id = chemical_results.chemical_sample_id
     SQL
   end


### PR DESCRIPTION
**Problem Description:**

-  [Issue #2577](https://github.com/ComPlat/chemotion_ELN/issues/2577)
- "Select all pages" export fails when inventory/chemicals fields are selected - works fine with default fields but crashes when any inventory field is included 

**Solution Implemented:**

- Refactored chemical query logic:
  -  updated chemical_query method to handle collection-based exports similar to the working build_sql_sample_sample pattern 
  - Fixed SQL join behavior - changed from JOIN to LEFT JOIN to include all samples even when they have no chemical/inventory data, preventing sample exclusion 
  - Added proper collection boundaries - implemented consistent collection filtering logic for both "select all" and "select specific" scenarios to ensure all samples in the collection are processed correctly
______________________________________________________________________________________________

- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
