### PR TITLE
fix: remove leftover handleEdit binding that caused creation error

### DIFF
--- a/app/javascript/src/components/generic/GenericAttachments.js
+++ b/app/javascript/src/components/generic/GenericAttachments.js
@@ -45,7 +45,6 @@ class GenericAttachments extends Component {
       sortDirection: 'asc',
     };
     this.createAttachmentPreviews = this.createAttachmentPreviews.bind(this);
-    this.handleEdit = this.handleEdit.bind(this);
     this.onImport = this.onImport.bind(this);
     this.handleFilterChange = this.handleFilterChange.bind(this);
     this.handleSortChange = this.handleSortChange.bind(this);


### PR DESCRIPTION
## Description

Fixes WSOD (White Screen of Death) when creating generic elements.

## Problem

The handleEdit method was removed in [commit](https://github.com/ComPlat/chemotion_ELN/commit/99ab08e2572c7d0207ce023b2ee911eca9e47ba0#diff-775fbde6a5a449800ce00f20a5dd4af3e26b0972b113c4acda2549a3c45fc3ba), but its binding (`this.handleEdit = this.handleEdit.bind(this)`) remained in the constructor, causing the runtime error.

## Solution

Removed the orphaned `this.handleEdit = this.handleEdit.bind(this);` line from the constructor. 
----------------------------------
- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
