### PR TITLE
feat: add history trace to cell-line elements

### DIFF
--- a/app/api/chemotion/version_api.rb
+++ b/app/api/chemotion/version_api.rb
@@ -134,7 +134,7 @@ module Chemotion
         end
       end
 
-      resource :cellline_sample do
+      resource :cellline_samples do
         desc 'Return versions of the given cell line sample'
 
         params do

--- a/app/api/chemotion/version_api.rb
+++ b/app/api/chemotion/version_api.rb
@@ -134,6 +134,25 @@ module Chemotion
         end
       end
 
+      resource :cellline_sample do
+        desc 'Return versions of the given cell line sample'
+
+        params do
+          requires :id, type: Integer, desc: 'cell line sample id'
+        end
+
+        paginate per_page: 10, offset: 0, max_per_page: 100
+
+        route_param :id do
+          get do
+            cellline_sample = CelllineSample.with_log_data.find(params[:id])
+
+            versions = Versioning::Fetcher.call(cellline_sample)
+            { versions: paginate(Kaminari.paginate_array(versions)) }
+          end
+        end
+      end
+
       resource :revert do
         desc 'Revert selected changes'
 

--- a/app/javascript/src/apps/mydb/elements/details/VersionsTable.js
+++ b/app/javascript/src/apps/mydb/elements/details/VersionsTable.js
@@ -12,6 +12,7 @@ import ResearchPlansFetcher from 'src/fetchers/ResearchPlansFetcher';
 import ScreensFetcher from 'src/fetchers/ScreensFetcher';
 import WellplatesFetcher from 'src/fetchers/WellplatesFetcher';
 import DeviceDescriptionFetcher from 'src/fetchers/DeviceDescriptionFetcher';
+import CellLinesFetcher from 'src/fetchers/CellLinesFetcher';
 import moment from 'moment';
 
 export default class VersionsTable extends Component {
@@ -84,6 +85,12 @@ export default class VersionsTable extends Component {
       case 'device_description': {
         DeviceDescriptionFetcher.fetchById(id).then((result) => {
           parent.setDeviceDescription(result);
+        });
+        break;
+      }
+      case 'cellline_sample': {
+        CellLinesFetcher.fetchById(id).then((result) => {
+          parent.convertCellLineToModel(result);
         });
         break;
       }

--- a/app/javascript/src/apps/mydb/elements/details/VersionsTable.js
+++ b/app/javascript/src/apps/mydb/elements/details/VersionsTable.js
@@ -90,7 +90,12 @@ export default class VersionsTable extends Component {
       }
       case 'cellline_sample': {
         CellLinesFetcher.fetchById(id).then((result) => {
-          parent.convertCellLineToModel(result);
+          parent.changeAmount(result.id, result.amount);
+          parent.changeUnit(result.id, result.unit);
+          parent.changePassage(result.id, result.passage);
+          parent.changeContamination(result.id, result.contamination);
+          parent.changeItemName(result.id, result.name);
+          parent.changeItemDescription(result.id, result.description);
         });
         break;
       }

--- a/app/javascript/src/apps/mydb/elements/details/cellLines/CellLineDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/CellLineDetails.js
@@ -227,7 +227,7 @@ class CellLineDetails extends React.Component {
             </Tab>
             <Tab eventKey="tab4" title="History" key="tab4" disabled={cellLineItem.is_new}>
               <VersionsTable
-                type="cellline_sample"
+                type="cellline_samples"
                 id={parseInt(cellLineItem.id, 10)}
                 element={cellLineItem}
                 parent={cellLineDetailsStore}

--- a/app/javascript/src/apps/mydb/elements/details/cellLines/CellLineDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/CellLineDetails.js
@@ -16,6 +16,7 @@ import DetailCard from 'src/apps/mydb/elements/details/DetailCard';
 import GeneralProperties from 'src/apps/mydb/elements/details/cellLines/propertiesTab/GeneralProperties';
 import AnalysesContainer from 'src/apps/mydb/elements/details/cellLines/analysesTab/AnalysesContainer';
 import DetailsTabLiteratures from 'src/apps/mydb/elements/details/literature/DetailsTabLiteratures';
+import VersionsTable from 'src/apps/mydb/elements/details/VersionsTable';
 
 class CellLineDetails extends React.Component {
   // eslint-disable-next-line react/static-property-placement
@@ -187,8 +188,9 @@ class CellLineDetails extends React.Component {
     const { cellLineItem } = this.props;
 
     if (!cellLineItem) { return (null); }
-    // eslint-disable-next-line react/destructuring-assignment
-    this.context.cellLineDetailsStore.convertCellLineToModel(cellLineItem);
+    const { cellLineDetailsStore } = this.context;
+    cellLineDetailsStore.convertCellLineToModel(cellLineItem);
+    const mobXItem = cellLineDetailsStore.cellLines(cellLineItem.id);
     const { readOnly } = this.state;
     const { activeTab } = this.state;
     return (
@@ -197,7 +199,13 @@ class CellLineDetails extends React.Component {
         footer={this.renderFooterContent()}
       >
         <div className="tabs-container--with-borders">
-          <Tabs activeKey={activeTab} onSelect={(event) => this.handleTabChange(event)} id="cell-line-details-tab">
+          <Tabs
+            activeKey={activeTab}
+            onSelect={(event) => this.handleTabChange(event)}
+            id="cell-line-details-tab"
+            mountOnEnter
+            unmountOnExit
+          >
             <Tab eventKey="tab1" title="Properties" key="tab1">
               <GeneralProperties
                 item={cellLineItem}
@@ -215,6 +223,15 @@ class CellLineDetails extends React.Component {
                 readOnly={readOnly}
                 element={cellLineItem}
                 literatures={cellLineItem.is_new ? cellLineItem.literatures : null}
+              />
+            </Tab>
+            <Tab eventKey="tab4" title="History" key="tab4" disabled={cellLineItem.is_new}>
+              <VersionsTable
+                type="cellline_sample"
+                id={parseInt(cellLineItem.id, 10)}
+                element={cellLineItem}
+                parent={cellLineDetailsStore}
+                isEdited={mobXItem.changed}
               />
             </Tab>
           </Tabs>

--- a/app/models/cellline_material.rb
+++ b/app/models/cellline_material.rb
@@ -29,6 +29,7 @@
 #  index_cellline_materials_on_name_and_source  (name,source) UNIQUE
 #
 class CelllineMaterial < ApplicationRecord
+  has_logidze
   acts_as_paranoid
 
   has_many :literals, as: :element, dependent: :destroy

--- a/app/models/cellline_sample.rb
+++ b/app/models/cellline_sample.rb
@@ -25,6 +25,7 @@
 #  index_cellline_samples_on_ancestry  (ancestry) WHERE (deleted_at IS NULL)
 #
 class CelllineSample < ApplicationRecord
+  has_logidze
   acts_as_paranoid
   has_ancestry orphan_strategy: :adopt
 

--- a/app/services/versioning/fetcher.rb
+++ b/app/services/versioning/fetcher.rb
@@ -30,6 +30,8 @@ module Versioning
         Versioning::Fetchers::WellplateFetcher.call(wellplate: record)
       when ::DeviceDescription
         Versioning::Fetchers::DeviceDescriptionFetcher.call(device_description: record)
+      when ::CelllineSample
+        Versioning::Fetchers::CelllineSampleFetcher.call(cellline_sample: record)
       end
     end
   end

--- a/app/services/versioning/fetchers/cellline_sample_fetcher.rb
+++ b/app/services/versioning/fetchers/cellline_sample_fetcher.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Versioning
+  module Fetchers
+    class CelllineSampleFetcher
+      include ActiveModel::Model
+
+      attr_accessor :cellline_sample
+
+      def self.call(**args)
+        new(**args).call
+      end
+
+      def call
+        Versioning::Serializers::CelllineSampleSerializer.call(cellline_sample)
+      end
+    end
+  end
+end

--- a/app/services/versioning/reverter.rb
+++ b/app/services/versioning/reverter.rb
@@ -6,8 +6,8 @@ module Versioning
 
     attr_accessor :changes
 
-    ALLOWED_REVERTERS = %w[Attachment Chemical Component Container DeviceDescription ElementalComposition Reaction
-                           ReactionsSample ResearchPlan ResearchPlanMetadata Residue
+    ALLOWED_REVERTERS = %w[Attachment Chemical Container CelllineSample DeviceDescription ElementalComposition
+                           Reaction ReactionsSample ResearchPlan ResearchPlanMetadata Residue
                            Sample Screen Wellplate Well].freeze
 
     def self.call(changes)

--- a/app/services/versioning/reverters/cellline_sample_reverter.rb
+++ b/app/services/versioning/reverters/cellline_sample_reverter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Versioning
+  module Reverters
+    class CelllineSampleReverter < Versioning::Reverters::BaseReverter
+      def self.scope
+        CelllineSample.with_deleted
+      end
+    end
+  end
+end

--- a/app/services/versioning/serializers/cellline_sample_serializer.rb
+++ b/app/services/versioning/serializers/cellline_sample_serializer.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Versioning
+  module Serializers
+    class CelllineSampleSerializer < Versioning::Serializers::BaseSerializer
+      def self.call(record, name = ['Cellline Sample Properties'])
+        new(record: record, name: name).call
+      end
+
+      def field_definitions
+        {
+          amount: {
+            label: 'Amount',
+            revert: %i[amount],
+          },
+          unit: {
+            label: 'Unit',
+            revert: %i[unit],
+          },
+          passage: {
+            label: 'Passage',
+            revert: %i[passage],
+          },
+          contamination: {
+            label: 'Contamination',
+            revert: %i[contamination],
+          },
+          name: {
+            label: 'Name of specific probe',
+            revert: %i[name],
+          },
+          description: {
+            label: 'Sample Description',
+            revert: %i[description],
+          },
+        }.with_indifferent_access
+      end
+    end
+  end
+end

--- a/db/migrate/20250521124547_add_logidze_to_celllines.rb
+++ b/db/migrate/20250521124547_add_logidze_to_celllines.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class AddLogidzeToCelllines < ActiveRecord::Migration[6.1]
+  def change
+    add_column :cellline_materials, :log_data, :jsonb
+    add_column :cellline_samples, :log_data, :jsonb
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL.squish
+          SELECT logidze_create_trigger_on_table('cellline_materials', 'logidze_on_cellline_materials', 'updated_at');
+          SELECT logidze_create_trigger_on_table('cellline_samples', 'logidze_on_cellline_samples', 'updated_at');
+        SQL
+
+        execute <<~SQL.squish
+          UPDATE cellline_materials as t
+          SET log_data = logidze_snapshot(to_jsonb(t), 'updated_at');
+        SQL
+        execute <<~SQL.squish
+          UPDATE cellline_samples as t
+          SET log_data = logidze_snapshot(to_jsonb(t), 'updated_at');
+        SQL
+      end
+
+      dir.down do
+        execute 'DROP TRIGGER IF EXISTS logidze_on_cellline_materials on cellline_materials;'
+        execute 'DROP TRIGGER IF EXISTS logidze_on_cellline_samples on cellline_samples;'
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -136,6 +136,7 @@ ActiveRecord::Schema.define(version: 2026_01_08_155328) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "created_by"
+    t.jsonb "log_data"
     t.index ["name", "source"], name: "index_cellline_materials_on_name_and_source", unique: true
   end
 
@@ -153,8 +154,9 @@ ActiveRecord::Schema.define(version: 2026_01_08_155328) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "short_label"
-    t.string "ancestry", default: "/", null: false, collation: "C"
-    t.index ["ancestry"], name: "index_cellline_samples_on_ancestry", opclass: :varchar_pattern_ops, where: "(deleted_at IS NULL)"
+    t.string "ancestry"
+    t.jsonb "log_data"
+    t.index ["ancestry"], name: "index_cellline_samples_on_ancestry"
   end
 
   create_table "channels", id: :serial, force: :cascade do |t|
@@ -2617,6 +2619,12 @@ ActiveRecord::Schema.define(version: 2026_01_08_155328) do
   SQL
   create_trigger :logidze_on_components, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_components BEFORE INSERT OR UPDATE ON public.components FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_cellline_materials, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_cellline_materials BEFORE INSERT OR UPDATE ON public.cellline_materials FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_cellline_samples, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_cellline_samples BEFORE INSERT OR UPDATE ON public.cellline_samples FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
   create_trigger :lab_trg_layers_changes, sql_definition: <<-SQL
       CREATE TRIGGER lab_trg_layers_changes AFTER UPDATE ON public.layers FOR EACH ROW EXECUTE FUNCTION lab_record_layers_changes()

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -154,9 +154,9 @@ ActiveRecord::Schema.define(version: 2026_01_08_155328) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "short_label"
-    t.string "ancestry"
+    t.string "ancestry", default: "/", null: false, collation: "C"
     t.jsonb "log_data"
-    t.index ["ancestry"], name: "index_cellline_samples_on_ancestry"
+    t.index ["ancestry"], name: "index_cellline_samples_on_ancestry", opclass: :varchar_pattern_ops, where: "(deleted_at IS NULL)"
   end
 
   create_table "channels", id: :serial, force: :cascade do |t|
@@ -2566,32 +2566,7 @@ ActiveRecord::Schema.define(version: 2026_01_08_155328) do
         RETURN result;
       END;
       $function$
-  SQL
 
-
-  create_trigger :logidze_on_reactions, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_reactions BEFORE INSERT OR UPDATE ON public.reactions FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-  create_trigger :logidze_on_samples, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_samples BEFORE INSERT OR UPDATE ON public.samples FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-  create_trigger :logidze_on_wells, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_wells BEFORE INSERT OR UPDATE ON public.wells FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-  create_trigger :logidze_on_wellplates, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_wellplates BEFORE INSERT OR UPDATE ON public.wellplates FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-  create_trigger :logidze_on_screens, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_screens BEFORE INSERT OR UPDATE ON public.screens FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-  create_trigger :logidze_on_residues, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_residues BEFORE INSERT OR UPDATE ON public.residues FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-  create_trigger :logidze_on_elemental_compositions, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_elemental_compositions BEFORE INSERT OR UPDATE ON public.elemental_compositions FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-  create_trigger :logidze_on_containers, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_containers BEFORE INSERT OR UPDATE ON public.containers FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
   create_trigger :logidze_on_attachments, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_attachments BEFORE INSERT OR UPDATE ON public.attachments FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
@@ -2626,8 +2601,53 @@ ActiveRecord::Schema.define(version: 2026_01_08_155328) do
   create_trigger :logidze_on_cellline_samples, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_cellline_samples BEFORE INSERT OR UPDATE ON public.cellline_samples FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
+  create_trigger :logidze_on_chemicals, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_chemicals BEFORE INSERT OR UPDATE ON public.chemicals FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_containers, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_containers BEFORE INSERT OR UPDATE ON public.containers FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_device_descriptions, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_device_descriptions BEFORE INSERT OR UPDATE ON public.device_descriptions FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_elemental_compositions, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_elemental_compositions BEFORE INSERT OR UPDATE ON public.elemental_compositions FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
   create_trigger :lab_trg_layers_changes, sql_definition: <<-SQL
       CREATE TRIGGER lab_trg_layers_changes AFTER UPDATE ON public.layers FOR EACH ROW EXECUTE FUNCTION lab_record_layers_changes()
+  SQL
+  create_trigger :update_users_matrix_trg, sql_definition: <<-SQL
+      CREATE TRIGGER update_users_matrix_trg AFTER INSERT OR UPDATE ON public.matrices FOR EACH ROW EXECUTE FUNCTION update_users_matrix()
+  SQL
+  create_trigger :logidze_on_reactions, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_reactions BEFORE INSERT OR UPDATE ON public.reactions FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_reactions_samples, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_reactions_samples BEFORE INSERT OR UPDATE ON public.reactions_samples FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_research_plan_metadata, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_research_plan_metadata BEFORE INSERT OR UPDATE ON public.research_plan_metadata FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_research_plans, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_research_plans BEFORE INSERT OR UPDATE ON public.research_plans FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_research_plans_wellplates, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_research_plans_wellplates BEFORE INSERT OR UPDATE ON public.research_plans_wellplates FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_residues, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_residues BEFORE INSERT OR UPDATE ON public.residues FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_samples, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_samples BEFORE INSERT OR UPDATE ON public.samples FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_screens, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_screens BEFORE INSERT OR UPDATE ON public.screens FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_wellplates, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_wellplates BEFORE INSERT OR UPDATE ON public.wellplates FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_wells, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_wells BEFORE INSERT OR UPDATE ON public.wells FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 
   create_view "v_samples_collections", sql_definition: <<-SQL


### PR DESCRIPTION
Added tracking for cellline sample and materials to database.
Added History Tab to Celllines to view and revert changes to cellline sample.
Celline Material changes cannot be viewed because there is no dedicated view for materials.