### PR TITLE
fix(UI): Removed all placement props from overlay triggers in Material.js

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
@@ -343,7 +343,6 @@ class Material extends Component {
       return (
         <div>
           <OverlayTrigger
-            placement="top"
             overlay={(
               <Tooltip id="yield-tooltip">
                 {yieldMessage}
@@ -462,7 +461,6 @@ class Material extends Component {
     return (
       (value === 'n.d' || !value) && !noSwitchUnits.includes(unit) ? (
         <OverlayTrigger
-          placement="top"
           overlay={<Tooltip id={`${field}-tooltip`}>{message}</Tooltip>}
         >
           <div>{inputComponent}</div>
@@ -652,7 +650,7 @@ class Material extends Component {
       && material.weight_percentage > 0 && materialGroup !== 'products' && !material.weight_percentage_reference;
 
     return (
-      <OverlayTrigger placement="top" overlay={tooltip}>
+      <OverlayTrigger overlay={tooltip}>
         <div>
           <NumeralInputWithUnitsCompo
             className={className}
@@ -1097,8 +1095,6 @@ class Material extends Component {
       && material.weight_percentage > 0 && materialGroup !== 'products' && !material.weight_percentage_reference;
     return (
       <OverlayTrigger
-        delay="100"
-        placement="top"
         overlay={tooltip}
       >
         <div>
@@ -1195,7 +1191,6 @@ class Material extends Component {
               <div className="reaction-material__coefficient-data" />
             ) : (
               <OverlayTrigger
-                placement="top"
                 overlay={<Tooltip id="reaction-coefficient-info"> Reaction Coefficient </Tooltip>}
               >
                 <div>
@@ -1221,7 +1216,6 @@ class Material extends Component {
             ) : (
               <div className="reaction-material__molar-mass-data">
                 <OverlayTrigger
-                  placement="top"
                   overlay={<Tooltip id="molar-weight-details">{this.molarWeightValue(material, reaction)}</Tooltip>}
                 >
                   <span>{this.molarWeightValue(material, reaction, true)}</span>
@@ -1345,7 +1339,7 @@ class Material extends Component {
         {this.dragHandle()}
         {this.materialNameWithIupac(material)}
         <div className="reaction-material__dry-solvent-data">
-          <OverlayTrigger placement="top" overlay={drySolvTooltip}>
+          <OverlayTrigger overlay={drySolvTooltip}>
             <Form.Check
               type="checkbox"
               checked={material.dry_solvent}
@@ -1357,7 +1351,6 @@ class Material extends Component {
         {this.switchTargetReal()}
         <InputGroup className="reaction-material__solvent-label-data">
           <OverlayTrigger
-            placement="top"
             overlay={(
               <Tooltip id="molecular-weight-info">
                 {material.amount_g}
@@ -1380,7 +1373,7 @@ class Material extends Component {
               onChange={(event) => this.handleExternalLabelChange(event)}
             />
           </OverlayTrigger>
-          <OverlayTrigger placement="bottom" overlay={refreshSvgTooltip}>
+          <OverlayTrigger overlay={refreshSvgTooltip}>
             <Button
               disabled={materialGroup === 'purification_solvents' || !permitOn(reaction)}
               onClick={(e) => this.handleExternalLabelCompleted(e)}
@@ -1466,7 +1459,7 @@ class Material extends Component {
     const tooltip = <Tooltip id="feedstockGas">{tooltipText}</Tooltip>;
     return (
       <div className="pe-1">
-        <OverlayTrigger placement="bottom" overlay={tooltip}>
+        <OverlayTrigger overlay={tooltip}>
           <span className="d-inline-block" style={{ cursor: isSbmmGasSchemeUnavailable ? 'not-allowed' : 'pointer' }}>
             <Button
               variant="primary"
@@ -1566,12 +1559,12 @@ class Material extends Component {
           <div className="d-flex align-items-center">
             {reaction.gaseous && materialGroup !== 'solvents'
               ? this.gasType(material) : null}
-            <OverlayTrigger placement="top" overlay={AddtoDescToolTip}>
+            <OverlayTrigger overlay={AddtoDescToolTip}>
               <Button variant="light" size="xsm" className="me-1" onClick={addToDesc} disabled={!permitOn(reaction)}>
                 {serialCode}
               </Button>
             </OverlayTrigger>
-            <OverlayTrigger placement="bottom" overlay={iupacNameTooltip(material)}>
+            <OverlayTrigger overlay={iupacNameTooltip(material)}>
               <div className="reaction-material__link">
                 {materialName}
               </div>
@@ -1602,7 +1595,6 @@ class Material extends Component {
       reaction.weight_percentage && !isSbmmSample(material) ? (
         <div>
           <OverlayTrigger
-            placement="top"
             overlay={(
               <Tooltip id="weight-percentage-reference-tooltip">
                 Select as reference product for weight percentage
@@ -1690,7 +1682,6 @@ class Material extends Component {
 
     return (
       <OverlayTrigger
-        placement="top"
         overlay={(
           <Tooltip id="nested-reference-tooltip">
             Outer Circle: Select Weight % Reference


### PR DESCRIPTION
- placement top is redundant/default behavior
- bottom can trigger layout shifts at the bottom of the view port

Also removed random delay props.