### PR TITLE
fix: element tab layout changes not applied on closing settings panel

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/ElementDetailSortTab.js
+++ b/app/javascript/src/apps/mydb/elements/details/ElementDetailSortTab.js
@@ -64,6 +64,8 @@ export default class ElementDetailSortTab extends Component {
 
   getOpenedFromCollection() {
     const { openedFromCollectionId } = this.props;
+    const uiCollection = UIStore.getState().currentCollection;
+    if (uiCollection && uiCollection.id == openedFromCollectionId) return uiCollection;
     const collectionState = CollectionStore.getState();
     const stack = [
       ...collectionState.unsharedRoots,
@@ -77,12 +79,12 @@ export default class ElementDetailSortTab extends Component {
       if (col.id == openedFromCollectionId) return col;
       if (col.children?.length > 0) stack.push(...col.children);
     }
-    return null;
+    return uiCollection;
   }
 
   onChangeUser(state) {
     const { type } = this.props;
-    const collection = this.getOpenedFromCollection() || UIStore.getState().currentCollection;
+    const collection = this.getOpenedFromCollection();
     const collectionTabs = collection?.tabs_segment;
     const layout = (!collectionTabs || _.isEmpty(collectionTabs[type]))
       ? state.profile?.data?.[`layout_detail_${type}`]
@@ -92,7 +94,7 @@ export default class ElementDetailSortTab extends Component {
 
   onChangeUI() {
     const { type } = this.props;
-    const collection = this.getOpenedFromCollection() || UIStore.getState().currentCollection;
+    const collection = this.getOpenedFromCollection();
     const collectionTabs = collection?.tabs_segment;
     const userProfile = UserStore.getState().profile;
     const layout = (!collectionTabs || _.isEmpty(collectionTabs[type]))
@@ -105,7 +107,10 @@ export default class ElementDetailSortTab extends Component {
     this.setState(
       (state) => ({ ...state, showTabLayoutContainer: !state.showTabLayoutContainer }),
       () => {
-        if (!show) this.updateLayout();
+        if (!show) {
+          this.props.onTabPositionChanged(this.state.visible);
+          this.updateLayout();
+        }
       }
     );
   }
@@ -118,7 +123,7 @@ export default class ElementDetailSortTab extends Component {
 
     if (currentCollection && !currentCollection.is_sync_to_me) {
       CollectionActions.updateTabsSegment({ segment: tabSegment, cId: currentCollection.id });
-      UIActions.selectCollection({ ...currentCollection, tabs_segment: tabSegment, clearSearch: true });
+      UIActions.selectCollectionWithoutUpdating({ ...currentCollection, tabs_segment: tabSegment });
     }
 
     const userProfile = UserStore.getState().profile;

--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -1603,6 +1603,12 @@ export default class SampleDetails extends React.Component {
       }
     });
 
+    if (sample.inventory_sample && visible.indexOf('inventory') < 0) {
+      const tabContent = tabContentsMap.inventory;
+      if (tabContent) { tabContents.push(tabContent); }
+      stb.push('inventory');
+    }
+
     const { pageMessage, ketcherSVGError } = this.state;
     const messageBlock = (pageMessage
       && (pageMessage.error.length > 0 || pageMessage.warning.length > 0)) ? (

--- a/app/javascript/src/stores/alt/actions/CollectionActions.js
+++ b/app/javascript/src/stores/alt/actions/CollectionActions.js
@@ -98,7 +98,7 @@ class CollectionActions {
     return (dispatch) => {
       CollectionsFetcher.createTabsSegment(params)
         .then(() => {
-          dispatch();
+          dispatch({ segment: params.layoutSegments, cId: params.currentCollectionId });
         }).catch((errorMessage) => {
           console.log(errorMessage);
         });
@@ -109,7 +109,7 @@ class CollectionActions {
     return (dispatch) => {
       CollectionsFetcher.updateTabsLayout(params)
         .then(() => {
-          dispatch();
+          dispatch(params);
         }).catch((errorMessage) => {
           console.log(errorMessage);
         });

--- a/app/javascript/src/stores/alt/stores/CollectionStore.js
+++ b/app/javascript/src/stores/alt/stores/CollectionStore.js
@@ -32,7 +32,8 @@ class CollectionStore {
       ],
       handleRejectSharedCollection: CollectionActions.rejectShared,
       handleRejectSyncdCollection: CollectionActions.rejectSync,
-      handleUpdateCollectrionTree: CollectionActions.updateCollectrionTree
+      handleUpdateCollectrionTree: CollectionActions.updateCollectrionTree,
+      handleUpdateTabsSegment: [CollectionActions.updateTabsSegment, CollectionActions.createTabsSegment],
     })
   }
 
@@ -84,6 +85,22 @@ class CollectionStore {
 
   handleUpdateCollectrionTree(visibleRootsIds) {
     this.state.visibleRootsIds = visibleRootsIds
+  }
+
+  handleUpdateTabsSegment({ segment, cId }) {
+    const updateInTree = (collections) => collections.map((col) => {
+      if (col.id === cId) {
+        return { ...col, tabs_segment: segment };
+      }
+      if (col.children?.length > 0) return { ...col, children: updateInTree(col.children) };
+      return col;
+    });
+
+    this.state.unsharedRoots = updateInTree(this.state.unsharedRoots);
+    this.state.sharedRoots = updateInTree(this.state.sharedRoots);
+    this.state.remoteRoots = updateInTree(this.state.remoteRoots);
+    this.state.syncInRoots = updateInTree(this.state.syncInRoots);
+    this.state.lockedRoots = updateInTree(this.state.lockedRoots);
   }
 
   handleRejectSharedCollection(results) {


### PR DESCRIPTION
 Summary
                                                                                              
- Fixed a bug where changing tab visibility in the element settings panel had no effect when closing the panel
- Inventory tab is now forced visible when a sample has inventory data, independently of collection layout settings

  Fixes ComPlat/chemotion#479
  
  
  ---------------------------
- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [x] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
