### PR TITLE
fix: NoMethodError undefined method includes for AllElementSearch

### DIFF
--- a/app/api/chemotion/search_api.rb
+++ b/app/api/chemotion/search_api.rb
@@ -368,7 +368,7 @@ module Chemotion
                   CelllineSample.by_sample_name(arg, c_id)
                 end
 
-        if search_method != 'advanced' && search_method != 'structure' && molecule_sort == true
+        if search_method != 'advanced' && search_method != 'structure' && molecule_sort == true && scope.respond_to?(:includes)
           scope.includes(:molecule)
                .joins(:molecule)
                .order(Arel.sql("LENGTH(SUBSTRING(molecules.sum_formular, 'C\\d+'))"))


### PR DESCRIPTION
**Description**

Fixes Sentry [Issue #977](https://complat-sentry-internal.ibcs.kit.edu/organizations/complat/issues/977): NoMethodError on AllElementSearch::Results.includes

Adds a check for scope.respond_to?(:includes) before calling .includes(:molecule) in the search API.

------------------------------------------------
- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
