### PR TITLE
 fix(UI): element detail tab layout refresh and persistence

### DIFF
--- a/app/assets/stylesheets/global-styles/bootstrap-mods.scss
+++ b/app/assets/stylesheets/global-styles/bootstrap-mods.scss
@@ -292,7 +292,7 @@ button.btn-close {
 
 .popover-multi-item {
   // Remove top-left radius for every child after the second
-  &:nth-child(n+3) .popover-header {
+  &:nth-child(n + 3) .popover-header {
     border-top-left-radius: 0;
   }
   &:not(:last-child) {
@@ -351,8 +351,9 @@ button.btn-close {
 }
 
 .dropdown {
-  > .btn {
-    line-height: 0;
+  line-height: 0;
+  > .dropdown-menu {
+    line-height: $line-height-base;
   }
 }
 

--- a/app/javascript/src/apps/mydb/elements/details/ElementDetailSortTab.js
+++ b/app/javascript/src/apps/mydb/elements/details/ElementDetailSortTab.js
@@ -1,10 +1,16 @@
 /* eslint-disable no-param-reassign */
 /* eslint-disable react/require-default-props */
-import React, { Component } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import PropTypes from 'prop-types';
 import { Popover } from 'react-bootstrap';
 import Immutable from 'immutable';
-import { isEmpty, isEqual, set } from 'lodash';
+import { isEmpty, set } from 'lodash';
 import UserStore from 'src/stores/alt/stores/UserStore';
 import UserActions from 'src/stores/alt/actions/UserActions';
 import TabLayoutEditor from 'src/apps/mydb/elements/tabLayout/TabLayoutEditor';
@@ -14,141 +20,158 @@ import { capitalizeWords } from 'src/utilities/textHelper';
 import { filterTabLayout, getArrayFromLayout } from 'src/utilities/CollectionTabsHelper';
 import { StoreContext } from 'src/stores/mobx/RootStore';
 
-export default class ElementDetailSortTab extends Component {
-  static contextType = StoreContext;
+export default function ElementDetailSortTab({
+  type,
+  onTabPositionChanged,
+  availableTabs,
+  tabTitles,
+  addInventoryTab,
+  openedFromCollectionId,
+}) {
+  const { collections } = useContext(StoreContext);
+  const [visible, setVisible] = useState(Immutable.List());
+  const [hidden, setHidden] = useState(Immutable.List());
+  const addInventoryTabRef = useRef(addInventoryTab);
+  const availableTabsRef = useRef(availableTabs);
+  const onTabPositionChangedRef = useRef(onTabPositionChanged);
+  const openedFromCollectionIdRef = useRef(openedFromCollectionId);
+  const availableTabsKey = availableTabs.join('|');
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      visible: Immutable.List(),
-      hidden: Immutable.List(),
-    };
+  useEffect(() => {
+    addInventoryTabRef.current = addInventoryTab;
+    availableTabsRef.current = availableTabs;
+    onTabPositionChangedRef.current = onTabPositionChanged;
+    openedFromCollectionIdRef.current = openedFromCollectionId;
+  }, [addInventoryTab, availableTabs, onTabPositionChanged, openedFromCollectionId]);
 
-    this.refreshTabLayout = this.refreshTabLayout.bind(this);
+  const getOpenedFromCollection = useCallback(() => {
+    const currentOpenedFromCollectionId = openedFromCollectionIdRef.current;
+    const stack = [
+      collections.own_collection_tree,
+      collections.shared_with_me_collection_tree,
+    ];
 
-    UserActions.fetchCurrentUser();
-  }
-
-  componentDidMount() {
-    UserStore.listen(this.refreshTabLayout);
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.addInventoryTab !== this.props.addInventoryTab
-      || !isEqual(prevProps.availableTabs, this.props.availableTabs)) {
-      this.refreshTabLayout(UserStore.getState());
+    while (stack.length > 0) {
+      const col = stack.pop();
+      if (col.id === currentOpenedFromCollectionId) return col;
+      if (col.children?.length > 0) stack.push(...col.children);
     }
-  }
 
-  componentWillUnmount() {
-    UserStore.unlisten(this.refreshTabLayout);
-  }
+    return null;
+  }, [collections]);
 
-  updateTabLayout(layout) {
-    const { addInventoryTab, availableTabs, type, onTabPositionChanged } = this.props;
+  const updateTabLayout = useCallback((layout) => {
+    const currentAvailableTabs = availableTabsRef.current;
+    const currentAddInventoryTab = addInventoryTabRef.current;
 
     // Ensure default tabs exist in layout (for backward compatibility)
-    if (layout && availableTabs) {
+    if (layout && currentAvailableTabs) {
       const defaultTabs = ['properties', 'analyses'];
       const layoutKeys = Object.keys(layout);
-      const maxOrder = Math.max(0, ...layoutKeys.map(k => Math.abs(layout[k])));
+      const maxOrder = Math.max(0, ...layoutKeys.map((key) => Math.abs(layout[key])));
 
       defaultTabs.forEach((tab, idx) => {
-        if (!layoutKeys.includes(tab) && availableTabs.includes(tab)) {
+        if (!layoutKeys.includes(tab) && currentAvailableTabs.includes(tab)) {
           layout[tab] = maxOrder + idx + 1;
         }
       });
     }
 
-    const { visible, hidden } = getArrayFromLayout(layout, type, addInventoryTab, availableTabs);
-    this.setState({ visible, hidden }, () => onTabPositionChanged(visible));
-  }
+    const nextLayout = getArrayFromLayout(
+      layout,
+      type,
+      currentAddInventoryTab,
+      currentAvailableTabs,
+    );
+    setVisible(nextLayout.visible);
+    setHidden(nextLayout.hidden);
+    onTabPositionChangedRef.current(nextLayout.visible);
+  }, [type]);
 
-  getOpenedFromCollection() {
-    const { openedFromCollectionId } = this.props;
-    const stack = [
-      this.context.collections.own_collection_tree,
-      this.context.collections.shared_with_me_collection_tree
-    ];
-    while (stack.length > 0) {
-      const col = stack.pop();
-      if (col.id == openedFromCollectionId) return col;
-      if (col.children?.length > 0) stack.push(...col.children);
-    }
-    return null;
-  }
+  const refreshTabLayout = useCallback((state) => {
+    const collection = getOpenedFromCollection() || UIStore.getState().currentCollection;
 
-  refreshTabLayout(state) {
-    const { type } = this.props;
-    const collection = this.getOpenedFromCollection() || UIStore.getState().currentCollection;
-
-    const collectionTabs = typeof (collection?.tabs_segment) == 'string'
+    const collectionTabs = typeof (collection?.tabs_segment) === 'string'
       ? JSON.parse(collection?.tabs_segment)
       : collection?.tabs_segment;
 
     const layout = (!collectionTabs || isEmpty(collectionTabs[`${type}`]))
       ? state.profile?.data?.[`layout_detail_${type}`]
       : collectionTabs[`${type}`];
-    this.updateTabLayout(layout);
-  }
 
-  updateLayout() {
-    const layout = filterTabLayout(this.state);
+    updateTabLayout(layout);
+  }, [getOpenedFromCollection, type, updateTabLayout]);
+
+  const updateLayout = useCallback(() => {
+    const layout = filterTabLayout({ visible, hidden });
     const { currentCollection } = UIStore.getState();
-    const { type } = this.props;
     const tabSegment = { ...currentCollection?.tabs_segment, [type]: layout };
 
-    this.context.collections.updateCollection(currentCollection, tabSegment);
+    collections.updateCollection(currentCollection, tabSegment);
 
     const userProfile = UserStore.getState().profile;
     set(userProfile, `data.layout_detail_${type}`, layout);
     UserActions.updateUserProfile(userProfile);
-  }
+  }, [collections, hidden, type, visible]);
 
-  onLayoutChange = (visible, hidden) => {
-    const { onTabPositionChanged } = this.props;
+  const onLayoutChange = useCallback((nextVisible, nextHidden) => {
+    setVisible(nextVisible);
+    setHidden(nextHidden);
+    onTabPositionChangedRef.current(nextVisible);
+  }, []);
 
-    this.setState({ visible, hidden }, () => onTabPositionChanged(visible));
-  };
+  const renderTabItem = useCallback(({ item }) => (
+    <div>{tabTitles[item] ?? capitalizeWords(item)}</div>
+  ), [tabTitles]);
 
-  render() {
-    const { visible, hidden } = this.state;
-    const { tabTitles } = this.props;
-    const { currentCollection } = UIStore.getState();
-    const isOwnCollection = this.context.collections.isOwnCollection(currentCollection?.id);
-    const allCollection = currentCollection?.is_locked && currentCollection.label === 'All';
-    if (!isOwnCollection && !allCollection) { return null; }
+  useEffect(() => {
+    UserActions.fetchCurrentUser();
+    UserStore.listen(refreshTabLayout);
+    refreshTabLayout(UserStore.getState());
 
-    const popoverSettings = (
-      <Popover>
-        <Popover.Header>Tab Layout</Popover.Header>
-        <Popover.Body>
-          <TabLayoutEditor
-            visible={visible}
-            hidden={hidden}
-            getItemComponent={({ item }) => (<div>{tabTitles[item] ?? capitalizeWords(item)}</div>)}
-            onLayoutChange={this.onLayoutChange}
-          />
-        </Popover.Body>
-      </Popover>
-    );
+    return () => {
+      UserStore.unlisten(refreshTabLayout);
+    };
+  }, [refreshTabLayout]);
 
-    return (
-      <ConfigOverlayButton
-        popoverSettings={popoverSettings}
-        onToggle={(show) => {
-          if (!show) this.updateLayout();
-        }}
-      />
-    );
-  }
+  useEffect(() => {
+    refreshTabLayout(UserStore.getState());
+  }, [addInventoryTab, availableTabsKey, refreshTabLayout]);
+
+  const { currentCollection } = UIStore.getState();
+  const isOwnCollection = collections.isOwnCollection(currentCollection?.id);
+  const allCollection = currentCollection?.is_locked && currentCollection.label === 'All';
+  if (!isOwnCollection && !allCollection) { return null; }
+
+  const popoverSettings = (
+    <Popover>
+      <Popover.Header>Tab Layout</Popover.Header>
+      <Popover.Body>
+        <TabLayoutEditor
+          visible={visible}
+          hidden={hidden}
+          getItemComponent={renderTabItem}
+          onLayoutChange={onLayoutChange}
+        />
+      </Popover.Body>
+    </Popover>
+  );
+
+  return (
+    <ConfigOverlayButton
+      popoverSettings={popoverSettings}
+      onToggle={(show) => {
+        if (!show) updateLayout();
+      }}
+    />
+  );
 }
 
 ElementDetailSortTab.propTypes = {
   type: PropTypes.string.isRequired,
   onTabPositionChanged: PropTypes.func.isRequired,
   availableTabs: PropTypes.arrayOf(PropTypes.string).isRequired,
-  tabTitles: PropTypes.object,
+  tabTitles: PropTypes.objectOf(PropTypes.node),
   addInventoryTab: PropTypes.bool,
   openedFromCollectionId: PropTypes.number,
 };

--- a/app/javascript/src/apps/mydb/elements/details/ElementDetailSortTab.js
+++ b/app/javascript/src/apps/mydb/elements/details/ElementDetailSortTab.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Popover, Button } from 'react-bootstrap';
 import Immutable from 'immutable';
-import { isEmpty, set } from 'lodash';
+import { isEmpty, isEqual, set } from 'lodash';
 import UserStore from 'src/stores/alt/stores/UserStore';
 import UserActions from 'src/stores/alt/actions/UserActions';
 import TabLayoutEditor from 'src/apps/mydb/elements/tabLayout/TabLayoutEditor';
@@ -24,24 +24,24 @@ export default class ElementDetailSortTab extends Component {
       hidden: Immutable.List(),
     };
 
-    this.onChangeUser = this.onChangeUser.bind(this);
+    this.refreshTabLayout = this.refreshTabLayout.bind(this);
 
     UserActions.fetchCurrentUser();
   }
 
   componentDidMount() {
-    UserStore.listen(this.onChangeUser);
+    UserStore.listen(this.refreshTabLayout);
   }
 
   componentDidUpdate(prevProps) {
     if (prevProps.addInventoryTab !== this.props.addInventoryTab
-      || !_.isEqual(prevProps.availableTabs, this.props.availableTabs)) {
-      this.onChangeUI();
+      || !isEqual(prevProps.availableTabs, this.props.availableTabs)) {
+      this.refreshTabLayout(UserStore.getState());
     }
   }
 
   componentWillUnmount() {
-    UserStore.unlisten(this.onChangeUser);
+    UserStore.unlisten(this.refreshTabLayout);
   }
 
   updateTabLayout(layout) {
@@ -78,7 +78,7 @@ export default class ElementDetailSortTab extends Component {
     return null;
   }
 
-  onChangeUser(state) {
+  refreshTabLayout(state) {
     const { type } = this.props;
     const collection = this.getOpenedFromCollection() || UIStore.getState().currentCollection;
 

--- a/app/javascript/src/apps/mydb/elements/details/ElementDetailSortTab.js
+++ b/app/javascript/src/apps/mydb/elements/details/ElementDetailSortTab.js
@@ -2,7 +2,7 @@
 /* eslint-disable react/require-default-props */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Popover, Button } from 'react-bootstrap';
+import { Popover } from 'react-bootstrap';
 import Immutable from 'immutable';
 import { isEmpty, isEqual, set } from 'lodash';
 import UserStore from 'src/stores/alt/stores/UserStore';
@@ -106,7 +106,9 @@ export default class ElementDetailSortTab extends Component {
   }
 
   onLayoutChange = (visible, hidden) => {
-    this.setState({ visible, hidden });
+    const { onTabPositionChanged } = this.props;
+
+    this.setState({ visible, hidden }, () => onTabPositionChanged(visible));
   };
 
   render() {
@@ -117,16 +119,9 @@ export default class ElementDetailSortTab extends Component {
     const allCollection = currentCollection?.is_locked && currentCollection.label === 'All';
     if (!isOwnCollection && !allCollection) { return null; }
 
-    const popoverSettings = ({ close }) => (
+    const popoverSettings = (
       <Popover>
-        <Popover.Header className="d-flex justify-content-between align-items-center">
-          Tab Layout
-          <Button
-            variant="close"
-            aria-label="Close"
-            onClick={close}
-          />
-        </Popover.Header>
+        <Popover.Header>Tab Layout</Popover.Header>
         <Popover.Body>
           <TabLayoutEditor
             visible={visible}
@@ -141,7 +136,9 @@ export default class ElementDetailSortTab extends Component {
     return (
       <ConfigOverlayButton
         popoverSettings={popoverSettings}
-        onClose={() => this.updateLayout()}
+        onToggle={(show) => {
+          if (!show) this.updateLayout();
+        }}
       />
     );
   }


### PR DESCRIPTION
Convert ElementDetailSortTab from class component to hooks so that
tab layout state is correctly refreshed when the collection or
available tabs change and persisted when the settings popover closes.
    
Also fix dropdown line-height:0 scoping — apply it to the .dropdown
container instead of the child .btn so that menu items inherit the
base line-height.