### PR TITLE
fix: add Alert in history tab for new elements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -801,7 +801,6 @@ GEM
 
 PLATFORMS
   aarch64-linux
-  ruby
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Added Alert for history tab in new elements:
Save the "element" to enable the history tab.
Similar to the one in reaction variations.