### PR TITLE
chore: bump nodejs engine from 22.16.0 to 22.17.1

### DIFF
--- a/.github/workflows/asset-precompilation.yml
+++ b/.github/workflows/asset-precompilation.yml
@@ -10,7 +10,7 @@ jobs:
       run:
         shell: bash
 
-    container: complat/chemotion_eln_runner:main-v2.0.0-16-gd3380de59a
+    container: complat/chemotion_eln_runner:main-v2.0.1-44-gd5b016b77
 
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       run:
         shell: bash
 
-    container: complat/chemotion_eln_runner:main-v2.0.0-16-gd3380de59a
+    container: complat/chemotion_eln_runner:main-v2.0.1-44-gd5b016b77
 
     services:
       postgres:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 22.16.0
+nodejs 22.17.1
 ruby 2.7.8

--- a/Dockerfile.github-ci
+++ b/Dockerfile.github-ci
@@ -20,11 +20,10 @@ ADD ${REMOTE}#${BRANCH} /chemotion/app
 
 RUN rm ${ASDF_DIR}/asdf
 ENV PATH="${ASDF_DIR}/bin:${PATH}"
-RUN ./prepare-asdf.sh
-RUN ./prepare-nodejs.sh
 ENV ASDF_NODEJS_VERSION=''
 ENV ASDF_RUBY_VERSION=''
-RUN asdf current && sleep 5s
+RUN ./prepare-asdf.sh
+RUN ./prepare-nodejs.sh
 RUN ./prepare-nodejspkg.sh
 RUN ./prepare-rubygems.sh
 

--- a/prepare-nodejs.sh
+++ b/prepare-nodejs.sh
@@ -42,13 +42,13 @@ else
   if [[ $NODEJS_FORCE_INSTALL == "true" ]]; then
     echo "NODEJS_FORCE_INSTALL is set to true, forcing installation of Node.js version $REQUIRED_NODE_VERSION"
     asdf install nodejs $REQUIRED_NODE_VERSION
-    asdf set nodejs $REQUIRED_NODE_VERSION
   else
     echo "NODEJS_FORCE_INSTALL is not set to true, proceeding with normal $CURRENT_NODE_VERSION installation"
     asdf install nodejs $CURRENT_NODE_VERSION
     REQUIRED_NODE_VERSION=$CURRENT_NODE_VERSION
   fi
 
+  asdf set nodejs $REQUIRED_NODE_VERSION
   asdf reshim nodejs
 fi
 echo "Node.js updated to version: $REQUIRED_NODE_VERSION"

--- a/prepare-nodejs.sh
+++ b/prepare-nodejs.sh
@@ -39,12 +39,19 @@ if [[ "$CURRENT_NODE_VERSION" == "$REQUIRED_NODE_VERSION" ]]; then
 else
   echo "Node.js version mismatch. Current: $CURRENT_NODE_VERSION, Required: $REQUIRED_NODE_VERSION"
   echo "Installing required Node.js version..."
-  asdf install nodejs $REQUIRED_NODE_VERSION
-  asdf set nodejs $REQUIRED_NODE_VERSION
+  if [[ $NODEJS_FORCE_INSTALL == "true" ]]; then
+    echo "NODEJS_FORCE_INSTALL is set to true, forcing installation of Node.js version $REQUIRED_NODE_VERSION"
+    asdf install nodejs $REQUIRED_NODE_VERSION
+    asdf set nodejs $REQUIRED_NODE_VERSION
+  else
+    echo "NODEJS_FORCE_INSTALL is not set to true, proceeding with normal $CURRENT_NODE_VERSION installation"
+    asdf install nodejs $CURRENT_NODE_VERSION
+    REQUIRED_NODE_VERSION=$CURRENT_NODE_VERSION
+  fi
 
-  echo "Node.js updated to version: $REQUIRED_NODE_VERSION"
   asdf reshim nodejs
 fi
+echo "Node.js updated to version: $REQUIRED_NODE_VERSION"
 export REQUIRED_NODE_VERSION
 echo $REQUIRED_NODE_VERSION
 


### PR DESCRIPTION
also:
- build(dev): prevent to automatically upgrade nodejs unless NODEJS_FORCE_INSTALL is set to 'true'

