### PR TITLE
fix: handle report generation request with an empty selection of items

### DIFF
--- a/app/api/chemotion/report_api.rb
+++ b/app/api/chemotion/report_api.rb
@@ -93,7 +93,7 @@ module Chemotion
         header('Content-Disposition', "attachment; filename=\"#{filename}\"")
         # header 'Content-Disposition', "attachment; filename*=UTF-8''#{fileURI}"
 
-        export.read
+        export.read || ''
       end
 
       params do
@@ -137,7 +137,7 @@ module Chemotion
 
         result = db_exec_query(sql_query)
         export.generate_sheet_with_samples(:wellplate, result)
-        export.read
+        export.read || ''
       end
 
       params do
@@ -159,7 +159,7 @@ module Chemotion
 
         result = db_exec_query(sql_query)
         export.generate_sheet_with_samples(:reaction, result)
-        export.read
+        export.read || ''
       end
     end
 


### PR DESCRIPTION
When exporting as SDF: Forgetting to select samples and using export samples from selection as SDF you get a htm file which contains an error message.
Added nil check to avoid the error and return an empty txt file instead.
