### PR TITLE
style(sample): auto-resize description textarea to content

### DIFF
--- a/app/assets/stylesheets/legacy/sample.scss
+++ b/app/assets/stylesheets/legacy/sample.scss
@@ -24,6 +24,15 @@
   }
 }
 
+@supports (field-sizing: content) {
+  .sample-description-auto {
+    field-sizing: content;
+    min-height: 2lh;
+    resize: none;
+    overflow: hidden;
+  }
+}
+
 .sample-form,
 .additional-form {
   margin-bottom: 0px !important;

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -1096,11 +1096,12 @@ export default class SampleForm extends React.Component {
         <Form.Label>Description</Form.Label>
         <Form.Control
           as="textarea"
+          className="sample-description-auto"
           placeholder={sample.description}
           value={sample.description || ''}
           onChange={(e) => this.handleFieldChanged('description', e.target.value)}
+          rows={2}
           disabled={!sample.can_update}
-          style={{ fieldSizing: 'content', minHeight: '2lh', resize: 'none', overflow: 'hidden' }}
         />
       </Form.Group>
     );

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -1099,8 +1099,8 @@ export default class SampleForm extends React.Component {
           placeholder={sample.description}
           value={sample.description || ''}
           onChange={(e) => this.handleFieldChanged('description', e.target.value)}
-          rows={2}
           disabled={!sample.can_update}
+          style={{ fieldSizing: 'content', minHeight: '2lh', resize: 'none', overflow: 'hidden' }}
         />
       </Form.Group>
     );


### PR DESCRIPTION
This PR enables automatic height adjustment based on the content length of the description property in the sample.

---------------------

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
