### PR TITLE
feat(UI): add temperature unit switch to melting  and boiling  points

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -13,6 +13,7 @@ import DetailActions from 'src/stores/alt/actions/DetailActions';
 import NumeralInputWithUnitsCompo from 'src/apps/mydb/elements/details/NumeralInputWithUnitsCompo';
 import NumericInputUnit from 'src/apps/mydb/elements/details/NumericInputUnit';
 import TextRangeWithAddon from 'src/apps/mydb/elements/details/samples/propertiesTab/TextRangeWithAddon';
+import { convertTemperatureBetween, nextTemperatureUnit } from 'src/utilities/UnitsConversion';
 import { SampleTypesOptions } from 'src/components/staticDropdownOptions/options';
 import SampleDetailsSolvents from 'src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsSolvents';
 import NotificationActions from 'src/stores/alt/actions/NotificationActions';
@@ -48,6 +49,7 @@ export default class SampleForm extends React.Component {
     this.updateStereoRel = this.updateStereoRel.bind(this);
     this.addMolName = this.addMolName.bind(this);
     this.handleRangeChanged = this.handleRangeChanged.bind(this);
+    this.handleTemperatureUnitToggle = this.handleTemperatureUnitToggle.bind(this);
     this.handleMetricsChange = this.handleMetricsChange.bind(this);
     this.fetchNextInventoryLabel = this.fetchNextInventoryLabel.bind(this);
     this.matchSelectedCollection = this.matchSelectedCollection.bind(this);
@@ -424,8 +426,33 @@ export default class SampleForm extends React.Component {
 
   handleRangeChanged(field, lower, upper) {
     const { sample } = this.props;
-    sample.updateRange(field, lower, upper);
+    const unitKey = `${field}_unit`;
+    const currentUnit = (sample.xref && sample.xref[unitKey]) || '°C';
+    const lowerC = lower !== '' ? convertTemperatureBetween(lower, currentUnit, '°C') : lower;
+    const upperC = upper !== '' ? convertTemperatureBetween(upper, currentUnit, '°C') : upper;
+    sample.updateRange(field, lowerC, upperC);
     this.props.handleSampleChanged(sample);
+  }
+
+  handleTemperatureUnitToggle(field) {
+    const { sample } = this.props;
+    const unitKey = `${field}_unit`;
+    const currentUnit = (sample.xref && sample.xref[unitKey]) || '°C';
+    const newUnit = nextTemperatureUnit(currentUnit);
+    sample.xref = { ...sample.xref, [unitKey]: newUnit };
+    this.props.handleSampleChanged(sample);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  convertRangeDisplay(display, fromUnit, toUnit) {
+    if (!display || fromUnit === toUnit) return display;
+    const parts = display.split(' – ');
+    const converted = parts.map((p) => {
+      const num = parseFloat(p.trim());
+      if (Number.isNaN(num)) return p;
+      return convertTemperatureBetween(num, fromUnit, toUnit);
+    });
+    return converted.join(' – ');
   }
 
   /* eslint-disable camelcase */
@@ -1242,27 +1269,39 @@ export default class SampleForm extends React.Component {
               </Row>
               <Row className="align-items-end mb-4">
                 <Col>
-                  <TextRangeWithAddon
-                    field="melting_point"
-                    label="Melting point"
-                    addon="°C"
-                    value={sample.melting_point_display}
-                    disabled={polyDisabled}
-                    onChange={this.handleRangeChanged}
-                    tipOnText="Use space-separated value to input a Temperature range"
-                  />
+                  {(() => {
+                    const meltingUnit = (sample.xref && sample.xref.melting_point_unit) || '°C';
+                    return (
+                      <TextRangeWithAddon
+                        field="melting_point"
+                        label="Melting point"
+                        addon={meltingUnit}
+                        value={this.convertRangeDisplay(sample.melting_point_display, '°C', meltingUnit)}
+                        disabled={polyDisabled}
+                        onChange={this.handleRangeChanged}
+                        onAddonClick={() => this.handleTemperatureUnitToggle('melting_point')}
+                        tipOnText="Use space-separated value to input a Temperature range"
+                      />
+                    );
+                  })()}
                 </Col>
 
                 <Col>
-                  <TextRangeWithAddon
-                    field="boiling_point"
-                    label="Boiling point"
-                    addon="°C"
-                    value={sample.boiling_point_display}
-                    disabled={polyDisabled}
-                    onChange={this.handleRangeChanged}
-                    tipOnText="Use space-separated value to input a Temperature range"
-                  />
+                  {(() => {
+                    const boilingUnit = (sample.xref && sample.xref.boiling_point_unit) || '°C';
+                    return (
+                      <TextRangeWithAddon
+                        field="boiling_point"
+                        label="Boiling point"
+                        addon={boilingUnit}
+                        value={this.convertRangeDisplay(sample.boiling_point_display, '°C', boilingUnit)}
+                        disabled={polyDisabled}
+                        onChange={this.handleRangeChanged}
+                        onAddonClick={() => this.handleTemperatureUnitToggle('boiling_point')}
+                        tipOnText="Use space-separated value to input a Temperature range"
+                      />
+                    );
+                  })()}
                 </Col>
                 <Col>{this.inputWithUnit(sample, 'xref_flash_point', 'Flash point')}</Col>
                 <Col>{this.textInput(sample, 'xref_refractive_index', 'Refractive index')}</Col>

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/TextRangeWithAddon.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/TextRangeWithAddon.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { InputGroup, Form } from 'react-bootstrap';
+import { InputGroup, Form, Button } from 'react-bootstrap';
 
 export default class TextRangeWithAddon extends Component {
   handleInputChange(e) {
@@ -54,7 +54,7 @@ export default class TextRangeWithAddon extends Component {
 
   render() {
     const {
-      addon, disabled, label, tipOnText, value
+      addon, disabled, label, onAddonClick, tipOnText, value
     } = this.props;
     return (
       <Form.Group size="sm">
@@ -70,7 +70,17 @@ export default class TextRangeWithAddon extends Component {
             onFocus={() => this.handleInputFocus()}
             onBlur={() => this.handleInputBlur()}
           />
-          <InputGroup.Text>{addon}</InputGroup.Text>
+          {onAddonClick ? (
+            <Button
+              disabled={disabled}
+              variant="light"
+              onClick={onAddonClick}
+            >
+              {addon}
+            </Button>
+          ) : (
+            <InputGroup.Text>{addon}</InputGroup.Text>
+          )}
         </InputGroup>
       </Form.Group>
     );
@@ -83,6 +93,7 @@ TextRangeWithAddon.propTypes = {
   value: PropTypes.string,
   addon: PropTypes.string,
   disabled: PropTypes.bool,
+  onAddonClick: PropTypes.func,
   onChange: PropTypes.func,
   tipOnText: PropTypes.string
 };
@@ -92,6 +103,7 @@ TextRangeWithAddon.defaultProps = {
   value: '',
   addon: '',
   disabled: false,
+  onAddonClick: null,
   onChange: () => {},
   tipOnText: ''
 };

--- a/app/javascript/src/utilities/UnitsConversion.js
+++ b/app/javascript/src/utilities/UnitsConversion.js
@@ -64,6 +64,36 @@ const convertTemperature = (valueToFormat, currentUnit) => {
   return [convertedValue, convertedUnit];
 };
 
+const TEMPERATURE_CYCLE = {
+  K: TEMPERATURE_UNITS.CELSIUS,
+  '°K': TEMPERATURE_UNITS.CELSIUS,
+  '°C': TEMPERATURE_UNITS.FAHRENHEIT,
+  '°F': TEMPERATURE_UNITS.KELVIN,
+};
+
+const temperatureToKelvinFn = {
+  '°C': (v) => v + 273.15,
+  '°F': (v) => ((v - 32) * 5) / 9 + 273.15,
+  K: (v) => v,
+  '°K': (v) => v,
+};
+
+const kelvinToTemperatureFn = {
+  '°C': (v) => v - 273.15,
+  '°F': (v) => ((v - 273.15) * 9) / 5 + 32,
+  K: (v) => v,
+};
+
+const convertTemperatureBetween = (value, fromUnit, toUnit) => {
+  if (fromUnit === toUnit) return value;
+  const numVal = Number(value);
+  if (Number.isNaN(numVal)) return value;
+  const kelvin = temperatureToKelvinFn[fromUnit](numVal);
+  return handleFloatNumbers(kelvinToTemperatureFn[toUnit](kelvin), 4);
+};
+
+const nextTemperatureUnit = (currentUnit) => TEMPERATURE_CYCLE[currentUnit] || '°C';
+
 const convertTemperatureToKelvin = (temperature) => {
   const { unit, value } = temperature || {};
   const temperatureValue = parseFloat(value);
@@ -259,6 +289,8 @@ export {
   // eslint-disable-next-line import/prefer-default-export
   handleFloatNumbers,
   convertTemperature,
+  convertTemperatureBetween,
+  nextTemperatureUnit,
   convertTemperatureToKelvin,
   convertTime,
   calculateFeedstockVolume,


### PR DESCRIPTION

The flash point field already supported cycling between °C, °F, and K. This extends the same unit toggle to melting point and boiling point, including proper handling of range values. The numrange column always stores °C; the display unit is persisted in xref.


