### PR TITLE
fix(spectra): enforce binary multipart uploads after httparty bump

### DIFF
--- a/lib/chemotion/jcamp.rb
+++ b/lib/chemotion/jcamp.rb
@@ -203,7 +203,7 @@ module Chemotion
             body: {
               file: f
             },
-            multipart: true
+            multipart: true,
           )
         end
         response
@@ -235,7 +235,7 @@ module Chemotion
               list_file_names: list_file_names,
               extras: extras,
             },
-            multipart: true
+            multipart: true,
           )
         ensure
           files_to_read.each(&:close)
@@ -286,7 +286,7 @@ module Chemotion
             response = HTTParty.post(
               api_endpoint,
               body: body,
-              multipart: true
+              multipart: true,
             )
           end
           response
@@ -320,7 +320,7 @@ module Chemotion
               response = HTTParty.post(
                 api_endpoint,
                 body: body,
-                multipart: true
+                multipart: true,
               )
             end
           end
@@ -355,7 +355,7 @@ module Chemotion
               response = HTTParty.post(
                 api_endpoint,
                 body: body,
-                multipart: true
+                multipart: true,
               )
             end
           end
@@ -439,7 +439,7 @@ module Chemotion
             body: {
               file: f
             },
-            multipart: true
+            multipart: true,
           )
         end
         response


### PR DESCRIPTION
## Context
After updating HTTParty from 0.23.1 to 0.24.0, uploads to chem-spectra-app started failing. The service did not receive the expected multipart file field or file content could be corrupted.

## Changes

Open all uploaded files in binary mode (rb)

Ensure multipart uploads are enabled for all HTTParty POST requests (multipart: true)

Keep request bodies consistent across endpoints (zip_jcamp_n_img, zip_image, combine_images, predict, nmrium)