### PR TITLE
chore(deps): bump inchi-gem to v1.07.5 (InChI 1.07.5)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem 'httparty'
 
 gem 'icalendar'
 gem 'image_processing', '~> 1.8'
-gem 'inchi-gem', git: 'https://github.com/ComPlat/inchi-gem.git', branch: 'main'
+gem 'inchi-gem', git: 'https://github.com/ComPlat/inchi-gem.git', tag: 'v1.07.5'
 
 gem 'jquery-rails' # must be in, otherwise the views lack jquery, even though the gem is supplied by ketcher-rails
 gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ComPlat/inchi-gem.git
-  revision: 55cf667c08f5391ae0ddcd7908f433b1ab0766c2
-  branch: main
+  revision: 9976f75ba21d06ea98b7fc328ed3f993d9aa4fda
+  tag: v1.07.5
   specs:
-    inchi-gem (1.06.1)
+    inchi-gem (1.07.5)
 
 GIT
   remote: https://github.com/ComPlat/rinchi-gem.git


### PR DESCRIPTION
## Summary

Upgrades the bundled InChI library from **1.06.1 to 1.07.5** and replaces the floating `branch: main` reference with a reproducible release-tag pin.

- `Gemfile`: `inchi-gem` now pinned to `tag: 'v1.07.5'` (was `branch: 'main'`).
- `Gemfile.lock`: revision `55cf667c08…` → `9976f75ba2…`, `inchi-gem (1.06.1)` → `(1.07.5)`.

Pinning to a tag instead of tracking `main` makes the dependency reproducible: the resolved revision no longer drifts whenever `ComPlat/inchi-gem`'s `main` advances.

## Changes

- `Gemfile` (+1 −1)
- `Gemfile.lock` (+3 −3)

## Testing

- CI must resolve the `v1.07.5` tag from `ComPlat/inchi-gem` and pass — confirm green before merge.