### PR TITLE
fix: chemdraw loadError function missing

### DIFF
--- a/app/javascript/src/components/structureEditor/ChemDrawEditor.js
+++ b/app/javascript/src/components/structureEditor/ChemDrawEditor.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import StructureEditor from 'src/models/StructureEditor';
 import loadScripts from 'src/components/structureEditor/loadScripts';
-import LoadingEditorModal from './LoadingEditorModal';
+import LoadingEditorModal from 'src/components/structureEditor/LoadingEditorModal';
 
 class ChemDrawEditor extends React.Component {
   constructor(props) {
@@ -19,8 +19,13 @@ class ChemDrawEditor extends React.Component {
     const { editor } = this.props;
     const { extJs, id } = editor;
     loadScripts({
-      es: extJs, id, cbError: () => loadError(id), cbLoaded: () => this.loaded()
+      es: extJs, id, cbError: () => this.loadError('Internal Server Error!'), cbLoaded: () => this.loaded()
     });
+  }
+
+  loadError(e) {
+    this.setState({ loading: false });
+    alert(`Chemdraw JS is failed to load or attach! Error: ${e}`);
   }
 
   cdAttached(cd) {

--- a/app/javascript/src/components/structureEditor/MarvinjsEditor.js
+++ b/app/javascript/src/components/structureEditor/MarvinjsEditor.js
@@ -3,12 +3,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import StructureEditor from 'src/models/StructureEditor';
 import loadScripts from 'src/components/structureEditor/loadScripts';
-import LoadingEditorModal from './LoadingEditorModal';
+import LoadingEditorModal from 'src/components/structureEditor/LoadingEditorModal';
 
 class MarvinjsEditor extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { loading: true };
+    this.state = { loading: true, message: '', failed: false };
     this.attachEditor = this.attachEditor.bind(this);
     this.loadError = this.loadError.bind(this);
     this.attachError = this.attachError.bind(this);
@@ -38,7 +38,7 @@ class MarvinjsEditor extends React.Component {
   }
 
   attachError(e) {
-    this.setState({ loading: false });
+    this.setState({ loading: false, message: 'Marvin JS is not available.', failed: true });
     alert(`Marvin JS is failed to load or attach! Error: ${e}`);
   }
 
@@ -51,10 +51,13 @@ class MarvinjsEditor extends React.Component {
 
   render() {
     const { iH, editor } = this.props;
+    const { loading, message, failed } = this.state;
     return (
-      <div>
-        <iframe title="Marvin JS" id="mvs" src={editor.extSrc} className="sketcher-frame" height={iH} width="100%" />
-        <LoadingEditorModal loading={this.state.loading} />
+      <div style={{ height: iH }}>
+        {!failed && (
+          <iframe title='Marvin JS' id='mvs' src={editor.extSrc} className='sketcher-frame' height={iH} width='100%' />
+        )}
+        <LoadingEditorModal loading={loading} message={message} />
       </div>
     );
   }


### PR DESCRIPTION
PR resolve issues: ChemDrawjs was missing with the loadError function. When the editor fails then error was not showing.

----------------------
- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
