### PR TITLE
test: fix sample api flaky specs

### DIFF
--- a/spec/api/chemotion/sample_api_spec.rb
+++ b/spec/api/chemotion/sample_api_spec.rb
@@ -357,23 +357,18 @@ describe Chemotion::SampleAPI do
       end
     end
 
-    context 'when molecule_sort is enabled' do
-      let!(:sample) { create(:sample, collections: [personal_collection]) }
-      let!(:sample2) { create(:sample, collections: [personal_collection]) }
+    context 'with molecule_sort' do
+      let(:molecules) { create_list(:molecule, 2) { |m, i| m.sum_formular = "C#{i}" } }
+      let(:samples) { create_list(:sample, 2, collections: [personal_collection]) { |s, i| s.molecule = molecules[i] } }
 
       it 'returns samples in the right order' do
+        sample_ids = samples.map(&:id)
+        # ascending order of C with molecule_sort enabled
         get '/api/v1/samples', params: { molecule_sort: 1 }
-        expect(JSON.parse(response.body)['samples'].pluck('id')).to eq([sample.id, sample2.id])
-      end
-    end
-
-    context 'when molecule_sort is disabled' do
-      let!(:sample) { create(:sample, collections: [personal_collection]) }
-      let!(:sample2) { create(:sample, collections: [personal_collection]) }
-
-      it 'returns samples in the right order' do
+        expect(JSON.parse(response.body)['samples'].pluck('id')).to eq(sample_ids)
+        # descending order of sample.updated_at with molecule_sort disabled
         get '/api/v1/samples', params: { molecule_sort: 0 }
-        expect(JSON.parse(response.body)['samples'].pluck('id')).to eq([sample2.id, sample.id])
+        expect(JSON.parse(response.body)['samples'].pluck('id')).to eq(sample_ids.reverse)
       end
     end
 


### PR DESCRIPTION
ensure the factory-bot samples and molecules can be deterministically sorted

```
Failures:

  1) Chemotion::SampleAPI GET /api/v1/samples when molecule_sort is enabled returns samples in the right order
     Failure/Error: expect(JSON.parse(response.body)['samples'].pluck('id')).to eq([sample.id, sample2.id])

       expected: [307, 308]
            got: [308, 307]

       (compared using ==)
     # ./spec/api/chemotion/sample_api_spec.rb:366:in `block (4 levels) in <top (required)>'
     # /cache/bundle/ruby/2.7.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'

Finished in 8 minutes 7 seconds (files took 11.11 seconds to load)
1913 examples, 1 failure, 53 pending

Failed examples:

rspec ./spec/api/chemotion/sample_api_spec.rb:364 # Chemotion::SampleAPI GET /api/v1/samples when molecule_sort is enabled returns samples in the right order
```