### PR TITLE
fix: combined image selection by latest update date

### DIFF
--- a/app/javascript/src/utilities/imageHelper.js
+++ b/app/javascript/src/utilities/imageHelper.js
@@ -38,7 +38,9 @@ const getAttachmentFromContainer = (container) => {
   const attachments = datasetChildren
     .flatMap((child) => child.attachments || [])
     .filter((att) => att.thumb);
-  const combinedImageAttachment = attachments.find((att) => att.filename?.toLowerCase().includes('combined'));
+  const combinedImageAttachment = attachments
+    .filter((att) => att.filename?.toLowerCase().includes('combined'))
+    .sort((a, b) => parseDateWithMoment(b.updated_at).valueOf() - parseDateWithMoment(a.updated_at).valueOf())[0];
   const latestImageAttachment = attachments
     .sort((a, b) => parseDateWithMoment(b.updated_at).valueOf() - parseDateWithMoment(a.updated_at).valueOf())[0];
   return combinedImageAttachment || latestImageAttachment || null;


### PR DESCRIPTION
# PR description:
Select the combined image by latest updated_at date.
Keep the existing fallback to the latest available image.
This fixes cases where an older combined image was shown.