### PR TITLE
fix(spectra): Display Unicode unit labels correctly

### DIFF
--- a/app/javascript/src/stores/alt/stores/SpectraStore.js
+++ b/app/javascript/src/stores/alt/stores/SpectraStore.js
@@ -47,7 +47,7 @@ class SpectraStore {
     }
 
     try {
-      const raw = base64.decode(file);
+      const raw = new TextDecoder("utf-8").decode(new Uint8Array([...(base64.decode(file))].map(ch => ch.charCodeAt(0))));
       const jcamp = FN.ExtractJcamp(raw);
       if (!jcamp.spectra) return null;
       spectrum = Object.assign({}, spectrum, { jcamp });
@@ -190,7 +190,7 @@ class SpectraStore {
   }
 
   handleAddOthers(rsp) {
-    const origData = base64.decode(rsp.jcamp);
+    const origData = new TextDecoder("utf-8").decode(new Uint8Array([...(base64.decode(rsp.jcamp))].map(ch => ch.charCodeAt(0))));
     const jcampData = FN.ExtractJcamp(origData);
     this.setState({ others: [jcampData] });
   }


### PR DESCRIPTION
## What
Keep original XUNITS/YUNITS/UNITS as UTF-8 and render them without stripping non-ASCII.

## Why
Symbols like "³" appeared as boxes or wrong characters in the UI.

## How
Use the UTF-8 labels from the backend

Before the fix :
<img width="139" height="630" alt="image" src="https://github.com/user-attachments/assets/ad0dc6ef-ecc0-44a1-90d5-35fa31531049" />

After the fix:
<img width="139" height="585" alt="image" src="https://github.com/user-attachments/assets/02746075-d16a-4ff9-888f-77169f5bb54f" />


## Testing
Loaded JCAMP files with Unicode labels and verified unit label show the correct characters