### PR TITLE
fix(build): development vessel template seeds

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -474,6 +474,8 @@ GEM
       net-protocol
     net-ssh (6.1.0)
     nio4r (2.7.4)
+    nokogiri (1.15.7-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.15.7-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.12)
@@ -850,6 +852,7 @@ GEM
     zeitwerk (2.6.18)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -474,8 +474,6 @@ GEM
       net-protocol
     net-ssh (6.1.0)
     nio4r (2.7.4)
-    nokogiri (1.15.7-aarch64-linux)
-      racc (~> 1.4)
     nokogiri (1.15.7-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.12)
@@ -852,7 +850,6 @@ GEM
     zeitwerk (2.6.18)
 
 PLATFORMS
-  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES

--- a/db/seeds/development/03_vessels.seed.rb
+++ b/db/seeds/development/03_vessels.seed.rb
@@ -153,19 +153,19 @@ def create_vessels_and_vessel_templates
     vessel_names.each_with_index do |vessel_name, index|
       next if VesselTemplate.find_by(name: vessel_name)
 
-      User.where(type: 'Person').find_each do |person|
-        vessel_template = VesselTemplate.create!(
-          name: vessel_name,
-          details: Faker::Science.element_subcategory,
-          material_details: Faker::Science.tool,
-          material_type: vessel_materials.sample,
-          vessel_type: ord_vessel_types.sample,
-          volume_amount: index < 21 ? small_vessel_sizes.sample : large_vessel_sizes.sample,
-          volume_unit: 'ml',
-          weight_amount: weight_amounts.sample,
-          weight_unit: 'g'
-        )
+      vessel_template = VesselTemplate.create!(
+        name: vessel_name,
+        details: Faker::Science.element_subcategory,
+        material_details: Faker::Science.tool,
+        material_type: vessel_materials.sample,
+        vessel_type: ord_vessel_types.sample,
+        volume_amount: index < 21 ? small_vessel_sizes.sample : large_vessel_sizes.sample,
+        volume_unit: 'ml',
+        weight_amount: weight_amounts.sample,
+        weight_unit: 'g'
+      )
 
+      User.where(type: 'Person').find_each do |person|
         description = "A #{vessel_template.vessel_type} with size " \
                       "#{vessel_template.volume_amount} #{vessel_template.volume_unit}."
 


### PR DESCRIPTION
With this change we create only one vessel template per user vessel in seeds.
This way the seeds respect the uniqueness constraint introduced in https://github.com/ComPlat/chemotion_ELN/pull/2441.