### PR TITLE
fix: clear reaction variations table after gas scheme switch

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -32,10 +32,6 @@ import columnDefinitionsReducer
 import GasPhaseReactionStore from 'src/stores/alt/stores/GasPhaseReactionStore';
 
 export default function ReactionVariations({ reaction, onReactionChange, isActive }) {
-  if (!isActive) {
-    return null;
-  }
-
   if (reaction.isNew) {
     return (
       <Alert variant="info">


### PR DESCRIPTION
This PR addresses #2877.

Prior to this PR, when switching from "Current Scheme: Default" to "Current Scheme: Gaseous" in the scheme tab, the table in the variations tab wouldn't be cleared, which led to gaseous materials being treated incorrectly in the variations table.

Applying this PR clears the table after the aforementioned switch, which is the expected behavior.