### PR TITLE
bugfix: no attachment handling in ImageModal to prevent crashes

### DIFF
--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -90,6 +90,13 @@ export default class ImageModal extends Component {
 
   fetchImage() {
     const { attachment } = this.props;
+    if (!attachment || !attachment.id) {
+      this.setState({
+        fetchSrc: '/images/wild_card/not_available.svg'
+      });
+      return;
+    }
+
     AttachmentFetcher.fetchImageAttachment({ id: attachment.id, annotated: true }).then(
       (result) => {
         if (result.data != null) {
@@ -100,7 +107,11 @@ export default class ImageModal extends Component {
           });
         }
       }
-    );
+    ).catch(() => {
+      this.setState({
+        fetchSrc: '/images/wild_card/not_available.svg'
+      });
+    });
   }
 
   async fetchImageThumbnail() {


### PR DESCRIPTION
**Description**

This PR addresses a bug in the ImageModal component where accessing properties of a null attachment caused a TypeError. The following changes were made:

- Added null checks in fetchImage() and fetchImageThumbnail() methods.
- Set fallback images when attachment is unavailable.
---------------------
- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
