### PR TITLE
fix: loading spinner not cleared after successful analysis save

### DIFF
--- a/app/javascript/src/components/generic/GenericElDetails.js
+++ b/app/javascript/src/components/generic/GenericElDetails.js
@@ -91,18 +91,19 @@ export default class GenericElDetails extends Component {
     ElementStore.unlisten(this.onChangeElement);
   }
 
-  handleElChanged(el) {
+  handleElChanged(el, cb) {
     const genericEl = el;
     genericEl.changed = true;
-    this.setState({ genericEl });
+    this.setState({ genericEl }, cb);
   }
 
-  handleGenericElChanged(el) {
+  handleGenericElChanged(el, cb) {
     const genericEl = el;
     genericEl.changed = true;
     this.setState({ genericEl }, () => {
       // ElementActions.opGenericAnalysis(el);
       renderFlowModal(genericEl, false);
+      if (typeof cb === 'function') cb();
     });
   }
 
@@ -143,12 +144,9 @@ export default class GenericElDetails extends Component {
     // eslint-disable-next-line react/destructuring-assignment
     this.context.attachmentNotificationStore.clearMessages();
 
-    genericEl.name = genericEl.name.trim();
-    // filter is_deleted analysis
-    const { container } = genericEl;
+    el.name = el.name.trim();
 
-    let ais =
-      (container && container.children && container.children[0].children) || [];
+    let ais = el.analysisContainers() || [];
     ais = ais
       .filter((x) => !x.is_deleted)
       .map((x, i) => {
@@ -159,16 +157,16 @@ export default class GenericElDetails extends Component {
         }
         return x.id;
       });
-    (Object.keys(genericEl.properties.layers) || {}).forEach((key) => {
-      if (genericEl.properties.layers[key].ai) {
-        genericEl.properties.layers[key].ai = genericEl.properties.layers[
+    (Object.keys(el.properties.layers) || {}).forEach((key) => {
+      if (el.properties.layers[key].ai) {
+        el.properties.layers[key].ai = el.properties.layers[
           key
         ].ai.filter((x) => ais.includes(x));
       } else {
-        genericEl.properties.layers[key].ai = [];
+        el.properties.layers[key].ai = [];
       }
-      genericEl.properties.layers[key].fields = (
-        genericEl.properties.layers[key].fields || []
+      el.properties.layers[key].fields = (
+        el.properties.layers[key].fields || []
       ).map((f) => {
         const field = f;
         if (
@@ -181,13 +179,13 @@ export default class GenericElDetails extends Component {
         return field;
       });
     });
-    if (genericEl && genericEl.isNew) {
-      ElementActions.createGenericEl(genericEl);
+    if (el && el.isNew) {
+      ElementActions.createGenericEl(el);
     } else {
-      ElementActions.updateGenericEl(genericEl, closeView);
+      ElementActions.updateGenericEl(el, closeView);
     }
-    if (genericEl.is_new || closeView) {
-      DetailActions.close(genericEl, true);
+    if (el.is_new || closeView) {
+      DetailActions.close(el, true);
     }
     return true;
   }

--- a/app/javascript/src/stores/alt/actions/ElementActions.js
+++ b/app/javascript/src/stores/alt/actions/ElementActions.js
@@ -272,10 +272,10 @@ class ElementActions {
     };
   }
 
-  updateGenericEl(params) {
+  updateGenericEl(params, closeView = false) {
     return (dispatch) => {
       GenericElsFetcher.update(params)
-        .then((result) => { dispatch(result); })
+        .then((result) => { dispatch({ element: result, closeView }); })
         .catch((errorMessage) => { console.log(errorMessage); });
     };
   }

--- a/app/javascript/src/stores/alt/stores/ElementStore.js
+++ b/app/javascript/src/stores/alt/stores/ElementStore.js
@@ -306,6 +306,7 @@ class ElementStore {
       handleUpdateLinkedElement: [
         ElementActions.updateReaction,
         ElementActions.updateSample,
+        ElementActions.updateGenericEl,
       ],
       handleUpdateElement: [
         // ElementActions.updateReaction,
@@ -318,7 +319,6 @@ class ElementStore {
         ElementActions.updateVessel,
         ElementActions.updateVesselTemplate,
         ElementActions.updateSequenceBasedMacromoleculeSample,
-        ElementActions.updateGenericEl,
       ],
       handleUpdateEmbeddedResearchPlan: ElementActions.updateEmbeddedResearchPlan,
       handleRefreshComputedProp: ElementActions.refreshComputedProp,


### PR DESCRIPTION


Problem:
When users close NMRium using "Close and Save", the page remains stuck in a loading state.

Fix:
The save process for Generic Elements was missing a callback execution after saving in the NMRium viewer. This has been fixed by ensuring the callback is properly triggered, allowing the loading state to clear correctly.
