### PR TITLE
feat: Show full-resolution image in hover preview in the attachment list

### DIFF
--- a/app/javascript/src/apps/mydb/elements/list/AttachmentList.js
+++ b/app/javascript/src/apps/mydb/elements/list/AttachmentList.js
@@ -38,6 +38,7 @@ export const attachmentThumbnail = (attachment) => (
         attachment={attachment}
         popObject={{}}
         disableClick
+        inlineFullRes
       />
     </div>
   </div>

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -34,6 +34,9 @@ export default class ImageModal extends Component {
 
   componentDidMount() {
     this.fetchImageThumbnail();
+    if (this.props.inlineFullRes) {
+      this.fetchImage();
+    }
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -52,6 +55,9 @@ export default class ImageModal extends Component {
   componentDidUpdate(prevProps) {
     if (this.props.attachment?.id !== prevProps.attachment?.id) {
       this.fetchImageThumbnail();
+      if (this.props.inlineFullRes) {
+        this.fetchImage();
+      }
     }
   }
 
@@ -125,6 +131,21 @@ export default class ImageModal extends Component {
       showPop, popObject, imageStyle, attachment
     } = this.props;
     const { pageIndex, numOfPages, isPdf, fetchSrc, thumbnail } = this.state;
+
+    if (this.props.inlineFullRes) {
+      const srcToUse = isPdf ? thumbnail : (fetchSrc || thumbnail);
+      return (
+        <div className="preview-table">
+          <img
+            src={srcToUse}
+            alt={attachment?.filename}
+            style={{ cursor: 'default', ...imageStyle }}
+            onError={this.handleImageError}
+
+          />
+        </div>
+      );
+    }
 
     if (showPop) {
       return (
@@ -233,9 +254,11 @@ ImageModal.propTypes = {
   }).isRequired,
   disableClick: PropTypes.bool,
   imageStyle: PropTypes.object,
+  inlineFullRes: PropTypes.bool,
 };
 
 ImageModal.defaultProps = {
   imageStyle: {},
   disableClick: false,
+  inlineFullRes: false,
 };


### PR DESCRIPTION
## Description:

- Show original image (not thumbnail) in the large hover preview in the attachment list.
- Do not load full-res for PDFs (does not exist).
- Keep other ImageModal behavior the same.

### Impact: 
Better image quality on hover, no breaking changes.

### Before:
<img width="1125" height="723" alt="image" src="https://github.com/user-attachments/assets/ffc20a9a-6ed4-49c0-b592-f05c62e4131a" />

### After:
<img width="1115" height="576" alt="image" src="https://github.com/user-attachments/assets/9fdcc20a-d038-4750-a831-850188656490" />