### PR TITLE
fix: trim molfile to avoid intialised issues, show error if ketcher/i…

### DIFF
--- a/app/javascript/src/components/structureEditor/KetcherEditor.js
+++ b/app/javascript/src/components/structureEditor/KetcherEditor.js
@@ -185,7 +185,9 @@ const KetcherEditor = forwardRef((props, ref) => {
     canvasIframeRefSetter(iframeRef);
     return () => canvasIframeRefSetter(null);
   }, [iframeRef]);
-  const initMol = molfile || '\n  noname\n\n  0  0  0  0  0  0  0  0  0  0999 V2000\nM  END\n';
+  const defaultEmptyMol = 'null\n  Ketcher  3272610132D 1   1.00000     0.00000     0\n\n'
+    + '  0  0  0  0  0  0  0  0  0  0999 V2000\nM  END\n';
+  const initMol = molfile || defaultEmptyMol;
 
   // action based on event-name
   const eventHandlers = {

--- a/app/javascript/src/utilities/ketcherSurfaceChemistry/InitializeAndParseKetcher.js
+++ b/app/javascript/src/utilities/ketcherSurfaceChemistry/InitializeAndParseKetcher.js
@@ -38,6 +38,7 @@ import {
 import {
   attachClickListeners
 } from 'src/utilities/ketcherSurfaceChemistry/DomHandeling';
+import NotificationActions from 'src/stores/alt/actions/NotificationActions';
 
 const loadTemplates = async () => {
   fetch('/json/surfaceChemistryShapes.json').then((response) => {
@@ -165,8 +166,9 @@ const hasTextNodes = async (molfile) => {
 // Return molfile string up to and including M  END so Indigo only sees standard CTAB.
 const getStandardMolfileForIndigo = (molfile) => {
   if (!molfile || typeof molfile !== 'string') return molfile;
-  const lines = molfile.trim().split('\n');
-  const endIndex = lines.findIndex((line) => line && /^M\s+END/.test(line));
+  const normalized = molfile.replace(/\r\n/g, '\n');
+  const lines = normalized.split('\n');
+  const endIndex = lines.findIndex((line) => /^M\s+END/.test(line));
   if (endIndex === -1) return molfile;
   return lines.slice(0, endIndex + 1).join('\n');
 };
@@ -276,18 +278,31 @@ const prepareKetcherData = async (editor, initMol, options = {}) => {
     const polymerTagFromPasted = await hasKetcherData(initMol);
     const textNodes = await hasTextNodes(initMol);
     const molfileForIndigo = getStandardMolfileForIndigo(initMol);
-    const formatError = (err) => (err?.message != null ? err.message : (err && typeof err?.toString === 'function' ? err.toString() : String(err)));
+    const formatError = (err) => {
+      if (err?.message != null) return err.message;
+      if (err && typeof err?.toString === 'function') return err.toString();
+      return String(err);
+    };
+    const notifyMolfileError = (details, level = 'error') => {
+      NotificationActions.add({
+        title: 'Structure Editor error',
+        message: `${details}`,
+        level,
+        position: 'tc',
+        dismissible: 'button',
+        autoDismiss: 12,
+      });
+    };
+    const conversionErrors = [];
 
     let ketFile = await editor._structureDef.editor.indigo.convert(molfileForIndigo).catch((err) => {
-      console.error('invalid molfile. Please try again', formatError(err));
+      conversionErrors.push(`Ketcher/Indigo ${formatError(err)}`);
       return null;
     });
 
-    if (!ketFile?.struct && molfileForIndigo !== initMol) {
-      ketFile = await editor._structureDef.editor.indigo.convert(initMol).catch((err) => {
-        console.error('invalid molfile (fallback). Please try again', formatError(err));
-        return null;
-      });
+    if (conversionErrors.length > 0) {
+      const uniqueErrors = [...new Set(conversionErrors)];
+      notifyMolfileError(uniqueErrors.join(' | '), 'error');
     }
 
     if (!ketFile || !ketFile.struct) {


### PR DESCRIPTION
This PR provides user a feedback alert if the sample molfile is invalid or Ketcher/indigo fails to render it.

<img width="1342" height="883" alt="Screenshot 2026-03-27 102948" src="https://github.com/user-attachments/assets/829af2c7-bf09-4004-9403-a7e16f097f48" />

-------------

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
