### PR TITLE
fix(datacollector): ensure recipient is a user

### DIFF
--- a/lib/datacollector/correspondence.rb
+++ b/lib/datacollector/correspondence.rb
@@ -36,6 +36,7 @@ module Datacollector
 
       raise Errors::DatacollectorError, "Sender not found #{from}" unless validate(@sender)
       raise Errors::DatacollectorError, "Recipient not found #{to}" unless validate(@recipient)
+      raise Errors::DatacollectorError, 'Recipient can only be a User' unless valid_recipient?(@recipient)
       raise Errors::DatacollectorError, 'User can only send to self' if @sender.is_a?(User) && @recipient != @sender
 
       prepare_containers

--- a/lib/datacollector/correspondence_array.rb
+++ b/lib/datacollector/correspondence_array.rb
@@ -18,7 +18,9 @@ module Datacollector
       errors = []
       raise Errors::DatacollectorError, "Sender not found #{from}" unless Correspondence.validate(@sender)
 
-      correspondences = (to_list.presence || [@sender]).filter_map do |receiver|
+      recipients = to_list.presence
+      recipients ||=  Correspondence.valid_recipient?(@sender) ? [@sender] : []
+      correspondences = recipients.filter_map do |receiver|
         Correspondence.new(@sender, receiver)
       rescue Errors::DatacollectorError => e
         errors << e.message

--- a/lib/datacollector/correspondence_helpers.rb
+++ b/lib/datacollector/correspondence_helpers.rb
@@ -36,6 +36,10 @@ module Datacollector
       end
     end
 
+    def valid_recipient?(obj)
+      obj.is_a?(User)
+    end
+
     # Find a device by email or name abbreviation
     # @param [String] The email or name abbreviation
     def find_device(raw_identifier)

--- a/spec/lib/datacollector/correspondence_spec.rb
+++ b/spec/lib/datacollector/correspondence_spec.rb
@@ -16,6 +16,7 @@ describe Datacollector::Correspondence do
   let(:person) { create(:person) }
   let(:device) { create(:device, :file_local, user_identifiers: [person.name_abbreviation]) }
 
+  # rubocop:disable RSpec/NestedGroups
   describe described_class do
     subject(:correspondence) { described_class.new(device, person) }
 
@@ -35,7 +36,16 @@ describe Datacollector::Correspondence do
         expect(container).to be_a(Container)
         expect(person.container.descendants).to include(container)
       end
+
+      context 'when the arguments are not valid' do
+        subject(:correspondence) { described_class.new(device, device) }
+
+        it 'raises a Errors::DatacollectorError' do
+          expect { correspondence }.to raise_error(Errors::DatacollectorError)
+        end
+      end
     end
+    # rubocop:enable RSpec/NestedGroups
 
     describe '#sender_container' do
       it 'has the proper name and container_type' do


### PR DESCRIPTION
usecase: when a mail is send by a registered device but only to the ELN address

