### PR TITLE
feat(analysis): browse and set the preview image for an analysis tab

### DIFF
--- a/app/api/entities/container_entity.rb
+++ b/app/api/entities/container_entity.rb
@@ -32,6 +32,7 @@ module Entities
         metadata[:kind] = object.extended_metadata['kind']
         metadata[:index] = object.extended_metadata['index']
         metadata[:instrument] = object.extended_metadata['instrument']
+        metadata[:preferred_thumbnail] = object.extended_metadata['preferred_thumbnail']
         if object.extended_metadata['content'].present?
           metadata[:content] =
             JSON.parse(object.extended_metadata['content'])

--- a/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/Header.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/Header.js
@@ -108,6 +108,7 @@ export default class Header extends React.Component {
   renderImagePreview = () => {
     const { container } = this.props;
     const attachment = getAttachmentFromContainer(container);
+    console.log('renderImagePreview');
 
     return (
       <ImageModal

--- a/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/Header.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/Header.js
@@ -112,7 +112,6 @@ export default class Header extends React.Component {
     const attachmentsIds = container?.children?.flatMap((child) => (child.attachments
       || []).map((att) => Number(att.id))) || [];
     const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
-      // Handle the change of preferred thumbnail
       if (currentPreferredThumbnail !== preferredThumbnail) {
         // Handle the change of preferred thumbnail
         container.extended_metadata = {

--- a/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/Header.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/Header.js
@@ -106,9 +106,22 @@ export default class Header extends React.Component {
 
   // eslint-disable-next-line class-methods-use-this
   renderImagePreview = () => {
-    const { container } = this.props;
+    const { container, handleChange } = this.props;
     const attachment = getAttachmentFromContainer(container);
-    console.log('renderImagePreview');
+    const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
+    const attachmentsIds = container?.children?.flatMap((child) => (child.attachments
+      || []).map((att) => Number(att.id))) || [];
+    const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
+      // Handle the change of preferred thumbnail
+      if (currentPreferredThumbnail !== preferredThumbnail) {
+        // Handle the change of preferred thumbnail
+        container.extended_metadata = {
+          ...container.extended_metadata,
+          preferred_thumbnail: currentPreferredThumbnail,
+        };
+        handleChange(container);
+      }
+    };
 
     return (
       <ImageModal
@@ -116,6 +129,11 @@ export default class Header extends React.Component {
         popObject={{
           title: container.name,
         }}
+        preferredThumbnail={preferredThumbnail}
+        ChildrenAttachmentsIds={attachmentsIds}
+        onChangePreferredThumbnail={(currentPreferredThumbnail) => onChangePreferredThumbnail(
+          currentPreferredThumbnail
+        )}
       />
     );
   }

--- a/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/Header.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/Header.js
@@ -108,9 +108,13 @@ export default class Header extends React.Component {
   renderImagePreview = () => {
     const { container, handleChange } = this.props;
     const attachment = getAttachmentFromContainer(container);
+    // Build list of non-deleted attachment IDs
+    const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
+    const nonDeletedAttachments = allAttachments.filter((att) => !att.is_deleted);
+    const attachmentsIds = nonDeletedAttachments.map((att) => Number(att.id));
+    // Get current preferred thumbnail (reassignment is handled by ContainerDatasets on deletion)
     const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
-    const attachmentsIds = container?.children?.flatMap((child) => (child.attachments
-      || []).map((att) => Number(att.id))) || [];
+
     const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
       if (currentPreferredThumbnail !== preferredThumbnail) {
         // Handle the change of preferred thumbnail

--- a/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/Header.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/Header.js
@@ -108,10 +108,12 @@ export default class Header extends React.Component {
   renderImagePreview = () => {
     const { container, handleChange } = this.props;
     const attachment = getAttachmentFromContainer(container);
-    // Build list of non-deleted attachment IDs
+    // Build list of saved, non-deleted attachment IDs (exclude is_new which don't have server IDs yet)
     const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
-    const nonDeletedAttachments = allAttachments.filter((att) => !att.is_deleted);
-    const attachmentsIds = nonDeletedAttachments.map((att) => Number(att.id));
+    const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new);
+    const attachmentsIds = savedAttachments
+      .map((att) => Number(att.id))
+      .filter((id) => !Number.isNaN(id) && id > 0);
     // Get current preferred thumbnail (reassignment is handled by ContainerDatasets on deletion)
     const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
 

--- a/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/Header.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/Header.js
@@ -110,7 +110,7 @@ export default class Header extends React.Component {
     const attachment = getAttachmentFromContainer(container);
     // Build list of saved, non-deleted attachment IDs (exclude is_new which don't have server IDs yet)
     const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
-    const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new);
+    const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new && att.thumb === true);
     const attachmentsIds = savedAttachments
       .map((att) => Number(att.id))
       .filter((id) => !Number.isNaN(id) && id > 0);
@@ -135,7 +135,7 @@ export default class Header extends React.Component {
           title: container.name,
         }}
         preferredThumbnail={preferredThumbnail}
-        ChildrenAttachmentsIds={attachmentsIds}
+        childrenAttachmentIds={attachmentsIds}
         onChangePreferredThumbnail={(currentPreferredThumbnail) => onChangePreferredThumbnail(
           currentPreferredThumbnail
         )}

--- a/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/Header.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/Header.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import QuillViewer from 'src/components/QuillViewer';
 import PropTypes from 'prop-types';
-import { getAttachmentFromContainer } from 'src/utilities/imageHelper';
 import ImageModal from 'src/components/common/ImageModal';
 import { Button } from 'react-bootstrap';
 
@@ -107,38 +106,22 @@ export default class Header extends React.Component {
   // eslint-disable-next-line class-methods-use-this
   renderImagePreview = () => {
     const { container, handleChange } = this.props;
-    const attachment = getAttachmentFromContainer(container);
-    // Build list of saved, non-deleted attachment IDs (exclude is_new which don't have server IDs yet)
-    const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
-    const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new && att.thumb === true);
-    const attachmentsIds = savedAttachments
-      .map((att) => Number(att.id))
-      .filter((id) => !Number.isNaN(id) && id > 0);
-    // Get current preferred thumbnail (reassignment is handled by ContainerDatasets on deletion)
-    const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
 
-    const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
-      if (currentPreferredThumbnail !== preferredThumbnail) {
-        // Handle the change of preferred thumbnail
-        container.extended_metadata = {
-          ...container.extended_metadata,
-          preferred_thumbnail: currentPreferredThumbnail,
-        };
-        handleChange(container);
-      }
+    const onPreferredThumbnailChange = (preferredId) => {
+      container.extended_metadata = {
+        ...container.extended_metadata,
+        preferred_thumbnail: preferredId,
+      };
+      handleChange(container);
     };
 
     return (
       <ImageModal
-        attachment={attachment}
+        container={container}
         popObject={{
           title: container.name,
         }}
-        preferredThumbnail={preferredThumbnail}
-        childrenAttachmentIds={attachmentsIds}
-        onChangePreferredThumbnail={(currentPreferredThumbnail) => onChangePreferredThumbnail(
-          currentPreferredThumbnail
-        )}
+        onPreferredThumbnailChange={onPreferredThumbnailChange}
       />
     );
   }

--- a/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysisHeader.js
+++ b/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysisHeader.js
@@ -160,7 +160,6 @@ function AnalysisHeader({ container, readonly }) {
   const attachmentsIds = container?.children?.flatMap((child) => (child.attachments
     || []).map((att) => Number(att.id))) || [];
   const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
-    // Handle the change of preferred thumbnail
     if (currentPreferredThumbnail !== preferredThumbnail) {
       // Handle the change of preferred thumbnail
       container.extended_metadata = {

--- a/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysisHeader.js
+++ b/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysisHeader.js
@@ -155,6 +155,7 @@ const AnalysisHeader = ({ container, readonly }) => {
       return c;
     }),
   };
+  console.log('container extended_metadata', container.extended_metadata);
   const attachment = getAttachmentFromContainer(container);
 
   const orderClass = deviceDescriptionsStore.analysis_mode == 'order' ? 'order pe-2' : '';

--- a/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysisHeader.js
+++ b/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysisHeader.js
@@ -15,7 +15,7 @@ import { StoreContext } from 'src/stores/mobx/RootStore';
 import UIStore from 'src/stores/alt/stores/UIStore';
 import UserStore from 'src/stores/alt/stores/UserStore';
 
-const AnalysisHeader = ({ container, readonly }) => {
+function AnalysisHeader({ container, readonly }) {
   const deviceDescriptionsStore = useContext(StoreContext).deviceDescriptions;
   const deviceDescription = deviceDescriptionsStore.device_description;
 
@@ -155,8 +155,21 @@ const AnalysisHeader = ({ container, readonly }) => {
       return c;
     }),
   };
-  console.log('container extended_metadata', container.extended_metadata);
+  const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
   const attachment = getAttachmentFromContainer(container);
+  const attachmentsIds = container?.children?.flatMap((child) => (child.attachments
+    || []).map((att) => Number(att.id))) || [];
+  const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
+    // Handle the change of preferred thumbnail
+    if (currentPreferredThumbnail !== preferredThumbnail) {
+      // Handle the change of preferred thumbnail
+      container.extended_metadata = {
+        ...container.extended_metadata,
+        preferred_thumbnail: currentPreferredThumbnail,
+      };
+      deviceDescriptionsStore.changeAnalysisContainerContent(container);
+    }
+  };
 
   const orderClass = deviceDescriptionsStore.analysis_mode == 'order' ? 'order pe-2' : '';
   const deleted = container?.is_deleted || false;
@@ -165,13 +178,20 @@ const AnalysisHeader = ({ container, readonly }) => {
     <div className={`analysis-header w-100 d-flex gap-3 lh-base ${orderClass}`}>
       <div className="preview border d-flex align-items-center">
         {deleted
-          ? <i className="fa fa-ban text-body-tertiary fs-2 text-center d-block" /> 
-          : <ImageModal
+          ? <i className="fa fa-ban text-body-tertiary fs-2 text-center d-block" />
+          : (
+            <ImageModal
               attachment={attachment}
               popObject={{
                 title: container.name,
               }}
-          />
+              preferredThumbnail={preferredThumbnail}
+              ChildrenAttachmentsIds={attachmentsIds}
+              onChangePreferredThumbnail={(currentPreferredThumbnail) => onChangePreferredThumbnail(
+                currentPreferredThumbnail
+              )}
+            />
+          )
         }
       </div>
       <div className={"flex-grow-1" + (deleted ? "" : " analysis-header-fade")}>

--- a/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysisHeader.js
+++ b/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysisHeader.js
@@ -158,8 +158,11 @@ function AnalysisHeader({ container, readonly }) {
   const attachment = getAttachmentFromContainer(container);
   // Build list of non-deleted attachment IDs
   const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
-  const nonDeletedAttachments = allAttachments.filter((att) => !att.is_deleted);
-  const attachmentsIds = nonDeletedAttachments.map((att) => Number(att.id));
+  // Filter: exclude deleted and is_new attachments (is_new don't have server IDs yet)
+  const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new);
+  const attachmentsIds = savedAttachments
+    .map((att) => Number(att.id))
+    .filter((id) => !Number.isNaN(id) && id > 0);
   // Get current preferred thumbnail (reassignment is handled by ContainerDatasets on deletion)
   const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
 

--- a/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysisHeader.js
+++ b/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysisHeader.js
@@ -155,10 +155,14 @@ function AnalysisHeader({ container, readonly }) {
       return c;
     }),
   };
-  const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
   const attachment = getAttachmentFromContainer(container);
-  const attachmentsIds = container?.children?.flatMap((child) => (child.attachments
-    || []).map((att) => Number(att.id))) || [];
+  // Build list of non-deleted attachment IDs
+  const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
+  const nonDeletedAttachments = allAttachments.filter((att) => !att.is_deleted);
+  const attachmentsIds = nonDeletedAttachments.map((att) => Number(att.id));
+  // Get current preferred thumbnail (reassignment is handled by ContainerDatasets on deletion)
+  const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
+
   const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
     if (currentPreferredThumbnail !== preferredThumbnail) {
       // Handle the change of preferred thumbnail

--- a/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysisHeader.js
+++ b/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysisHeader.js
@@ -159,7 +159,7 @@ function AnalysisHeader({ container, readonly }) {
   // Build list of non-deleted attachment IDs
   const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
   // Filter: exclude deleted and is_new attachments (is_new don't have server IDs yet)
-  const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new);
+  const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new && att.thumb === true);
   const attachmentsIds = savedAttachments
     .map((att) => Number(att.id))
     .filter((id) => !Number.isNaN(id) && id > 0);
@@ -192,7 +192,7 @@ function AnalysisHeader({ container, readonly }) {
                 title: container.name,
               }}
               preferredThumbnail={preferredThumbnail}
-              ChildrenAttachmentsIds={attachmentsIds}
+              childrenAttachmentIds={attachmentsIds}
               onChangePreferredThumbnail={(currentPreferredThumbnail) => onChangePreferredThumbnail(
                 currentPreferredThumbnail
               )}

--- a/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysisHeader.js
+++ b/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysisHeader.js
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import { Form, Button } from 'react-bootstrap';
 
 import QuillViewer from 'src/components/QuillViewer';
-import { getAttachmentFromContainer } from 'src/utilities/imageHelper';
 import ImageModal from 'src/components/common/ImageModal';
 import PrintCodeButton from 'src/components/common/PrintCodeButton';
 import SpectraActions from 'src/stores/alt/actions/SpectraActions';
@@ -155,26 +154,10 @@ function AnalysisHeader({ container, readonly }) {
       return c;
     }),
   };
-  const attachment = getAttachmentFromContainer(container);
-  // Build list of non-deleted attachment IDs
-  const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
-  // Filter: exclude deleted and is_new attachments (is_new don't have server IDs yet)
-  const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new && att.thumb === true);
-  const attachmentsIds = savedAttachments
-    .map((att) => Number(att.id))
-    .filter((id) => !Number.isNaN(id) && id > 0);
-  // Get current preferred thumbnail (reassignment is handled by ContainerDatasets on deletion)
-  const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
-
-  const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
-    if (currentPreferredThumbnail !== preferredThumbnail) {
-      // Handle the change of preferred thumbnail
-      container.extended_metadata = {
-        ...container.extended_metadata,
-        preferred_thumbnail: currentPreferredThumbnail,
-      };
-      deviceDescriptionsStore.changeAnalysisContainerContent(container);
-    }
+  const onPreferredThumbnailChange = (preferredId) => {
+    // eslint-disable-next-line no-param-reassign, react/prop-types
+    container.extended_metadata = { ...container.extended_metadata, preferred_thumbnail: preferredId };
+    deviceDescriptionsStore.changeAnalysisContainerContent(container);
   };
 
   const orderClass = deviceDescriptionsStore.analysis_mode == 'order' ? 'order pe-2' : '';
@@ -187,15 +170,11 @@ function AnalysisHeader({ container, readonly }) {
           ? <i className="fa fa-ban text-body-tertiary fs-2 text-center d-block" />
           : (
             <ImageModal
-              attachment={attachment}
+              container={container}
               popObject={{
                 title: container.name,
               }}
-              preferredThumbnail={preferredThumbnail}
-              childrenAttachmentIds={attachmentsIds}
-              onChangePreferredThumbnail={(currentPreferredThumbnail) => onChangePreferredThumbnail(
-                currentPreferredThumbnail
-              )}
+              onPreferredThumbnailChange={onPreferredThumbnailChange}
             />
           )
         }

--- a/app/javascript/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.js
@@ -21,7 +21,6 @@ import ImageModal from 'src/components/common/ImageModal';
 import { hNmrCount, cNmrCount, instrumentText } from 'src/utilities/ElementUtils';
 import { contentToText } from 'src/utilities/quillFormat';
 import { chmoConversions } from 'src/components/OlsComponent';
-import { getAttachmentFromContainer } from 'src/utilities/imageHelper';
 import {
   JcampIds, BuildSpcInfos, BuildSpcInfosForNMRDisplayer, isNMRKind
 } from 'src/utilities/SpectraHelper';
@@ -318,15 +317,23 @@ export default class ReactionDetailsContainers extends Component {
           return c;
         }),
       };
-      const attachment = getAttachmentFromContainer(container);
+      const onPreferredThumbnailChange = (preferredId) => {
+        // eslint-disable-next-line no-param-reassign
+        container.extended_metadata = {
+          ...container.extended_metadata,
+          preferred_thumbnail: preferredId,
+        };
+        this.handleChange();
+      };
       return (
         <div className="analysis-header w-100 d-flex gap-3 lh-base">
           <div className="preview border d-flex align-items-center">
             <ImageModal
-              attachment={attachment}
+              container={container}
               popObject={{
                 title: container.name,
               }}
+              onPreferredThumbnailChange={onPreferredThumbnailChange}
             />
           </div>
           <div className="flex-grow-1">

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
@@ -218,9 +218,13 @@ export default class ResearchPlanDetailsContainers extends Component {
         }),
       };
       const attachment = getAttachmentFromContainer(container);
+      // Build list of non-deleted attachment IDs
+      const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
+      const nonDeletedAttachments = allAttachments.filter((att) => !att.is_deleted);
+      const attachmentsIds = nonDeletedAttachments.map((att) => Number(att.id));
+      // Get current preferred thumbnail (reassignment is handled by ContainerDatasets on deletion)
       const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
-      const attachmentsIds = container?.children?.flatMap((child) => (child.attachments || [])
-        .map((att) => Number(att.id))) || [];
+
       const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
         if (currentPreferredThumbnail !== preferredThumbnail) {
           // Handle the change of preferred thumbnail

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
@@ -220,7 +220,7 @@ export default class ResearchPlanDetailsContainers extends Component {
       const attachment = getAttachmentFromContainer(container);
       // Build list of saved, non-deleted attachment IDs (exclude is_new which don't have server IDs yet)
       const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
-      const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new);
+      const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new && att.thumb === true);
       const attachmentsIds = savedAttachments
         .map((att) => Number(att.id))
         .filter((id) => !Number.isNaN(id) && id > 0);
@@ -247,7 +247,7 @@ export default class ResearchPlanDetailsContainers extends Component {
                 title: container.name,
               }}
               preferredThumbnail={preferredThumbnail}
-              ChildrenAttachmentsIds={attachmentsIds}
+              childrenAttachmentIds={attachmentsIds}
               onChangePreferredThumbnail={(currentPreferredThumbnail) => onChangePreferredThumbnail(
                 currentPreferredThumbnail
               )}

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
@@ -222,7 +222,6 @@ export default class ResearchPlanDetailsContainers extends Component {
       const attachmentsIds = container?.children?.flatMap((child) => (child.attachments || [])
         .map((att) => Number(att.id))) || [];
       const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
-        // Handle the change of preferred thumbnail
         if (currentPreferredThumbnail !== preferredThumbnail) {
           // Handle the change of preferred thumbnail
           container.extended_metadata = {

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
@@ -218,10 +218,12 @@ export default class ResearchPlanDetailsContainers extends Component {
         }),
       };
       const attachment = getAttachmentFromContainer(container);
-      // Build list of non-deleted attachment IDs
+      // Build list of saved, non-deleted attachment IDs (exclude is_new which don't have server IDs yet)
       const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
-      const nonDeletedAttachments = allAttachments.filter((att) => !att.is_deleted);
-      const attachmentsIds = nonDeletedAttachments.map((att) => Number(att.id));
+      const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new);
+      const attachmentsIds = savedAttachments
+        .map((att) => Number(att.id))
+        .filter((id) => !Number.isNaN(id) && id > 0);
       // Get current preferred thumbnail (reassignment is handled by ContainerDatasets on deletion)
       const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
 

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
@@ -218,6 +218,20 @@ export default class ResearchPlanDetailsContainers extends Component {
         }),
       };
       const attachment = getAttachmentFromContainer(container);
+      const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
+      const attachmentsIds = container?.children?.flatMap((child) => (child.attachments || [])
+        .map((att) => Number(att.id))) || [];
+      const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
+        // Handle the change of preferred thumbnail
+        if (currentPreferredThumbnail !== preferredThumbnail) {
+          // Handle the change of preferred thumbnail
+          container.extended_metadata = {
+            ...container.extended_metadata,
+            preferred_thumbnail: currentPreferredThumbnail,
+          };
+          this.handleChange();
+        }
+      };
 
       return (
         <div className="analysis-header w-100 d-flex gap-3 lh-base">
@@ -227,6 +241,11 @@ export default class ResearchPlanDetailsContainers extends Component {
               popObject={{
                 title: container.name,
               }}
+              preferredThumbnail={preferredThumbnail}
+              ChildrenAttachmentsIds={attachmentsIds}
+              onChangePreferredThumbnail={(currentPreferredThumbnail) => onChangePreferredThumbnail(
+                currentPreferredThumbnail
+              )}
             />
           </div>
           <div className="flex-grow-1">

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
@@ -15,7 +15,6 @@ import ContainerComponent from 'src/components/container/ContainerComponent';
 import QuillViewer from 'src/components/QuillViewer';
 import ImageModal from 'src/components/common/ImageModal';
 import { instrumentText } from 'src/utilities/ElementUtils';
-import { getAttachmentFromContainer } from 'src/utilities/imageHelper';
 import { JcampIds, BuildSpcInfos, BuildSpcInfosForNMRDisplayer, isNMRKind } from 'src/utilities/SpectraHelper';
 import UIStore from 'src/stores/alt/stores/UIStore';
 import UserStore from 'src/stores/alt/stores/UserStore';
@@ -217,40 +216,24 @@ export default class ResearchPlanDetailsContainers extends Component {
           return c;
         }),
       };
-      const attachment = getAttachmentFromContainer(container);
-      // Build list of saved, non-deleted attachment IDs (exclude is_new which don't have server IDs yet)
-      const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
-      const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new && att.thumb === true);
-      const attachmentsIds = savedAttachments
-        .map((att) => Number(att.id))
-        .filter((id) => !Number.isNaN(id) && id > 0);
-      // Get current preferred thumbnail (reassignment is handled by ContainerDatasets on deletion)
-      const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
-
-      const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
-        if (currentPreferredThumbnail !== preferredThumbnail) {
-          // Handle the change of preferred thumbnail
-          container.extended_metadata = {
-            ...container.extended_metadata,
-            preferred_thumbnail: currentPreferredThumbnail,
-          };
-          this.handleChange();
-        }
+      const onPreferredThumbnailChange = (preferredId) => {
+        // eslint-disable-next-line no-param-reassign
+        container.extended_metadata = {
+          ...container.extended_metadata,
+          preferred_thumbnail: preferredId,
+        };
+        this.handleChange();
       };
 
       return (
         <div className="analysis-header w-100 d-flex gap-3 lh-base">
           <div className="preview border d-flex align-items-center">
             <ImageModal
-              attachment={attachment}
+              container={container}
               popObject={{
                 title: container.name,
               }}
-              preferredThumbnail={preferredThumbnail}
-              childrenAttachmentIds={attachmentsIds}
-              onChangePreferredThumbnail={(currentPreferredThumbnail) => onChangePreferredThumbnail(
-                currentPreferredThumbnail
-              )}
+              onPreferredThumbnailChange={onPreferredThumbnailChange}
             />
           </div>
           <div className="flex-grow-1">

--- a/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainers.js
@@ -156,7 +156,14 @@ export default class SampleDetailsContainers extends Component {
     this.handleChange(container);
   }
 
-  updateContainerPreferredThumbnail() {
+  // Persist the chosen preferred preview image for an analysis container. Shared across all
+  // viewers: writes extended_metadata and flags the sample changed via the existing path.
+  updateContainerPreferredThumbnail(container, preferredId) {
+    // eslint-disable-next-line no-param-reassign
+    container.extended_metadata = {
+      ...container.extended_metadata,
+      preferred_thumbnail: preferredId,
+    };
     this.handleChange();
   }
 

--- a/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainers.js
@@ -43,6 +43,7 @@ export default class SampleDetailsContainers extends Component {
     this.handleAdd = this.handleAdd.bind(this);
     this.handleMove = this.handleMove.bind(this);
     this.toggleAddToReport = this.toggleAddToReport.bind(this);
+    this.updateContainerPreferredThumbnail = this.updateContainerPreferredThumbnail.bind(this);
     this.handleToggleMode = this.handleToggleMode.bind(this);
   }
 
@@ -155,6 +156,10 @@ export default class SampleDetailsContainers extends Component {
     this.handleChange(container);
   }
 
+  updateContainerPreferredThumbnail() {
+    this.handleChange();
+  }
+
   handleToggleMode(mode) {
     this.setState({ mode });
   }
@@ -194,6 +199,7 @@ export default class SampleDetailsContainers extends Component {
             handleCommentTextChange={this.handleCommentTextChange}
             commentBoxVisible={commentBoxVisible}
             toggleCommentBox={this.toggleCommentBox}
+            updateContainerPreferredThumbnail={this.updateContainerPreferredThumbnail}
           />
           <ViewSpectra
             sample={sample}

--- a/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
@@ -188,10 +188,12 @@ function AnalysesHeader({
     }),
   };
   const attachment = getAttachmentFromContainer(container);
-  // Build list of non-deleted attachment IDs
+  // Build list of saved, non-deleted attachment IDs (exclude is_new which don't have server IDs yet)
   const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
-  const nonDeletedAttachments = allAttachments.filter((att) => !att.is_deleted);
-  const attachmentsIds = nonDeletedAttachments.map((att) => Number(att.id));
+  const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new);
+  const attachmentsIds = savedAttachments
+    .map((att) => Number(att.id))
+    .filter((id) => !Number.isNaN(id) && id > 0);
   // Get current preferred thumbnail (reassignment is handled by ContainerDatasets on deletion)
   const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
 

--- a/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
@@ -180,7 +180,14 @@ const AnalysesHeader = ({
     }),
   };
    const attachment = getAttachmentFromContainer(container);
- 
+   const preferredThumbnail = container.children[0]?.extended_metadata?.preferred_thumbnail || null;
+  const attachmentsIds = container?.children?.flatMap((child) =>
+    (child.attachments || [])
+      .filter(att => typeof att.id === 'number')
+      .map(att => att.id)
+  ) || [];
+   console.log('container.children', container.children);
+   console.log('attachmentsIds', attachmentsIds);
   return (
     <div className={`analysis-header w-100 d-flex gap-3 lh-base ${mode === 'edit' ? '' : 'order pe-2'}`}>
       <div className="preview border d-flex align-items-center">
@@ -191,6 +198,8 @@ const AnalysesHeader = ({
             popObject={{
               title: container.name,
             }}
+            preferredThumbnail={preferredThumbnail}
+            ChildrenAttachmentsIds={attachmentsIds}
           />
     }
       </div>

--- a/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
@@ -188,9 +188,13 @@ function AnalysesHeader({
     }),
   };
   const attachment = getAttachmentFromContainer(container);
+  // Build list of non-deleted attachment IDs
+  const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
+  const nonDeletedAttachments = allAttachments.filter((att) => !att.is_deleted);
+  const attachmentsIds = nonDeletedAttachments.map((att) => Number(att.id));
+  // Get current preferred thumbnail (reassignment is handled by ContainerDatasets on deletion)
   const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
-  const attachmentsIds = container?.children?.flatMap((child) => (child.attachments
-    || []).map((att) => Number(att.id))) || [];
+
   const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
     if (currentPreferredThumbnail !== preferredThumbnail) {
       // Handle the change of preferred thumbnail

--- a/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
@@ -190,7 +190,7 @@ function AnalysesHeader({
   const attachment = getAttachmentFromContainer(container);
   // Build list of saved, non-deleted attachment IDs (exclude is_new which don't have server IDs yet)
   const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
-  const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new);
+  const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new && att.thumb === true);
   const attachmentsIds = savedAttachments
     .map((att) => Number(att.id))
     .filter((id) => !Number.isNaN(id) && id > 0);
@@ -218,7 +218,7 @@ function AnalysesHeader({
                 title: container.name,
               }}
               preferredThumbnail={preferredThumbnail}
-              ChildrenAttachmentsIds={attachmentsIds}
+              childrenAttachmentIds={attachmentsIds}
               onChangePreferredThumbnail={(currentPreferredThumbnail) => onChangePreferredThumbnail(
                 currentPreferredThumbnail
               )}

--- a/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
@@ -15,7 +15,6 @@ import MolViewerListBtn from 'src/components/viewer/MolViewerListBtn';
 import MolViewerSet from 'src/components/viewer/MolViewerSet';
 import MatrixCheck from 'src/components/common/MatrixCheck';
 import SpectraEditorButton from 'src/components/common/SpectraEditorButton';
-import { getAttachmentFromContainer } from 'src/utilities/imageHelper';
 
 const qCheckPass = () => (
   <i className="fa fa-check ms-1 text-success"/>
@@ -187,41 +186,17 @@ function AnalysesHeader({
       return c;
     }),
   };
-  const attachment = getAttachmentFromContainer(container);
-  // Build list of saved, non-deleted attachment IDs (exclude is_new which don't have server IDs yet)
-  const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
-  const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new && att.thumb === true);
-  const attachmentsIds = savedAttachments
-    .map((att) => Number(att.id))
-    .filter((id) => !Number.isNaN(id) && id > 0);
-  // Get current preferred thumbnail (reassignment is handled by ContainerDatasets on deletion)
-  const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
-
-  const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
-    if (currentPreferredThumbnail !== preferredThumbnail) {
-      // Handle the change of preferred thumbnail
-      container.extended_metadata = {
-        ...container.extended_metadata,
-        preferred_thumbnail: currentPreferredThumbnail,
-      };
-      updateContainerPreferredThumbnail();
-    }
-  };
   return (
     <div className={`analysis-header w-100 d-flex gap-3 lh-base ${mode === 'edit' ? '' : 'order pe-2'}`}>
       <div className="preview border d-flex align-items-center">
         {deleted
           ? <i className="fa fa-ban text-body-tertiary fs-2 text-center d-block" /> : (
             <ImageModal
-              attachment={attachment}
+              container={container}
               popObject={{
                 title: container.name,
               }}
-              preferredThumbnail={preferredThumbnail}
-              childrenAttachmentIds={attachmentsIds}
-              onChangePreferredThumbnail={(currentPreferredThumbnail) => onChangePreferredThumbnail(
-                currentPreferredThumbnail
-              )}
+              onPreferredThumbnailChange={(id) => updateContainerPreferredThumbnail(container, id)}
             />
           )}
       </div>

--- a/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
@@ -192,7 +192,6 @@ function AnalysesHeader({
   const attachmentsIds = container?.children?.flatMap((child) => (child.attachments
     || []).map((att) => Number(att.id))) || [];
   const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
-    // Handle the change of preferred thumbnail
     if (currentPreferredThumbnail !== preferredThumbnail) {
       // Handle the change of preferred thumbnail
       container.extended_metadata = {

--- a/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
@@ -162,10 +162,18 @@ const headerBtnGroup = (
   );
 };
 
-const AnalysesHeader = ({
-  sample, container, mode, readOnly, isDisabled, handleRemove, handleUndo, handleSubmit, toggleAddToReport,
-}) => {
-
+function AnalysesHeader({
+  sample,
+  container,
+  mode,
+  readOnly,
+  isDisabled,
+  handleRemove,
+  handleUndo,
+  handleSubmit,
+  toggleAddToReport,
+  updateContainerPreferredThumbnail,
+}) {
   let kind = container.extended_metadata.kind || '';
   kind = (kind.split('|')[1] || kind).trim();
   const deleted = container.is_deleted;
@@ -179,29 +187,38 @@ const AnalysesHeader = ({
       return c;
     }),
   };
-   const attachment = getAttachmentFromContainer(container);
-   const preferredThumbnail = container.children[0]?.extended_metadata?.preferred_thumbnail || null;
-  const attachmentsIds = container?.children?.flatMap((child) =>
-    (child.attachments || [])
-      .filter(att => typeof att.id === 'number')
-      .map(att => att.id)
-  ) || [];
-   console.log('container.children', container.children);
-   console.log('attachmentsIds', attachmentsIds);
+  const attachment = getAttachmentFromContainer(container);
+  const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
+  const attachmentsIds = container?.children?.flatMap((child) => (child.attachments
+    || []).map((att) => Number(att.id))) || [];
+  const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
+    // Handle the change of preferred thumbnail
+    if (currentPreferredThumbnail !== preferredThumbnail) {
+      // Handle the change of preferred thumbnail
+      container.extended_metadata = {
+        ...container.extended_metadata,
+        preferred_thumbnail: currentPreferredThumbnail,
+      };
+      updateContainerPreferredThumbnail();
+    }
+  };
   return (
     <div className={`analysis-header w-100 d-flex gap-3 lh-base ${mode === 'edit' ? '' : 'order pe-2'}`}>
       <div className="preview border d-flex align-items-center">
-        {deleted ?
-          <i className="fa fa-ban text-body-tertiary fs-2 text-center d-block" /> :
-          <ImageModal
-            attachment={attachment}
-            popObject={{
-              title: container.name,
-            }}
-            preferredThumbnail={preferredThumbnail}
-            ChildrenAttachmentsIds={attachmentsIds}
-          />
-    }
+        {deleted
+          ? <i className="fa fa-ban text-body-tertiary fs-2 text-center d-block" /> : (
+            <ImageModal
+              attachment={attachment}
+              popObject={{
+                title: container.name,
+              }}
+              preferredThumbnail={preferredThumbnail}
+              ChildrenAttachmentsIds={attachmentsIds}
+              onChangePreferredThumbnail={(currentPreferredThumbnail) => onChangePreferredThumbnail(
+                currentPreferredThumbnail
+              )}
+            />
+          )}
       </div>
       <div className={"flex-grow-1" + (deleted ? "" : " analysis-header-fade")}>
         <div className="d-flex justify-content-between align-items-center">
@@ -229,6 +246,6 @@ const AnalysesHeader = ({
       </div>
     </div>
   );
-};
+}
 
 export { AnalysesHeader };

--- a/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersCom.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersCom.js
@@ -66,7 +66,8 @@ function ReactionsDisplay({
   handleCommentTextChange,
   rootContainer,
   commentBoxVisible,
-  toggleCommentBox
+  toggleCommentBox,
+  updateContainerPreferredThumbnail
 }) {
   return (
     <div>
@@ -114,6 +115,7 @@ function ReactionsDisplay({
                       handleRemove={handleRemove}
                       handleSubmit={handleSubmit}
                       toggleAddToReport={toggleAddToReport}
+                      updateContainerPreferredThumbnail={updateContainerPreferredThumbnail}
                     />
                   </AccordionHeaderWithButtons>
                 </Card.Header>
@@ -155,6 +157,7 @@ function ReactionsDisplay({
                 handleSubmit={handleSubmit}
                 handleUndo={handleUndo}
                 toggleAddToReport={toggleAddToReport}
+                updateContainerPreferredThumbnail={updateContainerPreferredThumbnail}
               />
             );
           })}

--- a/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersDnd.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersDnd.js
@@ -37,7 +37,7 @@ const orderDropCollect = (connect, monitor) => ({
 const ContainerRow = ({
   sample, container, mode, readOnly, isDisabled, handleRemove,
   handleSubmit, toggleAddToReport, handleUndo,
-  connectDragSource, connectDropTarget, isDragging, isOver, canDrop,
+  connectDragSource, connectDropTarget, isDragging, isOver, canDrop, updateContainerPreferredThumbnail
 }) => {
   let dndClass = " border";
   if (canDrop) {
@@ -65,6 +65,7 @@ const ContainerRow = ({
         handleRemove={handleRemove}
         handleSubmit={handleSubmit}
         toggleAddToReport={toggleAddToReport}
+        updateContainerPreferredThumbnail={updateContainerPreferredThumbnail}
       />
     </div>,
   );

--- a/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/analysesTab/AnalysesContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/analysesTab/AnalysesContainer.js
@@ -101,7 +101,15 @@ function AnalysesContainer({ readonly }) {
                     readOnly={readonly}
                     templateType="sbmmSample"
                     container={container}
-                    onChange={() => sbmmStore.changeAnalysisContainerContent(container)}
+                    onChange={(cont) => {
+                      if (cont.id === sbmmSample.container.id) {
+                        // Root container from modal save: update all analyses from fresh server data
+                        sbmmStore.changeAnalysisContainer(cont.children[0].children);
+                      } else {
+                        // Individual analysis container update (e.g. preferred thumbnail change)
+                        sbmmStore.changeAnalysisContainerContent(cont);
+                      }
+                    }}
                     rootContainer={sbmmSample.container}
                     index={index}
                   />

--- a/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/analysesTab/AnalysesContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/analysesTab/AnalysesContainer.js
@@ -102,9 +102,14 @@ function AnalysesContainer({ readonly }) {
                     templateType="sbmmSample"
                     container={container}
                     onChange={(cont) => {
-                      if (cont.id === sbmmSample.container.id) {
+                      const rootId = sbmmSample?.container?.id;
+                      // Only the post-save root container carries the full analyses tree under
+                      // children[0]. `rootId != null` prevents the undefined === undefined
+                      // false-match on unsaved samples (which would wipe all analyses).
+                      const isRootContainerSave = rootId != null && cont.id === rootId;
+                      if (isRootContainerSave) {
                         // Root container from modal save: update all analyses from fresh server data
-                        sbmmStore.changeAnalysisContainer(cont.children[0].children);
+                        sbmmStore.changeAnalysisContainer(cont.children?.[0]?.children ?? []);
                       } else {
                         // Individual analysis container update (e.g. preferred thumbnail change)
                         sbmmStore.changeAnalysisContainerContent(cont);

--- a/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/analysesTab/AnalysisHeader.js
+++ b/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/analysesTab/AnalysisHeader.js
@@ -156,6 +156,22 @@ const AnalysisHeader = ({ container, readonly }) => {
     }),
   };
   const attachment = getAttachmentFromContainer(container);
+  const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
+  const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new && att.thumb === true);
+  const attachmentsIds = savedAttachments
+    .map((att) => Number(att.id))
+    .filter((id) => !Number.isNaN(id) && id > 0);
+  const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
+
+  const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
+    if (currentPreferredThumbnail !== preferredThumbnail) {
+      container.extended_metadata = {
+        ...container.extended_metadata,
+        preferred_thumbnail: currentPreferredThumbnail,
+      };
+      sbmmStore.changeAnalysisContainerContent(container);
+    }
+  };
 
   const orderClass = sbmmStore.analysis_mode == 'order' ? 'order pe-2' : '';
   const deleted = container?.is_deleted || false;
@@ -165,12 +181,19 @@ const AnalysisHeader = ({ container, readonly }) => {
       <div className="preview border d-flex align-items-center">
         {deleted
           ? <i className="fa fa-ban text-body-tertiary fs-2 text-center d-block" /> 
-          : <ImageModal
-            attachment={attachment}
-            popObject={{
-              title: container.name,
-            }}
-          />
+          : (
+            <ImageModal
+              attachment={attachment}
+              popObject={{
+                title: container.name,
+              }}
+              preferredThumbnail={preferredThumbnail}
+              childrenAttachmentIds={attachmentsIds}
+              onChangePreferredThumbnail={(currentPreferredThumbnail) => onChangePreferredThumbnail(
+                currentPreferredThumbnail
+              )}
+            />
+          )
         }
       </div>
       <div className={"flex-grow-1" + (deleted ? "" : " analysis-header-fade")}>

--- a/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/analysesTab/AnalysisHeader.js
+++ b/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/analysesTab/AnalysisHeader.js
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import { Form, Button } from 'react-bootstrap';
 
 import QuillViewer from 'src/components/QuillViewer';
-import { getAttachmentFromContainer } from 'src/utilities/imageHelper';
 import ImageModal from 'src/components/common/ImageModal';
 import PrintCodeButton from 'src/components/common/PrintCodeButton';
 import SpectraActions from 'src/stores/alt/actions/SpectraActions';
@@ -155,22 +154,10 @@ const AnalysisHeader = ({ container, readonly }) => {
       return c;
     }),
   };
-  const attachment = getAttachmentFromContainer(container);
-  const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
-  const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new && att.thumb === true);
-  const attachmentsIds = savedAttachments
-    .map((att) => Number(att.id))
-    .filter((id) => !Number.isNaN(id) && id > 0);
-  const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
-
-  const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
-    if (currentPreferredThumbnail !== preferredThumbnail) {
-      container.extended_metadata = {
-        ...container.extended_metadata,
-        preferred_thumbnail: currentPreferredThumbnail,
-      };
-      sbmmStore.changeAnalysisContainerContent(container);
-    }
+  const onPreferredThumbnailChange = (preferredId) => {
+    // eslint-disable-next-line no-param-reassign, react/prop-types
+    container.extended_metadata = { ...container.extended_metadata, preferred_thumbnail: preferredId };
+    sbmmStore.changeAnalysisContainerContent(container);
   };
 
   const orderClass = sbmmStore.analysis_mode == 'order' ? 'order pe-2' : '';
@@ -180,18 +167,14 @@ const AnalysisHeader = ({ container, readonly }) => {
     <div className={`analysis-header w-100 d-flex gap-3 lh-base ${orderClass}`}>
       <div className="preview border d-flex align-items-center">
         {deleted
-          ? <i className="fa fa-ban text-body-tertiary fs-2 text-center d-block" /> 
+          ? <i className="fa fa-ban text-body-tertiary fs-2 text-center d-block" />
           : (
             <ImageModal
-              attachment={attachment}
+              container={container}
               popObject={{
                 title: container.name,
               }}
-              preferredThumbnail={preferredThumbnail}
-              childrenAttachmentIds={attachmentsIds}
-              onChangePreferredThumbnail={(currentPreferredThumbnail) => onChangePreferredThumbnail(
-                currentPreferredThumbnail
-              )}
+              onPreferredThumbnailChange={onPreferredThumbnailChange}
             />
           )
         }

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -18,18 +18,15 @@ const DEFAULT_UNAVAILABLE = '/images/wild_card/not_available.svg';
 const isValidImageSrc = (src) => typeof src === 'string' && src.length > 0;
 
 export default class ImageModal extends Component {
-  // Resolve effective inputs from `container` (analysis mode) or `attachment` (legacy).
+  // Resolve effective inputs from `container` (analysis mode) or `attachment` (single image).
   // Usable before `this` is set up (called from the constructor).
   static derive(props) {
     if (props.container) {
       const { previewAttachment, candidateIds, preferredId } = getContainerImageData(props.container);
       return { attachment: previewAttachment, candidateIds, preferredId };
     }
-    return {
-      attachment: props.attachment,
-      candidateIds: props.childrenAttachmentIds || [],
-      preferredId: props.preferredThumbnail ? Number(props.preferredThumbnail) : null,
-    };
+    // single-image mode (e.g. element table/list thumbnails): no carousel, no preferred
+    return { attachment: props.attachment, candidateIds: [], preferredId: null };
   }
 
   constructor(props) {
@@ -172,16 +169,12 @@ export default class ImageModal extends Component {
     }
   };
 
-  // explicit, separate action = persist preferred (shared across viewers).
-  // Accepts the new `onPreferredThumbnailChange` and the legacy `onChangePreferredThumbnail`
-  // (still emitted by element headers not yet migrated to the `container` prop).
+  // explicit, separate action = persist preferred (shared across viewers)
   handleSetPreferred = () => {
     const { selectedId, preferredId } = this.state;
     if (!selectedId || selectedId === preferredId) return;
-    const { onPreferredThumbnailChange, onChangePreferredThumbnail } = this.props;
-    const persist = onPreferredThumbnailChange || onChangePreferredThumbnail || (() => {});
     this.setState({ preferredId: selectedId });
-    persist(selectedId); // parent writes metadata + persists
+    this.props.onPreferredThumbnailChange(selectedId); // parent writes metadata + persists
     this.fetchPreviewThumbnail(); // refresh grey-area preview to the new preferred
   };
 
@@ -267,9 +260,11 @@ export default class ImageModal extends Component {
   render() {
     const { showPop, popObject, placement = 'right' } = this.props;
     const {
-      isPdf, isLoading, modalPreviewSrc, selectedId, preferredId,
+      isPdf, isLoading, modalPreviewSrc, selectedId, preferredId, thumbnails,
     } = this.state;
     const { attachment } = ImageModal.derive(this.props);
+    // Preferred selection only applies in analysis mode (a carousel of candidates exists).
+    const canSelectPreferred = thumbnails.length > 0;
     const canSetPreferred = selectedId && selectedId !== preferredId;
 
     if (showPop) {
@@ -330,17 +325,19 @@ export default class ImageModal extends Component {
                     />
                   )}
                 </div>
-                <div className="d-flex justify-content-center mt-2">
-                  <Button
-                    variant="primary"
-                    size="sm"
-                    disabled={!canSetPreferred}
-                    onClick={this.handleSetPreferred}
-                  >
-                    <i className="fa fa-star me-1" />
-                    {preferredId && selectedId === preferredId ? 'Preferred image' : 'Set as preferred'}
-                  </Button>
-                </div>
+                {canSelectPreferred && (
+                  <div className="d-flex justify-content-center mt-2">
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      disabled={!canSetPreferred}
+                      onClick={this.handleSetPreferred}
+                    >
+                      <i className="fa fa-star me-1" />
+                      {preferredId && selectedId === preferredId ? 'Preferred image' : 'Set as preferred'}
+                    </Button>
+                  </div>
+                )}
                 {this.renderCarousel()}
               </>
             )}
@@ -359,7 +356,7 @@ ImageModal.propTypes = {
     extended_metadata: PropTypes.shape({}),
   }),
   onPreferredThumbnailChange: PropTypes.func,
-  // legacy single-image mode (mutually exclusive with `container`)
+  // single-image mode (mutually exclusive with `container`): element table/list thumbnails
   attachment: PropTypes.shape({
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     filename: PropTypes.string,
@@ -372,13 +369,6 @@ ImageModal.propTypes = {
       preview: PropTypes.string,
     }),
   }),
-  // legacy analysis props (consumed via the static derive()/handleSetPreferred for element
-  // headers not yet migrated to the `container` prop)
-  // eslint-disable-next-line react/no-unused-prop-types
-  preferredThumbnail: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  // eslint-disable-next-line react/no-unused-prop-types
-  childrenAttachmentIds: PropTypes.arrayOf(PropTypes.number),
-  onChangePreferredThumbnail: PropTypes.func,
   popObject: PropTypes.shape({
     title: PropTypes.string,
   }).isRequired,
@@ -394,10 +384,7 @@ ImageModal.propTypes = {
 ImageModal.defaultProps = {
   container: null,
   attachment: null,
-  onPreferredThumbnailChange: null,
-  onChangePreferredThumbnail: null,
-  preferredThumbnail: null,
-  childrenAttachmentIds: [],
+  onPreferredThumbnailChange: () => { },
   placement: 'right',
   disableClick: false,
   imageStyle: {},

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -95,8 +95,13 @@ export default class ImageModal extends Component {
   handleModalShow(e) {
     if (this.props.disableClick) return;
     stopEvent(e);
-    const { attachment, preferredId } = ImageModal.derive(this.props);
-    const selectedId = preferredId || (attachment?.id ? Number(attachment.id) : null);
+    const { attachment, candidateIds, preferredId } = ImageModal.derive(this.props);
+    // Fall back to the first candidate so a PDF-only analysis (no thumbnailed default) still
+    // opens on a selectable attachment.
+    const selectedId = preferredId
+      || (attachment?.id ? Number(attachment.id) : null)
+      || candidateIds[0]
+      || null;
     this.setState({
       showModal: true, selectedId, preferredId, modalPreviewSrc: '',
     });

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -116,14 +116,11 @@ export default class ImageModal extends Component {
         (result) => {
           if (!result?.data) throw new Error('Attachment is not provided');
           const src = result.data;
-          // Only update modalPreviewSrc from fetchImage if no preferred thumbnail is active
-          this.setState((prevState) => ({
+          this.setState({
             fetchSrc: src,
             isPdf: result.type === 'application/pdf',
-            modalPreviewSrc: prevState.currentPreferredThumbnail
-              ? prevState.modalPreviewSrc
-              : src,
-          }));
+            modalPreviewSrc: src,
+          });
         }
       );
     } catch (error) {

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -37,9 +37,38 @@ export default class ImageModal extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.attachment?.id !== prevProps.attachment?.id) {
+    const { attachment, ChildrenAttachmentsIds, preferredThumbnail } = this.props;
+    const prevIds = prevProps.ChildrenAttachmentsIds || [];
+    const currIds = ChildrenAttachmentsIds || [];
+    // Attachment changed - refetch thumbnail
+    if (attachment?.id !== prevProps.attachment?.id) {
       this.fetchImageThumbnail();
     }
+    // Preferred thumbnail prop changed - sync state and refetch
+    if (preferredThumbnail !== prevProps.preferredThumbnail) {
+      this.setState({
+        currentPreferredThumbnail: preferredThumbnail ? Number(preferredThumbnail) : null
+      });
+      this.fetchImageThumbnail();
+    }
+    // ChildrenAttachmentsIds changed (attachment added/deleted) - refresh thumbnails
+    if (prevIds.length !== currIds.length || !prevIds.every((id, i) => id === currIds[i])) {
+      this.fetchThumbnails();
+      // If current preferred thumbnail is no longer in the list, clear it from state
+      const { currentPreferredThumbnail } = this.state;
+      if (currentPreferredThumbnail && !currIds.includes(currentPreferredThumbnail)) {
+        // Parent will handle reassigning; clear local state
+        this.setState({ currentPreferredThumbnail: null });
+        this.fetchImageThumbnail();
+      }
+    }
+  }
+
+  // Check if src is a valid displayable image source
+  isValidImageSrc(src) {
+    return typeof src === 'string'
+      && src.length > 0
+      && !src.includes('[object Object]');
   }
 
   // keyboard handler extracted from inline render for thumbnails
@@ -85,10 +114,12 @@ export default class ImageModal extends Component {
 
   buildImageSrcArrayFromThumbnails(thumbnails) {
     if (thumbnails && thumbnails.length > 0) {
-      return thumbnails.map(({ id, thumbnail }) => ({
-        id,
-        thumbnail: thumbnail ? `data:image/png;base64,${thumbnail}` : null
-      }));
+      return thumbnails.map(({ id, thumbnail }) => {
+        const src = (typeof thumbnail === 'string' && thumbnail.length > 0)
+          ? `data:image/png;base64,${thumbnail}`
+          : null;
+        return { id, thumbnail: src };
+      });
     }
     return [];
   }
@@ -150,7 +181,10 @@ export default class ImageModal extends Component {
 
     return (
       <Tooltip id="popObject" className="large-preview-modal">
-        <img src={thumbnail} alt={attachment?.filename} />
+        <img
+          src={this.isValidImageSrc(thumbnail) ? thumbnail : '/images/wild_card/not_available.svg'}
+          alt={attachment?.filename}
+        />
       </Tooltip>
     );
   }
@@ -221,7 +255,8 @@ export default class ImageModal extends Component {
                   }}
                 >
                   <img
-                    src={thumb.thumbnail || '/images/wild_card/no_attachment.svg'}
+                    src={this.isValidImageSrc(thumb.thumbnail)
+                      ? thumb.thumbnail : '/images/wild_card/no_attachment.svg'}
                     alt={`Thumbnail ${thumb.id}`}
                     className="img-thumbnail"
                     style={{
@@ -264,6 +299,7 @@ export default class ImageModal extends Component {
       fetchSrc,
       thumbnail,
     } = this.state;
+    const defaultUnavailable = '/images/wild_card/not_available.svg';
 
     if (showPop) {
       return (
@@ -285,7 +321,7 @@ export default class ImageModal extends Component {
             </div>
           ) : (
             <img
-              src={thumbnail}
+              src={this.isValidImageSrc(thumbnail) ? thumbnail : defaultUnavailable}
               alt={attachment?.filename}
               style={{ cursor: 'default', ...imageStyle }}
               onError={this.handleImageError}
@@ -325,7 +361,7 @@ export default class ImageModal extends Component {
               overlay={this.showPopObject()}
             >
               <img
-                src={thumbnail}
+                src={this.isValidImageSrc(thumbnail) ? thumbnail : defaultUnavailable}
                 alt={attachment?.filename}
                 style={{ ...imageStyle }}
                 role="button"
@@ -377,7 +413,7 @@ export default class ImageModal extends Component {
                   </div>
                 ) : (
                   <img
-                    src={this.state.fetchSrc}
+                    src={this.isValidImageSrc(fetchSrc) ? fetchSrc : defaultUnavailable}
                     style={{ maxHeight: '100%', maxWidth: '100%', display: 'block' }}
                     alt={attachment?.filename}
                     onError={this.handleImageError}

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -304,15 +304,6 @@ export default class ImageModal extends Component {
           role="button"
           tabIndex={0}
         >
-          <OverlayTrigger
-            placement={placement}
-            overlay={this.showPopObject()}
-          >
-            <img
-              src={thumbnail}
-              alt={attachment?.filename}
-            />
-          </OverlayTrigger>
           {this.state.isLoading ? (
             <div
               className="d-flex justify-content-center align-items-center"
@@ -329,12 +320,17 @@ export default class ImageModal extends Component {
               </div>
             </div>
           ) : (
-            <img
-              src={thumbnail}
-              alt={attachment?.filename}
-              style={{ ...imageStyle }}
-              role="button"
-            />
+            <OverlayTrigger
+              placement={placement}
+              overlay={this.showPopObject()}
+            >
+              <img
+                src={thumbnail}
+                alt={attachment?.filename}
+                style={{ ...imageStyle }}
+                role="button"
+              />
+            </OverlayTrigger>
           )}
         </div>
         <AppModal
@@ -363,17 +359,31 @@ export default class ImageModal extends Component {
                 </p>
               </iframe>
             ) : (
-              <img
-                src={fetchSrc}
-                style={{
-                  display: 'block',
-                  maxHeight: '80vh',
-                  maxWidth: '100%',
-                  margin: '0 auto'
-                }}
-                alt={attachment?.filename}
-                onError={this.handleImageError}
-              />
+              <div className="d-flex justify-content-center align-items-center mt-2">
+                {this.state.isLoading ? (
+                  <div
+                    className="d-flex justify-content-center align-items-center"
+                    style={{
+                      width: imageStyle?.width || 300,
+                      height: imageStyle?.height || 300,
+                      minWidth: 120,
+                      minHeight: 120,
+                      ...imageStyle
+                    }}
+                  >
+                    <div className="spinner-border text-primary" role="status">
+                      <span className="visually-hidden">Loading...</span>
+                    </div>
+                  </div>
+                ) : (
+                  <img
+                    src={this.state.fetchSrc}
+                    style={{ maxHeight: '100%', maxWidth: '100%', display: 'block' }}
+                    alt={attachment?.filename}
+                    onError={this.handleImageError}
+                  />
+                )}
+              </div>
             )}
           </div>
           <div>

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -1,421 +1,279 @@
-/* eslint-disable react/destructuring-assignment */
+/* eslint-disable react/destructuring-assignment, react/sort-comp */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {
-  OverlayTrigger, Tooltip, Button,
-} from 'react-bootstrap';
+import { OverlayTrigger, Tooltip, Button } from 'react-bootstrap';
 import AppModal from 'src/components/common/AppModal';
 import AttachmentFetcher from 'src/fetchers/AttachmentFetcher';
 import { stopEvent } from 'src/utilities/DomHelper';
-import { fetchImageSrcByAttachmentId } from 'src/utilities/imageHelper';
+import {
+  fetchImageSrcByAttachmentId,
+  getContainerImageData,
+} from 'src/utilities/imageHelper';
+
+const DEFAULT_NO_ATTACHMENT = '/images/wild_card/no_attachment.svg';
+const DEFAULT_UNAVAILABLE = '/images/wild_card/not_available.svg';
+
+// Valid, displayable image src. (The upstream `[object Object]` leak from
+// fetchImageSrcByAttachmentId's error path should be fixed there, not masked here.)
+const isValidImageSrc = (src) => typeof src === 'string' && src.length > 0;
 
 export default class ImageModal extends Component {
+  // Resolve effective inputs from `container` (analysis mode) or `attachment` (legacy).
+  // Usable before `this` is set up (called from the constructor).
+  static derive(props) {
+    if (props.container) {
+      const { previewAttachment, candidateIds, preferredId } = getContainerImageData(props.container);
+      return { attachment: previewAttachment, candidateIds, preferredId };
+    }
+    return {
+      attachment: props.attachment,
+      candidateIds: props.childrenAttachmentIds || [],
+      preferredId: props.preferredThumbnail ? Number(props.preferredThumbnail) : null,
+    };
+  }
+
   constructor(props) {
     super(props);
+    const { preferredId } = ImageModal.derive(props);
     this.state = {
-      fetchSrc: '',
       showModal: false,
       isPdf: false,
-      thumbnail: '',
-      thumbnails: [],
-      currentPreferredThumbnail: Number(props.preferredThumbnail) || null,
-      thumbPage: 0,
       isLoading: false,
-      // 'preview' = clicking thumbnail only previews it; 'select' = sets it as preferred
-      thumbMode: 'select',
-      // src shown in modal main image area (may differ from the saved preferred)
-      modalPreviewSrc: '',
+      thumbnail: '', // grey-area preview src (= preferred, else default)
+      thumbnails: [], // carousel: [{ id, thumbnail }]
+      preferredId, // persisted preferred id (shared across viewers)
+      selectedId: null, // currently previewed-large id (transient, not persisted)
+      modalPreviewSrc: '', // full-res src shown large in the modal main area
     };
 
-    this.fetchImage = this.fetchImage.bind(this);
-    this.handleModalClose = this.handleModalClose.bind(this);
     this.handleModalShow = this.handleModalShow.bind(this);
+    this.handleModalClose = this.handleModalClose.bind(this);
     this.handleImageError = this.handleImageError.bind(this);
-    this.fetchImageThumbnail = this.fetchImageThumbnail.bind(this);
+    this.fetchPreviewThumbnail = this.fetchPreviewThumbnail.bind(this);
   }
 
   componentDidMount() {
-    this.fetchImageThumbnail();
+    this.fetchPreviewThumbnail();
   }
 
   componentDidUpdate(prevProps) {
-    const { attachment, childrenAttachmentIds, preferredThumbnail } = this.props;
-    const prevIds = prevProps.childrenAttachmentIds || [];
-    const currIds = childrenAttachmentIds || [];
+    const prev = ImageModal.derive(prevProps);
+    const curr = ImageModal.derive(this.props);
 
-    const attachmentChanged = attachment?.id !== prevProps.attachment?.id;
-    const preferredChanged = preferredThumbnail !== prevProps.preferredThumbnail;
-    const idsChanged = prevIds.length !== currIds.length
-      || !prevIds.every((id, i) => id === currIds[i]);
+    const attachmentChanged = prev.attachment?.id !== curr.attachment?.id;
+    const preferredChanged = prev.preferredId !== curr.preferredId;
+    const idsChanged = prev.candidateIds.length !== curr.candidateIds.length
+      || !prev.candidateIds.every((id, i) => id === curr.candidateIds[i]);
 
-    if (preferredChanged) {
-      this.setState({
-        currentPreferredThumbnail: preferredThumbnail ? Number(preferredThumbnail) : null
-      });
-    }
-
-    if (idsChanged) {
-      this.fetchThumbnails();
-      const { currentPreferredThumbnail } = this.state;
-      if (currentPreferredThumbnail && !currIds.includes(currentPreferredThumbnail)) {
-        this.setState({ currentPreferredThumbnail: null });
-      }
-    }
-
-    if (attachmentChanged || preferredChanged || idsChanged) {
-      this.fetchImageThumbnail();
-    }
+    if (preferredChanged) this.setState({ preferredId: curr.preferredId });
+    if (attachmentChanged || preferredChanged || idsChanged) this.fetchPreviewThumbnail();
   }
 
-  // Check if src is a valid displayable image source
-  isValidImageSrc(src) {
-    return typeof src === 'string'
-      && src.length > 0
-      && !src.includes('[object Object]');
+  handleImageError() {
+    this.setState({ modalPreviewSrc: DEFAULT_UNAVAILABLE });
   }
-
-  // keyboard handler extracted from inline render for thumbnails
-  handleThumbKeyDown = (e, thumb) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      this.handleThumbClick(thumb);
-    }
-  };
 
   handleModalClose(e) {
     stopEvent(e);
+    // Pure no-op on cancel: nothing is mutated or persisted by previewing.
     this.setState({ showModal: false });
   }
 
   handleModalShow(e) {
-    if (!this.props.disableClick) {
-      stopEvent(e);
-      // Sync currentPreferredThumbnail with prop when modal opens
-      const { preferredThumbnail } = this.props;
-      this.setState((prevState) => ({
-        showModal: true,
-        currentPreferredThumbnail: preferredThumbnail ? Number(preferredThumbnail) : null,
-        // Reset modal preview to current thumbnail so preferred image shows immediately
-        modalPreviewSrc: prevState.thumbnail || '',
-        thumbMode: 'select',
-      }));
-      this.fetchImage();
-      this.fetchThumbnails();
-    }
+    if (this.props.disableClick) return;
+    stopEvent(e);
+    const { attachment, preferredId } = ImageModal.derive(this.props);
+    const selectedId = preferredId || (attachment?.id ? Number(attachment.id) : null);
+    this.setState({
+      showModal: true, selectedId, preferredId, modalPreviewSrc: '',
+    });
+    this.fetchCarouselThumbnails();
+    if (selectedId) this.fetchLargeImage(selectedId);
   }
 
-  handleImageError() {
-    this.setState({ fetchSrc: '/images/wild_card/not_available.svg' });
-  }
-
-  fetchImage() {
+  // grey-area preview (preferred, else default attachment)
+  async fetchPreviewThumbnail() {
+    const { attachment, preferredId } = ImageModal.derive(this.props);
     try {
-      const { attachment } = this.props;
-      if (!attachment) throw new Error('Attachment is not provided');
-      AttachmentFetcher.fetchImageAttachment({ id: attachment.id }).then(
-        (result) => {
-          if (!result?.data) throw new Error('Attachment is not provided');
-          const src = result.data;
-          // Only update modalPreviewSrc from fetchImage if no preferred thumbnail is active
-          this.setState((prevState) => ({
-            fetchSrc: src,
-            isPdf: result.type === 'application/pdf',
-            modalPreviewSrc: prevState.currentPreferredThumbnail
-              ? prevState.modalPreviewSrc
-              : src,
-          }));
-        }
-      );
-    } catch (error) {
-      this.handleImageError();
-    }
-  }
-
-  buildImageSrcArrayFromThumbnails(thumbnails) {
-    if (thumbnails && thumbnails.length > 0) {
-      return thumbnails.map(({ id, thumbnail }) => {
-        const src = (typeof thumbnail === 'string' && thumbnail.length > 0)
-          ? `data:image/png;base64,${thumbnail}`
-          : null;
-        return { id, thumbnail: src };
-      });
-    }
-    return [];
-  }
-
-  fetchThumbnails() {
-    const { childrenAttachmentIds } = this.props;
-    // Filter to ensure only valid numeric IDs are sent to the API
-    const validIds = (childrenAttachmentIds || []).filter(
-      (id) => typeof id === 'number' && !Number.isNaN(id) && id > 0
-    );
-    if (validIds.length > 0) {
-      AttachmentFetcher.fetchThumbnails(validIds)
-        .then((result) => {
-          this.setState({ thumbnails: this.buildImageSrcArrayFromThumbnails(result.thumbnails) });
-        })
-        .catch((err) => {
-          console.error('Failed to fetch thumbnails', err);
-          this.setState({ thumbnails: [] });
-        });
-    } else {
-      // Clear thumbnails when no valid attachment IDs exist
-      this.setState({ thumbnails: [] });
-    }
-  }
-
-  async fetchImageThumbnail() {
-    const { attachment, preferredThumbnail, childrenAttachmentIds } = this.props;
-    const fileType = attachment?.file?.type;
-    const isImage = fileType?.startsWith('image/');
-    const defaultNoAttachment = '/images/wild_card/no_attachment.svg';
-    const defaultUnavailable = '/images/wild_card/not_available.svg';
-
-    // Validate preferredThumbnail is still in the list of valid attachment IDs
-    const preferredId = Number(preferredThumbnail);
-    const isPreferredValid = preferredThumbnail
-      && !Number.isNaN(preferredId)
-      && preferredId > 0
-      && (childrenAttachmentIds || []).includes(preferredId);
-
-    // render image of preferred attachment thumbnail if available and valid
-    if (isPreferredValid) {
-      this.setState({ isLoading: true });
-      try {
-        const src = await fetchImageSrcByAttachmentId(preferredThumbnail);
-        this.setState({
-          thumbnail: src,
-          fetchSrc: src,
-          modalPreviewSrc: src,
-          isLoading: false,
-        });
+      if (preferredId) {
+        const src = await fetchImageSrcByAttachmentId(preferredId);
+        this.setState({ thumbnail: src });
         return;
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error('Failed to fetch preferred thumbnail', err);
-        this.setState({ isLoading: false });
       }
-    }
-
-    try {
       if (attachment?.thumb) {
         const src = await fetchImageSrcByAttachmentId(attachment.id);
         this.setState({ thumbnail: src });
       } else if (attachment?.is_new || attachment?.is_pending) {
-        const previewSrc = isImage ? attachment?.file?.preview : defaultUnavailable;
-        this.setState({ thumbnail: previewSrc });
+        const isImage = attachment?.file?.type?.startsWith('image/');
+        this.setState({ thumbnail: isImage ? attachment?.file?.preview : DEFAULT_UNAVAILABLE });
       } else {
-        this.setState({ thumbnail: defaultNoAttachment });
+        this.setState({ thumbnail: DEFAULT_NO_ATTACHMENT });
       }
     } catch (err) {
       // eslint-disable-next-line no-console
-      console.error('Failed to fetch image thumbnail', err);
-      this.setState({ thumbnail: defaultUnavailable, isLoading: false });
+      console.error('Failed to fetch preview thumbnail', err);
+      this.setState({ thumbnail: DEFAULT_UNAVAILABLE });
     }
   }
 
+  // carousel of all selectable thumbnails
+  fetchCarouselThumbnails() {
+    const { candidateIds } = ImageModal.derive(this.props);
+    if (!candidateIds.length) {
+      this.setState({ thumbnails: [] });
+      return;
+    }
+    AttachmentFetcher.fetchThumbnails(candidateIds)
+      .then((result) => {
+        const thumbnails = (result.thumbnails || []).map(({ id, thumbnail }) => ({
+          id,
+          thumbnail: (typeof thumbnail === 'string' && thumbnail.length > 0)
+            ? `data:image/png;base64,${thumbnail}`
+            : null,
+        }));
+        this.setState({ thumbnails });
+      })
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error('Failed to fetch thumbnails', err);
+        this.setState({ thumbnails: [] });
+      });
+  }
+
+  // full-resolution large display of the selected image; the spinner covers the load.
+  fetchLargeImage(id) {
+    this.setState({ isLoading: true, isPdf: false });
+    AttachmentFetcher.fetchImageAttachment({ id })
+      .then((result) => {
+        if (!result?.data) throw new Error('No image data');
+        this.setState({
+          modalPreviewSrc: result.data,
+          isPdf: result.type === 'application/pdf',
+          isLoading: false,
+        });
+      })
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error('Failed to fetch full image', err);
+        this.setState({ isLoading: false, modalPreviewSrc: DEFAULT_UNAVAILABLE });
+      });
+  }
+
+  // click a thumbnail = preview large only; never persists
+  handleSelectThumbnail = (thumb) => {
+    this.setState({ selectedId: thumb.id });
+    this.fetchLargeImage(thumb.id);
+  };
+
+  handleThumbKeyDown = (e, thumb) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      this.handleSelectThumbnail(thumb);
+    }
+  };
+
+  // explicit, separate action = persist preferred (shared across viewers).
+  // Accepts the new `onPreferredThumbnailChange` and the legacy `onChangePreferredThumbnail`
+  // (still emitted by element headers not yet migrated to the `container` prop).
+  handleSetPreferred = () => {
+    const { selectedId, preferredId } = this.state;
+    if (!selectedId || selectedId === preferredId) return;
+    const { onPreferredThumbnailChange, onChangePreferredThumbnail } = this.props;
+    const persist = onPreferredThumbnailChange || onChangePreferredThumbnail || (() => {});
+    this.setState({ preferredId: selectedId });
+    persist(selectedId); // parent writes metadata + persists
+    this.fetchPreviewThumbnail(); // refresh grey-area preview to the new preferred
+  };
+
   showPopObject() {
     const { thumbnail } = this.state;
-    const { attachment } = this.props;
-
+    const { attachment } = ImageModal.derive(this.props);
     return (
       <Tooltip id="popObject" className="large-preview-modal">
         <img
-          src={this.isValidImageSrc(thumbnail) ? thumbnail : '/images/wild_card/not_available.svg'}
+          src={isValidImageSrc(thumbnail) ? thumbnail : DEFAULT_UNAVAILABLE}
           alt={attachment?.filename}
         />
       </Tooltip>
     );
   }
 
-  handleSetPreferred = (thumb) => {
-    const { onChangePreferredThumbnail } = this.props;
-    this.setState({
-      currentPreferredThumbnail: thumb.id,
-      thumbnail: thumb.thumbnail,
-      modalPreviewSrc: thumb.thumbnail,
-    });
-    if (thumb.id !== this.state.currentPreferredThumbnail) {
-      onChangePreferredThumbnail(thumb.id);
-    }
-  };
-
-  // Handles thumbnail click depending on current mode
-  handleThumbClick = (thumb) => {
-    const { thumbMode } = this.state;
-    if (thumbMode === 'select') {
-      this.handleSetPreferred(thumb);
-    } else {
-      // preview mode: only update the modal preview image, do not change preferred
-      this.setState({ modalPreviewSrc: thumb.thumbnail });
-    }
-  };
-
-  handleThumbPage = (delta) => {
-    const { thumbPage, thumbnails } = this.state;
-    const thumbnailsPerPage = 6;
-    const totalThumbPages = Math.ceil((thumbnails?.length || 0) / thumbnailsPerPage);
-    const newPage = thumbPage + delta;
-    if (newPage >= 0 && newPage < totalThumbPages) {
-      this.setState({ thumbPage: newPage });
-    }
-  };
-
-  renderAttachmentsThumbnails = () => {
-    const {
-      thumbnails: allThumbnails, currentPreferredThumbnail, thumbPage, thumbMode,
-    } = this.state;
-    const thumbnailsPerPage = 6;
-    const totalThumbPages = Math.ceil((allThumbnails?.length || 0) / thumbnailsPerPage);
-    const currentThumbs = (allThumbnails || [])
-      .slice(
-        thumbPage * thumbnailsPerPage,
-        (thumbPage + 1) * thumbnailsPerPage
-      );
-
-    if (!allThumbnails || allThumbnails.length === 0) return null;
-
+  renderCarousel() {
+    const { thumbnails, selectedId, preferredId } = this.state;
+    if (!thumbnails.length) return null;
     return (
-      <div className="mt-3 pt-2">
-        {/* Mode toggle */}
-        <div className="d-flex align-items-center justify-content-center gap-2 mb-2">
-          <span className="text-muted small">Thumbnail mode:</span>
-          <div className="btn-group btn-group-sm" role="group" aria-label="Thumbnail mode">
-            <button
-              type="button"
-              className={`btn ${thumbMode === 'preview' ? 'btn-primary' : 'btn-outline-secondary'}`}
-              onClick={() => this.setState({ thumbMode: 'preview' })}
-              title="Click a thumbnail to preview it without changing the preferred selection"
+      <div className="d-flex flex-row flex-nowrap overflow-auto gap-2 justify-content-center mt-3 pt-2">
+        {thumbnails.map((thumb) => {
+          const isPreferred = thumb.id === preferredId;
+          const isSelected = thumb.id === selectedId;
+          const cls = isSelected ? 'border-2 border-primary' : 'border border-secondary';
+          return (
+            <div
+              key={thumb.id}
+              className={`d-flex flex-column align-items-center p-1 rounded bg-white ${cls}`}
+              style={{
+                cursor: 'pointer', minWidth: 64, height: 90,
+              }}
+              role="button"
+              tabIndex={0}
+              title={isPreferred ? 'Current preferred image' : 'Click to preview'}
+              onClick={() => this.handleSelectThumbnail(thumb)}
+              onKeyDown={(e) => this.handleThumbKeyDown(e, thumb)}
             >
-              <i className="fa fa-eye me-1" />
-              Preview only
-            </button>
-            <button
-              type="button"
-              className={`btn ${thumbMode === 'select' ? 'btn-primary' : 'btn-outline-secondary'}`}
-              onClick={() => this.setState({ thumbMode: 'select' })}
-              title="Click a thumbnail to set it as the preferred display image"
-            >
-              <i className="fa fa-star me-1" />
-              Set preferred
-            </button>
-          </div>
-        </div>
-
-        {/* Thumbnail strip */}
-        <div className="d-flex align-items-center justify-content-center">
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => this.handleThumbPage(-1)}
-            disabled={thumbPage === 0}
-            className="me-2 flex-shrink-0"
-          >
-            <i className="fa fa-chevron-left" />
-          </Button>
-          <div className="d-flex flex-row flex-nowrap overflow-auto gap-2">
-            {currentThumbs.map((thumb) => {
-              const isPreferred = thumb.id === currentPreferredThumbnail;
-              const cardClass = isPreferred
-                ? 'border-2 border-info bg-info-subtle'
-                : 'border border-secondary bg-white';
-              let modeTitle;
-              if (thumbMode === 'select') {
-                modeTitle = isPreferred ? 'Current preferred thumbnail'
-                  : 'Set as preferred display thumbnail by selecting this image using set preferred mode';
-              } else {
-                modeTitle = 'Preview this image';
-              }
-              return (
-                <div
-                  key={thumb.id}
-                  className={`d-flex flex-column align-items-center justify-content-center p-1 rounded ${cardClass}`}
-                  style={{
-                    cursor: 'pointer', minWidth: 64, minHeight: 90, maxWidth: 70, height: 80,
-                  }}
-                  title={modeTitle}
-                  role="button"
-                  tabIndex={0}
-                  onClick={() => this.handleThumbClick(thumb)}
-                  onKeyDown={(e) => this.handleThumbKeyDown(e, thumb)}
-                >
-                  <img
-                    src={this.isValidImageSrc(thumb.thumbnail)
-                      ? thumb.thumbnail : '/images/wild_card/no_attachment.svg'}
-                    alt={`Thumbnail ${thumb.id}`}
-                    className="img-thumbnail"
-                    style={{
-                      width: 60, height: 60, objectFit: 'cover', display: 'block',
-                    }}
-                  />
-                  {isPreferred && (
-                    <div className="text-primary small mt-1" style={{ fontSize: '0.65rem' }}>
-                      <i className="fa fa-star me-1" />
-                      Preferred
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => this.handleThumbPage(1)}
-            disabled={thumbPage >= totalThumbPages - 1}
-            className="ms-2 flex-shrink-0"
-          >
-            <i className="fa fa-chevron-right" />
-          </Button>
-        </div>
+              <img
+                src={isValidImageSrc(thumb.thumbnail) ? thumb.thumbnail : DEFAULT_NO_ATTACHMENT}
+                alt={`Thumbnail ${thumb.id}`}
+                style={{ width: 60, height: 60, objectFit: 'cover' }}
+              />
+              {isPreferred && (
+                <span className="text-primary" style={{ fontSize: '0.65rem' }}>
+                  <i className="fa fa-star me-1" />
+                  Preferred
+                </span>
+              )}
+            </div>
+          );
+        })}
       </div>
     );
-  };
+  }
 
-  render() {
-    const {
-      showPop,
-      popObject,
-      imageStyle,
-      attachment,
-      placement = 'right'
-    } = this.props;
-    const {
-      isPdf,
-      fetchSrc,
-      thumbnail,
-      modalPreviewSrc,
-    } = this.state;
-    const defaultUnavailable = '/images/wild_card/not_available.svg';
-
-    if (showPop) {
+  renderPreviewBox() {
+    const { isLoading, thumbnail } = this.state;
+    const { imageStyle } = this.props;
+    const { attachment } = ImageModal.derive(this.props);
+    if (isLoading) {
       return (
-        <div className="preview-table">
-          {this.state.isLoading ? (
-            <div
-              className="d-flex justify-content-center align-items-center"
-              style={{
-                width: imageStyle?.width || 120,
-                height: imageStyle?.height || 120,
-                minWidth: 60,
-                minHeight: 60,
-                ...imageStyle
-              }}
-            >
-              <div className="spinner-border text-primary" role="status">
-                <span className="visually-hidden">Loading...</span>
-              </div>
-            </div>
-          ) : (
-            <img
-              src={this.isValidImageSrc(thumbnail) ? thumbnail : defaultUnavailable}
-              alt={attachment?.filename}
-              style={{ cursor: 'default', ...imageStyle }}
-              onError={this.handleImageError}
-            />
-          )}
+        <div
+          className="d-flex justify-content-center align-items-center"
+          style={{ width: imageStyle?.width || 120, height: imageStyle?.height || 120, ...imageStyle }}
+        >
+          <div className="spinner-border text-primary" role="status">
+            <span className="visually-hidden">Loading...</span>
+          </div>
         </div>
       );
+    }
+    return (
+      <img
+        src={isValidImageSrc(thumbnail) ? thumbnail : DEFAULT_UNAVAILABLE}
+        alt={attachment?.filename}
+        style={{ ...imageStyle }}
+        onError={this.handleImageError}
+      />
+    );
+  }
+
+  render() {
+    const { showPop, popObject, placement = 'right' } = this.props;
+    const {
+      isPdf, isLoading, modalPreviewSrc, selectedId, preferredId,
+    } = this.state;
+    const { attachment } = ImageModal.derive(this.props);
+    const canSetPreferred = selectedId && selectedId !== preferredId;
+
+    if (showPop) {
+      return <div className="preview-table">{this.renderPreviewBox()}</div>;
     }
 
     return (
@@ -427,35 +285,13 @@ export default class ImageModal extends Component {
           role="button"
           tabIndex={0}
         >
-          {this.state.isLoading ? (
-            <div
-              className="d-flex justify-content-center align-items-center"
-              style={{
-                width: imageStyle?.width || 120,
-                height: imageStyle?.height || 120,
-                minWidth: 60,
-                minHeight: 60,
-                ...imageStyle
-              }}
-            >
-              <div className="spinner-border text-primary" role="status">
-                <span className="visually-hidden">Loading...</span>
-              </div>
-            </div>
-          ) : (
-            <OverlayTrigger
-              placement={placement}
-              overlay={this.showPopObject()}
-            >
-              <img
-                src={this.isValidImageSrc(thumbnail) ? thumbnail : defaultUnavailable}
-                alt={attachment?.filename}
-                style={{ ...imageStyle }}
-                role="button"
-              />
+          {isLoading ? this.renderPreviewBox() : (
+            <OverlayTrigger placement={placement} overlay={this.showPopObject()}>
+              {this.renderPreviewBox()}
             </OverlayTrigger>
           )}
         </div>
+
         <AppModal
           title={popObject.title}
           show={this.state.showModal}
@@ -465,45 +301,49 @@ export default class ImageModal extends Component {
           closeLabel="Close"
           showFooter
         >
-          <div style={{ overflow: 'auto', position: 'relative', minHeight: '400px' }}>
-            {isPdf && fetchSrc ? (
+          <div style={{ overflow: 'auto', position: 'relative', minHeight: 400 }}>
+            {isPdf && modalPreviewSrc ? (
               <iframe
-                src={fetchSrc}
+                src={modalPreviewSrc}
                 width="100%"
                 height="500px"
                 style={{ border: 'none' }}
                 title="PDF Viewer"
-              >
-                <p>
-                  Your browser does not support PDFs.
-                  <a href={fetchSrc} target="_blank" rel="noopener noreferrer">
-                    Download the PDF
-                  </a>
-                </p>
-              </iframe>
+              />
             ) : (
-              <div
-                className="d-flex justify-content-center align-items-center bg-light rounded"
-                style={{ minHeight: 300, maxHeight: 420 }}
-              >
-                {this.state.isLoading ? (
-                  <div className="spinner-border text-primary" role="status">
-                    <span className="visually-hidden">Loading...</span>
-                  </div>
-                ) : (
-                  <img
-                    src={this.isValidImageSrc(modalPreviewSrc) ? modalPreviewSrc : defaultUnavailable}
-                    className="img-fluid"
-                    style={{ maxHeight: 400, objectFit: 'contain' }}
-                    alt={attachment?.filename}
-                    onError={this.handleImageError}
-                  />
-                )}
-              </div>
+              <>
+                <div
+                  className="d-flex justify-content-center align-items-center bg-light rounded position-relative"
+                  style={{ minHeight: 300, maxHeight: 420 }}
+                >
+                  {isLoading ? (
+                    <div className="spinner-border text-primary" role="status">
+                      <span className="visually-hidden">Loading...</span>
+                    </div>
+                  ) : (
+                    <img
+                      src={isValidImageSrc(modalPreviewSrc) ? modalPreviewSrc : DEFAULT_UNAVAILABLE}
+                      className="img-fluid"
+                      style={{ maxHeight: 400, objectFit: 'contain' }}
+                      alt={attachment?.filename}
+                      onError={this.handleImageError}
+                    />
+                  )}
+                </div>
+                <div className="d-flex justify-content-center mt-2">
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    disabled={!canSetPreferred}
+                    onClick={this.handleSetPreferred}
+                  >
+                    <i className="fa fa-star me-1" />
+                    {preferredId && selectedId === preferredId ? 'Preferred image' : 'Set as preferred'}
+                  </Button>
+                </div>
+                {this.renderCarousel()}
+              </>
             )}
-          </div>
-          <div>
-            {this.renderAttachmentsThumbnails()}
           </div>
         </AppModal>
       </div>
@@ -512,6 +352,14 @@ export default class ImageModal extends Component {
 }
 
 ImageModal.propTypes = {
+  // analysis mode (preferred): everything is derived from the container
+  container: PropTypes.shape({
+    name: PropTypes.string,
+    children: PropTypes.arrayOf(PropTypes.shape({})),
+    extended_metadata: PropTypes.shape({}),
+  }),
+  onPreferredThumbnailChange: PropTypes.func,
+  // legacy single-image mode (mutually exclusive with `container`)
   attachment: PropTypes.shape({
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     filename: PropTypes.string,
@@ -522,27 +370,36 @@ ImageModal.propTypes = {
     file: PropTypes.shape({
       type: PropTypes.string,
       preview: PropTypes.string,
-    })
+    }),
   }),
+  // legacy analysis props (consumed via the static derive()/handleSetPreferred for element
+  // headers not yet migrated to the `container` prop)
+  // eslint-disable-next-line react/no-unused-prop-types
+  preferredThumbnail: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  // eslint-disable-next-line react/no-unused-prop-types
+  childrenAttachmentIds: PropTypes.arrayOf(PropTypes.number),
+  onChangePreferredThumbnail: PropTypes.func,
   popObject: PropTypes.shape({
     title: PropTypes.string,
   }).isRequired,
   placement: PropTypes.string,
   disableClick: PropTypes.bool,
-  imageStyle: PropTypes.object,
-  preferredThumbnail: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  childrenAttachmentIds: PropTypes.arrayOf(PropTypes.number),
-  onChangePreferredThumbnail: PropTypes.func,
+  imageStyle: PropTypes.shape({
+    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  }),
   showPop: PropTypes.bool,
 };
 
 ImageModal.defaultProps = {
-  imageStyle: {},
+  container: null,
   attachment: null,
-  disableClick: false,
+  onPreferredThumbnailChange: null,
+  onChangePreferredThumbnail: null,
   preferredThumbnail: null,
   childrenAttachmentIds: [],
-  onChangePreferredThumbnail: () => { },
   placement: 'right',
+  disableClick: false,
+  imageStyle: {},
   showPop: false,
 };

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -2,7 +2,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
-  OverlayTrigger, Tooltip
+  OverlayTrigger, Tooltip, Button,
 } from 'react-bootstrap';
 import AppModal from 'src/components/common/AppModal';
 import AttachmentFetcher from 'src/fetchers/AttachmentFetcher';
@@ -529,9 +529,10 @@ ImageModal.propTypes = {
   placement: PropTypes.string,
   disableClick: PropTypes.bool,
   imageStyle: PropTypes.object,
-  preferredThumbnail: PropTypes.string,
+  preferredThumbnail: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   ChildrenAttachmentsIds: PropTypes.arrayOf(PropTypes.number),
   onChangePreferredThumbnail: PropTypes.func,
+  showPop: PropTypes.bool,
 };
 
 ImageModal.defaultProps = {
@@ -540,8 +541,6 @@ ImageModal.defaultProps = {
   preferredThumbnail: null,
   ChildrenAttachmentsIds: [],
   onChangePreferredThumbnail: () => { },
-};
-
-ImageModal.defaultProps = {
   placement: 'right',
+  showPop: false,
 };

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -20,8 +20,9 @@ export default class ImageModal extends Component {
       numOfPages: 0,
       thumbnail: '',
       thumbnails: [],
-      currentPreferredThumbnail: props.preferredThumbnail || null,
+      currentPreferredThumbnail: Number(props.preferredThumbnail) || null,
       thumbPage: 0,
+      isLoading: false,
     };
 
     this.fetchImage = this.fetchImage.bind(this);
@@ -95,27 +96,6 @@ export default class ImageModal extends Component {
     }
   }
 
-  buildImageSrcArrayFromThumbnails(thumbnails) {
-    console.log(thumbnails);
-    if (thumbnails && thumbnails.length > 0) {
-      return thumbnails.map(({ id, thumbnail }) => ({
-        id,
-        thumbnail: thumbnail ? `data:image/png;base64,${thumbnail}` : null
-      }));
-    }
-    return [];
-  }
-
-  fetchThumbnails() {
-    const { ChildrenAttachmentsIds } = this.props;
-    console.log('ChildrenAttachmentsIds', ChildrenAttachmentsIds);
-    if (ChildrenAttachmentsIds && ChildrenAttachmentsIds.length > 0) {
-      AttachmentFetcher.fetchThumbnails(ChildrenAttachmentsIds).then((result) => {
-        this.setState({ thumbnails: this.buildImageSrcArrayFromThumbnails(result.thumbnails) });
-      });
-    }
-  }
-
   async fetchImageThumbnail() {
     const { attachment, preferredThumbnail } = this.props;
     const fileType = attachment?.file?.type;
@@ -124,8 +104,9 @@ export default class ImageModal extends Component {
     const defaultUnavailable = '/images/wild_card/not_available.svg';
     // render image of preferred attachment thumbnail if available
     if (preferredThumbnail) {
+      this.setState({ isLoading: true });
       const src = await fetchImageSrcByAttachmentId(preferredThumbnail);
-      this.setState({ thumbnail: src, fetchSrc: src });
+      this.setState({ thumbnail: src, fetchSrc: src, isLoading: false });
       return;
     }
     if (attachment?.thumb) {
@@ -152,9 +133,10 @@ export default class ImageModal extends Component {
 
   handleSetPreferred = (thumb) => {
     const { onChangePreferredThumbnail } = this.props;
-    const { currentPreferredThumbnail } = this.state;
     this.setState({ currentPreferredThumbnail: thumb.id, thumbnail: thumb.thumbnail });
-    onChangePreferredThumbnail(currentPreferredThumbnail);
+    if (thumb.id !== this.state.currentPreferredThumbnail) {
+      onChangePreferredThumbnail(thumb.id);
+    }
   };
 
   handleThumbPage = (delta) => {
@@ -194,7 +176,7 @@ export default class ImageModal extends Component {
                 <div
                   key={thumb.id}
                   className={`d-flex flex-column align-items-center justify-content-center p-1 rounded
-                    ${thumb.id === currentPreferredThumbnail
+                      ${thumb.id === currentPreferredThumbnail
                     ? 'border-2 border-info bg-info-subtle' : 'border border-secondary bg-white'}`}
                   style={{
                     cursor: 'pointer',
@@ -210,8 +192,9 @@ export default class ImageModal extends Component {
                   role="button"
                   tabIndex={0}
                   onClick={() => this.handleSetPreferred(thumb)}
-                  onKeyPress={(e) => {
+                  onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
                       this.handleSetPreferred(thumb);
                     }
                   }}
@@ -259,21 +242,34 @@ export default class ImageModal extends Component {
       isPdf,
       fetchSrc,
       thumbnail,
-      thumbnails,
     } = this.state;
-    console.log(thumbnail);
-    console.log("hamada");
-    console.log(this.state.fetchSrc);
 
     if (showPop) {
       return (
         <div className="preview-table">
-          <img
-            src={thumbnail}
-            alt={attachment?.filename}
-            style={{ cursor: 'default', ...imageStyle }}
-            onError={this.handleImageError}
-          />
+          {this.state.isLoading ? (
+            <div
+              className="d-flex justify-content-center align-items-center"
+              style={{
+                width: imageStyle?.width || 120,
+                height: imageStyle?.height || 120,
+                minWidth: 60,
+                minHeight: 60,
+                ...imageStyle
+              }}
+            >
+              <div className="spinner-border text-primary" role="status">
+                <span className="visually-hidden">Loading...</span>
+              </div>
+            </div>
+          ) : (
+            <img
+              src={thumbnail}
+              alt={attachment?.filename}
+              style={{ cursor: 'default', ...imageStyle }}
+              onError={this.handleImageError}
+            />
+          )}
         </div>
       );
     }
@@ -296,6 +292,29 @@ export default class ImageModal extends Component {
               alt={attachment?.filename}
             />
           </OverlayTrigger>
+          {this.state.isLoading ? (
+            <div
+              className="d-flex justify-content-center align-items-center"
+              style={{
+                width: imageStyle?.width || 120,
+                height: imageStyle?.height || 120,
+                minWidth: 60,
+                minHeight: 60,
+                ...imageStyle
+              }}
+            >
+              <div className="spinner-border text-primary" role="status">
+                <span className="visually-hidden">Loading...</span>
+              </div>
+            </div>
+          ) : (
+            <img
+              src={thumbnail}
+              alt={attachment?.filename}
+              style={{ ...imageStyle }}
+              role="button"
+            />
+          )}
         </div>
         <AppModal
           title={popObject.title}
@@ -374,6 +393,7 @@ ImageModal.defaultProps = {
   disableClick: false,
   preferredThumbnail: null,
   ChildrenAttachmentsIds: [],
+  onChangePreferredThumbnail: () => { },
 };
 
 ImageModal.defaultProps = {

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -116,11 +116,14 @@ export default class ImageModal extends Component {
         (result) => {
           if (!result?.data) throw new Error('Attachment is not provided');
           const src = result.data;
-          this.setState({
+          // Only update modalPreviewSrc from fetchImage if no preferred thumbnail is active
+          this.setState((prevState) => ({
             fetchSrc: src,
             isPdf: result.type === 'application/pdf',
-            modalPreviewSrc: src,
-          });
+            modalPreviewSrc: prevState.currentPreferredThumbnail
+              ? prevState.modalPreviewSrc
+              : src,
+          }));
         }
       );
     } catch (error) {
@@ -537,7 +540,6 @@ ImageModal.defaultProps = {
   imageStyle: {},
   attachment: null,
   disableClick: false,
-  attachment: null,
   preferredThumbnail: null,
   childrenAttachmentIds: [],
   onChangePreferredThumbnail: () => { },

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -87,9 +87,14 @@ export default class ImageModal extends Component {
   handleModalShow(e) {
     if (!this.props.disableClick) {
       stopEvent(e);
+      // Sync currentPreferredThumbnail with prop when modal opens
+      const { preferredThumbnail } = this.props;
+      this.setState({
+        showModal: true,
+        currentPreferredThumbnail: preferredThumbnail ? Number(preferredThumbnail) : null,
+      });
       this.fetchImage();
       this.fetchThumbnails();
-      this.setState({ showModal: true });
     }
   }
 
@@ -126,8 +131,12 @@ export default class ImageModal extends Component {
 
   fetchThumbnails() {
     const { ChildrenAttachmentsIds } = this.props;
-    if (ChildrenAttachmentsIds && ChildrenAttachmentsIds.length > 0) {
-      AttachmentFetcher.fetchThumbnails(ChildrenAttachmentsIds)
+    // Filter to ensure only valid numeric IDs are sent to the API
+    const validIds = (ChildrenAttachmentsIds || []).filter(
+      (id) => typeof id === 'number' && !Number.isNaN(id) && id > 0
+    );
+    if (validIds.length > 0) {
+      AttachmentFetcher.fetchThumbnails(validIds)
         .then((result) => {
           this.setState({ thumbnails: this.buildImageSrcArrayFromThumbnails(result.thumbnails) });
         })
@@ -135,17 +144,28 @@ export default class ImageModal extends Component {
           console.error('Failed to fetch thumbnails', err);
           this.setState({ thumbnails: [] });
         });
+    } else {
+      // Clear thumbnails when no valid attachment IDs exist
+      this.setState({ thumbnails: [] });
     }
   }
 
   async fetchImageThumbnail() {
-    const { attachment, preferredThumbnail } = this.props;
+    const { attachment, preferredThumbnail, ChildrenAttachmentsIds } = this.props;
     const fileType = attachment?.file?.type;
     const isImage = fileType?.startsWith('image/');
     const defaultNoAttachment = '/images/wild_card/no_attachment.svg';
     const defaultUnavailable = '/images/wild_card/not_available.svg';
-    // render image of preferred attachment thumbnail if available
-    if (preferredThumbnail) {
+
+    // Validate preferredThumbnail is still in the list of valid attachment IDs
+    const preferredId = Number(preferredThumbnail);
+    const isPreferredValid = preferredThumbnail
+      && !Number.isNaN(preferredId)
+      && preferredId > 0
+      && (ChildrenAttachmentsIds || []).includes(preferredId);
+
+    // render image of preferred attachment thumbnail if available and valid
+    if (isPreferredValid) {
       this.setState({ isLoading: true });
       try {
         const src = await fetchImageSrcByAttachmentId(preferredThumbnail);

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -17,16 +17,32 @@ const DEFAULT_UNAVAILABLE = '/images/wild_card/not_available.svg';
 // fetchImageSrcByAttachmentId's error path should be fixed there, not masked here.)
 const isValidImageSrc = (src) => typeof src === 'string' && src.length > 0;
 
+// Font-awesome icon for an attachment that has no rendered thumbnail, by extension.
+const fileIconClass = (filename) => {
+  const ext = (filename || '').split('.').pop().toLowerCase();
+  if (ext === 'pdf') return 'fa-file-pdf-o';
+  if (['doc', 'docx', 'odt'].includes(ext)) return 'fa-file-word-o';
+  if (['xls', 'xlsx', 'csv', 'ods'].includes(ext)) return 'fa-file-excel-o';
+  if (['zip', 'gz', 'tar', '7z', 'rar'].includes(ext)) return 'fa-file-archive-o';
+  return 'fa-file-o';
+};
+
 export default class ImageModal extends Component {
   // Resolve effective inputs from `container` (analysis mode) or `attachment` (single image).
   // Usable before `this` is set up (called from the constructor).
   static derive(props) {
     if (props.container) {
-      const { previewAttachment, candidateIds, preferredId } = getContainerImageData(props.container);
-      return { attachment: previewAttachment, candidateIds, preferredId };
+      const {
+        previewAttachment, candidates, candidateIds, preferredId,
+      } = getContainerImageData(props.container);
+      return {
+        attachment: previewAttachment, candidates, candidateIds, preferredId,
+      };
     }
     // single-image mode (e.g. element table/list thumbnails): no carousel, no preferred
-    return { attachment: props.attachment, candidateIds: [], preferredId: null };
+    return {
+      attachment: props.attachment, candidates: [], candidateIds: [], preferredId: null,
+    };
   }
 
   constructor(props) {
@@ -37,7 +53,7 @@ export default class ImageModal extends Component {
       isPdf: false,
       isLoading: false,
       thumbnail: '', // grey-area preview src (= preferred, else default)
-      thumbnails: [], // carousel: [{ id, thumbnail }]
+      thumbnails: [], // carousel: [{ id, filename, thumbnail }]
       preferredId, // persisted preferred id (shared across viewers)
       selectedId: null, // currently previewed-large id (transient, not persisted)
       modalPreviewSrc: '', // full-res src shown large in the modal main area
@@ -115,15 +131,19 @@ export default class ImageModal extends Component {
 
   // carousel of all selectable thumbnails
   fetchCarouselThumbnails() {
-    const { candidateIds } = ImageModal.derive(this.props);
+    const { candidates, candidateIds } = ImageModal.derive(this.props);
     if (!candidateIds.length) {
       this.setState({ thumbnails: [] });
       return;
     }
+    const nameById = new Map(candidates.map((c) => [c.id, c.filename]));
     AttachmentFetcher.fetchThumbnails(candidateIds)
       .then((result) => {
         const thumbnails = (result.thumbnails || []).map(({ id, thumbnail }) => ({
           id,
+          filename: nameById.get(id) || '',
+          // null when the attachment has no rendered thumbnail (e.g. PDF without a
+          // generated preview) — the carousel then shows a typed file-icon placeholder.
           thumbnail: (typeof thumbnail === 'string' && thumbnail.length > 0)
             ? `data:image/png;base64,${thumbnail}`
             : null,
@@ -205,25 +225,36 @@ export default class ImageModal extends Component {
               key={thumb.id}
               className={`d-flex flex-column align-items-center p-1 rounded bg-white ${cls}`}
               style={{
-                cursor: 'pointer', minWidth: 64, height: 90,
+                cursor: 'pointer', minWidth: 72, maxWidth: 72, height: 96,
               }}
               role="button"
               tabIndex={0}
-              title={isPreferred ? 'Current preferred image' : 'Click to preview'}
+              title={`${thumb.filename || `attachment ${thumb.id}`}${isPreferred ? ' (current preferred)' : ''}`}
               onClick={() => this.handleSelectThumbnail(thumb)}
               onKeyDown={(e) => this.handleThumbKeyDown(e, thumb)}
             >
-              <img
-                src={isValidImageSrc(thumb.thumbnail) ? thumb.thumbnail : DEFAULT_NO_ATTACHMENT}
-                alt={`Thumbnail ${thumb.id}`}
-                style={{ width: 60, height: 60, objectFit: 'cover' }}
-              />
-              {isPreferred && (
-                <span className="text-primary" style={{ fontSize: '0.65rem' }}>
-                  <i className="fa fa-star me-1" />
-                  Preferred
-                </span>
+              {isValidImageSrc(thumb.thumbnail) ? (
+                <img
+                  src={thumb.thumbnail}
+                  alt={thumb.filename || `attachment ${thumb.id}`}
+                  style={{ width: 56, height: 56, objectFit: 'cover' }}
+                />
+              ) : (
+                // no rendered thumbnail (e.g. PDF without a generated preview)
+                <div
+                  className="d-flex align-items-center justify-content-center text-body-tertiary"
+                  style={{ width: 56, height: 56 }}
+                >
+                  <i className={`fa ${fileIconClass(thumb.filename)} fa-2x`} aria-hidden="true" />
+                </div>
               )}
+              <span
+                className="text-truncate w-100 text-center"
+                style={{ fontSize: '0.6rem', lineHeight: 1.1 }}
+              >
+                {isPreferred && <i className="fa fa-star text-primary me-1" />}
+                {thumb.filename || `#${thumb.id}`}
+              </span>
             </div>
           );
         })}
@@ -262,10 +293,13 @@ export default class ImageModal extends Component {
     const {
       isPdf, isLoading, modalPreviewSrc, selectedId, preferredId, thumbnails,
     } = this.state;
-    const { attachment } = ImageModal.derive(this.props);
+    const { attachment, candidates } = ImageModal.derive(this.props);
     // Preferred selection only applies in analysis mode (a carousel of candidates exists).
     const canSelectPreferred = thumbnails.length > 0;
     const canSetPreferred = selectedId && selectedId !== preferredId;
+    // Filename of the image currently shown large (any file type), for the caption.
+    const selectedFilename = candidates.find((c) => c.id === selectedId)?.filename
+      || attachment?.filename || '';
 
     if (showPop) {
       return <div className="preview-table">{this.renderPreviewBox()}</div>;
@@ -297,6 +331,12 @@ export default class ImageModal extends Component {
           showFooter
         >
           <div style={{ overflow: 'auto', position: 'relative', minHeight: 400 }}>
+            {selectedFilename && (
+              <div className="text-center text-body-secondary text-truncate mb-2" title={selectedFilename}>
+                <i className="fa fa-file-o me-1" aria-hidden="true" />
+                {selectedFilename}
+              </div>
+            )}
             {isPdf && modalPreviewSrc ? (
               <iframe
                 src={modalPreviewSrc}

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -16,7 +16,12 @@ export default class ImageModal extends Component {
       fetchSrc: '',
       showModal: false,
       isPdf: false,
-      thumbnail: ''
+      pageIndex: 1,
+      numOfPages: 0,
+      thumbnail: '',
+      thumbnails: [],
+      currentPreferredThumbnail: props.preferredThumbnail || null,
+      thumbPage: 0,
     };
 
     this.fetchImage = this.fetchImage.bind(this);
@@ -42,9 +47,12 @@ export default class ImageModal extends Component {
   }
 
   handleModalShow(e) {
-    stopEvent(e);
-    this.fetchImage();
-    this.setState({ showModal: true });
+    if (!this.props.disableClick) {
+      stopEvent(e);
+      this.fetchImage();
+      this.fetchThumbnails();
+      this.setState({ showModal: true });
+    }
   }
 
   handleImageError() {
@@ -66,12 +74,39 @@ export default class ImageModal extends Component {
     }
   }
 
+  buildImageSrcArrayFromThumbnails(thumbnails) {
+    console.log(thumbnails);
+    if (thumbnails && thumbnails.length > 0) {
+      return thumbnails.map(({ id, thumbnail }) => ({
+        id,
+        thumbnail: thumbnail ? `data:image/png;base64,${thumbnail}` : null
+      }));
+    }
+    return [];
+  }
+
+  fetchThumbnails() {
+    const { ChildrenAttachmentsIds } = this.props;
+    console.log('ChildrenAttachmentsIds', ChildrenAttachmentsIds);
+    if (ChildrenAttachmentsIds && ChildrenAttachmentsIds.length > 0) {
+      AttachmentFetcher.fetchThumbnails(ChildrenAttachmentsIds).then((result) => {
+        this.setState({ thumbnails: this.buildImageSrcArrayFromThumbnails(result.thumbnails) });
+      });
+    }
+  }
+
   async fetchImageThumbnail() {
-    const { attachment } = this.props;
+    const { attachment, preferredThumbnail } = this.props;
     const fileType = attachment?.file?.type;
     const isImage = fileType?.startsWith('image/');
     const defaultNoAttachment = '/images/wild_card/no_attachment.svg';
     const defaultUnavailable = '/images/wild_card/not_available.svg';
+    // render image of preferred attachment thumbnail if available
+    if (preferredThumbnail) {
+      const src = await fetchImageSrcByAttachmentId(preferredThumbnail);
+      this.setState({ thumbnail: src, fetchSrc: src });
+      return;
+    }
     if (attachment?.thumb) {
       const src = await fetchImageSrcByAttachmentId(attachment.id);
       this.setState({ thumbnail: src });
@@ -94,13 +129,133 @@ export default class ImageModal extends Component {
     );
   }
 
+  handleSetPreferred = (thumb) => {
+    const { onChangePreferredThumbnail } = this.props;
+    const { currentPreferredThumbnail } = this.state;
+    this.setState({ currentPreferredThumbnail: thumb.id, thumbnail: thumb.thumbnail });
+    onChangePreferredThumbnail(currentPreferredThumbnail);
+  };
+
+  handleThumbPage = (delta) => {
+    const { thumbPage, thumbnails } = this.state;
+    const thumbnailsPerPage = 6;
+    const totalThumbPages = Math.ceil((thumbnails?.length || 0) / thumbnailsPerPage);
+    const newPage = thumbPage + delta;
+    if (newPage >= 0 && newPage < totalThumbPages) {
+      this.setState({ thumbPage: newPage });
+    }
+  };
+
+  renderAttachmentsThumbnails = () => {
+    const { thumbnails: allThumbnails, currentPreferredThumbnail, thumbPage } = this.state;
+    const thumbnailsPerPage = 6;
+    const totalThumbPages = Math.ceil((allThumbnails?.length || 0) / thumbnailsPerPage);
+    const currentThumbs = (allThumbnails || [])
+      .slice(
+        thumbPage * thumbnailsPerPage,
+        (thumbPage + 1) * thumbnailsPerPage
+      );
+    return (
+      <div className="text-center mt-2">
+        {allThumbnails && allThumbnails.length > 0 && (
+          <div className="d-flex align-items-center justify-content-center my-3">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => this.handleThumbPage(-1)}
+              disabled={thumbPage === 0}
+              className="me-2"
+            >
+              <i className="fa fa-chevron-left" />
+            </Button>
+            <div className="d-flex flex-row flex-nowrap overflow-auto gap-2">
+              {currentThumbs.map((thumb) => (
+                <div
+                  key={thumb.id}
+                  className={`d-flex flex-column align-items-center justify-content-center p-1 rounded
+                    ${thumb.id === currentPreferredThumbnail
+                    ? 'border-2 border-info bg-info-subtle' : 'border border-secondary bg-white'}`}
+                  style={{
+                    cursor: 'pointer',
+                    minWidth: 64,
+                    minHeight: 90,
+                    maxWidth: 70,
+                    height: 80,
+                  }}
+                  title={
+                    thumb.id === currentPreferredThumbnail
+                      ? 'Current Preferred Thumbnail' : 'Set as Preferred display thumbnail for this analysis item'
+                  }
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => this.handleSetPreferred(thumb)}
+                  onKeyPress={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      this.handleSetPreferred(thumb);
+                    }
+                  }}
+                >
+                  <img
+                    src={thumb.thumbnail || '/images/wild_card/no_attachment.svg'}
+                    alt={`Thumbnail ${thumb.id}`}
+                    className="img-thumbnail"
+                    style={{
+                      width: 60, height: 60, objectFit: 'cover', display: 'block'
+                    }}
+                  />
+                  {thumb.id === currentPreferredThumbnail && (
+                    <div className="text-primary small mt-1">Preferred</div>
+                  )}
+                </div>
+              ))}
+            </div>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => this.handleThumbPage(1)}
+              disabled={thumbPage >= totalThumbPages - 1}
+              className="ms-2"
+            >
+              <i className="fa fa-chevron-right" />
+            </Button>
+          </div>
+        )}
+      </div>
+    );
+  };
+
   render() {
     const {
-      popObject, attachment, placement = 'right'
+      showPop,
+      popObject,
+      imageStyle,
+      attachment,
+      placement = 'right'
     } = this.props;
     const {
-      isPdf, fetchSrc, thumbnail
+      pageIndex,
+      numOfPages,
+      isPdf,
+      fetchSrc,
+      thumbnail,
+      thumbnails,
     } = this.state;
+    console.log(thumbnail);
+    console.log("hamada");
+    console.log(this.state.fetchSrc);
+
+    if (showPop) {
+      return (
+        <div className="preview-table">
+          <img
+            src={thumbnail}
+            alt={attachment?.filename}
+            style={{ cursor: 'default', ...imageStyle }}
+            onError={this.handleImageError}
+          />
+        </div>
+      );
+    }
 
     return (
       <div>
@@ -160,6 +315,9 @@ export default class ImageModal extends Component {
               />
             )}
           </div>
+          <div>
+            {this.renderAttachmentsThumbnails()}
+          </div>
         </AppModal>
       </div>
     );
@@ -183,6 +341,18 @@ ImageModal.propTypes = {
     title: PropTypes.string,
   }).isRequired,
   placement: PropTypes.string,
+  disableClick: PropTypes.bool,
+  imageStyle: PropTypes.object,
+  preferredThumbnail: PropTypes.string,
+  ChildrenAttachmentsIds: PropTypes.arrayOf(PropTypes.number),
+  onChangePreferredThumbnail: PropTypes.func,
+};
+
+ImageModal.defaultProps = {
+  imageStyle: {},
+  disableClick: false,
+  preferredThumbnail: null,
+  ChildrenAttachmentsIds: [],
 };
 
 ImageModal.defaultProps = {

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -95,6 +95,27 @@ export default class ImageModal extends Component {
     }
   }
 
+  buildImageSrcArrayFromThumbnails(thumbnails) {
+    console.log(thumbnails);
+    if (thumbnails && thumbnails.length > 0) {
+      return thumbnails.map(({ id, thumbnail }) => ({
+        id,
+        thumbnail: thumbnail ? `data:image/png;base64,${thumbnail}` : null
+      }));
+    }
+    return [];
+  }
+
+  fetchThumbnails() {
+    const { ChildrenAttachmentsIds } = this.props;
+    console.log('ChildrenAttachmentsIds', ChildrenAttachmentsIds);
+    if (ChildrenAttachmentsIds && ChildrenAttachmentsIds.length > 0) {
+      AttachmentFetcher.fetchThumbnails(ChildrenAttachmentsIds).then((result) => {
+        this.setState({ thumbnails: this.buildImageSrcArrayFromThumbnails(result.thumbnails) });
+      });
+    }
+  }
+
   async fetchImageThumbnail() {
     const { attachment, preferredThumbnail } = this.props;
     const fileType = attachment?.file?.type;

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -16,13 +16,15 @@ export default class ImageModal extends Component {
       fetchSrc: '',
       showModal: false,
       isPdf: false,
-      pageIndex: 1,
-      numOfPages: 0,
       thumbnail: '',
       thumbnails: [],
       currentPreferredThumbnail: Number(props.preferredThumbnail) || null,
       thumbPage: 0,
       isLoading: false,
+      // 'preview' = clicking thumbnail only previews it; 'select' = sets it as preferred
+      thumbMode: 'select',
+      // src shown in modal main image area (may differ from the saved preferred)
+      modalPreviewSrc: '',
     };
 
     this.fetchImage = this.fetchImage.bind(this);
@@ -75,7 +77,7 @@ export default class ImageModal extends Component {
   handleThumbKeyDown = (e, thumb) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
-      this.handleSetPreferred(thumb);
+      this.handleThumbClick(thumb);
     }
   };
 
@@ -89,10 +91,13 @@ export default class ImageModal extends Component {
       stopEvent(e);
       // Sync currentPreferredThumbnail with prop when modal opens
       const { preferredThumbnail } = this.props;
-      this.setState({
+      this.setState((prevState) => ({
         showModal: true,
         currentPreferredThumbnail: preferredThumbnail ? Number(preferredThumbnail) : null,
-      });
+        // Reset modal preview to current thumbnail so preferred image shows immediately
+        modalPreviewSrc: prevState.thumbnail || '',
+        thumbMode: 'select',
+      }));
       this.fetchImage();
       this.fetchThumbnails();
     }
@@ -109,7 +114,15 @@ export default class ImageModal extends Component {
       AttachmentFetcher.fetchImageAttachment({ id: attachment.id }).then(
         (result) => {
           if (!result?.data) throw new Error('Attachment is not provided');
-          this.setState({ fetchSrc: result.data, isPdf: result.type === 'application/pdf' });
+          const src = result.data;
+          // Only update modalPreviewSrc from fetchImage if no preferred thumbnail is active
+          this.setState((prevState) => ({
+            fetchSrc: src,
+            isPdf: result.type === 'application/pdf',
+            modalPreviewSrc: prevState.currentPreferredThumbnail
+              ? prevState.modalPreviewSrc
+              : src,
+          }));
         }
       );
     } catch (error) {
@@ -169,7 +182,12 @@ export default class ImageModal extends Component {
       this.setState({ isLoading: true });
       try {
         const src = await fetchImageSrcByAttachmentId(preferredThumbnail);
-        this.setState({ thumbnail: src, fetchSrc: src, isLoading: false });
+        this.setState({
+          thumbnail: src,
+          fetchSrc: src,
+          modalPreviewSrc: src,
+          isLoading: false,
+        });
         return;
       } catch (err) {
         // eslint-disable-next-line no-console
@@ -211,9 +229,24 @@ export default class ImageModal extends Component {
 
   handleSetPreferred = (thumb) => {
     const { onChangePreferredThumbnail } = this.props;
-    this.setState({ currentPreferredThumbnail: thumb.id, thumbnail: thumb.thumbnail });
+    this.setState({
+      currentPreferredThumbnail: thumb.id,
+      thumbnail: thumb.thumbnail,
+      modalPreviewSrc: thumb.thumbnail,
+    });
     if (thumb.id !== this.state.currentPreferredThumbnail) {
       onChangePreferredThumbnail(thumb.id);
+    }
+  };
+
+  // Handles thumbnail click depending on current mode
+  handleThumbClick = (thumb) => {
+    const { thumbMode } = this.state;
+    if (thumbMode === 'select') {
+      this.handleSetPreferred(thumb);
+    } else {
+      // preview mode: only update the modal preview image, do not change preferred
+      this.setState({ modalPreviewSrc: thumb.thumbnail });
     }
   };
 
@@ -228,7 +261,9 @@ export default class ImageModal extends Component {
   };
 
   renderAttachmentsThumbnails = () => {
-    const { thumbnails: allThumbnails, currentPreferredThumbnail, thumbPage } = this.state;
+    const {
+      thumbnails: allThumbnails, currentPreferredThumbnail, thumbPage, thumbMode,
+    } = this.state;
     const thumbnailsPerPage = 6;
     const totalThumbPages = Math.ceil((allThumbnails?.length || 0) / thumbnailsPerPage);
     const currentThumbs = (allThumbnails || [])
@@ -236,43 +271,72 @@ export default class ImageModal extends Component {
         thumbPage * thumbnailsPerPage,
         (thumbPage + 1) * thumbnailsPerPage
       );
+
+    if (!allThumbnails || allThumbnails.length === 0) return null;
+
     return (
-      <div className="text-center mt-2">
-        {allThumbnails && allThumbnails.length > 0 && (
-          <div className="d-flex align-items-center justify-content-center my-3">
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => this.handleThumbPage(-1)}
-              disabled={thumbPage === 0}
-              className="me-2"
+      <div className="mt-3 pt-2">
+        {/* Mode toggle */}
+        <div className="d-flex align-items-center justify-content-center gap-2 mb-2">
+          <span className="text-muted small">Thumbnail mode:</span>
+          <div className="btn-group btn-group-sm" role="group" aria-label="Thumbnail mode">
+            <button
+              type="button"
+              className={`btn ${thumbMode === 'preview' ? 'btn-primary' : 'btn-outline-secondary'}`}
+              onClick={() => this.setState({ thumbMode: 'preview' })}
+              title="Click a thumbnail to preview it without changing the preferred selection"
             >
-              <i className="fa fa-chevron-left" />
-            </Button>
-            <div className="d-flex flex-row flex-nowrap overflow-auto gap-2">
-              {currentThumbs.map((thumb) => (
+              <i className="fa fa-eye me-1" />
+              Preview only
+            </button>
+            <button
+              type="button"
+              className={`btn ${thumbMode === 'select' ? 'btn-primary' : 'btn-outline-secondary'}`}
+              onClick={() => this.setState({ thumbMode: 'select' })}
+              title="Click a thumbnail to set it as the preferred display image"
+            >
+              <i className="fa fa-star me-1" />
+              Set preferred
+            </button>
+          </div>
+        </div>
+
+        {/* Thumbnail strip */}
+        <div className="d-flex align-items-center justify-content-center">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => this.handleThumbPage(-1)}
+            disabled={thumbPage === 0}
+            className="me-2 flex-shrink-0"
+          >
+            <i className="fa fa-chevron-left" />
+          </Button>
+          <div className="d-flex flex-row flex-nowrap overflow-auto gap-2">
+            {currentThumbs.map((thumb) => {
+              const isPreferred = thumb.id === currentPreferredThumbnail;
+              const cardClass = isPreferred
+                ? 'border-2 border-info bg-info-subtle'
+                : 'border border-secondary bg-white';
+              let modeTitle;
+              if (thumbMode === 'select') {
+                modeTitle = isPreferred ? 'Current preferred thumbnail'
+                  : 'Set as preferred display thumbnail by selecting this image using set preferred mode';
+              } else {
+                modeTitle = 'Preview this image';
+              }
+              return (
                 <div
                   key={thumb.id}
-                  className={`d-flex flex-column align-items-center justify-content-center p-1 rounded
-                      ${thumb.id === currentPreferredThumbnail
-                    ? 'border-2 border-info bg-info-subtle' : 'border border-secondary bg-white'}`}
+                  className={`d-flex flex-column align-items-center justify-content-center p-1 rounded ${cardClass}`}
                   style={{
-                    cursor: 'pointer',
-                    minWidth: 64,
-                    minHeight: 90,
-                    maxWidth: 70,
-                    height: 80,
+                    cursor: 'pointer', minWidth: 64, minHeight: 90, maxWidth: 70, height: 80,
                   }}
-                  title={
-                    thumb.id === currentPreferredThumbnail
-                      ? 'Current Preferred Thumbnail' : 'Set as Preferred display thumbnail for this analysis item'
-                  }
+                  title={modeTitle}
                   role="button"
                   tabIndex={0}
-                  onClick={() => this.handleSetPreferred(thumb)}
-                  onKeyDown={(e) => {
-                    this.handleThumbKeyDown(e, thumb);
-                  }}
+                  onClick={() => this.handleThumbClick(thumb)}
+                  onKeyDown={(e) => this.handleThumbKeyDown(e, thumb)}
                 >
                   <img
                     src={this.isValidImageSrc(thumb.thumbnail)
@@ -280,26 +344,29 @@ export default class ImageModal extends Component {
                     alt={`Thumbnail ${thumb.id}`}
                     className="img-thumbnail"
                     style={{
-                      width: 60, height: 60, objectFit: 'cover', display: 'block'
+                      width: 60, height: 60, objectFit: 'cover', display: 'block',
                     }}
                   />
-                  {thumb.id === currentPreferredThumbnail && (
-                    <div className="text-primary small mt-1">Preferred</div>
+                  {isPreferred && (
+                    <div className="text-primary small mt-1" style={{ fontSize: '0.65rem' }}>
+                      <i className="fa fa-star me-1" />
+                      Preferred
+                    </div>
                   )}
                 </div>
-              ))}
-            </div>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => this.handleThumbPage(1)}
-              disabled={thumbPage >= totalThumbPages - 1}
-              className="ms-2"
-            >
-              <i className="fa fa-chevron-right" />
-            </Button>
+              );
+            })}
           </div>
-        )}
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => this.handleThumbPage(1)}
+            disabled={thumbPage >= totalThumbPages - 1}
+            className="ms-2 flex-shrink-0"
+          >
+            <i className="fa fa-chevron-right" />
+          </Button>
+        </div>
       </div>
     );
   };
@@ -313,11 +380,10 @@ export default class ImageModal extends Component {
       placement = 'right'
     } = this.props;
     const {
-      pageIndex,
-      numOfPages,
       isPdf,
       fetchSrc,
       thumbnail,
+      modalPreviewSrc,
     } = this.state;
     const defaultUnavailable = '/images/wild_card/not_available.svg';
 
@@ -403,7 +469,7 @@ export default class ImageModal extends Component {
               <iframe
                 src={fetchSrc}
                 width="100%"
-                height="600px"
+                height="500px"
                 style={{ border: 'none' }}
                 title="PDF Viewer"
               >
@@ -415,26 +481,19 @@ export default class ImageModal extends Component {
                 </p>
               </iframe>
             ) : (
-              <div className="d-flex justify-content-center align-items-center mt-2">
+              <div
+                className="d-flex justify-content-center align-items-center bg-light rounded"
+                style={{ minHeight: 300, maxHeight: 420 }}
+              >
                 {this.state.isLoading ? (
-                  <div
-                    className="d-flex justify-content-center align-items-center"
-                    style={{
-                      width: imageStyle?.width || 300,
-                      height: imageStyle?.height || 300,
-                      minWidth: 120,
-                      minHeight: 120,
-                      ...imageStyle
-                    }}
-                  >
-                    <div className="spinner-border text-primary" role="status">
-                      <span className="visually-hidden">Loading...</span>
-                    </div>
+                  <div className="spinner-border text-primary" role="status">
+                    <span className="visually-hidden">Loading...</span>
                   </div>
                 ) : (
                   <img
-                    src={this.isValidImageSrc(fetchSrc) ? fetchSrc : defaultUnavailable}
-                    style={{ maxHeight: '100%', maxWidth: '100%', display: 'block' }}
+                    src={this.isValidImageSrc(modalPreviewSrc) ? modalPreviewSrc : defaultUnavailable}
+                    className="img-fluid"
+                    style={{ maxHeight: 400, objectFit: 'contain' }}
                     alt={attachment?.filename}
                     onError={this.handleImageError}
                   />

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -42,6 +42,14 @@ export default class ImageModal extends Component {
     }
   }
 
+  // keyboard handler extracted from inline render for thumbnails
+  handleThumbKeyDown = (e, thumb) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      this.handleSetPreferred(thumb);
+    }
+  };
+
   handleModalClose(e) {
     stopEvent(e);
     this.setState({ showModal: false });
@@ -76,7 +84,6 @@ export default class ImageModal extends Component {
   }
 
   buildImageSrcArrayFromThumbnails(thumbnails) {
-    console.log(thumbnails);
     if (thumbnails && thumbnails.length > 0) {
       return thumbnails.map(({ id, thumbnail }) => ({
         id,
@@ -88,11 +95,15 @@ export default class ImageModal extends Component {
 
   fetchThumbnails() {
     const { ChildrenAttachmentsIds } = this.props;
-    console.log('ChildrenAttachmentsIds', ChildrenAttachmentsIds);
     if (ChildrenAttachmentsIds && ChildrenAttachmentsIds.length > 0) {
-      AttachmentFetcher.fetchThumbnails(ChildrenAttachmentsIds).then((result) => {
-        this.setState({ thumbnails: this.buildImageSrcArrayFromThumbnails(result.thumbnails) });
-      });
+      AttachmentFetcher.fetchThumbnails(ChildrenAttachmentsIds)
+        .then((result) => {
+          this.setState({ thumbnails: this.buildImageSrcArrayFromThumbnails(result.thumbnails) });
+        })
+        .catch((err) => {
+          console.error('Failed to fetch thumbnails', err);
+          this.setState({ thumbnails: [] });
+        });
     }
   }
 
@@ -105,18 +116,31 @@ export default class ImageModal extends Component {
     // render image of preferred attachment thumbnail if available
     if (preferredThumbnail) {
       this.setState({ isLoading: true });
-      const src = await fetchImageSrcByAttachmentId(preferredThumbnail);
-      this.setState({ thumbnail: src, fetchSrc: src, isLoading: false });
-      return;
+      try {
+        const src = await fetchImageSrcByAttachmentId(preferredThumbnail);
+        this.setState({ thumbnail: src, fetchSrc: src, isLoading: false });
+        return;
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to fetch preferred thumbnail', err);
+        this.setState({ isLoading: false });
+      }
     }
-    if (attachment?.thumb) {
-      const src = await fetchImageSrcByAttachmentId(attachment.id);
-      this.setState({ thumbnail: src });
-    } else if (attachment?.is_new || attachment?.is_pending) {
-      const previewSrc = isImage ? attachment?.file?.preview : defaultUnavailable;
-      this.setState({ thumbnail: previewSrc });
-    } else {
-      this.setState({ thumbnail: defaultNoAttachment });
+
+    try {
+      if (attachment?.thumb) {
+        const src = await fetchImageSrcByAttachmentId(attachment.id);
+        this.setState({ thumbnail: src });
+      } else if (attachment?.is_new || attachment?.is_pending) {
+        const previewSrc = isImage ? attachment?.file?.preview : defaultUnavailable;
+        this.setState({ thumbnail: previewSrc });
+      } else {
+        this.setState({ thumbnail: defaultNoAttachment });
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to fetch image thumbnail', err);
+      this.setState({ thumbnail: defaultUnavailable, isLoading: false });
     }
   }
 
@@ -193,10 +217,7 @@ export default class ImageModal extends Component {
                   tabIndex={0}
                   onClick={() => this.handleSetPreferred(thumb)}
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      this.handleSetPreferred(thumb);
-                    }
+                    this.handleThumbKeyDown(e, thumb);
                   }}
                 >
                   <img

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -39,30 +39,31 @@ export default class ImageModal extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { attachment, ChildrenAttachmentsIds, preferredThumbnail } = this.props;
-    const prevIds = prevProps.ChildrenAttachmentsIds || [];
-    const currIds = ChildrenAttachmentsIds || [];
-    // Attachment changed - refetch thumbnail
-    if (attachment?.id !== prevProps.attachment?.id) {
-      this.fetchImageThumbnail();
-    }
-    // Preferred thumbnail prop changed - sync state and refetch
-    if (preferredThumbnail !== prevProps.preferredThumbnail) {
+    const { attachment, childrenAttachmentIds, preferredThumbnail } = this.props;
+    const prevIds = prevProps.childrenAttachmentIds || [];
+    const currIds = childrenAttachmentIds || [];
+
+    const attachmentChanged = attachment?.id !== prevProps.attachment?.id;
+    const preferredChanged = preferredThumbnail !== prevProps.preferredThumbnail;
+    const idsChanged = prevIds.length !== currIds.length
+      || !prevIds.every((id, i) => id === currIds[i]);
+
+    if (preferredChanged) {
       this.setState({
         currentPreferredThumbnail: preferredThumbnail ? Number(preferredThumbnail) : null
       });
-      this.fetchImageThumbnail();
     }
-    // ChildrenAttachmentsIds changed (attachment added/deleted) - refresh thumbnails
-    if (prevIds.length !== currIds.length || !prevIds.every((id, i) => id === currIds[i])) {
+
+    if (idsChanged) {
       this.fetchThumbnails();
-      // If current preferred thumbnail is no longer in the list, clear it from state
       const { currentPreferredThumbnail } = this.state;
       if (currentPreferredThumbnail && !currIds.includes(currentPreferredThumbnail)) {
-        // Parent will handle reassigning; clear local state
         this.setState({ currentPreferredThumbnail: null });
-        this.fetchImageThumbnail();
       }
+    }
+
+    if (attachmentChanged || preferredChanged || idsChanged) {
+      this.fetchImageThumbnail();
     }
   }
 
@@ -143,9 +144,9 @@ export default class ImageModal extends Component {
   }
 
   fetchThumbnails() {
-    const { ChildrenAttachmentsIds } = this.props;
+    const { childrenAttachmentIds } = this.props;
     // Filter to ensure only valid numeric IDs are sent to the API
-    const validIds = (ChildrenAttachmentsIds || []).filter(
+    const validIds = (childrenAttachmentIds || []).filter(
       (id) => typeof id === 'number' && !Number.isNaN(id) && id > 0
     );
     if (validIds.length > 0) {
@@ -164,7 +165,7 @@ export default class ImageModal extends Component {
   }
 
   async fetchImageThumbnail() {
-    const { attachment, preferredThumbnail, ChildrenAttachmentsIds } = this.props;
+    const { attachment, preferredThumbnail, childrenAttachmentIds } = this.props;
     const fileType = attachment?.file?.type;
     const isImage = fileType?.startsWith('image/');
     const defaultNoAttachment = '/images/wild_card/no_attachment.svg';
@@ -175,7 +176,7 @@ export default class ImageModal extends Component {
     const isPreferredValid = preferredThumbnail
       && !Number.isNaN(preferredId)
       && preferredId > 0
-      && (ChildrenAttachmentsIds || []).includes(preferredId);
+      && (childrenAttachmentIds || []).includes(preferredId);
 
     // render image of preferred attachment thumbnail if available and valid
     if (isPreferredValid) {
@@ -522,7 +523,7 @@ ImageModal.propTypes = {
       type: PropTypes.string,
       preview: PropTypes.string,
     })
-  }).isRequired,
+  }),
   popObject: PropTypes.shape({
     title: PropTypes.string,
   }).isRequired,
@@ -530,16 +531,18 @@ ImageModal.propTypes = {
   disableClick: PropTypes.bool,
   imageStyle: PropTypes.object,
   preferredThumbnail: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  ChildrenAttachmentsIds: PropTypes.arrayOf(PropTypes.number),
+  childrenAttachmentIds: PropTypes.arrayOf(PropTypes.number),
   onChangePreferredThumbnail: PropTypes.func,
   showPop: PropTypes.bool,
 };
 
 ImageModal.defaultProps = {
   imageStyle: {},
+  attachment: null,
   disableClick: false,
+  attachment: null,
   preferredThumbnail: null,
-  ChildrenAttachmentsIds: [],
+  childrenAttachmentIds: [],
   onChangePreferredThumbnail: () => { },
   placement: 'right',
   showPop: false,

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -342,6 +342,7 @@ export default class ImageModal extends Component {
                 {selectedFilename}
               </div>
             )}
+            {/* main preview: PDF in an iframe, everything else as an image */}
             {isPdf && modalPreviewSrc ? (
               <iframe
                 src={modalPreviewSrc}
@@ -351,41 +352,40 @@ export default class ImageModal extends Component {
                 title="PDF Viewer"
               />
             ) : (
-              <>
-                <div
-                  className="d-flex justify-content-center align-items-center bg-light rounded position-relative"
-                  style={{ minHeight: 300, maxHeight: 420 }}
-                >
-                  {isLoading ? (
-                    <div className="spinner-border text-primary" role="status">
-                      <span className="visually-hidden">Loading...</span>
-                    </div>
-                  ) : (
-                    <img
-                      src={isValidImageSrc(modalPreviewSrc) ? modalPreviewSrc : DEFAULT_UNAVAILABLE}
-                      className="img-fluid"
-                      style={{ maxHeight: 400, objectFit: 'contain' }}
-                      alt={attachment?.filename}
-                      onError={this.handleImageError}
-                    />
-                  )}
-                </div>
-                {canSelectPreferred && (
-                  <div className="d-flex justify-content-center mt-2">
-                    <Button
-                      variant="primary"
-                      size="sm"
-                      disabled={!canSetPreferred}
-                      onClick={this.handleSetPreferred}
-                    >
-                      <i className="fa fa-star me-1" />
-                      {preferredId && selectedId === preferredId ? 'Preferred image' : 'Set as preferred'}
-                    </Button>
+              <div
+                className="d-flex justify-content-center align-items-center bg-light rounded position-relative"
+                style={{ minHeight: 300, maxHeight: 420 }}
+              >
+                {isLoading ? (
+                  <div className="spinner-border text-primary" role="status">
+                    <span className="visually-hidden">Loading...</span>
                   </div>
+                ) : (
+                  <img
+                    src={isValidImageSrc(modalPreviewSrc) ? modalPreviewSrc : DEFAULT_UNAVAILABLE}
+                    className="img-fluid"
+                    style={{ maxHeight: 400, objectFit: 'contain' }}
+                    alt={attachment?.filename}
+                    onError={this.handleImageError}
+                  />
                 )}
-                {this.renderCarousel()}
-              </>
+              </div>
             )}
+            {/* selection controls — shown for both image and PDF previews */}
+            {canSelectPreferred && (
+              <div className="d-flex justify-content-center mt-2">
+                <Button
+                  variant="primary"
+                  size="sm"
+                  disabled={!canSetPreferred}
+                  onClick={this.handleSetPreferred}
+                >
+                  <i className="fa fa-star me-1" />
+                  {preferredId && selectedId === preferredId ? 'Preferred image' : 'Set as preferred'}
+                </Button>
+              </div>
+            )}
+            {this.renderCarousel()}
           </div>
         </AppModal>
       </div>

--- a/app/javascript/src/components/container/ContainerDatasetModalContent.js
+++ b/app/javascript/src/components/container/ContainerDatasetModalContent.js
@@ -229,9 +229,14 @@ export class ContainerDatasetModalContent extends Component {
 
   handleAttachmentRemove(attachment) {
     const { datasetContainer } = this.state;
+    const { onChange } = this.props;
     const index = datasetContainer.attachments.indexOf(attachment);
     datasetContainer.attachments[index].is_deleted = true;
     this.setState({ datasetContainer });
+    // Propagate change immediately so parent can handle preferred thumbnail reassignment
+    if (onChange) {
+      onChange(datasetContainer);
+    }
   }
 
   handleAttachmentBackToInbox(attachment) {

--- a/app/javascript/src/components/container/ContainerDatasetModalContent.js
+++ b/app/javascript/src/components/container/ContainerDatasetModalContent.js
@@ -82,7 +82,13 @@ export class ContainerDatasetModalContent extends Component {
 
   constructor(props) {
     super(props);
-    const datasetContainer = { ...props.datasetContainer };
+    // Deep-clone attachments so edits (delete/undo) stay isolated to this modal's working
+    // copy and are committed to the parent only on Save. A shallow clone would share the
+    // parent's attachments array, making Cancel unable to revert a deletion.
+    const datasetContainer = {
+      ...props.datasetContainer,
+      attachments: (props.datasetContainer.attachments || []).map((att) => ({ ...att })),
+    };
     const { thirdPartyApps } = UIStore.getState() || [];
     this.thirdPartyApps = thirdPartyApps;
     this.state = {
@@ -91,7 +97,7 @@ export class ContainerDatasetModalContent extends Component {
       instrumentInputValue: '',
       timeoutReference: null,
       imageEditModalShown: false,
-      filteredAttachments: [...props.datasetContainer.attachments],
+      filteredAttachments: [...datasetContainer.attachments],
       prevMessages: [],
       newMessages: [],
       filterText: '',
@@ -114,13 +120,13 @@ export class ContainerDatasetModalContent extends Component {
     this.handleAttachmentRemove = this.handleAttachmentRemove.bind(this);
     this.handleAttachmentBackToInbox = this.handleAttachmentBackToInbox.bind(this);
     this.classifyAttachments = this.classifyAttachments.bind(this);
-    this.state.attachmentGroups = this.classifyAttachments(props.datasetContainer.attachments);
+    this.state.attachmentGroups = this.classifyAttachments(datasetContainer.attachments);
   }
 
   componentDidMount() {
     const { datasetContainer } = this.state;
     this.setState({
-      attachmentGroups: this.classifyAttachments(this.props.datasetContainer.attachments),
+      attachmentGroups: this.classifyAttachments(datasetContainer.attachments),
       instrumentInputValue: datasetContainer?.extended_metadata?.instrument || ''
     });
   }
@@ -229,14 +235,13 @@ export class ContainerDatasetModalContent extends Component {
 
   handleAttachmentRemove(attachment) {
     const { datasetContainer } = this.state;
-    const { onChange } = this.props;
     const index = datasetContainer.attachments.indexOf(attachment);
+    if (index === -1) return;
+    // Mutate the working copy only. The deletion is committed to the parent exclusively
+    // via handleSave() -> onChange(), so Cancel reverts and preferred-thumbnail reassignment
+    // runs only on a real Save.
     datasetContainer.attachments[index].is_deleted = true;
     this.setState({ datasetContainer });
-    // Propagate change immediately so parent can handle preferred thumbnail reassignment
-    if (onChange) {
-      onChange(datasetContainer);
-    }
   }
 
   handleAttachmentBackToInbox(attachment) {
@@ -328,22 +333,25 @@ export class ContainerDatasetModalContent extends Component {
   };
 
   filterAttachments() {
-    const filterTextLower = this.state.filterText.toLowerCase();
-    const filteredGroups = this.classifyAttachments(this.props.datasetContainer.attachments);
+    this.setState((prevState) => {
+      const filterTextLower = prevState.filterText.toLowerCase();
+      // Classify from the working copy so filtering reflects in-modal deletes/undos.
+      const filteredGroups = this.classifyAttachments(prevState.datasetContainer.attachments);
 
-    Object.keys(filteredGroups).forEach((group) => {
-      if (Array.isArray(filteredGroups[group])) {
-        filteredGroups[group] = filteredGroups[group]
-          .filter((attachment) => attachment.filename.toLowerCase().includes(filterTextLower));
-      } else {
-        Object.keys(filteredGroups[group]).forEach((subGroup) => {
-          filteredGroups[group][subGroup] = filteredGroups[group][subGroup]
+      Object.keys(filteredGroups).forEach((group) => {
+        if (Array.isArray(filteredGroups[group])) {
+          filteredGroups[group] = filteredGroups[group]
             .filter((attachment) => attachment.filename.toLowerCase().includes(filterTextLower));
-        });
-      }
-    });
+        } else {
+          Object.keys(filteredGroups[group]).forEach((subGroup) => {
+            filteredGroups[group][subGroup] = filteredGroups[group][subGroup]
+              .filter((attachment) => attachment.filename.toLowerCase().includes(filterTextLower));
+          });
+        }
+      });
 
-    this.setState({ attachmentGroups: filteredGroups });
+      return { attachmentGroups: filteredGroups };
+    });
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/app/javascript/src/components/container/ContainerDatasets.js
+++ b/app/javascript/src/components/container/ContainerDatasets.js
@@ -84,6 +84,41 @@ export default class ContainerDatasets extends Component {
         container.children[datasetId] = datasetContainer;
       }
     });
+
+    // Check and reassign preferred thumbnail if the current one was deleted
+    this.reassignPreferredThumbnailIfNeeded(container);
+  };
+
+  reassignPreferredThumbnailIfNeeded = (analysisContainer) => {
+    // Get all non-deleted attachment IDs from all datasets
+    const allAttachments = analysisContainer?.children?.flatMap(
+      (child) => (child.attachments || [])
+    ) || [];
+    const nonDeletedAttachments = allAttachments.filter((att) => !att.is_deleted);
+    const validAttachmentIds = nonDeletedAttachments.map((att) => Number(att.id));
+
+    const currentPreferred = analysisContainer?.extended_metadata?.preferred_thumbnail;
+    const preferredIsValid = currentPreferred
+      && validAttachmentIds.includes(Number(currentPreferred));
+
+    if (!preferredIsValid) {
+      // Need to reassign
+      if (validAttachmentIds.length > 0) {
+        // Assign first available
+        analysisContainer.extended_metadata = {
+          ...analysisContainer.extended_metadata,
+          preferred_thumbnail: String(validAttachmentIds[0]),
+        };
+      } else {
+        // No attachments available - clear preferred
+        analysisContainer.extended_metadata = {
+          ...analysisContainer.extended_metadata,
+          preferred_thumbnail: null,
+        };
+      }
+      // Propagate change to parent
+      this.props.onChange(analysisContainer);
+    }
   };
 
   handleModalHide() {

--- a/app/javascript/src/components/container/ContainerDatasets.js
+++ b/app/javascript/src/components/container/ContainerDatasets.js
@@ -90,12 +90,14 @@ export default class ContainerDatasets extends Component {
   };
 
   reassignPreferredThumbnailIfNeeded = (analysisContainer) => {
-    // Get all non-deleted attachment IDs from all datasets
+    // Get all saved, non-deleted attachment IDs from all datasets (exclude is_new which don't have server IDs yet)
     const allAttachments = analysisContainer?.children?.flatMap(
       (child) => (child.attachments || [])
     ) || [];
-    const nonDeletedAttachments = allAttachments.filter((att) => !att.is_deleted);
-    const validAttachmentIds = nonDeletedAttachments.map((att) => Number(att.id));
+    const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new);
+    const validAttachmentIds = savedAttachments
+      .map((att) => Number(att.id))
+      .filter((id) => !Number.isNaN(id) && id > 0);
 
     const currentPreferred = analysisContainer?.extended_metadata?.preferred_thumbnail;
     const preferredIsValid = currentPreferred

--- a/app/javascript/src/components/container/ContainerDatasets.js
+++ b/app/javascript/src/components/container/ContainerDatasets.js
@@ -85,7 +85,9 @@ export default class ContainerDatasets extends Component {
       }
     });
 
-    // Check and reassign preferred thumbnail if the current one was deleted
+    // Always propagate changes to parent
+    this.props.onChange(container);
+    // Also check and reassign preferred thumbnail if the current one was deleted
     this.reassignPreferredThumbnailIfNeeded(container);
   };
 

--- a/app/javascript/src/components/container/ContainerDatasets.js
+++ b/app/javascript/src/components/container/ContainerDatasets.js
@@ -85,18 +85,18 @@ export default class ContainerDatasets extends Component {
       }
     });
 
-    // Always propagate changes to parent
-    this.props.onChange(container);
-    // Also check and reassign preferred thumbnail if the current one was deleted
+    // Reassign preferred thumbnail if needed, then propagate once to parent
     this.reassignPreferredThumbnailIfNeeded(container);
   };
 
   reassignPreferredThumbnailIfNeeded = (analysisContainer) => {
-    // Get all saved, non-deleted attachment IDs from all datasets (exclude is_new which don't have server IDs yet)
+    // Get all saved, non-deleted attachment IDs that actually have thumbnails
     const allAttachments = analysisContainer?.children?.flatMap(
       (child) => (child.attachments || [])
     ) || [];
-    const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new);
+    const savedAttachments = allAttachments.filter(
+      (att) => !att.is_deleted && !att.is_new && att.thumb === true
+    );
     const validAttachmentIds = savedAttachments
       .map((att) => Number(att.id))
       .filter((id) => !Number.isNaN(id) && id > 0);
@@ -120,9 +120,9 @@ export default class ContainerDatasets extends Component {
           preferred_thumbnail: null,
         };
       }
-      // Propagate change to parent
-      this.props.onChange(analysisContainer);
     }
+    // Propagate final state to parent once
+    this.props.onChange(analysisContainer);
   };
 
   handleModalHide() {

--- a/app/javascript/src/components/generic/GenericContainer.js
+++ b/app/javascript/src/components/generic/GenericContainer.js
@@ -117,7 +117,7 @@ const newHeader = (props) => {
   const attachment = getAttachmentFromContainer(container);
   // Build list of saved, non-deleted attachment IDs (exclude is_new which don't have server IDs yet)
   const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
-  const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new);
+  const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new && att.thumb === true);
   const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
   const attachmentsIds = savedAttachments
     .map((att) => Number(att.id))
@@ -146,7 +146,7 @@ const newHeader = (props) => {
               title: container.name,
             }}
             preferredThumbnail={preferredThumbnail}
-            ChildrenAttachmentsIds={attachmentsIds}
+            childrenAttachmentIds={attachmentsIds}
             onChangePreferredThumbnail={(currentPreferredThumbnail) => onChangePreferredThumbnail(
               currentPreferredThumbnail
             )}

--- a/app/javascript/src/components/generic/GenericContainer.js
+++ b/app/javascript/src/components/generic/GenericContainer.js
@@ -93,7 +93,12 @@ const headerBtnGroup = (props) => {
 };
 
 const newHeader = (props) => {
-  const { container, noAct, mode } = props;
+  const {
+    container,
+    noAct,
+    mode,
+    fnChange
+  } = props;
   const deleted = container.is_deleted;
   let kind = container.extended_metadata.kind || '';
   kind = (kind.split('|')[1] || kind).trim();
@@ -110,6 +115,24 @@ const newHeader = (props) => {
     }),
   };
   const attachment = getAttachmentFromContainer(container);
+  // Build list of saved, non-deleted attachment IDs (exclude is_new which don't have server IDs yet)
+  const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
+  const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new);
+  const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
+  const attachmentsIds = savedAttachments
+    .map((att) => Number(att.id))
+    .filter((id) => !Number.isNaN(id) && id > 0);
+
+  const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
+    if (currentPreferredThumbnail !== preferredThumbnail && fnChange) {
+      // Handle the change of preferred thumbnail
+      container.extended_metadata = {
+        ...container.extended_metadata,
+        preferred_thumbnail: currentPreferredThumbnail,
+      };
+      fnChange(container);
+    }
+  };
 
   return (
     <div className={`analysis-header w-100 d-flex gap-3 lh-base${mode === 'order' ? ' order pe-2' : ''}`}>
@@ -122,6 +145,11 @@ const newHeader = (props) => {
             popObject={{
               title: container.name,
             }}
+            preferredThumbnail={preferredThumbnail}
+            ChildrenAttachmentsIds={attachmentsIds}
+            onChangePreferredThumbnail={(currentPreferredThumbnail) => onChangePreferredThumbnail(
+              currentPreferredThumbnail
+            )}
           />
         )}
       </div>

--- a/app/javascript/src/components/generic/GenericContainer.js
+++ b/app/javascript/src/components/generic/GenericContainer.js
@@ -8,7 +8,6 @@ import ContainerComponent from 'src/components/container/ContainerComponent';
 import QuillViewer from 'src/components/QuillViewer';
 import ImageModal from 'src/components/common/ImageModal';
 import { instrumentText } from 'src/utilities/ElementUtils';
-import { getAttachmentFromContainer } from 'src/utilities/imageHelper';
 import {
   JcampIds, BuildSpcInfos, BuildSpcInfosForNMRDisplayer, isNMRKind
 } from 'src/utilities/SpectraHelper';
@@ -114,24 +113,14 @@ const newHeader = (props) => {
       return c;
     }),
   };
-  const attachment = getAttachmentFromContainer(container);
-  // Build list of saved, non-deleted attachment IDs (exclude is_new which don't have server IDs yet)
-  const allAttachments = container?.children?.flatMap((child) => (child.attachments || [])) || [];
-  const savedAttachments = allAttachments.filter((att) => !att.is_deleted && !att.is_new && att.thumb === true);
-  const preferredThumbnail = container?.extended_metadata?.preferred_thumbnail || null;
-  const attachmentsIds = savedAttachments
-    .map((att) => Number(att.id))
-    .filter((id) => !Number.isNaN(id) && id > 0);
-
-  const onChangePreferredThumbnail = (currentPreferredThumbnail) => {
-    if (currentPreferredThumbnail !== preferredThumbnail && fnChange) {
-      // Handle the change of preferred thumbnail
-      container.extended_metadata = {
-        ...container.extended_metadata,
-        preferred_thumbnail: currentPreferredThumbnail,
-      };
-      fnChange(container);
-    }
+  const onPreferredThumbnailChange = (preferredId) => {
+    if (!fnChange) return;
+    // eslint-disable-next-line no-param-reassign
+    container.extended_metadata = {
+      ...container.extended_metadata,
+      preferred_thumbnail: preferredId,
+    };
+    fnChange(container);
   };
 
   return (
@@ -141,15 +130,11 @@ const newHeader = (props) => {
           <i className="fa fa-ban text-body-tertiary fs-2 text-center d-block" aria-hidden="true" />
         ) : (
           <ImageModal
-            attachment={attachment}
+            container={container}
             popObject={{
               title: container.name,
             }}
-            preferredThumbnail={preferredThumbnail}
-            childrenAttachmentIds={attachmentsIds}
-            onChangePreferredThumbnail={(currentPreferredThumbnail) => onChangePreferredThumbnail(
-              currentPreferredThumbnail
-            )}
+            onPreferredThumbnailChange={onPreferredThumbnailChange}
           />
         )}
       </div>

--- a/app/javascript/src/utilities/imageHelper.js
+++ b/app/javascript/src/utilities/imageHelper.js
@@ -60,6 +60,7 @@ const getAttachmentFromContainer = (container) => {
  * @returns {Promise<string>} A promise that resolves to a base64 image source string or a fallback SVG path.
  */
 const fetchImageSrcByAttachmentId = async (id) => {
+  console.log('preferred-attachment-id', id);
   try {
     if (!id) {
       return '/images/wild_card/no_attachment.svg';

--- a/app/javascript/src/utilities/imageHelper.js
+++ b/app/javascript/src/utilities/imageHelper.js
@@ -61,10 +61,12 @@ const getAttachmentFromContainer = (container) => {
  */
 const fetchImageSrcByAttachmentId = async (id) => {
   try {
-    if (!id) {
+    // Validate that id is a valid positive number
+    const numericId = Number(id);
+    if (!id || Number.isNaN(numericId) || numericId <= 0) {
       return '/images/wild_card/no_attachment.svg';
     }
-    const response = await AttachmentFetcher.fetchThumbnail({ id });
+    const response = await AttachmentFetcher.fetchThumbnail({ id: numericId });
     return `data:image/png;base64,${response}`;
   } catch {
     return '/images/wild_card/not_available.svg';

--- a/app/javascript/src/utilities/imageHelper.js
+++ b/app/javascript/src/utilities/imageHelper.js
@@ -60,7 +60,6 @@ const getAttachmentFromContainer = (container) => {
  * @returns {Promise<string>} A promise that resolves to a base64 image source string or a fallback SVG path.
  */
 const fetchImageSrcByAttachmentId = async (id) => {
-  console.log('preferred-attachment-id', id);
   try {
     if (!id) {
       return '/images/wild_card/no_attachment.svg';

--- a/app/javascript/src/utilities/imageHelper.js
+++ b/app/javascript/src/utilities/imageHelper.js
@@ -55,25 +55,30 @@ const getAttachmentFromContainer = (container) => {
  * all viewers, so it must reference a persisted attachment.
  *
  * @param {Object} container - The analysis container with children[].attachments[].
- * @returns {{previewAttachment: (Object|null), candidateIds: number[], preferredId: (number|null)}}
+ * @returns {{previewAttachment: (Object|null), candidates: Array<{id: number, filename: string}>,
+ *   candidateIds: number[], preferredId: (number|null)}}
  *   previewAttachment - the default preview attachment (see getAttachmentFromContainer);
- *   candidateIds - selectable attachment ids;
+ *   candidates - selectable attachments ({ id, filename }) for the carousel;
+ *   candidateIds - the candidate ids only;
  *   preferredId - the persisted preferred id, only if still among candidateIds, else null.
  */
 const getContainerImageData = (container) => {
   const previewAttachment = getAttachmentFromContainer(container);
 
   const datasetChildren = container?.children?.filter((child) => child.container_type === 'dataset') || [];
-  const candidateIds = datasetChildren
+  const candidates = datasetChildren
     .flatMap((child) => child.attachments || [])
     .filter((att) => att.thumb === true && !att.is_deleted && !att.is_new)
-    .map((att) => Number(att.id))
-    .filter((id) => !Number.isNaN(id) && id > 0);
+    .map((att) => ({ id: Number(att.id), filename: att.filename }))
+    .filter((c) => !Number.isNaN(c.id) && c.id > 0);
+  const candidateIds = candidates.map((c) => c.id);
 
   const raw = container?.extended_metadata?.preferred_thumbnail;
   const preferredId = raw && candidateIds.includes(Number(raw)) ? Number(raw) : null;
 
-  return { previewAttachment, candidateIds, preferredId };
+  return {
+    previewAttachment, candidates, candidateIds, preferredId,
+  };
 };
 
 /**

--- a/app/javascript/src/utilities/imageHelper.js
+++ b/app/javascript/src/utilities/imageHelper.js
@@ -54,6 +54,9 @@ const getAttachmentFromContainer = (container) => {
  * Saved attachments only (thumb, not new, not deleted) — the preferred id is shared across
  * all viewers, so it must reference a persisted attachment.
  *
+ * Candidates are previewable saved attachments — images and PDFs (plus anything that already
+ * has a thumbnail) — so PDFs are selectable even when their thumbnail wasn't generated.
+ *
  * @param {Object} container - The analysis container with children[].attachments[].
  * @returns {{previewAttachment: (Object|null), candidates: Array<{id: number, filename: string}>,
  *   candidateIds: number[], preferredId: (number|null)}}
@@ -62,13 +65,18 @@ const getAttachmentFromContainer = (container) => {
  *   candidateIds - the candidate ids only;
  *   preferredId - the persisted preferred id, only if still among candidateIds, else null.
  */
+const isPreviewableAttachment = (att) => att.thumb === true
+  || (att.content_type || '').startsWith('image/')
+  || att.content_type === 'application/pdf'
+  || /\.pdf$/i.test(att.filename || '');
+
 const getContainerImageData = (container) => {
   const previewAttachment = getAttachmentFromContainer(container);
 
   const datasetChildren = container?.children?.filter((child) => child.container_type === 'dataset') || [];
   const candidates = datasetChildren
     .flatMap((child) => child.attachments || [])
-    .filter((att) => att.thumb === true && !att.is_deleted && !att.is_new)
+    .filter((att) => !att.is_deleted && !att.is_new && isPreviewableAttachment(att))
     .map((att) => ({ id: Number(att.id), filename: att.filename }))
     .filter((c) => !Number.isNaN(c.id) && c.id > 0);
   const candidateIds = candidates.map((c) => c.id);

--- a/app/javascript/src/utilities/imageHelper.js
+++ b/app/javascript/src/utilities/imageHelper.js
@@ -47,6 +47,36 @@ const getAttachmentFromContainer = (container) => {
 };
 
 /**
+ * Derives everything ImageModal needs for analysis "browse & set preferred" mode from a
+ * single container, so the generic ImageModal stays domain-thin and the attachment pipeline
+ * isn't copy-pasted across every analysis-header parent.
+ *
+ * Saved attachments only (thumb, not new, not deleted) — the preferred id is shared across
+ * all viewers, so it must reference a persisted attachment.
+ *
+ * @param {Object} container - The analysis container with children[].attachments[].
+ * @returns {{previewAttachment: (Object|null), candidateIds: number[], preferredId: (number|null)}}
+ *   previewAttachment - the default preview attachment (see getAttachmentFromContainer);
+ *   candidateIds - selectable attachment ids;
+ *   preferredId - the persisted preferred id, only if still among candidateIds, else null.
+ */
+const getContainerImageData = (container) => {
+  const previewAttachment = getAttachmentFromContainer(container);
+
+  const datasetChildren = container?.children?.filter((child) => child.container_type === 'dataset') || [];
+  const candidateIds = datasetChildren
+    .flatMap((child) => child.attachments || [])
+    .filter((att) => att.thumb === true && !att.is_deleted && !att.is_new)
+    .map((att) => Number(att.id))
+    .filter((id) => !Number.isNaN(id) && id > 0);
+
+  const raw = container?.extended_metadata?.preferred_thumbnail;
+  const preferredId = raw && candidateIds.includes(Number(raw)) ? Number(raw) : null;
+
+  return { previewAttachment, candidateIds, preferredId };
+};
+
+/**
  * Fetches the base64 thumbnail image source for a given attachment ID.
  *
  * If no ID is provided, or if the fetch fails, a fallback SVG image path is returned.
@@ -84,5 +114,9 @@ const previewAttachmentImage = (
 };
 
 export {
-  previewContainerImage, previewAttachmentImage, fetchImageSrcByAttachmentId, getAttachmentFromContainer
+  previewContainerImage,
+  previewAttachmentImage,
+  fetchImageSrcByAttachmentId,
+  getAttachmentFromContainer,
+  getContainerImageData,
 };


### PR DESCRIPTION
## Summary

Lets a researcher choose which image is shown as the preview for an analysis that has several datasets/attachments, and browse all of an analysis's images (and PDFs) in the preview modal. Resolves #2740.

## What changed

**ImageModal — a single `container` prop instead of three derived props**
- `ImageModal` now takes either a `container` (analysis mode) or an `attachment` (single-image mode, e.g. element table/list thumbnails), plus one `onPreferredThumbnailChange` callback.
- A new `getContainerImageData(container)` helper (`utilities/imageHelper.js`) derives the default preview attachment, the selectable candidates, and the validated preferred id — so the attachment-id/preferred pipeline is no longer copy-pasted into every analysis header.

**Preview modal — browse & select**
- Shows all previewable attachments of the analysis (images and PDFs) as a thumbnail carousel.
- The selected attachment is rendered large in the main area (PDFs in an iframe), and the filename of the current item is shown for any file type.
- Attachments without a rendered thumbnail (e.g. a PDF whose preview wasn't generated) show a typed file-icon + filename instead of a blank placeholder, and remain selectable.
- Making an image the preferred preview is an explicit action ("Set as preferred"), persisted per container and shared across viewers (`extended_metadata.preferred_thumbnail`), so an accidental click can't change everyone's preview.

**Coverage**
- Wired across every element analysis header: sample, reaction, research plan, cell line, device description, sbmm, and generic elements (reactions were previously not wired).

**Backend**
- Container entity exposes `preferred_thumbnail`.

## Bug fixes folded in
- **Dataset modal:** delete-then-Cancel no longer persists the deletion — the modal owns a deep-cloned working copy and commits only on Save, so Cancel is a true no-op.
- **SBMM analyses:** the root-vs-analysis `onChange` discriminator no longer false-matches `undefined === undefined` on an unsaved sample (which could wipe all analyses); it now requires a real root id and guards `children[0]`.

## Notes
- Rebased onto latest `main`; compatible with the edit/order-mode toggle (#3114) and the unified `ChemotionApiClient` fetchers (#3294).
- PDFs are selectable/previewable even when their thumbnail wasn't generated; generating real first-page thumbnails for large PDFs (and making the `attachment.thumb` flag reliable) is tracked separately as a backend issue.
- Known follow-up: generic-element *order* mode doesn't forward the change handler (fails safe; not addressed here).

________________________________________________________________________________________________________________________________

- [ ] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [x] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
