### PR TITLE
fix: missing gem daemons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'charlock_holmes'
 gem 'closure_tree'
 gem 'countries'
 
+gem 'daemons'
 gem 'delayed_cron_job'
 gem 'delayed_job_active_record'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,7 @@ GEM
     csv (3.3.5)
     cypress-on-rails (1.17.0)
       rack
+    daemons (1.4.1)
     database_cleaner (2.1.0)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.2.1)
@@ -823,6 +824,7 @@ DEPENDENCIES
   closure_tree
   countries
   cypress-on-rails
+  daemons
   database_cleaner
   database_cleaner-active_record
   debase


### PR DESCRIPTION
add gems daemons used to start delayed_job

609731467 removed it as an indirect dependency of ketcher-rails

ref: #2591

