### PR TITLE
ci: push2deploy: move base image v3.0.0

### DIFF
--- a/Dockerfile.p2d
+++ b/Dockerfile.p2d
@@ -1,4 +1,4 @@
-FROM ptrxyz/chemotion:eln-2.2.0
+FROM ptrxyz/chemotion:eln-3.0.0
 
 ARG REMOTE=https://github.com/ComPlat/chemotion_ELN.git
 ARG BUNDLER_VERSION=2.4.22
@@ -73,14 +73,14 @@ ADD https://payload.chemserv.scc.kit.edu/initialize.sh /initialize.sh
 ADD https://payload.chemserv.scc.kit.edu/converter.yml /chemotion/app/config/converter.yml
 ADD https://payload.chemserv.scc.kit.edu/spectra.yml /chemotion/app/config/spectra.yml
 ADD https://payload.chemserv.scc.kit.edu/indigo.yml /chemotion/app/config/indigo_service.yml
+ADD https://payload.chemserv.scc.kit.edu/ketcher.yml /chemotion/app/config/ketcher_service.yml
+
 # stop check for ketcherails
 RUN sed -i '/# add ketcherails templates if needed/,$d' /embed/scripts/dbcheck.sh
 
 RUN chmod +x /embed/run.sh && \
     chmod +x /embed/health.sh && \
     chmod +x /initialize.sh
-
-ADD https://github.com/haditariq/ketcher-build-holder.git /chemotion/app/public/editors/ketcher/standalone
 
 EXPOSE 4000
 
@@ -93,5 +93,3 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=300s --retries=3 \
 
 VOLUME [ "/chemotion/app", "/chemotion/data" ]
 
-RUN cp config/structure_editors.yml.example config/structure_editors.yml
-RUN cp config/ketcher_service.yml.example config/ketcher_service.yml

--- a/config/ketcher_service.yml.example
+++ b/config/ketcher_service.yml.example
@@ -1,5 +1,5 @@
 development:
-  :url: 'https://220.ketcher.chemserv.scc.kit.edu/render'
+  :url: 'http://ketchersvc:4000/render'
 
 production:
-  :url: 'https://220.ketcher.chemserv.scc.kit.edu/render'
+  :url: 'http://ketchersvc:4000/render'

--- a/docker-compose.p2d.yml
+++ b/docker-compose.p2d.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: ptrxyz/chemotion:db-2.2.0
+    image: ptrxyz/chemotion:db-3.0.0
     restart: unless-stopped
     hostname: db
     environment:
@@ -37,7 +37,7 @@ services:
       - ../files/pullin:/shared
 
   configure:
-    image: ptrxyz/chemotion:eln-2.2.0 # same as the base image in Dockerfile.p2d for efficiency
+    image: ptrxyz/chemotion:eln-3.0.0 # same as the base image in Dockerfile.p2d for efficiency
     profiles:
       - configure
     restart: no


### PR DESCRIPTION
- base image for building push2deploy images is now v3.0.0
