### PR TITLE
ci: ensure nodejs version set in all cases

### DIFF
--- a/prepare-nodejs.sh
+++ b/prepare-nodejs.sh
@@ -47,10 +47,10 @@ else
     asdf install nodejs $CURRENT_NODE_VERSION
     REQUIRED_NODE_VERSION=$CURRENT_NODE_VERSION
   fi
-
-  asdf set nodejs $REQUIRED_NODE_VERSION
-  asdf reshim nodejs
 fi
+
+asdf set nodejs $REQUIRED_NODE_VERSION
+asdf reshim nodejs
 echo "Node.js updated to version: $REQUIRED_NODE_VERSION"
 export REQUIRED_NODE_VERSION
 echo $REQUIRED_NODE_VERSION


### PR DESCRIPTION
- we _always_ set the version and force a reshim
- otherwise (sometimes it gives) error: `No version is set for nodejs; please run asdf set [options] nodejs <version>`
- error is not always easily reproducible