### PR TITLE
fix: backend conversion with quill-delta-to-html (^0.12.1)

### DIFF
--- a/lib/chemotion/quill_to_html.rb
+++ b/lib/chemotion/quill_to_html.rb
@@ -11,7 +11,7 @@ module Chemotion
       @root = root
       @env = env
       @schmooze_dependencies = schmooze_dependencies.merge(
-        quillDeltaToHtml: 'quill-delta-to-html'
+        quillDeltaToHtml: 'quill-delta-to-html',
       )
       @schmooze_methods = schmooze_methods.merge(
         convert: lambda { |delta_ops = '[]'|


### PR DESCRIPTION
PR resolves QuillDeltaToHtmlConverter, after the upgrade of versions.

Version bump PR: https://github.com/ComPlat/chemotion_ELN/pull/2828

--------------------------------------

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
