### PR TITLE
fix: scope dropdown line-height:0 to toggle button only

### DIFF
--- a/app/assets/stylesheets/global-styles/bootstrap-mods.scss
+++ b/app/assets/stylesheets/global-styles/bootstrap-mods.scss
@@ -351,7 +351,9 @@ button.btn-close {
 }
 
 .dropdown {
-  line-height: 0;
+  > .btn {
+    line-height: 0;
+  }
 }
 
 .modal-header {


### PR DESCRIPTION
Commit 54e62b38 set line-height:0 on .dropdown containers to size toggle buttons, but dropdown-item elements inherited it, causing menu items to overlap. Restrict the rule to .dropdown > .btn.


