### PR TITLE
fix: swagger csp

### DIFF
--- a/config/initializers/swagger.rb
+++ b/config/initializers/swagger.rb
@@ -5,3 +5,9 @@ end
 GrapeSwaggerRails.options.url = Rails.env.development? ? '/api/v1/swagger_doc' : '/swagger_doc.json'
 GrapeSwaggerRails.options.app_url  = "#{ENV['APPLICATION_URL']}"
 
+# The grape-swagger-rails gem's view has inline <script> tags without a CSP
+# nonce, which the app-wide policy blocks. Disable CSP on the engine's
+# controller so the Swagger UI page can load its bundled scripts.
+Rails.application.config.to_prepare do
+  GrapeSwaggerRails::ApplicationController.content_security_policy false
+end


### PR DESCRIPTION
The CSP change for OnlyOffice (e54969113c) enabled nonce enforcement on
script-src/script-src-elem. The grape-swagger-rails gem renders inline
<script> tags without nonces in its third-party index template, so all
Swagger bootstrap scripts are blocked by the browser and the UI fails to load.
    
Since we cannot inject nonces into the gem's view, disable CSP only on
GrapeSwaggerRails::ApplicationController via to_prepare. The rest of the
app keeps its policy intact; only the /swagger dev-tool endpoint runs
without CSP