### PR TITLE
refactor(UI): restructure CAS input layout in SampleDetails component

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -897,50 +897,52 @@ export default class SampleDetails extends React.Component {
     return (
       <div className="my-4">
         <InputGroup>
-          <InputGroup.Text>CAS</InputGroup.Text>
-          <CreatableSelect
-            name="cas"
-            isClearable
-            isInputEditable
-            inputValue={this.state.casInputValue}
-            options={options}
-            onChange={(selectedOption) => {
-              if (selectedOption) {
-                const value = selectedOption.value;
-                this.setState({ casInputValue: value });
-                this.updateCas(selectedOption);
-              } else {
-                this.setState({ casInputValue: '' });
-                this.updateCas(null);
-              }
-            }}
-            onInputChange={(inputValue, { action }) => {
-              if (action === 'input-change' || action === 'set-value') {
-                this.setState({ casInputValue: inputValue });
-              }
-            }}
-            onFocus={() => {
-              const currentCas = cas || '';
-              this.setState({ casInputValue: currentCas });
-            }}
-            onMenuOpen={() => this.onCasSelectOpen(casArr)}
-            isLoading={isCasLoading}
-            value={options.find(({ value }) => value === cas) || null}
-            onBlur={() => this.isCASNumberValid(cas || '', true)}
-            isDisabled={!sample.can_update}
-            className="flex-grow-1"
-            placeholder="Select or enter CAS number"
-            allowCreateWhileLoading
-            formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
-          />
-          <OverlayTrigger placement="bottom" overlay={this.clipboardTooltip()}>
-            <Button
-              variant="light"
-              onClick={() => copyToClipboard(cas)}
-            >
-              <i className="fa fa-clipboard" />
-            </Button>
-          </OverlayTrigger>
+          <div className="d-flex flex-grow-1">
+            <InputGroup.Text>CAS</InputGroup.Text>
+            <CreatableSelect
+              name="cas"
+              isClearable
+              isInputEditable
+              inputValue={this.state.casInputValue}
+              options={options}
+              onChange={(selectedOption) => {
+                if (selectedOption) {
+                  const value = selectedOption.value;
+                  this.setState({ casInputValue: value });
+                  this.updateCas(selectedOption);
+                } else {
+                  this.setState({ casInputValue: '' });
+                  this.updateCas(null);
+                }
+              }}
+              onInputChange={(inputValue, { action }) => {
+                if (action === 'input-change' || action === 'set-value') {
+                  this.setState({ casInputValue: inputValue });
+                }
+              }}
+              onFocus={() => {
+                const currentCas = cas || '';
+                this.setState({ casInputValue: currentCas });
+              }}
+              onMenuOpen={() => this.onCasSelectOpen(casArr)}
+              isLoading={isCasLoading}
+              value={options.find(({ value }) => value === cas) || null}
+              onBlur={() => this.isCASNumberValid(cas || '', true)}
+              isDisabled={!sample.can_update}
+              className="flex-grow-1"
+              placeholder="Select or enter CAS number"
+              allowCreateWhileLoading
+              formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
+            />
+            <OverlayTrigger placement="bottom" overlay={this.clipboardTooltip()}>
+              <Button
+                variant="light"
+                onClick={() => copyToClipboard(cas)}
+              >
+                <i className="fa fa-clipboard" />
+              </Button>
+            </OverlayTrigger>
+          </div>
         </InputGroup>
         {!validCas && errorMessage}
       </div>


### PR DESCRIPTION
Updated the layout of the CAS input section in the SampleDetails component to improve UI consistency. The InputGroup now includes a flex container for better alignment of the CAS label and input field, while maintaining existing functionality.

Closes https://github.com/ComPlat/chemotion_ELN/issues/2814
