### PR TITLE
fix: UI reaction refresg svg button group z-index

### DIFF
--- a/app/assets/stylesheets/components/ReactionSchemeGraphic.scss
+++ b/app/assets/stylesheets/components/ReactionSchemeGraphic.scss
@@ -18,7 +18,7 @@
     height: 100%;
     min-height: 300px;
     background-color: rgba(255, 255, 255, 0.95);
-    z-index: 9999;
+    z-index: 10;
     border-radius: 4px;
     display: flex;
     justify-content: center;
@@ -34,7 +34,7 @@
     top: 0;
     right: 0;
     display: flex;
-    z-index: 10000;
+    z-index: 11;
   }
 
   &__material-name {

--- a/app/javascript/src/apps/mydb/elements/details/reactions/ReactionSchemeGraphic.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/ReactionSchemeGraphic.js
@@ -8,7 +8,8 @@ import Reaction from 'src/models/Reaction';
 import ConfigOverlayButton from 'src/components/common/ConfigOverlayButton';
 import ButtonGroupToggleButton from 'src/components/common/ButtonGroupToggleButton';
 
-// Ensure tooltips/popovers render above the scheme toolbar (z-index: 10000)
+// Ensure popovers/tooltips from this toolbar render above the scheme toolbar (z-index: 11)
+// and above Bootstrap tooltips (z-index: 1080) when open
 const popperConfigAboveToolbar = {
   modifiers: [
     {
@@ -17,7 +18,7 @@ const popperConfigAboveToolbar = {
       phase: 'write',
       fn: ({ state }) => {
         // eslint-disable-next-line no-param-reassign
-        state.styles.popper.zIndex = 10001;
+        state.styles.popper.zIndex = 1100;
       },
     },
   ],


### PR DESCRIPTION
PR Resolves:

Issues with button group z-index:

- tooltip hiding behind buttons
- button groups displaying on menu pages

------------------------

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
