### PR TITLE
fix(UI): menu action buttons initialized before user data is available

### DIFF
--- a/app/javascript/src/components/contextActions/ExportImportButton.js
+++ b/app/javascript/src/components/contextActions/ExportImportButton.js
@@ -30,11 +30,12 @@ const editMetadataFunction = () => {
 
 function ExportImportButton() {
   const [modal, showModal] = useState(null);
+  const [hasRadar, setHasRadar] = useState(false);
   const hideModal = () => showModal(null);
 
   const [isDisabled, setIsDisabled] = useState(true);
 
-  const onUIStoreChange = ({ currentCollection }) => {
+  const onUIStoreChange = ({ currentCollection, hasRadar: storeHasRadar }) => {
     if (!currentCollection) {
       setIsDisabled(true);
       return;
@@ -47,9 +48,8 @@ function ExportImportButton() {
       (label === 'All' && is_locked)
       || (is_shared === true && permission_level < PermissionConst.ImportElements)
     );
-
-
     setIsDisabled(newIsDisabled);
+    setHasRadar(storeHasRadar);
   };
 
   useEffect(() => {
@@ -75,7 +75,6 @@ function ExportImportButton() {
     }
   })(modal);
 
-  const showRadar = UIStore.getState().hasRadar;
   return (
     <>
       <Dropdown as={ButtonGroup} id="export-dropdown">
@@ -117,7 +116,7 @@ function ExportImportButton() {
           >
             Import collections
           </Dropdown.Item>
-          {showRadar && (
+          {hasRadar && (
             <>
               <Dropdown.Divider />
               <Dropdown.Item

--- a/app/javascript/src/components/contextActions/ReportUtilButton.js
+++ b/app/javascript/src/components/contextActions/ReportUtilButton.js
@@ -1,87 +1,82 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Dropdown, ButtonGroup } from 'react-bootstrap';
 
 import ElementActions from 'src/stores/alt/actions/ElementActions';
-import UserStore from 'src/stores/alt/stores/UserStore';
 import MatrixCheck from 'src/components/common/MatrixCheck';
+import UserStore from 'src/stores/alt/stores/UserStore';
 
-const showReportContainer = () => {
-  ElementActions.showReportContainer();
-};
+function ReportUtilButton() {
+  const [matrix, setMatrix] = useState(null);
+  const [enableComputedProps, setEnableComputedProps] = useState(null);
+  const [enableReactionPredict, setEnableReactionPredict] = useState(null);
+  const [showMenu, setShowMenu] = useState(false);
 
-const showFormatContainer = () => {
-  ElementActions.showFormatContainer();
-};
+  const handleToggle = (isOpen) => {
+    setShowMenu(isOpen);
+  };
 
-const showPredictionContainer = () => {
-  ElementActions.showPredictionContainer();
-};
+  const onChange = (state) => {
+    const { matrix: storeMatrix } = state?.currentUser || {};
+    if (matrix !== storeMatrix) {
+      setMatrix(storeMatrix);
+      setEnableComputedProps(MatrixCheck(storeMatrix, 'computedProp'));
+      setEnableReactionPredict(MatrixCheck(storeMatrix, 'reactionPrediction'));
+    }
+  };
 
-const showComputedPropsGraph = () => {
-  ElementActions.showComputedPropsGraph();
-};
-
-const showComputedPropsTasks = () => {
-  ElementActions.showComputedPropsTasks();
-};
-
-const ReportUtilButton = () => {
-  const currentUser = (UserStore.getState() && UserStore.getState().currentUser) || {};
-  const enableComputedProps = MatrixCheck(currentUser.matrix, 'computedProp');
-  const enableReactionPredict = MatrixCheck(currentUser.matrix, 'reactionPrediction');
-
-  let graph = <span />;
-  let task = <span />;
-  if (enableComputedProps) {
-    graph = (
-      <Dropdown.Item onClick={showComputedPropsGraph} title="Graph">
-        Computed Props Graph
-      </Dropdown.Item>
-    );
-    task = (
-      <Dropdown.Item onClick={showComputedPropsTasks} title="Graph">
-        Computed Props Tasks
-      </Dropdown.Item>
-    );
-  }
-
-  let predDiv = <span />;
-  let divider = <span />;
-  if (enableReactionPredict) {
-    divider = <Dropdown.Divider />;
-    predDiv = (
-      <Dropdown.Item onClick={showPredictionContainer} title="Predict">
-        Synthesis Prediction
-      </Dropdown.Item>
-    );
-  }
+  useEffect(() => {
+    const unsubscribe = UserStore.listen(onChange);
+    return () => unsubscribe();
+  }, []);
 
   return (
-    <Dropdown as={ButtonGroup} id="format-dropdown">
+    <Dropdown as={ButtonGroup} id="format-dropdown" onToggle={handleToggle}>
       <Dropdown.Toggle variant="success">
         <i className="fa fa-file-text-o" style={{ marginRight: 4 }} />
         <i className="fa fa-pencil" style={{ marginRight: 4 }} />
         <i className="fa fa-percent" />
       </Dropdown.Toggle>
-      <Dropdown.Menu>
-        <Dropdown.Item onClick={showReportContainer} title="Report">
-          Report
-        </Dropdown.Item>
-        <Dropdown.Divider />
-        <Dropdown.Item onClick={showFormatContainer} title="Analyses Formatting">
-          Format Analyses
-        </Dropdown.Item>
-        <Dropdown.Item onClick={ElementActions.showLiteratureDetail} title="Reference Manager">
-          Reference Manager
-        </Dropdown.Item>
-        {graph}
-        {task}
-        {divider}
-        {predDiv}
-      </Dropdown.Menu>
+
+      {showMenu && (
+        <Dropdown.Menu>
+          <Dropdown.Item onClick={ElementActions.showReportContainer} title="Report">
+            Report
+          </Dropdown.Item>
+
+          <Dropdown.Divider />
+
+          <Dropdown.Item onClick={ElementActions.showFormatContainer} title="Analyses Formatting">
+            Format Analyses
+          </Dropdown.Item>
+
+          <Dropdown.Item onClick={ElementActions.showLiteratureDetail} title="Reference Manager">
+            Reference Manager
+          </Dropdown.Item>
+
+          {enableComputedProps && (
+            <>
+              <Dropdown.Item onClick={ElementActions.showComputedPropsGraph} title="Graph">
+                Computed Props Graph
+              </Dropdown.Item>
+              <Dropdown.Item onClick={ElementActions.showComputedPropsTasks} title="Graph">
+                Computed Props Tasks
+              </Dropdown.Item>
+            </>
+          )}
+
+          {enableReactionPredict && (
+            <>
+              <Dropdown.Divider />
+              <Dropdown.Item onClick={ElementActions.showPredictionContainer} title="Predict">
+                Synthesis Prediction
+              </Dropdown.Item>
+            </>
+          )}
+        </Dropdown.Menu>
+      )}
     </Dropdown>
   );
-};
+}
 
 export default ReportUtilButton;


### PR DESCRIPTION
Resolves: [#359](https://github.com/ComPlat/chemotion/issues/359) (only option issue fixed)

**WHY**:
Bug: some options in Report Utils were not showing in initial load of home page.

**HOW**: 
Refactor ReportUtilButton for toggle-driven rendering and add store listen for matrix change
<img width="333" height="254" alt="image" src="https://github.com/user-attachments/assets/eb55fd6a-b042-4913-b8ed-a48790776b22" />

How to verify its working: 
- Reload the home page multiple times
- Verify that the ReportUtilButton dropdown consistently displays all expected options



---------------------------------------
- [X] rather 1-story 1-commit than sub-atomic commits

- [X] commit title is meaningful =>  git history search

- [X] commit description is helpful => helps the reviewer to understand the changes

- [X] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [X] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [X] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
