### PR TITLE
fix: selecting text when dnd tab layout options

### DIFF
--- a/app/javascript/src/apps/mydb/elements/tabLayout/TabLayoutEditor.js
+++ b/app/javascript/src/apps/mydb/elements/tabLayout/TabLayoutEditor.js
@@ -170,6 +170,7 @@ export default function TabLayoutEditor({
         <div
           key={title}
           ref={ref}
+          onMouseDown={(e) => e.preventDefault()}
         >
           <h5>{title}</h5>
           <ListGroup className="my-1 tab-layout-editor-list" variant="flush">


### PR DESCRIPTION
Prevent default selection on mousedown for draggable items in the tab layout menu