### PR TITLE
fix: missing reference type during collection import

### DIFF
--- a/lib/import/import_collections.rb
+++ b/lib/import/import_collections.rb
@@ -714,6 +714,7 @@ module Import
           fields.slice(
             'element_type',
             'category',
+            'litype',
             'created_at',
             'updated_at',
           ).merge(


### PR DESCRIPTION
- Based on v3.x.
- Fixes an issue where collections can be imported successfully, but the reference type is not preserved.