### PR TITLE
refactor: display account and profile page with iframe in modal

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -44,10 +44,10 @@ class PagesController < ApplicationController
     end
 
     if @user.save
-      flash[:success] = 'User settings were successfully saved!'
-      render 'pages/redirect_parent'
+      flash['success'] = 'User settings is successfully saved!'
+      redirect_to pages_settings_path
     else
-      flash.now[:danger] = 'Not saved! Please check input fields.'
+      flash.now['danger'] = 'Not saved! Please check input fields.'
       render 'user'
     end
   end
@@ -61,10 +61,10 @@ class PagesController < ApplicationController
     @profile.assign_attributes(profile_params)
 
     if @profile.save
-      flash[:success] = 'Profile is successfully saved!'
-      render 'pages/redirect_parent'
+      flash['success'] = 'User settings is successfully saved!'
+      redirect_to pages_settings_path
     else
-      flash.now[:danger] = 'Not saved! Please check input fields.'
+      flash.now['danger'] = 'Not saved! Please check input fields.'
       render 'profile'
     end
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -13,7 +13,7 @@ class PagesController < ApplicationController
 
   def docx; end
 
-  def welcome;
+  def welcome
     flash.clear
   end
 
@@ -28,22 +28,26 @@ class PagesController < ApplicationController
       provider_authorize = Chemotion::ScifinderNService.provider_authorize(code, sf_verifer)
       sfc = ScifinderNCredential.find_by(created_by: current_user.id)
       ScifinderNCredential.create!(provider_authorize.merge(created_by: current_user.id)) if sfc.blank?
-      sfc.update!(provider_authorize) unless sfc.blank?
+      sfc.update!(provider_authorize) if sfc.present?
       redirect_to root_path
-    rescue StandardError => e
+    rescue StandardError
       redirect_to '/500.html'
     end
   end
 
   def update_user
     @user = current_user
-    @user.counters['reactions'] = params[:reactions_count].to_i if params[:reactions_count].present?
-    @user.reaction_name_prefix = params[:reaction_name_prefix] if params[:reactions_count].present?
+
+    if params[:reactions_count].present?
+      @user.counters['reactions'] = params[:reactions_count].to_i
+      @user.reaction_name_prefix = params[:reaction_name_prefix]
+    end
+
     if @user.save
-      flash['success'] = 'User settings is successfully saved!'
-      redirect_to root_path
+      flash[:success] = 'User settings were successfully saved!'
+      render 'pages/redirect_parent'
     else
-      flash.now['danger'] = 'Not saved! Please check input fields.'
+      flash.now[:danger] = 'Not saved! Please check input fields.'
       render 'user'
     end
   end
@@ -57,16 +61,15 @@ class PagesController < ApplicationController
     @profile.assign_attributes(profile_params)
 
     if @profile.save
-      flash['success'] = 'Profile is successfully saved!'
-      redirect_to root_path
+      flash[:success] = 'Profile is successfully saved!'
+      render 'pages/redirect_parent'
     else
-      flash.now['danger'] = 'Not saved! Please check input fields.'
+      flash.now[:danger] = 'Not saved! Please check input fields.'
       render 'profile'
     end
   end
 
   private
-
 
   def profile_params
     params.require(:profile).permit(:show_external_name, :show_sample_name, :show_sample_short_label, :curation)

--- a/app/javascript/src/components/navigation/UserAuth.js
+++ b/app/javascript/src/components/navigation/UserAuth.js
@@ -308,6 +308,9 @@ export default class UserAuth extends Component {
   }
 
   handleSettingsHide = () => {
+    UserActions.fetchCurrentUser();
+    const { currentUser } = this.state;
+    UserActions.updateUserProfile(currentUser.profile);
     this.setState({ showSettings: false });
   };
 

--- a/app/javascript/src/components/navigation/UserAuth.js
+++ b/app/javascript/src/components/navigation/UserAuth.js
@@ -34,6 +34,7 @@ export default class UserAuth extends Component {
       selectedUsers: null,
       showSubscription: false,
       showAffiliations: false,
+      showSettings: false,
       currentSubscriptions: [],
       showDeviceMetadataModal: false,
       device: {},
@@ -54,6 +55,9 @@ export default class UserAuth extends Component {
     this.handleAffiliationsShow = this.handleAffiliationsShow.bind(this);
     this.handleAffiliationsHide = this.handleAffiliationsHide.bind(this);
     this.renderAffiliations = this.renderAffiliations.bind(this);
+    this.handleSettingsShow = this.handleSettingsShow.bind(this);
+    this.handleSettingsHide = this.handleSettingsHide.bind(this);
+    this.renderSettings = this.renderSettings.bind(this);
 
     this.promptTextCreator = this.promptTextCreator.bind(this);
 
@@ -284,6 +288,7 @@ export default class UserAuth extends Component {
   handleAffiliationsShow() {
     this.setState({ showAffiliations: true });
   }
+
   handleAffiliationsHide = () => {
     this.setState({ showAffiliations: false });
   };
@@ -292,14 +297,47 @@ export default class UserAuth extends Component {
     return this.state.showAffiliations ? (
       <Affiliations
         show={this.state.showAffiliations}
-        onHide={this.handleAffiliationsHide} />
+        onHide={this.handleAffiliationsHide}
+      />
     ) : null;
+  }
 
+  // eslint-disable-next-line class-methods-use-this
+  handleSettingsShow() {
+    this.setState({ showSettings: true });
+  }
+
+  handleSettingsHide = () => {
+    this.setState({ showSettings: false });
+  };
+
+  renderSettings() {
+    const { showSettings } = this.state;
+
+    return (
+      <Modal
+        fullscreen
+        show={showSettings}
+        onHide={this.handleSettingsHide}
+        centered
+      >
+        <Modal.Header closeButton />
+        <Modal.Body style={{ padding: 0, overflow: 'hidden' }}>
+          <iframe
+            title="settings"
+            src="/pages/settings"
+            style={{ width: '100%', height: '100%', border: 'none' }}
+          />
+        </Modal.Body>
+      </Modal>
+    );
   }
 
   // render modal
   renderModal() {
-    const { showModal, currentUser, currentGroups, currentDevices } = this.state;
+    const {
+      showModal, currentUser, currentGroups, currentDevices
+    } = this.state;
 
     const tBodyGroups = currentGroups.map((g) => (
       <GroupElement
@@ -614,7 +652,10 @@ export default class UserAuth extends Component {
             {currentUser.name}
           </Dropdown.Toggle>
           <Dropdown.Menu>
-            <Dropdown.Item eventKey="1" href="/pages/settings">
+            <Dropdown.Item
+              eventKey="1"
+              onClick={this.handleSettingsShow}
+            >
               Account &amp; Profile
             </Dropdown.Item>
             {currentUser.is_templates_moderator && (
@@ -626,7 +667,8 @@ export default class UserAuth extends Component {
               Change Password
             </Dropdown.Item>
             <Dropdown.Item
-              onClick={this.handleAffiliationsShow}>
+              onClick={this.handleAffiliationsShow}
+            >
               My Affiliations
             </Dropdown.Item>
             <Dropdown.Item onClick={this.handleShow}>My Groups & Devices</Dropdown.Item>
@@ -655,6 +697,7 @@ export default class UserAuth extends Component {
 
         {this.renderModal()}
         {this.renderAffiliations()}
+        {this.renderSettings()}
         <UserLabelModal
           showLabelModal={showLabelModal}
           onHide={() => this.handleLabelClose()}

--- a/app/views/pages/redirect_parent.html.haml
+++ b/app/views/pages/redirect_parent.html.haml
@@ -1,0 +1,6 @@
+- if flash[:success]
+  .alert.alert-success
+    = flash[:success]
+
+:javascript
+  window.top.location.href = "#{root_path}";

--- a/app/views/pages/redirect_parent.html.haml
+++ b/app/views/pages/redirect_parent.html.haml
@@ -1,6 +1,0 @@
-- if flash[:success]
-  .alert.alert-success
-    = flash[:success]
-
-:javascript
-  window.top.location.href = "#{root_path}";

--- a/app/views/pages/settings.haml
+++ b/app/views/pages/settings.haml
@@ -91,7 +91,4 @@
 
   #UserCounter
 
-  = link_to(root_path) do
-    %button.btn.btn-primary.mb-5 Back
-
   %script{:src => asset_path('pages.js')}


### PR DESCRIPTION
account and profile page is now displayed with an iframe inside a modal
when changing profile automatically reloading the page is no longer necessary
also fixes https://github.com/ComPlat/chemotion_ELN/issues/2658 because modal have the close button in the header