### PR TITLE
feat(UI): refactor analyses tab to use a dedicated hint component

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.js
@@ -30,11 +30,11 @@ import NMRiumDisplayer from 'src/components/nmriumWrapper/NMRiumDisplayer';
 import TextTemplateActions from 'src/stores/alt/actions/TextTemplateActions';
 import SpectraEditorButton from 'src/components/common/SpectraEditorButton';
 // eslint-disable-next-line max-len
-import {AnalysisVariationLink} from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses';
-import {truncateText} from 'src/utilities/textHelper';
+import { AnalysisVariationLink } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsAnalyses';
+import { truncateText } from 'src/utilities/textHelper';
 import AccordionHeaderWithButtons from 'src/components/common/AccordionHeaderWithButtons';
-import {CommentButton, CommentBox} from 'src/components/common/AnalysisCommentBoxComponent';
-import {UploadField} from 'src/apps/mydb/elements/details/analyses/UploadField';
+import { CommentButton, CommentBox } from 'src/components/common/AnalysisCommentBoxComponent';
+import { UploadField } from 'src/apps/mydb/elements/details/analyses/UploadField';
 
 const nmrMsg = (reaction, container) => {
   const ols = container.extended_metadata?.kind?.split('|')[0].trim();


### PR DESCRIPTION
- Introduced a new method `renderAnalysesHint` to encapsulate the hint message for the analyses tab.
- Replaced the inline hint message with a call to `renderAnalysesHint` for better code organization and reusability.
- Ensured the hint is displayed consistently in various states of the analyses tab.

Closes https://github.com/ComPlat/chemotion_ELN/issues/2714
