### PR TITLE
fix: prefer processed peaks and auto select single spectrum on load

### DIFF
--- a/app/javascript/src/stores/alt/stores/SpectraStore.js
+++ b/app/javascript/src/stores/alt/stores/SpectraStore.js
@@ -95,11 +95,16 @@ class SpectraStore {
     spcMetas.sort((a, b) => {
       return sortedSpcIdxs.indexOf(a.idx) - sortedSpcIdxs.indexOf(b.idx);
     });
-    let newArrSpcIdx = spcMetas.map(spci => (
-      spci.idx
-    )).filter(r => r !== null);
-    if (newArrSpcIdx.length <= 1) {
-      newArrSpcIdx = [];
+    let newArrSpcIdx = [];
+    if (spcMetas.length >= 1) {
+      const spcInfoWithLabel = sortedSpcInfo.find(
+        info => typeof info.label === "string" && info.label.toLowerCase().includes('processed')
+      );
+      if (spcInfoWithLabel) {
+        newArrSpcIdx = [spcInfoWithLabel.idx];
+      } else {
+        newArrSpcIdx = spcMetas.map(spc => spc.idx);
+      }
     }
     
     this.setState({


### PR DESCRIPTION
## Summary:
Ensure the initial selection logic picks processed data when available and auto selects a single spectrum.

## Changes:
Update handleLoadSpectra to:
- Scan spcInfos for a label that includes processed (case insensitive) and set arrSpcIdx accordingly.
- Fallback to all indices when no processed label is found.
- Change the entry conditions to cover single spectra in multi spectra layout

## Why:
Users expect processed peaks to be the default when present. Also, if there is only one spectrum, it should be selected without extra clicks.