### PR TITLE
fix: temperature unit display and unit conversion

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetailsMainProperties.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetailsMainProperties.js
@@ -126,7 +126,7 @@ export default class ReactionDetailsMainProperties extends Component {
             <Col>
               <LineChartContainer
                 data={temperature}
-                xAxis="Time"
+                xAxis="Time (h)"
                 yAxis={`Temperature (${temperature.valueUnit})`}
               />
             </Col>

--- a/app/javascript/src/models/Reaction.js
+++ b/app/javascript/src/models/Reaction.js
@@ -381,8 +381,6 @@ export default class Reaction extends Element {
     // If userText is number only, treat as normal temperature value
     if (/^[\-|\d]\d*\.{0,1}\d{0,2}$/.test(temperature.userText)) {
       temperature.userText = convertTemperature(temperature.userText, oldUnit, newUnit).toFixed(2);
-
-      return temperature;
     }
 
     temperature.data.forEach((data, index, theArray) => {


### PR DESCRIPTION
When a temperature value was inserted into the top right input field, the system assumed, temperature was a single value and not a time chart. Therefore the chart data was not converted when unit changed. But this is unintuitive for the user, so I fixed it to always convert all data. 