### PR TITLE
fix: use given short_label in reaction

### DIFF
--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -291,7 +291,7 @@ class Reaction < ApplicationRecord
   end
 
   def scrub
-    return unless temperature&.fetch('userText', nil).present?
+    return if temperature&.fetch('userText', nil).blank?
 
     self.temperature = temperature.merge('userText' => scrubber(temperature['userText']))
 

--- a/spec/lib/import/import_collections_spec.rb
+++ b/spec/lib/import/import_collections_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'ImportCollection' do
         expect(reaction.temperature.to_s).to eq('{"data"=>[], "userText"=>"30", "valueUnit"=>"°C"}')
         expect(reaction.status).to eq('Done')
         expect(reaction.solvent).to eq('')
-        expect(reaction.short_label).to eq('UU-R1')
+        expect(reaction.short_label).to eq('FM-R2')
         expect(reaction.role).to eq('gp')
         expect(reaction.duration).to eq('1 Day(s)')
         expect(reaction.conditions).to eq('')


### PR DESCRIPTION
- Samples keep short label if unique (tbd. if duplicates should be allowed)
- Modified reactions to keep given short labels (duplicates were already allowed)
  - Changed test to reflect this