### PR TITLE
build: bump recommended versions for services

### DIFF
--- a/.service-dependencies
+++ b/.service-dependencies
@@ -1,7 +1,7 @@
 #syntax=v1
-CONVERTER=ComPlat/chemotion-converter-app@1.6.1
+CONVERTER=ComPlat/chemotion-converter-app@1.6.2
 KETCHER=ptrxyz/chemotion-ketchersvc@main
-SPECTRA=ComPlat/chem-spectra-app@v1.3.0
+SPECTRA=ComPlat/chem-spectra-app@v1.3.1
 NMRIUMWRAPPER=NFDI4Chem/nmrium-react-wrapper@v1.0.0
-KETCHER2=epam/ketcher@v3.4.0
-CHEMLOCALLINK=Chemotion/ChemLocalLink@v2.0.0
+KETCHER2=epam/ketcher@v3.5.0
+CHEMLOCALLINK=Chemotion/ChemLocalLink@v2.0.1


### PR DESCRIPTION
- converter app to 1.6.2 https://github.com/ComPlat/chemotion-converter-app/compare/v1.6.1...v1.6.2
- spectra-app to 1.3.1 https://github.com/ComPlat/chem-spectra-app/compare/v1.3.0...v1.3.1
- ChemLocalLink to 2.0.1 https://github.com/Chemotion/ChemLocalLink/releases/tag/v2.0.1
- epam/ketcher to 3.5.0 https://github.com/epam/ketcher/releases/tag/v3.5.0



