### PR TITLE
fix: calculate width for long labels for centering and scaling sample svg

### DIFF
--- a/lib/ketcher_service/svg_processor.rb
+++ b/lib/ketcher_service/svg_processor.rb
@@ -197,7 +197,7 @@ module KetcherService
         return [[x,y],[x+font*l,y+font]]
       end
       
-      # For longer strings (>3 chars), use new logic with text-anchor positioning
+      # For longer strings (>3 chars), use logic with text-anchor positioning
       calculate_long_text_bounds(text, text_content)
     end
 
@@ -212,13 +212,14 @@ module KetcherService
       x, y = text["x"].to_f, text["y"].to_f
       
       # Get font size from font attribute or font-size attribute
-      # Priority: font attribute (e.g., "24px Arial") > font-size attribute > default 24.0
+      # Priority: font attribute (e.g., "24px Arial") > font-size attribute > old extraction method
       font = if text["font"] && text["font"].match(/(\d+\.?\d*)px/)
                text["font"].match(/(\d+\.?\d*)px/)[1].to_f
              elsif text["font-size"] && text["font-size"].match(/(\d+\.?\d*)/)
                text["font-size"].match(/(\d+\.?\d*)/)[1].to_f
              else
-               24.0 # default font size
+               # Use old extraction method as fallback
+               (text["font"].match(/(\d+\.?\d*)px/) && $1).to_f
              end
       
       # Calculate text width more accurately


### PR DESCRIPTION
### WHAT:
- In Samples SVG, there is an extra space on the right side of the SVG that is being generated due to the long labels, for example, CHIRAL.
<img width="983" height="297" alt="image" src="https://github.com/user-attachments/assets/ba47df29-0b1a-4eb0-ab23-52a97706041c" />


### HOW:
- Resolve the issue by recalculating the sizing(width) for the text labels that have three or more than 3 characters in a label.

<img width="990" height="302" alt="image" src="https://github.com/user-attachments/assets/19a79fe4-19a5-4d0e-85c3-001bddea256e" />

#### IMPORTANT: 
This editor would only work like labels:
- Chiral
- Custom labels (if bigger then 3 character)

Not on (will run with the original logic): 
- CH3
- C3H
- Or any atom 

--------------------
- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
