### PR TITLE
fix: Reorder DnD backends to prioritize touch support on hybrid and mobile devices

### DIFF
--- a/app/javascript/src/apps/mydb/index.js
+++ b/app/javascript/src/apps/mydb/index.js
@@ -25,12 +25,12 @@ Sentry.init({
 const backendOptions = {
   backends: [
     {
-      backend: HTML5Backend, // Mouse Drag Support
-    },
-    {
       backend: TouchBackend, // Touch Drag Support
       options: { enableMouseEvents: true },
       transition: TouchTransition, // Detects if touch is used
+    },
+    {
+      backend: HTML5Backend, // Mouse Drag Support
     },
   ],
 };


### PR DESCRIPTION
Summary

Reordered the drag-and-drop backend array so that the TouchBackend is evaluated before the HTML5Backend.
This ensures that touch input is correctly detected on touch-capable and hybrid devices.

Details

Previously, the HTML5Backend was listed first, which caused it to be initialized even on devices that also emit mouse events (e.g. tablets, touch laptops). As a result, drag-and-drop interactions would fail or behave inconsistently on mobile devices.

By placing the TouchBackend first and enabling enableMouseEvents: true, we allow:

Proper detection of touch interactions via TouchTransition.

Consistent DnD behavior across both touch and mouse inputs.

The HTML5Backend to act as a fallback when touch is not available.