### PR TITLE
fix: rename device type to device class

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/propertiesTab/PropertiesForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/propertiesTab/PropertiesForm.js
@@ -85,7 +85,7 @@ const PropertiesForm = () => {
   ];
 
   const setupDescription = () => {
-    const type = deviceDescription.device_type;
+    const type = deviceDescription.device_class;
     if (!['setup', 'component'].includes(type)) { return ''; }
     const rowFields = type == 'setup' ? setupFields : componentFields;
     const label = type == 'setup' ? 'Component' : 'Setup';


### PR DESCRIPTION
setup area wasn't shown after renaming device_type to device_class