### PR TITLE
fix: ensure loading spinner stops when MolViewer modal is closed

### DIFF
--- a/app/javascript/src/components/viewer/MolViewerModal.js
+++ b/app/javascript/src/components/viewer/MolViewerModal.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/forbid-prop-types */
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Modal } from 'react-bootstrap';
 import { MolViewer } from 'react-molviewer';
@@ -15,13 +15,23 @@ function MolViewerModal(props) {
 
   if (!config?.featureEnabled || !fileContent) return null;
 
+  const handleHide = () => {
+    // Ensure global loading spinner is stopped when the modal is closed,
+    // even if the MolViewer unmounts before its callback fires.
+    handleModalOpen();
+    // Use setTimeout to defer outside any ongoing dispatch cycle
+    setTimeout(() => {
+      LoadingActions.stop();
+    }, 0);
+  };
+
   return (
     <Modal
       animation
       centered
       className="modal-xxxl"
       show={show}
-      onHide={handleModalOpen}
+      onHide={handleHide}
     >
       <Modal.Header closeButton>
         <Modal.Title>


### PR DESCRIPTION
- Updated the modal's onHide handler to stop the global loading spinner when the modal is closed, ensuring proper cleanup even if the MolViewer unmounts before its callback executes.

Closes https://github.com/ComPlat/chemotion/issues/430
