### PR TITLE
fix: not available check for image thumbnail in research plan list

### DIFF
--- a/app/javascript/src/apps/mydb/elements/list/ElementsTableEntries.js
+++ b/app/javascript/src/apps/mydb/elements/list/ElementsTableEntries.js
@@ -60,7 +60,7 @@ export default class ElementsTableEntries extends Component {
       );
     }
     if (element.type === 'research_plan' || element.element_klass) {
-      if (element.preview_attachment !== 'not available') {
+      if (element.preview_attachment) {
         return (
           <div
             className="flex-grow-1"


### PR DESCRIPTION
previously refactor image modal changed `if (element.thumb_svg !== 'not available')` to` if (element.preview_attachment !== 'not available')` but preview_attachment is null when thumb is "not available".