### PR TITLE
fix(search): invalid statement in advanced search

### DIFF
--- a/app/api/chemotion/search_api.rb
+++ b/app/api/chemotion/search_api.rb
@@ -542,6 +542,12 @@ module Chemotion
         end
 
         post do
+          # Ensure the first element's 'link' is an empty string unless already set.
+          # This prevents invalid SQL fragments like "AND ( OR (samples.name=..." from being generated.
+          if (link_hash = params.dig('selection', 'advanced_params', 0)).is_a?(Hash) && link_hash['link'] != ''
+            link_hash['link'] = ''
+          end
+
           conditions =
             Usecases::Search::ConditionsForAdvancedSearch.new(
               detail_levels: @dl,

--- a/app/javascript/src/components/searchModal/forms/SearchModalFunctions.js
+++ b/app/javascript/src/components/searchModal/forms/SearchModalFunctions.js
@@ -21,12 +21,12 @@ const showErrorMessage = (store) => {
 }
 
 const filterSearchValues = (store) => {
-  let filteredOptions = [];
+  const filteredOptions = [];
 
   if (store.detail_search_values.length >= 1) {
-    store.detailSearchValues.map((f, i) => {
-      let values = { ...Object.values(f)[0] };
-      if (values.value != '') {
+    store.detailSearchValues.forEach((f) => {
+      const values = { ...Object.values(f)[0] };
+      if (values.value !== '') {
         filteredOptions.push(values);
       }
     });
@@ -34,17 +34,26 @@ const filterSearchValues = (store) => {
       filteredOptions[0].link = '';
     }
   } else {
-    let searchValues =
-      store.searchModalSelectedForm.value == 'publication' ? store.publicationSearchValues : store.advancedSearchValues;
-    filteredOptions = searchValues.filter((f, id) => {
-      return (f.field && f.link && f.value) ||
-        (id == 0 && f.field && f.value)
+    const isPublication = store.searchModalSelectedForm.value === 'publication';
+    const searchValues = isPublication ? store.publicationSearchValues : store.advancedSearchValues;
+    searchValues.forEach((f, id) => {
+      const isValid = (f.field && f.link && f.value) || (id === 0 && f.field && f.value);
+      if (isValid) {
+        filteredOptions.push({ ...f });
+      }
     });
+    if (!isPublication) {
+      store.resetAdvancedSearchValue();
+      if (filteredOptions[0]) {
+        filteredOptions[0].link = '';
+      }
+      filteredOptions.forEach((f, id) => { store.addAdvancedSearchValue(id, f); });
+    }
   }
   store.changeSearchFilter(filteredOptions);
   const storedFilter = store.searchFilters;
-  return storedFilter.length == 0 ? [] : storedFilter[0].filters;
-}
+  return storedFilter.length === 0 ? [] : storedFilter[0].filters;
+};
 
 const handleSearch = (store, uiState) => {
   const { currentCollection } = uiState;

--- a/app/javascript/src/components/searchModal/forms/SearchResult.js
+++ b/app/javascript/src/components/searchModal/forms/SearchResult.js
@@ -32,13 +32,24 @@ function SearchValuesList({ searchStore }) {
       <div className="search-value-list">
         <h4>Your Search</h4>
         {
-            searchStore.searchValues.map((val, i) => <div key={i}>{val.replace('ILIKE', 'LIKE')}</div>)
-          }
+          searchStore.searchValues.map((val, i) => {
+            let cleanVal = val.replace(/\bILIKE\b/, 'LIKE');
+
+            if (i === 0) {
+              cleanVal = cleanVal
+                .replace(/^AND\b\s*/, '')
+                .replace(/^OR\b\s*/, '')
+                .trim();
+            }
+
+            return <div key={i}>{cleanVal}</div>;
+          })
+        }
         {
-            searchStore.searchResultsCount > 0 ? null : (
-              <div className="search-spinner"><i className="fa fa-spinner fa-pulse fa-4x fa-fw" /></div>
-            )
-          }
+          searchStore.searchResultsCount > 0 ? null : (
+            <div className="search-spinner"><i className="fa fa-spinner fa-pulse fa-4x fa-fw" /></div>
+          )
+        }
         {showResultErrorMessage()}
       </div>
     );

--- a/app/javascript/src/components/searchModal/forms/SearchResult.js
+++ b/app/javascript/src/components/searchModal/forms/SearchResult.js
@@ -1,6 +1,7 @@
+/* eslint-disable react/prop-types */
 import React, { useContext, useState, useEffect } from 'react';
 import {
-  Col, Navbar, Nav, NavItem, Row, Tab, OverlayTrigger, Tooltip,
+  Tab, OverlayTrigger, Tooltip,
   ButtonToolbar, Button, Alert, Stack, ToggleButtonGroup, ToggleButton,
 } from 'react-bootstrap';
 import UIActions from 'src/stores/alt/actions/UIActions';
@@ -11,52 +12,107 @@ import { observer } from 'mobx-react';
 import { StoreContext } from 'src/stores/mobx/RootStore';
 import UserStore from 'src/stores/alt/stores/UserStore';
 import UIStore from 'src/stores/alt/stores/UIStore';
-import SearchResultTabContent from './SearchResultTabContent';
 import Aviator from 'aviator';
+import SearchResultTabContent from 'src/components/searchModal/forms/SearchResultTabContent';
 
-const SearchResult = ({ handleClear }) => {
-  const searchStore = useContext(StoreContext).search;
-  const results = searchStore.searchResultValues;
-  const userState = UserStore.getState();
-  const profile = userState.profile || {};
-  const genericElements = userState.genericEls || [];
-  const [visibleTabs, setVisibleTabs] = useState([]);
-  let activeTab = searchStore.search_result_active_tab_key;
-
-  useEffect(() => {
-    if (typeof (profile) !== 'undefined' && profile &&
-      typeof (profile.data) !== 'undefined' && profile.data) {
-      const visible = [];
-
-      Object.entries(profile.data.layout).filter((value) => {
-        return value[1] > 0;
-      })
-        .sort((a, b) => a[1] - b[1])
-        .map((value, i) => {
-          let tab = results.find(val => val.id.indexOf(value[0]) !== -1);
-          let totalElements = tab === undefined ? 0 : tab.results.total_elements;
-          if (value[1] > 0 && tab !== undefined) {
-            visible.push({ key: value[0], index: i, totalElements: totalElements });
-          }
-        });
-      setVisibleTabs(visible);
-      let activeTabElement = visible.find((v) => { return v.totalElements != 0 });
-      activeTabElement = activeTabElement !== undefined ? activeTabElement.index : 1;
-      handleChangeTab(activeTabElement);
+function SearchValuesList({ searchStore }) {
+  const showResultErrorMessage = () => {
+    if (searchStore.resultErrorMessage.length >= 1) {
+      return (
+        <Alert variant="danger" className="result-error-message">
+          {searchStore.resultErrorMessage.join(', ')}
+        </Alert>
+      );
     }
-  }, [results]);
+    return null;
+  };
 
-  const handleChangeTab = (key) => {
-    searchStore.changeSearchResultActiveTabKey(key);
+  if (searchStore.searchResultVisible && searchStore.searchValues.length > 0) {
+    return (
+      <div className="search-value-list">
+        <h4>Your Search</h4>
+        {
+            searchStore.searchValues.map((val, i) => <div key={i}>{val.replace('ILIKE', 'LIKE')}</div>)
+          }
+        {
+            searchStore.searchResultsCount > 0 ? null : (
+              <div className="search-spinner"><i className="fa fa-spinner fa-pulse fa-4x fa-fw" /></div>
+            )
+          }
+        {showResultErrorMessage()}
+      </div>
+    );
   }
+  return null;
+}
 
-  const handleAdoptResult = () => {
-    const preparedResult = prepareResultForDispatch();
-    UIActions.setSearchById(preparedResult);
-    ElementActions.changeSorting(true);
-    ElementActions.dispatchSearchResult(preparedResult);
-    searchStore.handleAdopt();
-  }
+function ResultsCount({ searchStore, results }) {
+  if (searchStore.searchResultsCount === 0) { return null; }
+
+  const counts = results.map((val) => {
+    if (val.id === 'literatures') { return 0; }
+
+    return val.results.total_elements;
+  });
+  const sum = counts.reduce((a, b) => a + b, 0);
+
+  return (
+    <div>
+      <h4 className="search-result-number-of-results">
+        {sum}
+        {' '}
+        results
+      </h4>
+    </div>
+  );
+}
+
+function SearchResultTabContainer({
+  searchStore, results, userState, visibleTabs, handleAdoptResult, handleChangeTab
+}) {
+  const genericElements = userState.genericEls || [];
+  const activeTab = searchStore.search_result_active_tab_key;
+
+  const searchResultNavItem = (list, tabResult) => {
+    if (searchStore.searchResultsCount === 0) { return null; }
+
+    const elnElements = ['cell_line', 'sample', 'reaction', 'screen', 'wellplate', 'research_plan'];
+    let iconClass = `icon-${list.key}`;
+    let tooltipText = list.key && (list.key.replace('_', ' ').replace(/(^\w|\s\w)/g, (m) => m.toUpperCase()));
+
+    if (!elnElements.includes(list.key)) {
+      const genericElement = (genericElements && genericElements.find((el) => el.name === list.key)) || {};
+      iconClass = `${genericElement.icon_name} icon_generic_nav`;
+      tooltipText = `${genericElement.label}<br />${genericElement.desc}`;
+    }
+    const tooltip = (
+      <Tooltip id="_tooltip_history" className="left_tooltip">
+        {tooltipText}
+      </Tooltip>
+    );
+    const itemClass = tabResult.total_elements === 0 ? ' no-result' : '';
+
+    return (
+      <ToggleButton
+        key={`result-${list.key}`}
+        id={`result-${list.key}`}
+        value={list.index}
+        variant="outline-dark"
+        className={itemClass}
+      >
+        <OverlayTrigger delayShow={500} placement="top" overlay={tooltip}>
+          <div className="d-inline-flex align-items-center">
+            <i className={`${iconClass} pe-1`} />
+            <span className="fs-3">
+              (
+              {tabResult.total_elements}
+              )
+            </span>
+          </div>
+        </OverlayTrigger>
+      </ToggleButton>
+    );
+  };
 
   const adoptResultAndOpenDetail = (element) => {
     const { currentCollection, isSync } = UIStore.getState();
@@ -78,12 +134,113 @@ const SearchResult = ({ handleClear }) => {
     handleAdoptResult();
 
     return null;
-  }
+  };
+
+  if (searchStore.searchResultsCount === 0) { return null; }
+
+  const navItems = [];
+  const tabContents = [];
+
+  visibleTabs.forEach((list) => {
+    const tab = results.find((val) => val.id.indexOf(list.key) !== -1);
+    if (tab === undefined) { return; }
+    const tabResult = tab.results;
+
+    const navItem = searchResultNavItem(list, tabResult);
+    const tabContent = (
+      <SearchResultTabContent
+        key={`${list.key}-result-tab`}
+        list={list}
+        tabResult={tabResult}
+        openDetail={adoptResultAndOpenDetail}
+      />
+    );
+
+    navItems.push(navItem);
+    tabContents.push(tabContent);
+  });
+
+  return (
+    <Tab.Container
+      id="tabList"
+      defaultActiveKey={1}
+      activeKey={activeTab}
+    >
+      <div className="search-result-tabs">
+        <Stack direction="horizontal" className="advanced-search-content-header">
+          <ToggleButtonGroup
+            type="radio"
+            name="options"
+            key="result-element-options"
+            value={searchStore.search_result_active_tab_key}
+            onChange={handleChangeTab}
+            className="advanced-search-result-toggle-elements"
+          >
+            {navItems}
+          </ToggleButtonGroup>
+        </Stack>
+        <Tab.Content className="search-result-tab-content">
+          {tabContents}
+        </Tab.Content>
+      </div>
+    </Tab.Container>
+  );
+}
+
+function ResultButtons({ searchStore, handleClear, handleAdoptResult }) {
+  if (searchStore.searchResultsCount === 0) { return null; }
+
+  return (
+    <ButtonToolbar className="advanced-search-buttons results">
+      <Button variant="warning" onClick={() => searchStore.handleCancel()}>
+        Cancel
+      </Button>
+      <Button variant="info" onClick={handleClear}>
+        Reset
+      </Button>
+      <Button variant="primary" onClick={handleAdoptResult}>
+        Adopt Result
+      </Button>
+    </ButtonToolbar>
+  );
+}
+
+function SearchResult({ handleClear }) {
+  const searchStore = useContext(StoreContext).search;
+  const results = searchStore.searchResultValues;
+  const userState = UserStore.getState();
+  const profile = userState.profile || {};
+  const [visibleTabs, setVisibleTabs] = useState([]);
+
+  const handleChangeTab = (key) => {
+    searchStore.changeSearchResultActiveTabKey(key);
+  };
+
+  useEffect(() => {
+    if (typeof (profile) !== 'undefined' && profile
+      && typeof (profile.data) !== 'undefined' && profile.data) {
+      const visible = [];
+
+      Object.entries(profile.data.layout).filter((value) => value[1] > 0)
+        .sort((a, b) => a[1] - b[1])
+        .forEach((value, i) => {
+          const tab = results.find((val) => val.id.indexOf(value[0]) !== -1);
+          const totalElements = tab === undefined ? 0 : tab.results.total_elements;
+          if (value[1] > 0 && tab !== undefined) {
+            visible.push({ key: value[0], index: i, totalElements });
+          }
+        });
+      setVisibleTabs(visible);
+      let activeTabElement = visible.find((v) => v.totalElements !== 0);
+      activeTabElement = activeTabElement !== undefined ? activeTabElement.index : 1;
+      handleChangeTab(activeTabElement);
+    }
+  }, [results]);
 
   const prepareResultForDispatch = () => {
-    let resultObject = {};
-    results.map((val, i) => {
-      let firstElements = searchStore.tabSearchResultValues.find(tab => tab.id == `${val.id}-1`);
+    const resultObject = {};
+    results.forEach((val) => {
+      const firstElements = searchStore.tabSearchResultValues.find((tab) => tab.id === `${val.id}-1`);
       resultObject[val.id] = {
         elements: firstElements.results.elements,
         ids: val.results.ids,
@@ -91,171 +248,34 @@ const SearchResult = ({ handleClear }) => {
         pages: val.results.pages,
         perPage: val.results.per_page,
         totalElements: val.results.total_elements
-      }
+      };
     });
     return resultObject;
-  }
+  };
 
-  const showResultErrorMessage = () => {
-    if (searchStore.resultErrorMessage.length >= 1) {
-      return <Alert variant="danger" className="result-error-message">{searchStore.resultErrorMessage.join(', ')}</Alert>;
-    }
-  }
-
-  const SearchValuesList = () => {
-    if (searchStore.searchResultVisible && searchStore.searchValues.length > 0) {
-      return (
-        <div className="search-value-list">
-          <h4>Your Search</h4>
-          {
-            searchStore.searchValues.map((val, i) => {
-              return <div key={i}>{val.replace('ILIKE', 'LIKE')}</div>
-            })
-          }
-          {
-            searchStore.searchResultsCount > 0 ? null : (
-              <div className="search-spinner"><i className="fa fa-spinner fa-pulse fa-4x fa-fw" /></div>
-            )
-          }
-          {showResultErrorMessage()}
-        </div>
-      );
-    } else {
-      return null;
-    }
-  }
-
-  const ResultsCount = () => {
-    if (searchStore.searchResultsCount === 0) { return null }
-
-    const counts = results.map((val) => {
-      if (val.id == 'literatures') { return 0; }
-
-      return val.results.total_elements;
-    });
-    const sum = counts.reduce((a, b) => a + b, 0);
-
-    return (
-      <div><h4 className="search-result-number-of-results">{sum} results</h4></div>
-    );
-  }
-
-  const searchResultNavItem = (list, tabResult) => {
-    if (searchStore.searchResultsCount === 0) { return null }
-
-    const elnElements = ['cell_line', 'sample', 'reaction', 'screen', 'wellplate', 'research_plan'];
-    let iconClass = `icon-${list.key}`;
-    let tooltipText = list.key && (list.key.replace('_', ' ').replace(/(^\w|\s\w)/g, m => m.toUpperCase()));
-    
-    if (!elnElements.includes(list.key)) {
-      const genericElement = (genericElements && genericElements.find(el => el.name === list.key)) || {};
-      iconClass = `${genericElement.icon_name} icon_generic_nav`;
-      tooltipText = `${genericElement.label}<br />${genericElement.desc}`;
-    }
-    let tooltip = (
-      <Tooltip id="_tooltip_history" className="left_tooltip">
-        {tooltipText}
-      </Tooltip>
-    );
-    let itemClass = tabResult.total_elements == 0 ? ' no-result' : '';
-
-    return (
-      <ToggleButton
-        key={`result-${list.key}`}
-        id={`result-${list.key}`}
-        value={list.index}
-        variant="outline-dark"
-        className={itemClass}
-      >
-        <OverlayTrigger delayShow={500} placement="top" overlay={tooltip}>
-          <div className="d-inline-flex align-items-center">
-            <i className={`${iconClass} pe-1`} />
-            <span className="fs-3">
-              ({tabResult.total_elements})
-            </span>
-          </div>
-        </OverlayTrigger>
-      </ToggleButton>
-    );
-  }
-
-  const SearchResultTabContainer = () => {
-    if (searchStore.searchResultsCount === 0) { return null }
-
-    const navItems = [];
-    const tabContents = [];
-
-    visibleTabs.map((list) => {
-      const tab = results.find(val => val.id.indexOf(list.key) !== -1);
-      if (tab === undefined) { return; }
-      const tabResult = tab.results;
-
-      const navItem = searchResultNavItem(list, tabResult);
-      const tabContent =
-        <SearchResultTabContent
-          key={`${list.key}-result-tab`}
-          list={list}
-          tabResult={tabResult}
-          openDetail={adoptResultAndOpenDetail}
-        />
-
-      navItems.push(navItem);
-      tabContents.push(tabContent);
-    });
-
-    return (
-      <Tab.Container
-        id="tabList"
-        defaultActiveKey={1}
-        activeKey={activeTab}
-      >
-        <div className="search-result-tabs">
-          <Stack direction="horizontal" className="advanced-search-content-header">
-            <ToggleButtonGroup
-              type="radio"
-              name="options"
-              key="result-element-options"
-              value={searchStore.search_result_active_tab_key}
-              onChange={handleChangeTab}
-              className="advanced-search-result-toggle-elements"
-            >
-              {navItems}
-            </ToggleButtonGroup>
-          </Stack>
-          <Tab.Content className="search-result-tab-content">
-            {tabContents}
-          </Tab.Content>
-        </div>
-      </Tab.Container>
-    );
-  }
-
-  const ResultButtons = () => {
-    if (searchStore.searchResultsCount === 0) { return null }
-
-    return (
-      <ButtonToolbar className="advanced-search-buttons results">
-        <Button variant="warning" onClick={() => searchStore.handleCancel()}>
-          Cancel
-        </Button>
-        <Button variant="info" onClick={handleClear}>
-          Reset
-        </Button>
-        <Button variant="primary" onClick={handleAdoptResult}>
-          Adopt Result
-        </Button>
-      </ButtonToolbar>
-    );
-  }
+  const handleAdoptResult = () => {
+    const preparedResult = prepareResultForDispatch();
+    UIActions.setSearchById(preparedResult);
+    ElementActions.changeSorting(true);
+    ElementActions.dispatchSearchResult(preparedResult);
+    searchStore.handleAdopt();
+  };
 
   return (
     <>
       <div className="result-content-header">
-        <SearchValuesList />
-        <ResultsCount />
+        <SearchValuesList searchStore={searchStore} />
+        <ResultsCount searchStore={searchStore} results={results} />
       </div>
-      <SearchResultTabContainer />
-      <ResultButtons />
+      <SearchResultTabContainer
+        searchStore={searchStore}
+        results={results}
+        userState={userState}
+        visibleTabs={visibleTabs}
+        handleAdoptResult={handleAdoptResult}
+        handleChangeTab={handleChangeTab}
+      />
+      <ResultButtons searchStore={searchStore} handleClear={handleClear} handleAdoptResult={handleAdoptResult} />
     </>
   );
 }

--- a/spec/api/chemotion/search_api_spec.rb
+++ b/spec/api/chemotion/search_api_spec.rb
@@ -220,6 +220,32 @@ describe Chemotion::SearchAPI do
         expect(result.dig('wellplates', 'totalElements')).to eq 1
         expect(result.dig('wellplates', 'ids')).to eq [wellplate.id]
       end
+
+      context 'when link is incorrectly set for first advanced param' do
+        let(:advanced_params) do
+          [
+            {
+              link: 'OR',
+              match: 'LIKE',
+              table: 'samples',
+              element_id: 0,
+              field: {
+                column: 'name',
+                label: 'Name',
+              },
+              value: search_term,
+              sub_values: [],
+              unit: '',
+            },
+          ]
+        end
+
+        it 'returns the same sample' do
+          result = JSON.parse(response.body)
+          expect(result.dig('samples', 'totalElements')).to eq 1
+          expect(result.dig('samples', 'ids')).to eq [sample_a.id]
+        end
+      end
     end
 
     context 'when searching a duration in reactions in correct collection' do


### PR DESCRIPTION
If you search with two or more conditions and the first is empty, it will result in an invalid SQL statement.
<img width="1701" height="671" alt="image" src="https://github.com/user-attachments/assets/bff21774-6f30-4ebf-849e-49b99c1ac597" />
This is fixed here. Now the empty condition is ignored.
