### PR TITLE
feat(analyses): add edit/order mode toggle across all element types

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/analyses/AnalysesOrderRow.js
+++ b/app/javascript/src/apps/mydb/elements/details/analyses/AnalysesOrderRow.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import { DragSource, DropTarget } from 'react-dnd';
+import { compose } from 'redux';
+import PropTypes from 'prop-types';
+import { DragDropItemTypes } from 'src/utilities/DndConst';
+import QuillViewer from 'src/components/QuillViewer';
+import ImageModal from 'src/components/common/ImageModal';
+import { instrumentText } from 'src/utilities/ElementUtils';
+import { getAttachmentFromContainer } from 'src/utilities/imageHelper';
+
+const orderSource = {
+  beginDrag(props) {
+    return { container: props.container };
+  },
+};
+
+const orderTarget = {
+  drop(targetProps, monitor) {
+    const source = monitor.getItem().container;
+    const target = targetProps.container;
+    if (source.id !== target.id) {
+      targetProps.handleMove(source, target);
+    }
+  },
+};
+
+const orderDragCollect = (connect, monitor) => ({
+  connectDragSource: connect.dragSource(),
+  isDragging: monitor.isDragging(),
+});
+
+const orderDropCollect = (connect, monitor) => ({
+  connectDropTarget: connect.dropTarget(),
+  isOver: monitor.isOver(),
+  canDrop: monitor.canDrop(),
+});
+
+const AnalysesOrderRowContent = ({
+  container,
+  connectDragSource, connectDropTarget, isDragging, isOver, canDrop,
+}) => {
+  let dndClass = ' border';
+  if (canDrop) dndClass = ' dnd-zone';
+  if (isOver) dndClass += ' dnd-zone-over';
+  if (isDragging) dndClass += ' dnd-dragging';
+
+  let kind = container.extended_metadata.kind || '';
+  kind = (kind.split('|')[1] || kind).trim();
+  const status = container.extended_metadata.status || '';
+  const insText = instrumentText(container);
+  const content = container.extended_metadata.content || { ops: [{ insert: '' }] };
+  const contentOneLine = {
+    ops: content.ops.map((x) => {
+      const c = { ...x };
+      if (c.insert) c.insert = c.insert.replace(/\n/g, ' ');
+      return c;
+    }),
+  };
+  const attachment = getAttachmentFromContainer(container);
+
+  return compose(connectDragSource, connectDropTarget)(
+    <div className={`d-flex gap-2 mb-3 bg-gray-100 px-2 py-3 rounded${dndClass}`}>
+      <div className="dnd-button d-flex align-items-center">
+        <i className="dnd-arrow-enable text-info fa fa-arrows" aria-hidden="true" />
+      </div>
+      <div className="analysis-header w-100 d-flex gap-3 lh-base order pe-2">
+        <div className="preview border d-flex align-items-center">
+          <ImageModal
+            attachment={attachment}
+            popObject={{ title: container.name }}
+          />
+        </div>
+        <div className="flex-grow-1 analysis-header-fade">
+          <div className="d-flex justify-content-between align-items-center">
+            <h4 className="flex-grow-1">{container.name}</h4>
+          </div>
+          <div>
+            Type:
+            {' '}
+            {kind}
+            <br />
+            Status:
+            {' '}
+            <span className="me-4">{status}</span>
+            {insText}
+          </div>
+          <div className="d-flex gap-2">
+            <span>Content:</span>
+            <div className="flex-grow-1">
+              <QuillViewer value={contentOneLine} className="p-0" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+AnalysesOrderRowContent.propTypes = {
+  container: PropTypes.object.isRequired,
+  connectDragSource: PropTypes.func.isRequired,
+  connectDropTarget: PropTypes.func.isRequired,
+  isDragging: PropTypes.bool.isRequired,
+  isOver: PropTypes.bool.isRequired,
+  canDrop: PropTypes.bool.isRequired,
+};
+
+export default compose(
+  DragSource(DragDropItemTypes.CONTAINER, orderSource, orderDragCollect),
+  DropTarget(DragDropItemTypes.CONTAINER, orderTarget, orderDropCollect),
+)(AnalysesOrderRowContent);

--- a/app/javascript/src/apps/mydb/elements/details/analyses/AnalysesOrderRow.js
+++ b/app/javascript/src/apps/mydb/elements/details/analyses/AnalysesOrderRow.js
@@ -103,6 +103,7 @@ AnalysesOrderRowContent.propTypes = {
   isDragging: PropTypes.bool.isRequired,
   isOver: PropTypes.bool.isRequired,
   canDrop: PropTypes.bool.isRequired,
+  handleMove: PropTypes.func.isRequired,
 };
 
 export default compose(

--- a/app/javascript/src/apps/mydb/elements/details/analyses/AnalysisModeToggle.js
+++ b/app/javascript/src/apps/mydb/elements/details/analyses/AnalysisModeToggle.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { ButtonGroup } from 'react-bootstrap';
+import ButtonGroupToggleButton from 'src/components/common/ButtonGroupToggleButton';
+
+const AnalysisModeToggle = (mode, handleToggleMode, isDisabled = false) => (
+  <ButtonGroup>
+    <ButtonGroupToggleButton
+      size="xsm"
+      active={mode === 'edit'}
+      onClick={() => handleToggleMode('edit')}
+      disabled={isDisabled}
+    >
+      <i className="fa fa-edit me-1" />
+      Edit mode
+    </ButtonGroupToggleButton>
+    <ButtonGroupToggleButton
+      size="xsm"
+      active={mode === 'order'}
+      onClick={() => handleToggleMode('order')}
+      disabled={isDisabled}
+    >
+      <i className="fa fa-reorder me-1" />
+      Order mode
+    </ButtonGroupToggleButton>
+  </ButtonGroup>
+);
+
+export default AnalysisModeToggle;

--- a/app/javascript/src/apps/mydb/elements/details/analyses/AnalysisModeToggle.js
+++ b/app/javascript/src/apps/mydb/elements/details/analyses/AnalysisModeToggle.js
@@ -1,14 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { ButtonGroup } from 'react-bootstrap';
 import ButtonGroupToggleButton from 'src/components/common/ButtonGroupToggleButton';
 
-const AnalysisModeToggle = (mode, handleToggleMode, isDisabled = false) => (
+const AnalysisModeToggle = ({ mode, onToggle, disabled = false }) => (
   <ButtonGroup>
     <ButtonGroupToggleButton
       size="xsm"
       active={mode === 'edit'}
-      onClick={() => handleToggleMode('edit')}
-      disabled={isDisabled}
+      onClick={() => onToggle('edit')}
+      disabled={disabled}
     >
       <i className="fa fa-edit me-1" />
       Edit mode
@@ -16,13 +17,19 @@ const AnalysisModeToggle = (mode, handleToggleMode, isDisabled = false) => (
     <ButtonGroupToggleButton
       size="xsm"
       active={mode === 'order'}
-      onClick={() => handleToggleMode('order')}
-      disabled={isDisabled}
+      onClick={() => onToggle('order')}
+      disabled={disabled}
     >
       <i className="fa fa-reorder me-1" />
       Order mode
     </ButtonGroupToggleButton>
   </ButtonGroup>
 );
+
+AnalysisModeToggle.propTypes = {
+  mode: PropTypes.string.isRequired,
+  onToggle: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+};
 
 export default AnalysisModeToggle;

--- a/app/javascript/src/apps/mydb/elements/details/analyses/utils.js
+++ b/app/javascript/src/apps/mydb/elements/details/analyses/utils.js
@@ -1,6 +1,7 @@
 import ElementContainer from 'src/models/Container';
 import ArrayUtils from 'src/utilities/ArrayUtils';
 import Attachment from 'src/models/Attachment';
+import { reOrderArr } from 'src/utilities/DndControl';
 
 function buildEmptyAnalyContainer() {
   const newContainer = ElementContainer.buildEmpty();
@@ -59,6 +60,19 @@ function createAnalsesForSingelFiles(element, files, name, ontology = '') {
   datasetContainer.attachments.push(...newAttachments);
 }
 
+function findAnalysesContainer(element) {
+  return element.container.children.find(
+    (c) => ~c.container_type.indexOf('analyses')
+  );
+}
+
+function reorderAnalyses(analysesContainer, source, target) {
+  const sorted = ArrayUtils.sortArrByIndex(analysesContainer.children);
+  const isEqCId = (c, t) => c.id === t.id;
+  const reordered = reOrderArr(source, target, isEqCId, sorted);
+  analysesContainer.children = indexedContainers(reordered);
+}
+
 export {
   addNewAnalyses,
   indexedContainers,
@@ -66,5 +80,7 @@ export {
   buildEmptyAnalyContainer,
   createDataset,
   createAnalsesForSingelFiles,
-  createAttachements
+  createAttachements,
+  findAnalysesContainer,
+  reorderAnalyses,
 };

--- a/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/AnalysesContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/AnalysesContainer.js
@@ -4,15 +4,16 @@ import { observer } from 'mobx-react';
 import {
   Accordion,
   Button,
-  ListGroup,
   ButtonToolbar
 } from 'react-bootstrap';
 import ElementStore from 'src/stores/alt/stores/ElementStore';
 import Container from 'src/models/Container';
+import ArrayUtils from 'src/utilities/ArrayUtils';
 import OrderModeRow from 'src/apps/mydb/elements/details/cellLines/analysesTab/OrderModeRow';
 import EditModeRow from 'src/apps/mydb/elements/details/cellLines/analysesTab/EditModeRow';
 import PropTypes from 'prop-types';
 import { CommentButton, CommentBox } from 'src/components/common/AnalysisCommentBoxComponent';
+import AnalysisModeToggle from 'src/apps/mydb/elements/details/analyses/AnalysisModeToggle';
 
 class AnalysesContainer extends Component {
   // eslint-disable-next-line react/static-property-placement
@@ -48,13 +49,8 @@ class AnalysesContainer extends Component {
     });
   };
 
-  handleModeToggle = () => {
-    const { mode } = this.state;
-    if (mode === 'edit') {
-      this.setState({ mode: 'order' });
-    } else {
-      this.setState({ mode: 'edit' });
-    }
+  handleModeToggle = (mode) => {
+    this.setState({ mode });
   };
 
   handleHoverOver = (containerId) => {
@@ -107,27 +103,14 @@ class AnalysesContainer extends Component {
   renderModeButton = () => {
     const { mode } = this.state;
     const { readOnly } = this.props;
-    const buttonText = mode === 'order' ? 'Order mode' : 'Edit mode';
-    const buttonIcon = mode === 'order' ? 'fa fa-reorder' : 'fa fa-edit';
-    const variant = mode === 'order' ? 'success' : 'primary';
-    return (
-      <Button
-        disabled={readOnly}
-        size="sm"
-        variant={variant}
-        onClick={() => this.handleModeToggle()}
-      >
-        <i className={`me-1 ${buttonIcon}`} aria-hidden="true" />
-        {buttonText}
-      </Button>
-    );
+    return AnalysisModeToggle(mode, this.handleModeToggle, readOnly);
   }
 
   renderEditModeContainer = () => {
     const { currentElement } = ElementStore.getState();
     const { readOnly } = this.props;
 
-    const containers = currentElement.container.children[0].children;
+    const containers = ArrayUtils.sortArrByIndex(currentElement.container.children[0].children);
     const analysisRows = containers.map((container,i) => (
       <EditModeRow
         key={container.id}
@@ -137,6 +120,7 @@ class AnalysesContainer extends Component {
         readOnly={readOnly}
         rootContainer={currentElement.container}
         index={i}
+        isFirst={i === 0}
       />
     ));
 
@@ -153,7 +137,7 @@ class AnalysesContainer extends Component {
   renderOrderModeContainer = () => {
     const { currentElement } = ElementStore.getState();
     const { draggingContainer, lastHoveredContainer } = this.state;
-    const containers = currentElement.container.children[0].children;
+    const containers = ArrayUtils.sortArrByIndex(currentElement.container.children[0].children);
 
     const analysisRows = containers.map((container) => {
       const chosenElementClass = container.id === draggingContainer ? 'opacity-25' : '';
@@ -161,7 +145,7 @@ class AnalysesContainer extends Component {
       const styleClass = chosenElementClass + lastHoveredClass;
 
       return (
-        <ListGroup.Item className={`p-3 ${styleClass}`} key={container.id}>
+        <div className={styleClass} key={container.id}>
           <OrderModeRow
             updateFunction={(e) => { this.handleChange(e); }}
             startDragFunction={() => { this.handleStartDrag(container); }}
@@ -169,14 +153,14 @@ class AnalysesContainer extends Component {
             hoverOverItem={(e) => { this.handleHoverOver(e); }}
             container={container}
           />
-        </ListGroup.Item>
+        </div>
       );
     });
 
     return (
-      <ListGroup>
+      <div>
         {analysisRows}
-      </ListGroup>
+      </div>
     );
   }
 

--- a/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/AnalysesContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/AnalysesContainer.js
@@ -103,7 +103,7 @@ class AnalysesContainer extends Component {
   renderModeButton = () => {
     const { mode } = this.state;
     const { readOnly } = this.props;
-    return AnalysisModeToggle(mode, this.handleModeToggle, readOnly);
+    return <AnalysisModeToggle mode={mode} onToggle={this.handleModeToggle} disabled={readOnly} />;
   }
 
   renderEditModeContainer = () => {

--- a/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/EditModeRow.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/EditModeRow.js
@@ -5,10 +5,10 @@ import PropTypes from 'prop-types';
 import { Accordion, Card } from 'react-bootstrap';
 import AccordionHeaderWithButtons from 'src/components/common/AccordionHeaderWithButtons';
 
-const EditModeRow = ({ container, handleChange, element, readOnly, index, rootContainer }) => (
-  <Card eventKey={container.id} className="border-0 rounded-0">
+const EditModeRow = ({ container, handleChange, element, readOnly, index, rootContainer, isFirst }) => (
+  <Card className={`rounded-0 border-0${isFirst ? '' : ' border-top'}`}>
     <Card.Header className="rounded-0 p-0 border-bottom-0">
-      <AccordionHeaderWithButtons as="div">
+      <AccordionHeaderWithButtons eventKey={container.id}>
         <Header
           isEditHeader
           element={element}
@@ -18,7 +18,7 @@ const EditModeRow = ({ container, handleChange, element, readOnly, index, rootCo
         />
       </AccordionHeaderWithButtons>
     </Card.Header>
-    <Accordion.Collapse>
+    <Accordion.Collapse eventKey={container.id}>
       <Card.Body>
         <ContainerComponent
           analysisMethodTitle="Type (BioAssay Ontology)"
@@ -44,7 +44,8 @@ EditModeRow.propTypes = {
   handleChange: PropTypes.func.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   element: PropTypes.object.isRequired,
-  readOnly: PropTypes.bool.isRequired
+  readOnly: PropTypes.bool.isRequired,
+  isFirst: PropTypes.bool,
 };
 
 export default EditModeRow;

--- a/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/OrderModeRow.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/analysesTab/OrderModeRow.js
@@ -57,11 +57,15 @@ const dropCollectHooks = (connect, monitor) => (
 
 class OrderModeRow extends Component {
   render() {
-    const { connectDragSource, connectDropTarget, container } = this.props;
+    const { connectDragSource, connectDropTarget, container, isDragging } = this.props;
+    const dndClass = isDragging ? ' dnd-no-display' : '';
 
     return (
       compose(connectDragSource, connectDropTarget)(
-        <div>
+        <div className={`d-flex gap-2 mb-3 bg-gray-100 px-2 py-3 rounded${dndClass}`}>
+          <div className="dnd-button d-flex align-items-center">
+            <i className="dnd-arrow-enable text-info fa fa-arrows" aria-hidden="true" />
+          </div>
           <Header container={container} />
         </div>
       )

--- a/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysesContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysesContainer.js
@@ -13,13 +13,14 @@ import { CommentButton, CommentBox } from 'src/components/common/AnalysisComment
 import TextTemplateActions from 'src/stores/alt/actions/TextTemplateActions';
 import { observer } from 'mobx-react';
 import { StoreContext } from 'src/stores/mobx/RootStore';
+import ArrayUtils from 'src/utilities/ArrayUtils';
 import AnalysisHeader from 'src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysisHeader';
 import AnalysesSortableContainer from 'src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysesSortableContainer';
 
 function AnalysesContainer({ readonly }) {
   const deviceDescriptionsStore = useContext(StoreContext).deviceDescriptions;
   const deviceDescription = deviceDescriptionsStore.device_description;
-  const containers = deviceDescription.container.children[0].children;
+  const containers = ArrayUtils.sortArrByIndex(deviceDescription.container.children[0].children);
   const mode = deviceDescriptionsStore.analysis_mode;
 
   useEffect(() => {

--- a/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysesSortableContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysesSortableContainer.js
@@ -5,11 +5,12 @@ import Container from 'src/models/Container';
 import { useDrag, useDrop } from 'react-dnd';
 import { DragDropItemTypes } from 'src/utilities/DndConst';
 import { StoreContext } from 'src/stores/mobx/RootStore';
+import ArrayUtils from 'src/utilities/ArrayUtils';
 
 const AnalysesSortableContainer = ({ readonly }) => {
   const deviceDescriptionsStore = useContext(StoreContext).deviceDescriptions;
   const deviceDescription = deviceDescriptionsStore.device_description;
-  const containers = deviceDescription.container.children[0].children;
+  const containers = ArrayUtils.sortArrByIndex(deviceDescription.container.children[0].children);
 
   const moveAnalyse = (idToMove, idOfPredecessor) => {
     Container.switchPositionOfChildContainer(
@@ -17,6 +18,7 @@ const AnalysesSortableContainer = ({ readonly }) => {
       idToMove,
       idOfPredecessor
     );
+    deviceDescriptionsStore.changeAnalysisContainer([...containers]);
   }
 
   const sortableCard = (container, index) => {

--- a/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysesSortableContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/analysesTab/AnalysesSortableContainer.js
@@ -7,73 +7,68 @@ import { DragDropItemTypes } from 'src/utilities/DndConst';
 import { StoreContext } from 'src/stores/mobx/RootStore';
 import ArrayUtils from 'src/utilities/ArrayUtils';
 
+const SortableCard = ({ container, index, readonly, onMove }) => {
+  const [{ isDragging }, drag] = useDrag({
+    type: DragDropItemTypes.CONTAINER,
+    item: { container },
+    collect: (monitor) => ({
+      isDragging: monitor.isDragging(),
+    }),
+  });
+
+  const [{ isOver, canDrop }, drop] = useDrop({
+    accept: DragDropItemTypes.CONTAINER,
+    collect: (monitor) => ({
+      isOver: monitor.isOver(),
+      canDrop: monitor.canDrop(),
+    }),
+    drop: (item) => {
+      if (item.container.id === container.id) { return; }
+      onMove(item.container.id, container.id);
+    },
+  });
+
+  const orderClass = ' d-flex align-items-center gap-2 px-2 py-3';
+  let dndClass = 'mb-3 rounded border';
+  if (canDrop) dndClass = ' dnd-zone-list-item';
+  if (isOver) dndClass += ' dnd-zone-over';
+  if (isDragging) dndClass += ' dnd-dragging';
+
+  return (
+    <Card
+      key={`container-${container.id}-${index}`}
+      className={dndClass}
+      ref={(node) => drag(drop(node))}
+    >
+      <Card.Header className={`rounded-0 p-0 border-bottom-0${orderClass}`}>
+        <div className="dnd-button">
+          <i className="dnd-arrow-enable text-info fa fa-arrows" />
+        </div>
+        <AnalysisHeader container={container} readonly={readonly} />
+      </Card.Header>
+    </Card>
+  );
+};
+
 const AnalysesSortableContainer = ({ readonly }) => {
   const deviceDescriptionsStore = useContext(StoreContext).deviceDescriptions;
   const deviceDescription = deviceDescriptionsStore.device_description;
   const containers = ArrayUtils.sortArrByIndex(deviceDescription.container.children[0].children);
 
   const moveAnalyse = (idToMove, idOfPredecessor) => {
-    Container.switchPositionOfChildContainer(
-      containers,
-      idToMove,
-      idOfPredecessor
-    );
+    Container.switchPositionOfChildContainer(containers, idToMove, idOfPredecessor);
     deviceDescriptionsStore.changeAnalysisContainer([...containers]);
-  }
-
-  const sortableCard = (container, index) => {
-    const [{ isDragging }, drag] = useDrag({
-      type: DragDropItemTypes.CONTAINER,
-      item: { container },
-      collect: (monitor) => ({
-        isDragging: monitor.isDragging(),
-      }),
-    });
-
-    const [{ isOver, canDrop }, drop] = useDrop({
-      accept: DragDropItemTypes.CONTAINER,
-      collect: (monitor) => ({
-        isOver: monitor.isOver(),
-        canDrop: monitor.canDrop(),
-      }),
-      drop: (item) => {
-        if (item.container.id === container.id) { return; }
-
-        moveAnalyse(item.container.id, container.id);
-      },
-    });
-
-    const orderClass = ' d-flex align-items-center gap-2 px-2 py-3';
-    let dndClass = 'mb-3 rounded border';
-    if (canDrop) {
-      dndClass = ' dnd-zone-list-item';
-    }
-    if (isOver) {
-      dndClass += ' dnd-zone-over';
-    }
-    if (isDragging) {
-      dndClass += ' dnd-dragging';
-    }
-
-    return (
-      <Card
-        key={`container-${container.id}-${index}`}
-        className={dndClass}
-        ref={(node) => drag(drop(node))}
-      >
-        <Card.Header className={`rounded-0 p-0 border-bottom-0${orderClass}`}>
-          <div className="dnd-button">
-            <i className="dnd-arrow-enable text-info fa fa-arrows" />
-          </div>
-          <AnalysisHeader container={container} readonly={readonly} />
-        </Card.Header>
-      </Card>
-    );
-  }
+  };
 
   return containers.map((container, index) => (
-    sortableCard(container, index)
+    <SortableCard
+      key={container.id}
+      container={container}
+      index={index}
+      readonly={readonly}
+      onMove={moveAnalyse}
+    />
   ));
-}
+};
 
 export default AnalysesSortableContainer;

--- a/app/javascript/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.js
@@ -10,6 +10,11 @@ import {
   ButtonToolbar, Tooltip,
 } from 'react-bootstrap';
 import Container from 'src/models/Container';
+import ArrayUtils from 'src/utilities/ArrayUtils';
+import { reOrderArr } from 'src/utilities/DndControl';
+import { indexedContainers } from 'src/apps/mydb/elements/details/analyses/utils';
+import AnalysisModeToggle from 'src/apps/mydb/elements/details/analyses/AnalysisModeToggle';
+import AnalysesOrderRow from 'src/apps/mydb/elements/details/analyses/AnalysesOrderRow';
 import ContainerComponent from 'src/components/container/ContainerComponent';
 import PrintCodeButton from 'src/components/common/PrintCodeButton';
 import QuillViewer from 'src/components/QuillViewer';
@@ -81,6 +86,7 @@ export default class ReactionDetailsContainers extends Component {
     this.state = {
       activeContainer: UIStore.getState().reaction.activeAnalysis,
       commentBoxVisible: hasComment,
+      mode: 'edit',
     };
     this.containerRefs = {};
 
@@ -90,6 +96,8 @@ export default class ReactionDetailsContainers extends Component {
     this.handleOnClickRemove = this.handleOnClickRemove.bind(this);
     this.handleAccordionOpen = this.handleAccordionOpen.bind(this);
     this.handleSpChange = this.handleSpChange.bind(this);
+    this.handleToggleMode = this.handleToggleMode.bind(this);
+    this.handleMove = this.handleMove.bind(this);
     this.onUIStoreChange = this.onUIStoreChange.bind(this);
   }
 
@@ -231,6 +239,22 @@ export default class ReactionDetailsContainers extends Component {
     this.setState({ activeContainer: key });
   }
 
+  handleToggleMode(mode) {
+    this.setState({ mode });
+  }
+
+  handleMove(source, target) {
+    const { reaction, handleReactionChange } = this.props;
+    const analysesContainer = reaction.container.children.filter(
+      (element) => ~element.container_type.indexOf('analyses'),
+    )[0];
+    const sortedConts = ArrayUtils.sortArrByIndex(analysesContainer.children);
+    const isEqCId = (container, tagEl) => container.id === tagEl.id;
+    const newSortConts = reOrderArr(source, target, isEqCId, sortedConts);
+    analysesContainer.children = indexedContainers(newSortConts);
+    handleReactionChange(reaction);
+  }
+
   // eslint-disable-next-line class-methods-use-this
   renderAnalysesHint() {
     return (
@@ -284,7 +308,7 @@ export default class ReactionDetailsContainers extends Component {
   };
 
   render() {
-    const { activeContainer, commentBoxVisible } = this.state;
+    const { activeContainer, commentBoxVisible, mode } = this.state;
     const { reaction, readOnly } = this.props;
 
     const containerHeader = (container) => {
@@ -374,67 +398,82 @@ export default class ReactionDetailsContainers extends Component {
       ));
 
       if (analyses_container.length === 1 && analyses_container[0].children.length > 0) {
+        const sortedChildren = ArrayUtils.sortArrByIndex(analyses_container[0].children);
         return (
           <div>
-            <div className="d-flex justify-content-between align-items-center mb-3">
+            <div className="mb-3">
               {this.renderAnalysesHint()}
-              <ButtonToolbar>
-                <CommentButton
-                  toggleCommentBox={this.toggleCommentBox}
-                  isVisible={commentBoxVisible}
-                  size="sm"
-                />
-                {this.addButton()}
-              </ButtonToolbar>
+              <div className="d-flex justify-content-between align-items-center mt-2">
+                {AnalysisModeToggle(mode, this.handleToggleMode, readOnly)}
+                <ButtonToolbar className="gap-2">
+                  <CommentButton
+                    toggleCommentBox={this.toggleCommentBox}
+                    isVisible={commentBoxVisible}
+                    size="sm"
+                  />
+                  {this.addButton()}
+                </ButtonToolbar>
+              </div>
             </div>
             <CommentBox
               isVisible={commentBoxVisible}
               value={reaction.container.description}
               handleCommentTextChange={this.handleCommentTextChange}
             />
-            <Accordion
-              className="border rounded overflow-hidden"
-              onSelect={this.handleAccordionOpen}
-              activeKey={activeContainer}
-            >
-              {analyses_container[0].children.map((container, key) => {
-                const isFirstTab = key === 0;
-                return (
-                  <Card
-                    ref={(element) => {
-                      this.containerRefs[key] = element;
-                    }}
-                    key={`reaction_container_${container.id}`}
-                    className={`rounded-0 border-0${isFirstTab ? '' : ' border-top'}`}
-                  >
-                    <Card.Header className="rounded-0 p-0 border-bottom-0">
-                      <AccordionHeaderWithButtons eventKey={key}>
-                        {container.is_deleted
-                          ? containerHeaderDeleted(container)
-                          : containerHeader(container)}
-                      </AccordionHeaderWithButtons>
-                    </Card.Header>
-
-                    {!container.is_deleted && (
-                    <Accordion.Collapse eventKey={key}>
-                      <Card.Body>
-                        <ContainerComponent
-                                    disabled={readOnly}
-                                    readOnly={readOnly}
-                                    templateType="reaction"
-                                    element={reaction}
-                                    container={container}
-                                    onChange={() => this.handleChange(container)}
-                                    rootContainer={reaction.container}
-                                    index={key}
-                                  />
-                      </Card.Body>
-                    </Accordion.Collapse>
-                    )}
-                  </Card>
-                );
-              })}
-            </Accordion>
+            {mode === 'order' ? (
+              <div>
+                {sortedChildren.map((container) => (
+                  <AnalysesOrderRow
+                    key={container.id}
+                    container={container}
+                    handleMove={this.handleMove}
+                  />
+                ))}
+              </div>
+            ) : (
+              <Accordion
+                className="border rounded overflow-hidden"
+                onSelect={this.handleAccordionOpen}
+                activeKey={activeContainer}
+              >
+                {sortedChildren.map((container, key) => {
+                  const isFirstTab = key === 0;
+                  return (
+                    <Card
+                      ref={(element) => {
+                        this.containerRefs[key] = element;
+                      }}
+                      key={`reaction_container_${container.id}`}
+                      className={`rounded-0 border-0${isFirstTab ? '' : ' border-top'}`}
+                    >
+                      <Card.Header className="rounded-0 p-0 border-bottom-0">
+                        <AccordionHeaderWithButtons eventKey={key}>
+                          {container.is_deleted
+                            ? containerHeaderDeleted(container)
+                            : containerHeader(container)}
+                        </AccordionHeaderWithButtons>
+                      </Card.Header>
+                      {!container.is_deleted && (
+                        <Accordion.Collapse eventKey={key}>
+                          <Card.Body>
+                            <ContainerComponent
+                              disabled={readOnly}
+                              readOnly={readOnly}
+                              templateType="reaction"
+                              element={reaction}
+                              container={container}
+                              onChange={() => this.handleChange(container)}
+                              rootContainer={reaction.container}
+                              index={key}
+                            />
+                          </Card.Body>
+                        </Accordion.Collapse>
+                      )}
+                    </Card>
+                  );
+                })}
+              </Accordion>
+            )}
             <ViewSpectra
               sample={reaction}
               handleSampleChanged={this.handleSpChange}

--- a/app/javascript/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.js
@@ -11,8 +11,7 @@ import {
 } from 'react-bootstrap';
 import Container from 'src/models/Container';
 import ArrayUtils from 'src/utilities/ArrayUtils';
-import { reOrderArr } from 'src/utilities/DndControl';
-import { indexedContainers } from 'src/apps/mydb/elements/details/analyses/utils';
+import { findAnalysesContainer, reorderAnalyses } from 'src/apps/mydb/elements/details/analyses/utils';
 import AnalysisModeToggle from 'src/apps/mydb/elements/details/analyses/AnalysisModeToggle';
 import AnalysesOrderRow from 'src/apps/mydb/elements/details/analyses/AnalysesOrderRow';
 import ContainerComponent from 'src/components/container/ContainerComponent';
@@ -245,13 +244,7 @@ export default class ReactionDetailsContainers extends Component {
 
   handleMove(source, target) {
     const { reaction, handleReactionChange } = this.props;
-    const analysesContainer = reaction.container.children.filter(
-      (element) => ~element.container_type.indexOf('analyses'),
-    )[0];
-    const sortedConts = ArrayUtils.sortArrByIndex(analysesContainer.children);
-    const isEqCId = (container, tagEl) => container.id === tagEl.id;
-    const newSortConts = reOrderArr(source, target, isEqCId, sortedConts);
-    analysesContainer.children = indexedContainers(newSortConts);
+    reorderAnalyses(findAnalysesContainer(reaction), source, target);
     handleReactionChange(reaction);
   }
 

--- a/app/javascript/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.js
@@ -404,7 +404,7 @@ export default class ReactionDetailsContainers extends Component {
             <div className="mb-3">
               {this.renderAnalysesHint()}
               <div className="d-flex justify-content-between align-items-center mt-2">
-                {AnalysisModeToggle(mode, this.handleToggleMode, readOnly)}
+                <AnalysisModeToggle mode={mode} onToggle={this.handleToggleMode} disabled={readOnly} />
                 <ButtonToolbar className="gap-2">
                   <CommentButton
                     toggleCommentBox={this.toggleCommentBox}

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
@@ -7,6 +7,11 @@ import {
   ButtonToolbar
 } from 'react-bootstrap';
 import Container from 'src/models/Container';
+import ArrayUtils from 'src/utilities/ArrayUtils';
+import { reOrderArr } from 'src/utilities/DndControl';
+import { indexedContainers } from 'src/apps/mydb/elements/details/analyses/utils';
+import AnalysisModeToggle from 'src/apps/mydb/elements/details/analyses/AnalysisModeToggle';
+import AnalysesOrderRow from 'src/apps/mydb/elements/details/analyses/AnalysesOrderRow';
 import ContainerComponent from 'src/components/container/ContainerComponent';
 import QuillViewer from 'src/components/QuillViewer';
 import ImageModal from 'src/components/common/ImageModal';
@@ -33,6 +38,7 @@ export default class ResearchPlanDetailsContainers extends Component {
     this.state = {
       activeContainer: 0,
       commentBoxVisible: hasComment,
+      mode: 'edit',
     };
 
     this.handleChange = this.handleChange.bind(this);
@@ -41,6 +47,8 @@ export default class ResearchPlanDetailsContainers extends Component {
     this.handleRemove = this.handleRemove.bind(this);
     this.handleUndo = this.handleUndo.bind(this);
     this.handleAccordionOpen = this.handleAccordionOpen.bind(this);
+    this.handleToggleMode = this.handleToggleMode.bind(this);
+    this.handleMove = this.handleMove.bind(this);
   }
 
   componentDidMount() {
@@ -60,6 +68,22 @@ export default class ResearchPlanDetailsContainers extends Component {
 
   handleAccordionOpen(key) {
     this.setState({ activeContainer: key });
+  }
+
+  handleToggleMode(mode) {
+    this.setState({ mode });
+  }
+
+  handleMove(source, target) {
+    const { researchPlan, handleResearchPlanChange } = this.props;
+    const analysesContainer = researchPlan.container.children.filter(
+      (element) => ~element.container_type.indexOf('analyses'),
+    )[0];
+    const sortedConts = ArrayUtils.sortArrByIndex(analysesContainer.children);
+    const isEqCId = (container, tagEl) => container.id === tagEl.id;
+    const newSortConts = reOrderArr(source, target, isEqCId, sortedConts);
+    analysesContainer.children = indexedContainers(newSortConts);
+    handleResearchPlanChange(researchPlan);
   }
 
   handleRemove(container) {
@@ -156,15 +180,13 @@ export default class ResearchPlanDetailsContainers extends Component {
     const { readOnly } = this.props;
     if (!readOnly) {
       return (
-        <div className="mt-2">
-          <Button
-            size="sm"
-            variant="success"
-            onClick={this.handleAdd}
-          >
-            Add analysis
-          </Button>
-        </div>
+        <Button
+          size="sm"
+          variant="success"
+          onClick={this.handleAdd}
+        >
+          Add analysis
+        </Button>
       );
     }
 
@@ -186,7 +208,7 @@ export default class ResearchPlanDetailsContainers extends Component {
 
   render() {
     const { researchPlan, readOnly } = this.props;
-    const { activeContainer, commentBoxVisible } = this.state;
+    const { activeContainer, commentBoxVisible, mode } = this.state;
 
     const containerHeader = (container) => {
       let kind = container.extended_metadata.kind || '';
@@ -271,17 +293,17 @@ export default class ResearchPlanDetailsContainers extends Component {
       ));
 
       if (analysesContainer.length === 1 && analysesContainer[0].children.length > 0) {
+        const sortedChildren = ArrayUtils.sortArrByIndex(analysesContainer[0].children);
         return (
           <div>
-            <div className="my-2 mx-3 d-flex justify-content-end">
-              <ButtonToolbar>
-                <div className="mt-2">
-                  <CommentButton
-                    toggleCommentBox={this.toggleCommentBox}
-                    isVisible={commentBoxVisible}
-                    size="sm"
-                  />
-                </div>
+            <div className="my-2 mx-3 d-flex justify-content-between align-items-center">
+              {AnalysisModeToggle(mode, this.handleToggleMode, readOnly)}
+              <ButtonToolbar className="gap-1">
+                <CommentButton
+                  toggleCommentBox={this.toggleCommentBox}
+                  isVisible={commentBoxVisible}
+                  size="sm"
+                />
                 {this.addButton()}
               </ButtonToolbar>
             </div>
@@ -290,45 +312,56 @@ export default class ResearchPlanDetailsContainers extends Component {
               value={researchPlan.container.description}
               handleCommentTextChange={this.handleCommentTextChange}
             />
-            <Accordion
-              className="border rounded overflow-hidden"
-              onSelect={this.handleAccordionOpen}
-              activeKey={activeContainer}
-            >
-              {analysesContainer[0].children.map((container, key) => {
-                const isFirstTab = key === 0;
-                return (
-                  <Card
-                    eventKey={key}
-                    key={`research_plan_container_${container.id}`}
-                    className={`rounded-0 border-0 ${isFirstTab ? '' : ' border-top'}`}
-                  >
-                    <Card.Header className="rounded-0 p-0 border-bottom-0">
-                      <AccordionHeaderWithButtons eventKey={key}>
-                        {container.is_deleted ? containerHeaderDeleted(container) : containerHeader(container)}
-                      </AccordionHeaderWithButtons>
-                    </Card.Header>
-
-                    {!container.is_deleted && (
-                      <Accordion.Collapse eventKey={key}>
-                        <Card.Body>
-                          <ContainerComponent
-                            templateType="researchPlan"
-                            element={researchPlan}
-                            readOnly={readOnly}
-                            disabled={readOnly}
-                            container={container}
-                            onChange={this.handleChange}
-                            rootContainer={researchPlan.container}
-                            index={key}
-                          />
-                        </Card.Body>
-                      </Accordion.Collapse>
-                    )}
-                  </Card>
-                );
-              })}
-            </Accordion>
+            {mode === 'order' ? (
+              <div>
+                {sortedChildren.map((container) => (
+                  <AnalysesOrderRow
+                    key={container.id}
+                    container={container}
+                    handleMove={this.handleMove}
+                  />
+                ))}
+              </div>
+            ) : (
+              <Accordion
+                className="border rounded overflow-hidden"
+                onSelect={this.handleAccordionOpen}
+                activeKey={activeContainer}
+              >
+                {sortedChildren.map((container, key) => {
+                  const isFirstTab = key === 0;
+                  return (
+                    <Card
+                      eventKey={key}
+                      key={`research_plan_container_${container.id}`}
+                      className={`rounded-0 border-0 ${isFirstTab ? '' : ' border-top'}`}
+                    >
+                      <Card.Header className="rounded-0 p-0 border-bottom-0">
+                        <AccordionHeaderWithButtons eventKey={key}>
+                          {container.is_deleted ? containerHeaderDeleted(container) : containerHeader(container)}
+                        </AccordionHeaderWithButtons>
+                      </Card.Header>
+                      {!container.is_deleted && (
+                        <Accordion.Collapse eventKey={key}>
+                          <Card.Body>
+                            <ContainerComponent
+                              templateType="researchPlan"
+                              element={researchPlan}
+                              readOnly={readOnly}
+                              disabled={readOnly}
+                              container={container}
+                              onChange={this.handleChange}
+                              rootContainer={researchPlan.container}
+                              index={key}
+                            />
+                          </Card.Body>
+                        </Accordion.Collapse>
+                      )}
+                    </Card>
+                  );
+                })}
+              </Accordion>
+            )}
             <ViewSpectra
               sample={this.props.researchPlan}
               handleSampleChanged={this.handleSpChange}
@@ -347,14 +380,12 @@ export default class ResearchPlanDetailsContainers extends Component {
         <div>
           <div className="d-flex align-items-center justify-content-between my-2 mx-3">
             <span className="ms-3"> There are currently no Analyses. </span>
-            <ButtonToolbar>
-              <div className="mt-2">
-                <CommentButton
-                  toggleCommentBox={this.toggleCommentBox}
-                  isVisible={commentBoxVisible}
-                  size="sm"
-                />
-              </div>
+            <ButtonToolbar className="gap-2">
+              <CommentButton
+                toggleCommentBox={this.toggleCommentBox}
+                isVisible={commentBoxVisible}
+                size="sm"
+              />
               {this.addButton()}
             </ButtonToolbar>
           </div>

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
@@ -8,8 +8,7 @@ import {
 } from 'react-bootstrap';
 import Container from 'src/models/Container';
 import ArrayUtils from 'src/utilities/ArrayUtils';
-import { reOrderArr } from 'src/utilities/DndControl';
-import { indexedContainers } from 'src/apps/mydb/elements/details/analyses/utils';
+import { findAnalysesContainer, reorderAnalyses } from 'src/apps/mydb/elements/details/analyses/utils';
 import AnalysisModeToggle from 'src/apps/mydb/elements/details/analyses/AnalysisModeToggle';
 import AnalysesOrderRow from 'src/apps/mydb/elements/details/analyses/AnalysesOrderRow';
 import ContainerComponent from 'src/components/container/ContainerComponent';
@@ -76,13 +75,7 @@ export default class ResearchPlanDetailsContainers extends Component {
 
   handleMove(source, target) {
     const { researchPlan, handleResearchPlanChange } = this.props;
-    const analysesContainer = researchPlan.container.children.filter(
-      (element) => ~element.container_type.indexOf('analyses'),
-    )[0];
-    const sortedConts = ArrayUtils.sortArrByIndex(analysesContainer.children);
-    const isEqCId = (container, tagEl) => container.id === tagEl.id;
-    const newSortConts = reOrderArr(source, target, isEqCId, sortedConts);
-    analysesContainer.children = indexedContainers(newSortConts);
+    reorderAnalyses(findAnalysesContainer(researchPlan), source, target);
     handleResearchPlanChange(researchPlan);
   }
 

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers.js
@@ -297,7 +297,7 @@ export default class ResearchPlanDetailsContainers extends Component {
         return (
           <div>
             <div className="my-2 mx-3 d-flex justify-content-between align-items-center">
-              {AnalysisModeToggle(mode, this.handleToggleMode, readOnly)}
+              <AnalysisModeToggle mode={mode} onToggle={this.handleToggleMode} disabled={readOnly} />
               <ButtonToolbar className="gap-1">
                 <CommentButton
                   toggleCommentBox={this.toggleCommentBox}

--- a/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainers.js
@@ -5,7 +5,6 @@ import {OverlayTrigger, Button, Tooltip} from 'react-bootstrap';
 import Container from 'src/models/Container';
 import UIStore from 'src/stores/alt/stores/UIStore';
 import ArrayUtils from 'src/utilities/ArrayUtils';
-import { reOrderArr } from 'src/utilities/DndControl';
 import ViewSpectra from 'src/apps/mydb/elements/details/ViewSpectra';
 
 import NMRiumDisplayer from 'src/components/nmriumWrapper/NMRiumDisplayer';
@@ -18,9 +17,9 @@ import TextTemplateActions from 'src/stores/alt/actions/TextTemplateActions';
 import { UploadField } from 'src/apps/mydb/elements/details/analyses/UploadField';
 import { CommentButton, CommentBox } from 'src/components/common/AnalysisCommentBoxComponent';
 import {
-  sortedContainers,
-  indexedContainers,
-  addNewAnalyses
+  addNewAnalyses,
+  findAnalysesContainer,
+  reorderAnalyses,
 } from 'src/apps/mydb/elements/details/analyses/utils';
 
 export default class SampleDetailsContainers extends Component {
@@ -45,8 +44,6 @@ export default class SampleDetailsContainers extends Component {
     this.handleMove = this.handleMove.bind(this);
     this.toggleAddToReport = this.toggleAddToReport.bind(this);
     this.handleToggleMode = this.handleToggleMode.bind(this);
-    this.isEqCId = this.isEqCId.bind(this);
-    this.indexedContainers = this.indexedContainers.bind(this);
   }
 
   componentDidMount() {
@@ -94,22 +91,8 @@ export default class SampleDetailsContainers extends Component {
 
   handleMove(source, target) {
     const { sample } = this.props;
-
-    const sortedConts = sortedContainers(sample);
-    const newSortConts = reOrderArr(source, target, this.isEqCId, sortedConts);
-    const newIndexedConts = this.indexedContainers(newSortConts);
-
-    sample.analysesContainers()[0].children = newIndexedConts;
+    reorderAnalyses(findAnalysesContainer(sample), source, target);
     this.props.setState((prevState) => ({ ...prevState, sample }));
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  isEqCId(container, tagEl) {
-    return container.id === tagEl.id;
-  }
-
-  indexedContainers(containers) {
-    return indexedContainers(containers);
   }
 
   handleRemove(container) {

--- a/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, ButtonGroup, Form } from 'react-bootstrap';
+import { Button, Form } from 'react-bootstrap';
 import QuillViewer from 'src/components/QuillViewer';
 import PrintCodeButton from 'src/components/common/PrintCodeButton';
 import ImageModal from 'src/components/common/ImageModal';
@@ -15,7 +15,6 @@ import MolViewerListBtn from 'src/components/viewer/MolViewerListBtn';
 import MolViewerSet from 'src/components/viewer/MolViewerSet';
 import MatrixCheck from 'src/components/common/MatrixCheck';
 import SpectraEditorButton from 'src/components/common/SpectraEditorButton';
-import ButtonGroupToggleButton from 'src/components/common/ButtonGroupToggleButton';
 import { getAttachmentFromContainer } from 'src/utilities/imageHelper';
 
 const qCheckPass = () => (
@@ -52,29 +51,6 @@ const qCheckMsg = (sample, container) => {
   }
   return '';
 };
-
-const AnalysisModeToggle = ({ mode, onToggle, disabled = false }) => (
-  <ButtonGroup>
-    <ButtonGroupToggleButton
-      size="xsm"
-      active={mode === 'edit'}
-      onClick={() => onToggle('edit')}
-      disabled={disabled}
-    >
-      <i className="fa fa-edit me-1" />
-      Edit mode
-    </ButtonGroupToggleButton>
-    <ButtonGroupToggleButton
-      size="xsm"
-      active={mode === 'order'}
-      onClick={() => onToggle('order')}
-      disabled={disabled}
-    >
-      <i className="fa fa-reorder me-1" />
-      Order mode
-    </ButtonGroupToggleButton>
-  </ButtonGroup>
-);
 
 const headerBtnGroup = (
   deleted, container, sample, handleRemove, handleSubmit,
@@ -246,4 +222,4 @@ const AnalysesHeader = ({
   );
 };
 
-export { AnalysesHeader, AnalysisModeToggle };
+export { AnalysesHeader };

--- a/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux.js
@@ -53,30 +53,28 @@ const qCheckMsg = (sample, container) => {
   return '';
 };
 
-const AnalysisModeToggle = (mode, handleToggleMode, isDisabled) => {
-  return (
-    <ButtonGroup>
-      <ButtonGroupToggleButton
-        size="xsm"
-        active={mode === 'edit'}
-        onClick={() => handleToggleMode('edit')}
-        disabled={isDisabled}
-      >
-        <i className="fa fa-edit me-1" />
-        Edit mode
-      </ButtonGroupToggleButton>
-      <ButtonGroupToggleButton
-        size="xsm"
-        active={mode === 'order'}
-        onClick={() => handleToggleMode('order')}
-        disabled={isDisabled}
-      >
-        <i className="fa fa-reorder me-1" />
-        Order mode
-      </ButtonGroupToggleButton>
-    </ButtonGroup>
-  )
-};
+const AnalysisModeToggle = ({ mode, onToggle, disabled = false }) => (
+  <ButtonGroup>
+    <ButtonGroupToggleButton
+      size="xsm"
+      active={mode === 'edit'}
+      onClick={() => onToggle('edit')}
+      disabled={disabled}
+    >
+      <i className="fa fa-edit me-1" />
+      Edit mode
+    </ButtonGroupToggleButton>
+    <ButtonGroupToggleButton
+      size="xsm"
+      active={mode === 'order'}
+      onClick={() => onToggle('order')}
+      disabled={disabled}
+    >
+      <i className="fa fa-reorder me-1" />
+      Order mode
+    </ButtonGroupToggleButton>
+  </ButtonGroup>
+);
 
 const headerBtnGroup = (
   deleted, container, sample, handleRemove, handleSubmit,

--- a/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersCom.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersCom.js
@@ -73,7 +73,7 @@ function ReactionsDisplay({
   return (
     <div>
       <div className="d-flex justify-content-between align-items-center mb-3">
-        {AnalysisModeToggle(mode, handleToggleMode, isDisabled)}
+        <AnalysisModeToggle mode={mode} onToggle={handleToggleMode} disabled={isDisabled} />
         <ButtonToolbar>
           <CommentButton
             toggleCommentBox={toggleCommentBox}

--- a/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersCom.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersCom.js
@@ -3,10 +3,8 @@ import React from 'react';
 import { ButtonToolbar, Accordion, Card } from 'react-bootstrap';
 import ContainerComponent from 'src/components/container/ContainerComponent';
 import ContainerRow from 'src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersDnd';
-import {
-  AnalysesHeader,
-  AnalysisModeToggle,
-} from 'src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux';
+import { AnalysesHeader } from 'src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersAux';
+import AnalysisModeToggle from 'src/apps/mydb/elements/details/analyses/AnalysisModeToggle';
 import AccordionHeaderWithButtons from 'src/components/common/AccordionHeaderWithButtons';
 import { CommentButton, CommentBox } from 'src/components/common/AnalysisCommentBoxComponent';
 

--- a/app/javascript/src/apps/mydb/elements/details/screens/analysesTab/ScreenDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/analysesTab/ScreenDetailsContainers.js
@@ -3,6 +3,11 @@ import PropTypes from 'prop-types';
 import { Button, Accordion, Card, ButtonToolbar } from 'react-bootstrap';
 
 import Container from 'src/models/Container';
+import ArrayUtils from 'src/utilities/ArrayUtils';
+import { reOrderArr } from 'src/utilities/DndControl';
+import { indexedContainers } from 'src/apps/mydb/elements/details/analyses/utils';
+import AnalysisModeToggle from 'src/apps/mydb/elements/details/analyses/AnalysisModeToggle';
+import AnalysesOrderRow from 'src/apps/mydb/elements/details/analyses/AnalysesOrderRow';
 import ContainerComponent from 'src/components/container/ContainerComponent';
 import PrintCodeButton from 'src/components/common/PrintCodeButton';
 import AccordionHeaderWithButtons from 'src/components/common/AccordionHeaderWithButtons';
@@ -18,6 +23,7 @@ export default class ScreenDetailsContainers extends Component {
       screen,
       activeContainer: 0,
       commentBoxVisible: hasComment,
+      mode: 'edit',
     };
     this.analysesContainer = screen.container.children.filter(element => ~element.container_type.indexOf('analyses'));
   }
@@ -81,6 +87,23 @@ export default class ScreenDetailsContainers extends Component {
     this.setState({ activeContainer: key });
   }
 
+  handleToggleMode(mode) {
+    this.setState({ mode });
+  }
+
+  handleMove(source, target) {
+    const { handleScreenChanged } = this.props;
+    const { screen } = this.state;
+    const analysesContainer = screen.container.children.filter(
+      (element) => ~element.container_type.indexOf('analyses'),
+    )[0];
+    const sortedConts = ArrayUtils.sortArrByIndex(analysesContainer.children);
+    const isEqCId = (container, tagEl) => container.id === tagEl.id;
+    const newSortConts = reOrderArr(source, target, isEqCId, sortedConts);
+    analysesContainer.children = indexedContainers(newSortConts);
+    handleScreenChanged(screen);
+  }
+
   stopToggleAccordion(event) {
     event.stopPropagation();
   }
@@ -90,16 +113,14 @@ export default class ScreenDetailsContainers extends Component {
     if (readOnly) { return null; }
 
     return (
-      <div className="my-2">
-        <Button
-          size="sm"
-          variant="success"
-          onClick={() => this.handleAdd()}
-        >
-          <i className="fa fa-plus me-1" />
-          Add analysis
-        </Button>
-      </div>
+      <Button
+        size="sm"
+        variant="success"
+        onClick={() => this.handleAdd()}
+      >
+        <i className="fa fa-plus me-1" />
+        Add analysis
+      </Button>
     );
   }
 
@@ -196,20 +217,20 @@ export default class ScreenDetailsContainers extends Component {
   };
 
   render() {
-    const { screen, commentBoxVisible } = this.state;
+    const { screen, commentBoxVisible, mode } = this.state;
     if (screen.container != null) {
       if (this.analysesContainer.length == 1 && this.analysesContainer[0].children.length > 0) {
+        const sortedChildren = ArrayUtils.sortArrByIndex(this.analysesContainer[0].children);
         return (
           <div>
-            <div className="mb-2 me-1 d-flex flex-row-reverse">
-              <ButtonToolbar>
-                <div className="mt-2">
-                  <CommentButton
-                    toggleCommentBox={this.toggleCommentBox}
-                    isVisible={commentBoxVisible}
-                    size="sm"
-                  />
-                </div>
+            <div className="mb-2 me-1 d-flex justify-content-between align-items-center">
+              {AnalysisModeToggle(mode, this.handleToggleMode.bind(this), this.props.readOnly)}
+              <ButtonToolbar className="gap-2">
+                <CommentButton
+                  toggleCommentBox={this.toggleCommentBox}
+                  isVisible={commentBoxVisible}
+                  size="sm"
+                />
                 {this.addButton()}
               </ButtonToolbar>
             </div>
@@ -218,26 +239,38 @@ export default class ScreenDetailsContainers extends Component {
               value={screen.container.description}
               handleCommentTextChange={this.handleCommentTextChange}
             />
-            <Accordion className="border rounded overflow-hidden">
-              {this.analysesContainer[0].children.map((container, key) => {
-                const isFirstTab = key === 0;
-                return (
-                  <Card
-                    key={`screen_container_${container.id}`}
-                    className={"rounded-0 border-0" + (isFirstTab ? '' : ' border-top')}
-                  >
-                    <Card.Header className="rounded-0 p-0 border-bottom-0">
-                      <AccordionHeaderWithButtons eventKey={key}>
-                        {container.is_deleted
-                          ? this.containerHeaderDeleted(container)
-                          : this.containerHeader(container)}
-                      </AccordionHeaderWithButtons>
-                    </Card.Header>
-                    {this.collapsableBody(container, key)}
-                  </Card>
-                );
-              })}
-            </Accordion>
+            {mode === 'order' ? (
+              <div>
+                {sortedChildren.map((container) => (
+                  <AnalysesOrderRow
+                    key={container.id}
+                    container={container}
+                    handleMove={this.handleMove.bind(this)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <Accordion className="border rounded overflow-hidden">
+                {sortedChildren.map((container, key) => {
+                  const isFirstTab = key === 0;
+                  return (
+                    <Card
+                      key={`screen_container_${container.id}`}
+                      className={`rounded-0 border-0${isFirstTab ? '' : ' border-top'}`}
+                    >
+                      <Card.Header className="rounded-0 p-0 border-bottom-0">
+                        <AccordionHeaderWithButtons eventKey={key}>
+                          {container.is_deleted
+                            ? this.containerHeaderDeleted(container)
+                            : this.containerHeader(container)}
+                        </AccordionHeaderWithButtons>
+                      </Card.Header>
+                      {this.collapsableBody(container, key)}
+                    </Card>
+                  );
+                })}
+              </Accordion>
+            )}
           </div>
         );
       } else {
@@ -246,13 +279,11 @@ export default class ScreenDetailsContainers extends Component {
             <div className="d-flex align-items-center justify-content-between my-2">
               <span> There are currently no Analyses.</span>
               <ButtonToolbar>
-                <div className="mt-2">
-                  <CommentButton
-                    toggleCommentBox={this.toggleCommentBox}
-                    isVisible={commentBoxVisible}
-                    size="sm"
-                  />
-                </div>
+                <CommentButton
+                  toggleCommentBox={this.toggleCommentBox}
+                  isVisible={commentBoxVisible}
+                  size="sm"
+                />
                 {this.addButton()}
               </ButtonToolbar>
             </div>

--- a/app/javascript/src/apps/mydb/elements/details/screens/analysesTab/ScreenDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/analysesTab/ScreenDetailsContainers.js
@@ -26,6 +26,8 @@ export default class ScreenDetailsContainers extends Component {
       mode: 'edit',
     };
     this.analysesContainer = screen.container.children.filter(element => ~element.container_type.indexOf('analyses'));
+    this.handleToggleMode = this.handleToggleMode.bind(this);
+    this.handleMove = this.handleMove.bind(this);
   }
 
   componentDidMount() {
@@ -217,6 +219,7 @@ export default class ScreenDetailsContainers extends Component {
   };
 
   render() {
+    const { readOnly } = this.props;
     const { screen, commentBoxVisible, mode } = this.state;
     if (screen.container != null) {
       if (this.analysesContainer.length == 1 && this.analysesContainer[0].children.length > 0) {
@@ -224,7 +227,7 @@ export default class ScreenDetailsContainers extends Component {
         return (
           <div>
             <div className="mb-2 me-1 d-flex justify-content-between align-items-center">
-              {AnalysisModeToggle(mode, this.handleToggleMode.bind(this), this.props.readOnly)}
+              <AnalysisModeToggle mode={mode} onToggle={this.handleToggleMode} disabled={readOnly} />
               <ButtonToolbar className="gap-2">
                 <CommentButton
                   toggleCommentBox={this.toggleCommentBox}
@@ -245,7 +248,7 @@ export default class ScreenDetailsContainers extends Component {
                   <AnalysesOrderRow
                     key={container.id}
                     container={container}
-                    handleMove={this.handleMove.bind(this)}
+                    handleMove={this.handleMove}
                   />
                 ))}
               </div>

--- a/app/javascript/src/apps/mydb/elements/details/screens/analysesTab/ScreenDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/analysesTab/ScreenDetailsContainers.js
@@ -4,8 +4,7 @@ import { Button, Accordion, Card, ButtonToolbar } from 'react-bootstrap';
 
 import Container from 'src/models/Container';
 import ArrayUtils from 'src/utilities/ArrayUtils';
-import { reOrderArr } from 'src/utilities/DndControl';
-import { indexedContainers } from 'src/apps/mydb/elements/details/analyses/utils';
+import { findAnalysesContainer, reorderAnalyses } from 'src/apps/mydb/elements/details/analyses/utils';
 import AnalysisModeToggle from 'src/apps/mydb/elements/details/analyses/AnalysisModeToggle';
 import AnalysesOrderRow from 'src/apps/mydb/elements/details/analyses/AnalysesOrderRow';
 import ContainerComponent from 'src/components/container/ContainerComponent';
@@ -96,13 +95,7 @@ export default class ScreenDetailsContainers extends Component {
   handleMove(source, target) {
     const { handleScreenChanged } = this.props;
     const { screen } = this.state;
-    const analysesContainer = screen.container.children.filter(
-      (element) => ~element.container_type.indexOf('analyses'),
-    )[0];
-    const sortedConts = ArrayUtils.sortArrByIndex(analysesContainer.children);
-    const isEqCId = (container, tagEl) => container.id === tagEl.id;
-    const newSortConts = reOrderArr(source, target, isEqCId, sortedConts);
-    analysesContainer.children = indexedContainers(newSortConts);
+    reorderAnalyses(findAnalysesContainer(screen), source, target);
     handleScreenChanged(screen);
   }
 

--- a/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/analysesTab/AnalysesContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/analysesTab/AnalysesContainer.js
@@ -13,13 +13,14 @@ import { CommentButton, CommentBox } from 'src/components/common/AnalysisComment
 import TextTemplateActions from 'src/stores/alt/actions/TextTemplateActions';
 import { observer } from 'mobx-react';
 import { StoreContext } from 'src/stores/mobx/RootStore';
+import ArrayUtils from 'src/utilities/ArrayUtils';
 import AnalysisHeader from 'src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/analysesTab/AnalysisHeader';
 import AnalysesSortableContainer from 'src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/analysesTab/AnalysesSortableContainer';
 
 function AnalysesContainer({ readonly }) {
   const sbmmStore = useContext(StoreContext).sequenceBasedMacromoleculeSamples;
   const sbmmSample = sbmmStore.sequence_based_macromolecule_sample;
-  const containers = sbmmSample.container.children[0].children;
+  const containers = ArrayUtils.sortArrByIndex(sbmmSample.container.children[0].children);
 
   useEffect(() => {
     TextTemplateActions.fetchTextTemplates('sbmmSample');

--- a/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/analysesTab/AnalysesSortableContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/analysesTab/AnalysesSortableContainer.js
@@ -7,73 +7,68 @@ import { DragDropItemTypes } from 'src/utilities/DndConst';
 import { StoreContext } from 'src/stores/mobx/RootStore';
 import ArrayUtils from 'src/utilities/ArrayUtils';
 
+const SortableCard = ({ container, index, readonly, onMove }) => {
+  const [{ isDragging }, drag] = useDrag({
+    type: DragDropItemTypes.CONTAINER,
+    item: { container },
+    collect: (monitor) => ({
+      isDragging: monitor.isDragging(),
+    }),
+  });
+
+  const [{ isOver, canDrop }, drop] = useDrop({
+    accept: DragDropItemTypes.CONTAINER,
+    collect: (monitor) => ({
+      isOver: monitor.isOver(),
+      canDrop: monitor.canDrop(),
+    }),
+    drop: (item) => {
+      if (item.container.id === container.id) { return; }
+      onMove(item.container.id, container.id);
+    },
+  });
+
+  const orderClass = ' d-flex align-items-center gap-2 px-2 py-3';
+  let dndClass = 'mb-3 rounded border';
+  if (canDrop) dndClass = ' dnd-zone-list-item';
+  if (isOver) dndClass += ' dnd-zone-over';
+  if (isDragging) dndClass += ' dnd-dragging';
+
+  return (
+    <Card
+      key={`container-${container.id}-${index}`}
+      className={dndClass}
+      ref={(node) => drag(drop(node))}
+    >
+      <Card.Header className={`rounded-0 p-0 border-bottom-0${orderClass}`}>
+        <div className="dnd-button">
+          <i className="dnd-arrow-enable text-info fa fa-arrows" />
+        </div>
+        <AnalysisHeader container={container} readonly={readonly} />
+      </Card.Header>
+    </Card>
+  );
+};
+
 const AnalysesSortableContainer = ({ readonly }) => {
   const sbmmStore = useContext(StoreContext).sequenceBasedMacromoleculeSamples;
   const sbmmSample = sbmmStore.sequence_based_macromolecule_sample;
   const containers = ArrayUtils.sortArrByIndex(sbmmSample.container.children[0].children);
 
   const moveAnalyse = (idToMove, idOfPredecessor) => {
-    Container.switchPositionOfChildContainer(
-      containers,
-      idToMove,
-      idOfPredecessor
-    );
+    Container.switchPositionOfChildContainer(containers, idToMove, idOfPredecessor);
     sbmmStore.changeAnalysisContainer([...containers]);
-  }
-
-  const sortableCard = (container, index) => {
-    const [{ isDragging }, drag] = useDrag({
-      type: DragDropItemTypes.CONTAINER,
-      item: { container },
-      collect: (monitor) => ({
-        isDragging: monitor.isDragging(),
-      }),
-    });
-
-    const [{ isOver, canDrop }, drop] = useDrop({
-      accept: DragDropItemTypes.CONTAINER,
-      collect: (monitor) => ({
-        isOver: monitor.isOver(),
-        canDrop: monitor.canDrop(),
-      }),
-      drop: (item) => {
-        if (item.container.id === container.id) { return; }
-
-        moveAnalyse(item.container.id, container.id);
-      },
-    });
-
-    const orderClass = ' d-flex align-items-center gap-2 px-2 py-3';
-    let dndClass = 'mb-3 rounded border';
-    if (canDrop) {
-      dndClass = ' dnd-zone-list-item';
-    }
-    if (isOver) {
-      dndClass += ' dnd-zone-over';
-    }
-    if (isDragging) {
-      dndClass += ' dnd-dragging';
-    }
-
-    return (
-      <Card
-        key={`container-${container.id}-${index}`}
-        className={dndClass}
-        ref={(node) => drag(drop(node))}
-      >
-        <Card.Header className={`rounded-0 p-0 border-bottom-0${orderClass}`}>
-          <div className="dnd-button">
-            <i className="dnd-arrow-enable text-info fa fa-arrows" />
-          </div>
-          <AnalysisHeader container={container} readonly={readonly} />
-        </Card.Header>
-      </Card>
-    );
-  }
+  };
 
   return containers.map((container, index) => (
-    sortableCard(container, index)
+    <SortableCard
+      key={container.id}
+      container={container}
+      index={index}
+      readonly={readonly}
+      onMove={moveAnalyse}
+    />
   ));
-}
+};
 
 export default AnalysesSortableContainer;

--- a/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/analysesTab/AnalysesSortableContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/analysesTab/AnalysesSortableContainer.js
@@ -5,11 +5,12 @@ import Container from 'src/models/Container';
 import { useDrag, useDrop } from 'react-dnd';
 import { DragDropItemTypes } from 'src/utilities/DndConst';
 import { StoreContext } from 'src/stores/mobx/RootStore';
+import ArrayUtils from 'src/utilities/ArrayUtils';
 
 const AnalysesSortableContainer = ({ readonly }) => {
   const sbmmStore = useContext(StoreContext).sequenceBasedMacromoleculeSamples;
   const sbmmSample = sbmmStore.sequence_based_macromolecule_sample;
-  const containers = sbmmSample.container.children[0].children;
+  const containers = ArrayUtils.sortArrByIndex(sbmmSample.container.children[0].children);
 
   const moveAnalyse = (idToMove, idOfPredecessor) => {
     Container.switchPositionOfChildContainer(
@@ -17,6 +18,7 @@ const AnalysesSortableContainer = ({ readonly }) => {
       idToMove,
       idOfPredecessor
     );
+    sbmmStore.changeAnalysisContainer([...containers]);
   }
 
   const sortableCard = (container, index) => {

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/analysesTab/WellplateDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/analysesTab/WellplateDetailsContainers.js
@@ -2,6 +2,11 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Accordion, Button, Card, ButtonToolbar } from 'react-bootstrap';
 import Container from 'src/models/Container';
+import ArrayUtils from 'src/utilities/ArrayUtils';
+import { reOrderArr } from 'src/utilities/DndControl';
+import { indexedContainers } from 'src/apps/mydb/elements/details/analyses/utils';
+import AnalysisModeToggle from 'src/apps/mydb/elements/details/analyses/AnalysisModeToggle';
+import AnalysesOrderRow from 'src/apps/mydb/elements/details/analyses/AnalysesOrderRow';
 import ContainerComponent from 'src/components/container/ContainerComponent';
 import PrintCodeButton from 'src/components/common/PrintCodeButton'
 
@@ -18,6 +23,7 @@ export default class WellplateDetailsContainers extends Component {
       wellplate,
       activeContainer: 0,
       commentBoxVisible: hasComment,
+      mode: 'edit',
     };
   }
 
@@ -73,6 +79,23 @@ export default class WellplateDetailsContainers extends Component {
     this.setState({ activeContainer: key });
   }
 
+  handleToggleMode = (mode) => {
+    this.setState({ mode });
+  }
+
+  handleMove = (source, target) => {
+    const { setWellplate } = this.props;
+    const { wellplate } = this.state;
+    const analysesContainer = wellplate.container.children.filter(
+      (element) => ~element.container_type.indexOf('analyses'),
+    )[0];
+    const sortedConts = ArrayUtils.sortArrByIndex(analysesContainer.children);
+    const isEqCId = (container, tagEl) => container.id === tagEl.id;
+    const newSortConts = reOrderArr(source, target, isEqCId, sortedConts);
+    analysesContainer.children = indexedContainers(newSortConts);
+    setWellplate(wellplate);
+  }
+
   addButton() {
     const { readOnly } = this.props;
     if (!readOnly) {
@@ -100,7 +123,7 @@ export default class WellplateDetailsContainers extends Component {
   };
 
   render() {
-    const { wellplate, activeContainer, commentBoxVisible } = this.state;
+    const { wellplate, activeContainer, commentBoxVisible, mode } = this.state;
     const { readOnly } = this.props;
 
     let containerHeader = (container) => <div className="analysis-header d-flex justify-content-between w-100">
@@ -194,10 +217,12 @@ export default class WellplateDetailsContainers extends Component {
       )
     }
 
+    const sortedChildren = ArrayUtils.sortArrByIndex(analyses_container[0].children);
     return (
       <div>
-        <div className="d-flex justify-content-end my-2 mx-3">
-          <ButtonToolbar>
+        <div className="d-flex justify-content-between align-items-center my-2 mx-3">
+          {AnalysisModeToggle(mode, this.handleToggleMode, readOnly)}
+          <ButtonToolbar className="gap-2">
             <CommentButton
               toggleCommentBox={this.toggleCommentBox}
               isVisible={commentBoxVisible}
@@ -211,27 +236,36 @@ export default class WellplateDetailsContainers extends Component {
           value={wellplate.container.description}
           handleCommentTextChange={this.handleCommentTextChange}
         />
-        <Accordion
-          className="border rounded overflow-hidden"
-          onSelect={this.handleAccordionOpen}
-          activeKey={activeContainer}
-        >
-          {
-            analyses_container[0].children.map((container, key) => {
+        {mode === 'order' ? (
+          <div>
+            {sortedChildren.map((container) => (
+              <AnalysesOrderRow
+                key={container.id}
+                container={container}
+                handleMove={this.handleMove}
+              />
+            ))}
+          </div>
+        ) : (
+          <Accordion
+            className="border rounded overflow-hidden"
+            onSelect={this.handleAccordionOpen}
+            activeKey={activeContainer}
+          >
+            {sortedChildren.map((container, key) => {
               const isFirstTab = key === 0;
               return (
                 <Card
                   eventKey={key}
                   key={`wellplate_container_${key}`}
-                  className={"rounded-0 border-0" + (isFirstTab ? '' : ' border-top')}
+                  className={`rounded-0 border-0${isFirstTab ? '' : ' border-top'}`}
                 >
                   <Card.Header className="rounded-0 p-0 border-bottom-0">
                     <AccordionHeaderWithButtons eventKey={key}>
                       {container.is_deleted ? containerHeaderDeleted(container) : containerHeader(container)}
                     </AccordionHeaderWithButtons>
                   </Card.Header>
-                  {
-                    !container.is_deleted &&
+                  {!container.is_deleted && (
                     <Accordion.Collapse eventKey={key}>
                       <Card.Body>
                         <ContainerComponent
@@ -239,18 +273,18 @@ export default class WellplateDetailsContainers extends Component {
                           element={wellplate}
                           readOnly={readOnly}
                           container={container}
-                          onChange={container => this.handleChange(container)}
+                          onChange={(c) => this.handleChange(c)}
                           rootContainer={wellplate.container}
                           index={key}
                         />
                       </Card.Body>
                     </Accordion.Collapse>
-                  }
+                  )}
                 </Card>
               );
-            })
-          }
-        </Accordion>
+            })}
+          </Accordion>
+        )}
       </div>
     );
   }

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/analysesTab/WellplateDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/analysesTab/WellplateDetailsContainers.js
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import { Accordion, Button, Card, ButtonToolbar } from 'react-bootstrap';
 import Container from 'src/models/Container';
 import ArrayUtils from 'src/utilities/ArrayUtils';
-import { reOrderArr } from 'src/utilities/DndControl';
-import { indexedContainers } from 'src/apps/mydb/elements/details/analyses/utils';
+import { findAnalysesContainer, reorderAnalyses } from 'src/apps/mydb/elements/details/analyses/utils';
 import AnalysisModeToggle from 'src/apps/mydb/elements/details/analyses/AnalysisModeToggle';
 import AnalysesOrderRow from 'src/apps/mydb/elements/details/analyses/AnalysesOrderRow';
 import ContainerComponent from 'src/components/container/ContainerComponent';
@@ -86,13 +85,7 @@ export default class WellplateDetailsContainers extends Component {
   handleMove = (source, target) => {
     const { setWellplate } = this.props;
     const { wellplate } = this.state;
-    const analysesContainer = wellplate.container.children.filter(
-      (element) => ~element.container_type.indexOf('analyses'),
-    )[0];
-    const sortedConts = ArrayUtils.sortArrByIndex(analysesContainer.children);
-    const isEqCId = (container, tagEl) => container.id === tagEl.id;
-    const newSortConts = reOrderArr(source, target, isEqCId, sortedConts);
-    analysesContainer.children = indexedContainers(newSortConts);
+    reorderAnalyses(findAnalysesContainer(wellplate), source, target);
     setWellplate(wellplate);
   }
 

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/analysesTab/WellplateDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/analysesTab/WellplateDetailsContainers.js
@@ -221,7 +221,7 @@ export default class WellplateDetailsContainers extends Component {
     return (
       <div>
         <div className="d-flex justify-content-between align-items-center my-2 mx-3">
-          {AnalysisModeToggle(mode, this.handleToggleMode, readOnly)}
+          <AnalysisModeToggle mode={mode} onToggle={this.handleToggleMode} disabled={readOnly} />
           <ButtonToolbar className="gap-2">
             <CommentButton
               toggleCommentBox={this.toggleCommentBox}

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/analysesTab/WellplateDetailsContainers.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/analysesTab/WellplateDetailsContainers.js
@@ -257,7 +257,7 @@ export default class WellplateDetailsContainers extends Component {
               return (
                 <Card
                   eventKey={key}
-                  key={`wellplate_container_${key}`}
+                  key={`wellplate_container_${container.id}`}
                   className={`rounded-0 border-0${isFirstTab ? '' : ' border-top'}`}
                 >
                   <Card.Header className="rounded-0 p-0 border-bottom-0">

--- a/app/javascript/src/components/generic/GenericElDetailsContainers.js
+++ b/app/javascript/src/components/generic/GenericElDetailsContainers.js
@@ -9,10 +9,9 @@ import Container from 'src/models/Container';
 import TextTemplateActions from 'src/stores/alt/actions/TextTemplateActions';
 import GenericContainerSet from 'src/components/generic/GenericContainerSet';
 import { CommentButton, CommentBox } from 'src/components/common/AnalysisCommentBoxComponent';
-import ArrayUtils from 'src/utilities/ArrayUtils';
-import { reOrderArr } from 'src/utilities/DndControl';
 import {
-  indexedContainers,
+  findAnalysesContainer,
+  reorderAnalyses,
 } from 'src/apps/mydb/elements/details/analyses/utils';
 import { UploadField } from 'src/apps/mydb/elements/details/analyses/UploadField';
 
@@ -74,14 +73,7 @@ export default class GenericElDetailsContainers extends Component {
 
   handleMove(source, target) {
     const { genericEl, handleElChanged } = this.props;
-    const analysesContainer = genericEl.container.children.filter(
-      (element) => ~element.container_type.indexOf('analyses'),
-    )[0];
-    const sortedConts = ArrayUtils.sortArrByIndex(analysesContainer.children);
-    const isEqCId = (container, tagEl) => container.id === tagEl.id;
-    const newSortConts = reOrderArr(source, target, isEqCId, sortedConts);
-    const newIndexedConts = indexedContainers(newSortConts);
-    analysesContainer.children = newIndexedConts;
+    reorderAnalyses(findAnalysesContainer(genericEl), source, target);
     handleElChanged(genericEl);
   }
 

--- a/app/javascript/src/utilities/collectionUtilities.js
+++ b/app/javascript/src/utilities/collectionUtilities.js
@@ -68,7 +68,7 @@ const collectionOptions = (store, showSharedCollections) => {
 };
 
 const collectionHasPermission = (collection, permissionLevel) => {
-  if (collection === null || collection.permission_level === undefined) { return true; }
+  if (!collection || collection.permission_level === undefined) { return true; }
 
   return collection.collection_share_id && collection.permission_level >= permissionLevel;
 };

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers.spec.js
@@ -10,6 +10,7 @@ import { Button } from 'react-bootstrap';
 
 import ReactionDetailsContainers from 'src/apps/mydb/elements/details/reactions/analysesTab/ReactionDetailsContainers';
 import AccordionHeaderWithButtons from 'src/components/common/AccordionHeaderWithButtons';
+import AnalysesOrderRow from 'src/apps/mydb/elements/details/analyses/AnalysesOrderRow';
 import Reaction from 'src/models/Reaction';
 import Container from 'src/models/Container';
 
@@ -108,6 +109,55 @@ describe('ReactionDetailsContainers', () => {
       const hintText = wrapper.text();
       expect(hintText).toContain('This tab can be used for reaction-related data');
       expect(hintText).toContain('For sample data (e.g., characterization), use the sample analysis tab.');
+    });
+
+    it('renders analyses sorted by index in edit mode', () => {
+      const a1 = Container.buildAnalysis('other', 'First');
+      a1.extended_metadata.index = 1;
+      const a2 = Container.buildAnalysis('other', 'Second');
+      a2.extended_metadata.index = 0;
+      reaction.container.children[0].children.push(a1, a2);
+
+      const wrapper = shallow(
+        React.createElement(ReactionDetailsContainers, { reaction, readOnly: false })
+      );
+
+      const headers = wrapper.find(AccordionHeaderWithButtons);
+      expect(shallow(headers.at(0).prop('children')).text()).toContain('Second');
+      expect(shallow(headers.at(1).prop('children')).text()).toContain('First');
+    });
+
+    it('renders AnalysesOrderRow in order mode', () => {
+      const analysis = Container.buildAnalysis();
+      reaction.container.children[0].children.push(analysis);
+
+      const wrapper = shallow(
+        React.createElement(ReactionDetailsContainers, { reaction, readOnly: false })
+      );
+
+      wrapper.instance().handleToggleMode('order');
+      wrapper.update();
+
+      expect(wrapper.find(AnalysesOrderRow)).toHaveLength(1);
+    });
+
+    it('renders analyses sorted by index in order mode', () => {
+      const a1 = Container.buildAnalysis('other', 'First');
+      a1.extended_metadata.index = 1;
+      const a2 = Container.buildAnalysis('other', 'Second');
+      a2.extended_metadata.index = 0;
+      reaction.container.children[0].children.push(a1, a2);
+
+      const wrapper = shallow(
+        React.createElement(ReactionDetailsContainers, { reaction, readOnly: false })
+      );
+
+      wrapper.instance().handleToggleMode('order');
+      wrapper.update();
+
+      const rows = wrapper.find(AnalysesOrderRow);
+      expect(rows.at(0).prop('container').name).toBe('Second');
+      expect(rows.at(1).prop('container').name).toBe('First');
     });
   });
 });

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainers.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainers.spec.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import expect from 'expect';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import { describe, it, beforeEach, afterEach } from 'mocha';
+
+import Container from 'src/models/Container';
+import Sample from 'src/models/Sample';
+import { ReactionsDisplay, RndNoAnalyses } from 'src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainersCom';
+import SampleDetailsContainers from 'src/apps/mydb/elements/details/samples/analysesTab/SampleDetailsContainers';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('SampleDetailsContainers', () => {
+  describe('when it does not have any analysis', () => {
+    it('renders no analyses message', () => {
+      const sample = Sample.buildEmpty();
+      const wrapper = shallow(
+        React.createElement(SampleDetailsContainers, { sample, readOnly: true, handleSampleChanged: () => {} })
+      );
+      expect(wrapper.find(RndNoAnalyses)).toHaveLength(1);
+    });
+  });
+
+  describe('when it has analyses', () => {
+    let sample;
+
+    beforeEach(() => {
+      sample = Sample.buildEmpty();
+    });
+
+    afterEach(() => {
+      sample = null;
+    });
+
+    it('passes analyses sorted by index to ReactionsDisplay', () => {
+      const a1 = Container.buildAnalysis('other', 'First');
+      a1.extended_metadata.index = 1;
+      const a2 = Container.buildAnalysis('other', 'Second');
+      a2.extended_metadata.index = 0;
+      sample.container.children[0].children.push(a1, a2);
+
+      const wrapper = shallow(
+        React.createElement(SampleDetailsContainers, { sample, readOnly: false, handleSampleChanged: () => {} })
+      );
+
+      const display = wrapper.find(ReactionsDisplay);
+      const orderContainers = display.prop('orderContainers');
+      expect(orderContainers[0].name).toBe('Second');
+      expect(orderContainers[1].name).toBe('First');
+    });
+
+    it('passes correct mode to ReactionsDisplay', () => {
+      const analysis = Container.buildAnalysis();
+      sample.container.children[0].children.push(analysis);
+
+      const wrapper = shallow(
+        React.createElement(SampleDetailsContainers, { sample, readOnly: false, handleSampleChanged: () => {} })
+      );
+
+      expect(wrapper.find(ReactionsDisplay).prop('mode')).toBe('edit');
+
+      wrapper.instance().handleToggleMode('order');
+      wrapper.update();
+
+      expect(wrapper.find(ReactionsDisplay).prop('mode')).toBe('order');
+    });
+  });
+});

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/screens/analysesTab/ScreenDetailsContainers.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/screens/analysesTab/ScreenDetailsContainers.spec.js
@@ -2,68 +2,43 @@ import React from 'react';
 import expect from 'expect';
 import Enzyme, { shallow } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
-import {
-  describe, it, beforeEach, afterEach
-} from 'mocha';
+import { describe, it, beforeEach, afterEach } from 'mocha';
 
 import { Button } from 'react-bootstrap';
 
 import Container from 'src/models/Container';
-import ResearchPlan from 'src/models/ResearchPlan';
+import Screen from 'src/models/Screen';
 import AccordionHeaderWithButtons from 'src/components/common/AccordionHeaderWithButtons';
 import AnalysesOrderRow from 'src/apps/mydb/elements/details/analyses/AnalysesOrderRow';
-
-import ResearchPlanDetailsContainers
-  from 'src/apps/mydb/elements/details/researchPlans/analysesTab/ResearchPlanDetailsContainers';
+import ScreenDetailsContainers from 'src/apps/mydb/elements/details/screens/analysesTab/ScreenDetailsContainers';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-describe('ResearchPlanDetailsContainers', () => {
+describe('ScreenDetailsContainers', () => {
   describe('when it does not have any analysis', () => {
-    const researchPlan = ResearchPlan.buildEmpty();
-    it('Render without any analysis and readonly', () => {
-      const wrapper = shallow(React.createElement(ResearchPlanDetailsContainers, { researchPlan: researchPlan, readOnly: true }));
+    it('renders without any analysis and readonly', () => {
+      const screen = Screen.buildEmpty();
+      const wrapper = shallow(React.createElement(ScreenDetailsContainers, { screen, readOnly: true, handleScreenChanged: () => {} }));
       expect(wrapper.text()).toEqual(expect.stringContaining('There are currently no Analyses.'));
       expect(wrapper.find(Button)).toHaveLength(0);
     });
 
-    it('Render without any analysis', () => {
-      const wrapper = shallow(React.createElement(ResearchPlanDetailsContainers, { researchPlan: researchPlan, readOnly: false }));
+    it('renders without any analysis', () => {
+      const screen = Screen.buildEmpty();
+      const wrapper = shallow(React.createElement(ScreenDetailsContainers, { screen, readOnly: false, handleScreenChanged: () => {} }));
       expect(wrapper.text()).toEqual(expect.stringContaining('There are currently no Analyses.'));
-      const button = wrapper.find(Button);
-      expect(button.text()).toEqual('Add analysis');
     });
   });
 
   describe('when it has analyses', () => {
-    let researchPlan = null;
+    let screen;
 
     beforeEach(() => {
-      researchPlan = ResearchPlan.buildEmpty();
+      screen = Screen.buildEmpty();
     });
 
     afterEach(() => {
-      researchPlan = null;
-    });
-
-    it('Render with analysis is deleted', () => {
-      const analysis = Container.buildAnalysis();
-      analysis.is_deleted = true;
-      researchPlan.container.children[0].children.push(analysis);
-
-      const wrapper = shallow(
-        React.createElement(ResearchPlanDetailsContainers, { researchPlan: researchPlan, readOnly: false })
-      );
-
-      const deletedHeader = wrapper.find(AccordionHeaderWithButtons).shallow().find('strike');
-      expect(deletedHeader.text()).toContain(analysis.name);
-
-      const button = wrapper.find(AccordionHeaderWithButtons).find(Button);
-      expect(button.html()).toEqual(shallow(
-        React.createElement(Button, { className: "ms-auto", size: "xsm", variant: "danger" },
-          React.createElement("i", { className: "fa fa-undo" })
-        )
-      ).html());
+      screen = null;
     });
 
     it('renders analyses sorted by index in edit mode', () => {
@@ -71,10 +46,10 @@ describe('ResearchPlanDetailsContainers', () => {
       a1.extended_metadata.index = 1;
       const a2 = Container.buildAnalysis('other', 'Second');
       a2.extended_metadata.index = 0;
-      researchPlan.container.children[0].children.push(a1, a2);
+      screen.container.children[0].children.push(a1, a2);
 
       const wrapper = shallow(
-        React.createElement(ResearchPlanDetailsContainers, { researchPlan, readOnly: false })
+        React.createElement(ScreenDetailsContainers, { screen, readOnly: false, handleScreenChanged: () => {} })
       );
 
       const headers = wrapper.find(AccordionHeaderWithButtons);
@@ -84,10 +59,10 @@ describe('ResearchPlanDetailsContainers', () => {
 
     it('renders AnalysesOrderRow in order mode', () => {
       const analysis = Container.buildAnalysis();
-      researchPlan.container.children[0].children.push(analysis);
+      screen.container.children[0].children.push(analysis);
 
       const wrapper = shallow(
-        React.createElement(ResearchPlanDetailsContainers, { researchPlan, readOnly: false })
+        React.createElement(ScreenDetailsContainers, { screen, readOnly: false, handleScreenChanged: () => {} })
       );
 
       wrapper.instance().handleToggleMode('order');
@@ -101,10 +76,10 @@ describe('ResearchPlanDetailsContainers', () => {
       a1.extended_metadata.index = 1;
       const a2 = Container.buildAnalysis('other', 'Second');
       a2.extended_metadata.index = 0;
-      researchPlan.container.children[0].children.push(a1, a2);
+      screen.container.children[0].children.push(a1, a2);
 
       const wrapper = shallow(
-        React.createElement(ResearchPlanDetailsContainers, { researchPlan, readOnly: false })
+        React.createElement(ScreenDetailsContainers, { screen, readOnly: false, handleScreenChanged: () => {} })
       );
 
       wrapper.instance().handleToggleMode('order');

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/analysesTab/WellplateDetailsContainers.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/wellplates/analysesTab/WellplateDetailsContainers.spec.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import expect from 'expect';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import { describe, it, beforeEach, afterEach } from 'mocha';
+
+import Container from 'src/models/Container';
+import Wellplate from 'src/models/Wellplate';
+import AccordionHeaderWithButtons from 'src/components/common/AccordionHeaderWithButtons';
+import AnalysesOrderRow from 'src/apps/mydb/elements/details/analyses/AnalysesOrderRow';
+import WellplateDetailsContainers from 'src/apps/mydb/elements/details/wellplates/analysesTab/WellplateDetailsContainers';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('WellplateDetailsContainers', () => {
+  describe('when it does not have any analysis', () => {
+    it('renders without any analysis and readonly', () => {
+      const wellplate = Wellplate.buildEmpty();
+      const wrapper = shallow(React.createElement(WellplateDetailsContainers, { wellplate, readOnly: true, handleWellplateChanged: () => {}, setWellplate: () => {} }));
+      expect(wrapper.text()).toEqual(expect.stringContaining('There are currently no Analyses.'));
+    });
+  });
+
+  describe('when it has analyses', () => {
+    let wellplate;
+
+    beforeEach(() => {
+      wellplate = Wellplate.buildEmpty();
+    });
+
+    afterEach(() => {
+      wellplate = null;
+    });
+
+    it('renders analyses sorted by index in edit mode', () => {
+      const a1 = Container.buildAnalysis('other', 'First');
+      a1.extended_metadata.index = 1;
+      const a2 = Container.buildAnalysis('other', 'Second');
+      a2.extended_metadata.index = 0;
+      wellplate.container.children[0].children.push(a1, a2);
+
+      const wrapper = shallow(
+        React.createElement(WellplateDetailsContainers, { wellplate, readOnly: false, handleWellplateChanged: () => {}, setWellplate: () => {} })
+      );
+
+      const headers = wrapper.find(AccordionHeaderWithButtons);
+      expect(shallow(headers.at(0).prop('children')).text()).toContain('Second');
+      expect(shallow(headers.at(1).prop('children')).text()).toContain('First');
+    });
+
+    it('renders AnalysesOrderRow in order mode', () => {
+      const analysis = Container.buildAnalysis();
+      wellplate.container.children[0].children.push(analysis);
+
+      const wrapper = shallow(
+        React.createElement(WellplateDetailsContainers, { wellplate, readOnly: false, handleWellplateChanged: () => {}, setWellplate: () => {} })
+      );
+
+      wrapper.instance().handleToggleMode('order');
+      wrapper.update();
+
+      expect(wrapper.find(AnalysesOrderRow)).toHaveLength(1);
+    });
+
+    it('renders analyses sorted by index in order mode', () => {
+      const a1 = Container.buildAnalysis('other', 'First');
+      a1.extended_metadata.index = 1;
+      const a2 = Container.buildAnalysis('other', 'Second');
+      a2.extended_metadata.index = 0;
+      wellplate.container.children[0].children.push(a1, a2);
+
+      const wrapper = shallow(
+        React.createElement(WellplateDetailsContainers, { wellplate, readOnly: false, handleWellplateChanged: () => {}, setWellplate: () => {} })
+      );
+
+      wrapper.instance().handleToggleMode('order');
+      wrapper.update();
+
+      const rows = wrapper.find(AnalysesOrderRow);
+      expect(rows.at(0).prop('container').name).toBe('Second');
+      expect(rows.at(1).prop('container').name).toBe('First');
+    });
+  });
+});


### PR DESCRIPTION
  - Add shared AnalysisModeToggle and AnalysesOrderRow components
  - Wire up mode toggle and drag-to-reorder in reaction, research plan, screen, wellplate, and cell line analyses tabs
  - Edit mode preserves existing accordion behaviour
  - Fix button misalignment in research plan and screen analyses tabs
  - Update cell line to use shared AnalysisModeToggle for consistency

  Closes #1641, #2019, #3151

Test Instance: https://az-ordermode.deploy.chemdev.scc.kit.edu/


-------------------------------

- [ ] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
