### PR TITLE
fix: dispatch error in gas phase reaction scheme UI

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -677,19 +677,24 @@ export default class ReactionDetails extends Component {
 
   // eslint-disable-next-line class-methods-use-this
   updateReactionVesselSize(reaction) {
+    if (!reaction) return;
+
     const { catalystMoles, vesselSize } = reaction.findReactionVesselSizeCatalystMaterialValues();
 
-    if (vesselSize) {
-      GasPhaseReactionActions.setReactionVesselSize(vesselSize);
-    } else {
-      GasPhaseReactionActions.setReactionVesselSize(null);
-    }
+    // Avoid dispatch while another Alt dispatch is in progress.
+    setTimeout(() => {
+      if (vesselSize) {
+        GasPhaseReactionActions.setReactionVesselSize(vesselSize);
+      } else {
+        GasPhaseReactionActions.setReactionVesselSize(null);
+      }
 
-    if (catalystMoles) {
-      GasPhaseReactionActions.setCatalystReferenceMole(catalystMoles);
-    } else {
-      GasPhaseReactionActions.setCatalystReferenceMole(null);
-    }
+      if (catalystMoles) {
+        GasPhaseReactionActions.setCatalystReferenceMole(catalystMoles);
+      } else {
+        GasPhaseReactionActions.setCatalystReferenceMole(null);
+      }
+    }, 0);
   }
 
   /**


### PR DESCRIPTION
**Problem:** Invariant Violation thrown intermittently while rendering reactions:
Error: Invariant Violation: Dispatch.dispatch(...): Cannot dispatch in the middle of a dispatch.
Stack (example):
invariant.js:39 Uncaught Error: Invariant Violation: Dispatch.dispatch(...): Cannot dispatch in the middle of a dispatch.
at ReactionDetails.updateReactionVesselSize (ReactionDetails.js:685:1)
at ReactionDetails.render (ReactionDetails.js:731:1)

**How to reproduce:** rebase to current main, then click on create new reaction button in the header bar.

**Cause:**
ReactionDetails.updateReactionVesselSize dispatches Alt actions (GasPhaseReactionActions.setReactionVesselSize, setCatalystReferenceMole) synchronously. When handleInputChange or a store-driven lifecycle event triggers during an existing Alt dispatch cycle, calling these actions immediately attempts a nested dispatch, which Alt forbids — producing the invariant error. The race/ordering makes the failure intermittent.

**Fix:**
- Defer dispatches out of the current call stack using setTimeout(..., 0) inside updateReactionVesselSize so actions run on the next tick.
- Add a null-check guard for reaction to avoid unnecessary work when no reaction is present.
- Also updated handleInputChange earlier to defer calling updateReactionVesselSize for vessel size changes (so dispatches are delayed and not executed during another dispatch).
______________________________________________________________________________________________________________________
- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
