### PR TITLE
feat(inventory): label info popover and improve error guidance

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -439,10 +439,10 @@ export default class SampleForm extends React.Component {
   fetchNextInventoryLabel() {
     const { currentCollection } = UIStore.getState();
     const message = (
-      <div style={{ textAlign: 'left' }}>
+      <div className="text-start">
         <p className="mb-1">Could not find next inventory label.</p>
         <p className="mb-1">
-          Please define an inventory label for this collection in the Account & Profile page.
+          Please define an inventory label for this collection in the Account &amp; Profile page.
           Select the collection and assign a name, prefix, and starting counter.
         </p>
       </div>
@@ -685,7 +685,7 @@ export default class SampleForm extends React.Component {
             </li>
           </ul>
           <a
-            href="https://chemotion.net/docs/eln/ui/first_steps?_highlight=inventory&_highlight=lab#define-a-sample-inventory-label-and-adjust-the-counter-inventory-label-for-a-collection"
+            href="https://chemotion.net/docs/eln/ui/first_steps#define-a-sample-inventory-label-and-adjust-the-counter-inventory-label-for-a-collection"
             target="_blank"
             rel="noopener noreferrer"
             className="d-block mt-2"
@@ -704,7 +704,13 @@ export default class SampleForm extends React.Component {
         delay={{ show: 250, hide: 650 }}
         rootClose
       >
-        <i className="ms-1 fa fa-info-circle" />
+        <span
+          tabIndex={0}
+          role="button"
+          aria-label="Information about sample inventory label configuration"
+        >
+          <i className="ms-1 fa fa-info-circle" />
+        </span>
       </OverlayTrigger>
     );
   }


### PR DESCRIPTION
**What:** Adds an info popover to the Inventory label input and improves error messaging.
**Why:** Users previously had no clear guidance about where to configure inventory labels and did not have an accessible navigation link to the docs.

**Changes:**
- Replaced tooltip with Bootstrap Popover (interactive, persistent until dismissed) next to the Inventory label field.
- The popover content explains where to create/assign inventory labels and the link to documentation of the feature and has the documentation link of the feature.
- Error messages updated to point users to Account & Profile → Sample Inventory Label and explain required steps (assign name, prefix, starting counter).
________________________________________________________________________________________________________________________________
- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
