### PR TITLE
fix(UI): sample measurements tab and empty measurement loading for new sample

### DIFF
--- a/app/javascript/src/fetchers/MeasurementsFetcher.js
+++ b/app/javascript/src/fetchers/MeasurementsFetcher.js
@@ -5,7 +5,7 @@ export default class MeasurementsFetcher {
   static fetchMeasurementHierarchy(sample_or_sample_id) {
     // No measurement fetching for new samples
     if (sample_or_sample_id.is_new === true) {
-      return new Promise(() => []);
+      return Promise.resolve([]);
     }
     let sample_id = sample_or_sample_id.id || sample_or_sample_id;
 

--- a/app/javascript/src/models/Sample.js
+++ b/app/javascript/src/models/Sample.js
@@ -232,6 +232,7 @@ export default class Sample extends Element {
       xref: {},
       sample_type: SAMPLE_TYPE_MICROMOLECULE,
       components: [],
+      ancestor_ids: []
     });
 
     sample.short_label = Sample.buildNewShortLabel();


### PR DESCRIPTION
**Description**

 This PR fixes a UI bug that caused a white screen when opening the measurements tab for new samples. Now, all samples are initialized with empty ancestor_ids, the fetcher always returns returns an empty array for new samples to ensure the loading state resets properly.


------------------------------
- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
