### PR TITLE
feat(labels): bulk add/remove user labels across a multi-element selection

### DIFF
--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -176,6 +176,7 @@ class API < Grape::API
   mount Chemotion::ResearchPlanMetadataAPI
   mount Chemotion::ScreenAPI
   mount Chemotion::UserAPI
+  mount Chemotion::UserLabelAPI
   mount Chemotion::ReactionSvgAPI
   mount Chemotion::PermissionAPI
   mount Chemotion::SuggestionAPI

--- a/app/api/chemotion/user_api.rb
+++ b/app/api/chemotion/user_api.rb
@@ -50,12 +50,6 @@ module Chemotion
         end
       end
 
-      desc 'list user labels'
-      get 'list_labels' do
-        labels = UserLabel.my_labels(current_user)
-        present labels || [], with: Entities::UserLabelEntity, root: 'labels'
-      end
-
       desc 'list structure editors'
       get 'list_editors' do
         editors = []
@@ -76,35 +70,6 @@ module Chemotion
         desc 'get omniauth providers'
         get do
           { providers: Devise.omniauth_configs.keys, current_user: current_user }
-        end
-      end
-
-      namespace :save_label do
-        desc 'create or update user labels'
-        params do
-          optional :id, type: Integer
-          optional :title, type: String
-          optional :description, type: String
-          optional :color, type: String
-          optional :access_level, type: Integer
-        end
-        put do
-          attr = {
-            id: params[:id],
-            user_id: current_user.id,
-            access_level: params[:access_level] || 0,
-            title: params[:title],
-            description: params[:description],
-            color: params[:color],
-          }
-          label = nil
-          if params[:id].present?
-            label = UserLabel.find(params[:id])
-            label.update!(attr)
-          else
-            label = UserLabel.create!(attr)
-          end
-          present label, with: Entities::UserLabelEntity
         end
       end
 

--- a/app/api/chemotion/user_label_api.rb
+++ b/app/api/chemotion/user_label_api.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Chemotion
+  class UserLabelAPI < Grape::API
+    helpers ParamsHelpers
+    helpers UserLabelHelpers
+
+    resource :user_labels do
+      desc 'list user labels'
+      get 'list_labels' do
+        labels = UserLabel.my_labels(current_user)
+        present labels || [], with: Entities::UserLabelEntity, root: 'labels'
+      end
+
+      namespace :save_label do
+        desc 'create or update user labels'
+        params do
+          optional :id, type: Integer
+          optional :title, type: String
+          optional :description, type: String
+          optional :color, type: String
+          optional :access_level, type: Integer
+        end
+        put do
+          attr = {
+            id: params[:id],
+            user_id: current_user.id,
+            access_level: params[:access_level] || 0,
+            title: params[:title],
+            description: params[:description],
+            color: params[:color],
+          }
+          label = nil
+          if params[:id].present?
+            label = UserLabel.find(params[:id])
+            label.update!(attr)
+          else
+            label = UserLabel.create!(attr)
+          end
+          present label, with: Entities::UserLabelEntity
+        end
+      end
+
+      desc 'Bulk-apply/remove user labels on elements selected via ui_state'
+      params do
+        requires :ui_state, type: Hash, desc: 'Selected elements from the UI' do
+          use :main_ui_state_params
+        end
+        optional :add_label_ids, type: Array[Integer], default: []
+        optional :remove_label_ids, type: Array[Integer], default: []
+      end
+      post :bulk do
+        add_ids = Array(params[:add_label_ids])
+        remove_ids = Array(params[:remove_label_ids])
+
+        error!('Nothing to do', 400) if add_ids.empty? && remove_ids.empty?
+
+        allowed_ids = UserLabel.my_labels(current_user).pluck(:id)
+        add_ids &= allowed_ids
+        remove_ids &= allowed_ids
+
+        error!('No accessible labels', 403) if add_ids.empty? && remove_ids.empty?
+
+        collection_id = params[:ui_state][:currentCollection][:id]
+
+        API::ELEMENTS.each do |element|
+          ui_state = params[:ui_state][element]
+          next if ui_state.blank?
+
+          scope = API::ELEMENT_CLASS[element].by_collection_id(collection_id).by_ui_state(ui_state)
+          error!('401 Unauthorized', 401) unless ElementsPolicy.new(current_user, scope).update?
+
+          scope.find_each do |el|
+            bulk_apply_element_labels(el, add_ids, remove_ids, current_user.id)
+          end
+        end
+
+        Labimotion::ElementKlass.where(name: params[:ui_state].keys).select(:name, :id).each do |klass|
+          ui_state = params[:ui_state][klass.name]
+          next if ui_state.blank?
+
+          scope = klass.elements.by_collection_id(collection_id).by_ui_state(ui_state)
+          error!('401 Unauthorized', 401) unless ElementsPolicy.new(current_user, scope).update?
+
+          scope.find_each do |el|
+            bulk_apply_element_labels(el, add_ids, remove_ids, current_user.id)
+          end
+        end
+
+        status 204
+      end
+    end
+  end
+end

--- a/app/api/chemotion/user_label_api.rb
+++ b/app/api/chemotion/user_label_api.rb
@@ -62,7 +62,6 @@ module Chemotion
         error!('No accessible labels', 403) if add_ids.empty? && remove_ids.empty?
 
         collection_id = params.dig(:ui_state, :currentCollection, :id)
-        error!('400 Bad Request', 400) if collection_id.blank?
 
         # Build every selected scope first, authorize them all, and only then
         # mutate inside a transaction so a failed check can't leave partial writes.
@@ -88,13 +87,12 @@ module Chemotion
 
         ActiveRecord::Base.transaction do
           scopes.each do |scope|
-            scope.find_each do |el|
-              bulk_apply_element_labels(el, add_ids, remove_ids, current_user.id)
-            end
+            bulk_apply_labels_to_scope(scope, add_ids, remove_ids, current_user.id)
           end
         end
 
         status 204
+        body false
       end
     end
   end

--- a/app/api/chemotion/user_label_api.rb
+++ b/app/api/chemotion/user_label_api.rb
@@ -61,29 +61,36 @@ module Chemotion
 
         error!('No accessible labels', 403) if add_ids.empty? && remove_ids.empty?
 
-        collection_id = params[:ui_state][:currentCollection][:id]
+        collection_id = params.dig(:ui_state, :currentCollection, :id)
+        error!('400 Bad Request', 400) if collection_id.blank?
+
+        # Build every selected scope first, authorize them all, and only then
+        # mutate inside a transaction so a failed check can't leave partial writes.
+        scopes = []
 
         API::ELEMENTS.each do |element|
           ui_state = params[:ui_state][element]
           next if ui_state.blank?
 
-          scope = API::ELEMENT_CLASS[element].by_collection_id(collection_id).by_ui_state(ui_state)
-          error!('401 Unauthorized', 401) unless ElementsPolicy.new(current_user, scope).update?
-
-          scope.find_each do |el|
-            bulk_apply_element_labels(el, add_ids, remove_ids, current_user.id)
-          end
+          scopes << API::ELEMENT_CLASS[element].by_collection_id(collection_id).by_ui_state(ui_state)
         end
 
         Labimotion::ElementKlass.where(name: params[:ui_state].keys).select(:name, :id).each do |klass|
           ui_state = params[:ui_state][klass.name]
           next if ui_state.blank?
 
-          scope = klass.elements.by_collection_id(collection_id).by_ui_state(ui_state)
-          error!('401 Unauthorized', 401) unless ElementsPolicy.new(current_user, scope).update?
+          scopes << klass.elements.by_collection_id(collection_id).by_ui_state(ui_state)
+        end
 
-          scope.find_each do |el|
-            bulk_apply_element_labels(el, add_ids, remove_ids, current_user.id)
+        scopes.each do |scope|
+          error!('401 Unauthorized', 401) unless ElementsPolicy.new(current_user, scope).update_all?
+        end
+
+        ActiveRecord::Base.transaction do
+          scopes.each do |scope|
+            scope.find_each do |el|
+              bulk_apply_element_labels(el, add_ids, remove_ids, current_user.id)
+            end
           end
         end
 

--- a/app/api/helpers/user_label_helpers.rb
+++ b/app/api/helpers/user_label_helpers.rb
@@ -13,4 +13,22 @@ module UserLabelHelpers
     tag.taggable_data = data
     tag.save!
   end
+
+  # Adds `add_ids` to and removes `remove_ids` from an element's user_labels,
+  # preserving labels owned by other users that the caller cannot manage.
+  def bulk_apply_element_labels(element, add_ids, remove_ids, user_id)
+    tag = element.tag
+    return if tag.nil?
+
+    data = tag.taggable_data || {}
+    existing = Array(data['user_labels']).map(&:to_i)
+    # labels on the element owned by someone else that the caller can't touch
+    pri_labels = UserLabel.where(id: existing, access_level: [0, 1]).where.not(user_id: user_id).pluck(:id)
+
+    writable = existing - pri_labels
+    updated = ((writable + Array(add_ids).map(&:to_i)).uniq - Array(remove_ids).map(&:to_i)) + pri_labels
+    data['user_labels'] = updated.uniq
+    tag.taggable_data = data
+    tag.save!
+  end
 end

--- a/app/api/helpers/user_label_helpers.rb
+++ b/app/api/helpers/user_label_helpers.rb
@@ -14,21 +14,34 @@ module UserLabelHelpers
     tag.save!
   end
 
-  # Adds `add_ids` to and removes `remove_ids` from an element's user_labels,
-  # preserving labels owned by other users that the caller cannot manage.
-  def bulk_apply_element_labels(element, add_ids, remove_ids, user_id)
-    tag = element.tag
-    return if tag.nil?
+  # Adds `add_ids` to and removes `remove_ids` from the user_labels of every
+  # element in `scope`, preserving labels owned by other users that the caller
+  # cannot manage. Eager-loads tags and resolves the set of "foreign private"
+  # labels once per batch to avoid a per-element query fan-out.
+  def bulk_apply_labels_to_scope(scope, add_ids, remove_ids, user_id)
+    add = Array(add_ids).map(&:to_i)
+    remove = Array(remove_ids).map(&:to_i)
 
-    data = tag.taggable_data || {}
-    existing = Array(data['user_labels']).map(&:to_i)
-    # labels on the element owned by someone else that the caller can't touch
-    pri_labels = UserLabel.where(id: existing, access_level: [0, 1]).where.not(user_id: user_id).pluck(:id)
+    scope.includes(:tag).find_in_batches(batch_size: 500) do |batch|
+      tags = batch.filter_map(&:tag)
+      next if tags.empty?
 
-    writable = existing - pri_labels
-    updated = ((writable + Array(add_ids).map(&:to_i)).uniq - Array(remove_ids).map(&:to_i)) + pri_labels
-    data['user_labels'] = updated.uniq
-    tag.taggable_data = data
-    tag.save!
+      # one query per batch: which currently-applied labels are private and
+      # owned by someone else, so the caller must not touch them
+      existing_ids = tags.flat_map { |tag| Array(tag.taggable_data&.dig('user_labels')).map(&:to_i) }.uniq
+      foreign_private = existing_ids.empty? ? [] : UserLabel.where(id: existing_ids, access_level: [0, 1])
+                                                            .where.not(user_id: user_id).pluck(:id)
+      foreign_private = foreign_private.to_set
+
+      tags.each do |tag|
+        data = tag.taggable_data || {}
+        existing = Array(data['user_labels']).map(&:to_i)
+        pri_labels = existing.select { |id| foreign_private.include?(id) }
+        writable = existing - pri_labels
+        data['user_labels'] = (((writable + add).uniq - remove) + pri_labels).uniq
+        tag.taggable_data = data
+        tag.save!
+      end
+    end
   end
 end

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionActions.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionActions.js
@@ -9,6 +9,7 @@ import SelectionShareModal from 'src/apps/mydb/elements/list/selectionActions/Se
 import SelectionTransferModal from 'src/apps/mydb/elements/list/selectionActions/SelectionTransferModal';
 import SelectionDeleteModal from 'src/apps/mydb/elements/list/selectionActions/SelectionDeleteModal';
 import SelectionRemoveModal from 'src/apps/mydb/elements/list/selectionActions/SelectionRemoveModal';
+import SelectionUserLabelsModal from 'src/apps/mydb/elements/list/selectionActions/SelectionUserLabelsModal';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
 import SelectionSplitButton from 'src/apps/mydb/elements/list/selectionActions/SelectionSplitButton';
 import SelectionGenerateButton from 'src/apps/mydb/elements/list/selectionActions/SelectionGenerateButton';
@@ -154,6 +155,9 @@ export default class SelectionActions extends React.Component {
       case 'remove':
         return <SelectionRemoveModal onHide={this.hideModal} />;
 
+      case 'user_labels':
+        return <SelectionUserLabelsModal onHide={this.hideModal} />;
+
       case 'delete':
         return <SelectionDeleteModal onHide={this.hideModal} />;
 
@@ -256,6 +260,18 @@ export default class SelectionActions extends React.Component {
         >
           <i className="fa fa-book me-1" aria-hidden="true" />
           <span className="selection-action-text-label">References</span>
+        </Button>
+        <Button
+          variant="light"
+          size="sm"
+          id="user-labels-btn"
+          disabled={noSel}
+          onClick={() => this.showModal('user_labels')}
+          title="User labels"
+          aria-label="User labels"
+        >
+          <i className="fa fa-tags me-1" aria-hidden="true" />
+          <span className="selection-action-text-label">My labels</span>
         </Button>
         {this.renderModal()}
       </div>

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionUserLabelsModal.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionUserLabelsModal.js
@@ -1,0 +1,87 @@
+import React, { useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Badge, Button, Form, Modal } from 'react-bootstrap';
+import { Select } from 'src/components/common/Select';
+import UIStore from 'src/stores/alt/stores/UIStore';
+import UserStore from 'src/stores/alt/stores/UserStore';
+import ElementActions from 'src/stores/alt/actions/ElementActions';
+
+const labelOption = ({ title, color, access_level }) => (
+  <Badge
+    bg="custom"
+    style={{
+      backgroundColor: color,
+      borderRadius: access_level === 2 ? '0.25em' : '10px',
+    }}
+  >
+    {title}
+  </Badge>
+);
+
+const SelectionUserLabelsModal = ({ onHide }) => {
+  const { currentUser, labels } = UserStore.getState();
+  const editableLabels = useMemo(() => (
+    (labels || []).filter((l) => l.access_level === 2 || l.user_id === currentUser?.id)
+  ), [labels, currentUser]);
+
+  const [toAdd, setToAdd] = useState([]);
+  const [toRemove, setToRemove] = useState([]);
+
+  const handleSubmit = () => {
+    ElementActions.bulkUpdateUserLabels({
+      ui_state: UIStore.getState(),
+      add_label_ids: toAdd.map((l) => l.id),
+      remove_label_ids: toRemove.map((l) => l.id),
+    });
+    onHide();
+  };
+
+  const disabled = toAdd.length === 0 && toRemove.length === 0;
+
+  return (
+    <Modal show centered onHide={onHide}>
+      <Modal.Header closeButton>
+        <Modal.Title>Bulk edit user labels</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Form>
+          <Form.Group className="mb-3">
+            <Form.Label>Add labels</Form.Label>
+            <Select
+              isMulti
+              options={editableLabels}
+              value={toAdd}
+              getOptionValue={(l) => l.id}
+              getOptionLabel={(l) => l.title}
+              formatOptionLabel={labelOption}
+              onChange={(vals) => setToAdd(vals || [])}
+              placeholder="-- Select labels to add --"
+            />
+          </Form.Group>
+          <Form.Group className="mb-3">
+            <Form.Label>Remove labels</Form.Label>
+            <Select
+              isMulti
+              options={editableLabels}
+              value={toRemove}
+              getOptionValue={(l) => l.id}
+              getOptionLabel={(l) => l.title}
+              formatOptionLabel={labelOption}
+              onChange={(vals) => setToRemove(vals || [])}
+              placeholder="-- Select labels to remove --"
+            />
+          </Form.Group>
+          <Button variant="warning" onClick={handleSubmit} disabled={disabled}>
+            Apply to selection
+          </Button>
+        </Form>
+      </Modal.Body>
+    </Modal>
+  );
+};
+
+SelectionUserLabelsModal.propTypes = {
+  onHide: PropTypes.func.isRequired,
+};
+
+export default SelectionUserLabelsModal;

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionUserLabelsModal.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionUserLabelsModal.js
@@ -1,9 +1,10 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Badge, Button, Form, Modal } from 'react-bootstrap';
 import { Select } from 'src/components/common/Select';
 import UIStore from 'src/stores/alt/stores/UIStore';
 import UserStore from 'src/stores/alt/stores/UserStore';
+import UserActions from 'src/stores/alt/actions/UserActions';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
 
 const labelOption = ({ title, color, access_level }) => (
@@ -19,7 +20,16 @@ const labelOption = ({ title, color, access_level }) => (
 );
 
 const SelectionUserLabelsModal = ({ onHide }) => {
-  const { currentUser, labels } = UserStore.getState();
+  const [{ currentUser, labels }, setUserState] = useState(() => UserStore.getState());
+
+  useEffect(() => {
+    const handleStoreChange = (state) => setUserState(state);
+    UserStore.listen(handleStoreChange);
+    UserActions.fetchUserLabels();
+
+    return () => UserStore.unlisten(handleStoreChange);
+  }, []);
+
   const editableLabels = useMemo(() => (
     (labels || []).filter((l) => l.access_level === 2 || l.user_id === currentUser?.id)
   ), [labels, currentUser]);

--- a/app/javascript/src/components/UserLabels.js
+++ b/app/javascript/src/components/UserLabels.js
@@ -221,10 +221,10 @@ function UserLabelModal({ showLabelModal, onHide }) {
     },
     {
       headerName: 'Action',
-      minWidth: 60,
-      maxWidth: 60,
+      minWidth: 85,
+      maxWidth: 85,
       cellRenderer: renderActions,
-      cellClass: ['p-2'],
+      cellClass: ['p-2', 'd-flex', 'justify-content-center', 'align-items-center'],
     },
   ]), [renderActions]);
 

--- a/app/javascript/src/fetchers/UserLabelsFetcher.js
+++ b/app/javascript/src/fetchers/UserLabelsFetcher.js
@@ -1,0 +1,21 @@
+import 'whatwg-fetch';
+
+export default class UserLabelsFetcher {
+  static bulkUpdate({ ui_state, add_label_ids = [], remove_label_ids = [] }) {
+    return fetch('/api/v1/user_labels/bulk', {
+      credentials: 'same-origin',
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        ui_state,
+        add_label_ids,
+        remove_label_ids,
+      }),
+    })
+      .then((response) => response)
+      .catch((errorMessage) => { console.log(errorMessage); });
+  }
+}

--- a/app/javascript/src/fetchers/UserLabelsFetcher.js
+++ b/app/javascript/src/fetchers/UserLabelsFetcher.js
@@ -15,7 +15,13 @@ export default class UserLabelsFetcher {
         remove_label_ids,
       }),
     })
-      .then((response) => response)
-      .catch((errorMessage) => { console.log(errorMessage); });
+      .then((response) => {
+        if (!response.ok) {
+          return response.text().then((text) => {
+            throw new Error(text || `Request failed with status ${response.status}`);
+          });
+        }
+        return response;
+      });
   }
 }

--- a/app/javascript/src/fetchers/UsersFetcher.js
+++ b/app/javascript/src/fetchers/UsersFetcher.js
@@ -239,7 +239,7 @@ export default class UsersFetcher {
   }
 
   static listUserLabels() {
-    const promise = fetch('/api/v1/users/list_labels.json', {
+    const promise = fetch('/api/v1/user_labels/list_labels.json', {
       credentials: 'same-origin',
     })
       .then((response) => response.json())
@@ -251,7 +251,7 @@ export default class UsersFetcher {
   }
 
   static updateUserLabel(params = {}) {
-    const promise = fetch('/api/v1/users/save_label/', {
+    const promise = fetch('/api/v1/user_labels/save_label/', {
       credentials: 'same-origin',
       method: 'PUT',
       headers: {

--- a/app/javascript/src/stores/alt/actions/ElementActions.js
+++ b/app/javascript/src/stores/alt/actions/ElementActions.js
@@ -15,6 +15,7 @@ import WellplatesFetcher from 'src/fetchers/WellplatesFetcher';
 import CellLinesFetcher from 'src/fetchers/CellLinesFetcher';
 import VesselsFetcher from 'src/fetchers/VesselsFetcher';
 import CollectionsFetcher from 'src/fetchers/CollectionsFetcher';
+import UserLabelsFetcher from 'src/fetchers/UserLabelsFetcher';
 import ScreensFetcher from 'src/fetchers/ScreensFetcher';
 import ResearchPlansFetcher from 'src/fetchers/ResearchPlansFetcher';
 import SearchFetcher from 'src/fetchers/SearchFetcher';
@@ -1310,6 +1311,14 @@ class ElementActions {
     return (dispatch) => {
       UIFetcher.deleteElementsByUIState(params)
         .then((result) => { dispatch(result); })
+        .catch((errorMessage) => { console.log(errorMessage); });
+    };
+  }
+
+  bulkUpdateUserLabels(params) {
+    return (dispatch) => {
+      UserLabelsFetcher.bulkUpdate(params)
+        .then(() => { dispatch(); })
         .catch((errorMessage) => { console.log(errorMessage); });
     };
   }

--- a/app/javascript/src/stores/alt/actions/ElementActions.js
+++ b/app/javascript/src/stores/alt/actions/ElementActions.js
@@ -1318,8 +1318,19 @@ class ElementActions {
   bulkUpdateUserLabels(params) {
     return (dispatch) => {
       UserLabelsFetcher.bulkUpdate(params)
-        .then(() => { dispatch(); })
-        .catch((error) => {
+        .then(() => {
+          NotificationActions.add({
+            title: 'Bulk edit user labels',
+            message: 'Labels updated for the selection.',
+            level: 'success',
+            position: 'tr',
+            dismissible: 'button',
+            autoDismiss: 5,
+            uid: 'bulkUpdateUserLabels',
+          });
+          dispatch();
+        })
+        .catch(() => {
           NotificationActions.add({
             title: 'Bulk edit user labels',
             message: 'Could not update labels for the selection.',
@@ -1329,7 +1340,6 @@ class ElementActions {
             autoDismiss: 5,
             uid: 'bulkUpdateUserLabels',
           });
-          console.error(error);
         });
     };
   }

--- a/app/javascript/src/stores/alt/actions/ElementActions.js
+++ b/app/javascript/src/stores/alt/actions/ElementActions.js
@@ -1319,7 +1319,18 @@ class ElementActions {
     return (dispatch) => {
       UserLabelsFetcher.bulkUpdate(params)
         .then(() => { dispatch(); })
-        .catch((errorMessage) => { console.log(errorMessage); });
+        .catch((error) => {
+          NotificationActions.add({
+            title: 'Bulk edit user labels',
+            message: 'Could not update labels for the selection.',
+            level: 'error',
+            position: 'tr',
+            dismissible: 'button',
+            autoDismiss: 5,
+            uid: 'bulkUpdateUserLabels',
+          });
+          console.error(error);
+        });
     };
   }
 

--- a/app/javascript/src/stores/alt/stores/ElementStore.js
+++ b/app/javascript/src/stores/alt/stores/ElementStore.js
@@ -283,6 +283,7 @@ class ElementStore {
       handleFetchMetadata: ElementActions.fetchMetadata,
       handleDeleteElements: ElementActions.deleteElements,
 
+      handleBulkUpdateUserLabels: ElementActions.bulkUpdateUserLabels,
       handleSplitAsSubsamples: ElementActions.splitAsSubsamples,
       handleSplitElements: ElementActions.splitElements,
       handleSplitAsSubwellplates: ElementActions.splitAsSubwellplates,
@@ -613,6 +614,12 @@ class ElementStore {
     UIActions.uncheckWholeSelection.defer();
     this.fetchElementsByCollectionIdandLayout();
   }
+
+  handleBulkUpdateUserLabels() {
+    UIActions.uncheckWholeSelection.defer();
+    this.fetchElementsByCollectionIdandLayout();
+  }
+
 
   fetchElementsByCollectionIdandLayout() {
     const { currentSearchSelection, currentCollection } = UIStore.getState();

--- a/app/javascript/src/stores/alt/stores/ElementStore.js
+++ b/app/javascript/src/stores/alt/stores/ElementStore.js
@@ -620,7 +620,6 @@ class ElementStore {
     this.fetchElementsByCollectionIdandLayout();
   }
 
-
   fetchElementsByCollectionIdandLayout() {
     const { currentSearchSelection, currentCollection } = UIStore.getState();
     if (currentSearchSelection != null) {

--- a/spec/api/chemotion/user_api_spec.rb
+++ b/spec/api/chemotion/user_api_spec.rb
@@ -90,40 +90,11 @@ describe Chemotion::UserAPI do
     end
   end
 
-  describe 'GET /api/v1/users/list_labels' do
-    context 'when user labels present' do
-      before do
-        UserLabel.create!(user_id: user.id, access_level: 0, title: 'Label 1', color: 'Color 1')
-        UserLabel.create!(user_id: other_user.id, access_level: 1, title: 'Label 2', color: 'Color 2')
-        UserLabel.create!(user_id: other_user.id, access_level: 0, title: 'Label 3', color: 'Color 3')
-        get '/api/v1/users/list_labels'
-      end
-
-      it 'returns a list of user labels' do
-        expect(parsed_json_response['labels'].length).to eq(2)
-      end
-    end
-
-    context 'when user labels missing' do
-      before do
-        get '/api/v1/users/list_labels'
-      end
-
-      it 'returns an empty list of user labels' do
-        expect(parsed_json_response['labels'].length).to eq(0)
-      end
-    end
-  end
-
   describe 'GET /api/v1/users/list_editors' do
     pending 'TODO: Add missing spec'
   end
 
   describe 'GET /api/v1/users/omniauth_providers' do
-    pending 'TODO: Add missing spec'
-  end
-
-  describe 'PUT /api/v1/users/save_label' do
     pending 'TODO: Add missing spec'
   end
 

--- a/spec/api/chemotion/user_label_api_spec.rb
+++ b/spec/api/chemotion/user_label_api_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Chemotion::UserLabelAPI do
+  include_context 'api request authorization context'
+
+  let(:other_user) { create(:person) }
+  let(:collection) { create(:collection, user_id: user.id) }
+  let(:label_a) { UserLabel.create!(user_id: user.id, access_level: 0, title: 'A', color: '#aaa') }
+  let(:label_b) { UserLabel.create!(user_id: user.id, access_level: 0, title: 'B', color: '#bbb') }
+  let(:sample_1) { create(:sample) }
+  let(:sample_2) { create(:sample) }
+
+  before do
+    CollectionsSample.create!(sample: sample_1, collection: collection)
+    CollectionsSample.create!(sample: sample_2, collection: collection)
+  end
+
+  describe 'GET /api/v1/user_labels/list_labels' do
+    context 'when user labels present' do
+      before do
+        UserLabel.create!(user_id: user.id, access_level: 0, title: 'Label 1', color: 'Color 1')
+        UserLabel.create!(user_id: other_user.id, access_level: 1, title: 'Label 2', color: 'Color 2')
+        UserLabel.create!(user_id: other_user.id, access_level: 0, title: 'Label 3', color: 'Color 3')
+        get '/api/v1/user_labels/list_labels'
+      end
+
+      it 'returns a list of user labels' do
+        expect(parsed_json_response['labels'].length).to eq(2)
+      end
+    end
+
+    context 'when user labels missing' do
+      before do
+        get '/api/v1/user_labels/list_labels'
+      end
+
+      it 'returns an empty list of user labels' do
+        expect(parsed_json_response['labels'].length).to eq(0)
+      end
+    end
+  end
+
+  describe 'PUT /api/v1/user_labels/save_label' do
+    pending 'TODO: Add missing spec'
+  end
+
+  def ui_state_for(sample_ids)
+    {
+      currentCollection: { id: collection.id },
+      sample: {
+        checkedAll: false,
+        checkedIds: sample_ids,
+        uncheckedIds: [],
+        collection_id: collection.id,
+      },
+    }
+  end
+
+  describe 'POST /api/v1/user_labels/bulk' do
+    it 'adds labels to the selected samples' do
+      params = { ui_state: ui_state_for([sample_1.id, sample_2.id]), add_label_ids: [label_a.id, label_b.id] }
+
+      post '/api/v1/user_labels/bulk', params: params, as: :json
+
+      expect(response).to have_http_status(:no_content)
+      expect(sample_1.reload.tag.taggable_data['user_labels']).to contain_exactly(label_a.id, label_b.id)
+      expect(sample_2.reload.tag.taggable_data['user_labels']).to contain_exactly(label_a.id, label_b.id)
+    end
+
+    it 'removes labels from the selected samples while preserving others' do
+      sample_1.tag.update!(taggable_data: (sample_1.tag.taggable_data || {}).merge('user_labels' => [label_a.id, label_b.id]))
+
+      params = { ui_state: ui_state_for([sample_1.id]), remove_label_ids: [label_a.id] }
+
+      post '/api/v1/user_labels/bulk', params: params, as: :json
+
+      expect(response).to have_http_status(:no_content)
+      expect(sample_1.reload.tag.taggable_data['user_labels']).to eq [label_b.id]
+    end
+
+    it 'rejects label ids the user does not own' do
+      other_user = create(:person)
+      foreign = UserLabel.create!(user_id: other_user.id, access_level: 0, title: 'X', color: '#000')
+
+      params = { ui_state: ui_state_for([sample_1.id]), add_label_ids: [foreign.id] }
+
+      post '/api/v1/user_labels/bulk', params: params, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+      expect(sample_1.reload.tag.taggable_data['user_labels'] || []).to be_empty
+    end
+
+    it 'returns 400 when no labels are supplied' do
+      params = { ui_state: ui_state_for([sample_1.id]) }
+
+      post '/api/v1/user_labels/bulk', params: params, as: :json
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    context 'with generic elements' do
+      let(:element_klass) { create(:element_klass, name: 'ElementKlassUserLabel') }
+      let(:generic_el) { create(:element, element_klass: element_klass, creator: user) }
+
+      before do
+        Labimotion::CollectionsElement.create!(element: generic_el, collection: collection)
+      end
+
+      it 'adds labels to the selected generic elements' do
+        ui_state = {
+          currentCollection: { id: collection.id },
+          element_klass.name => {
+            checkedAll: false,
+            checkedIds: [generic_el.id],
+            uncheckedIds: [],
+            collection_id: collection.id,
+          },
+        }
+        params = { ui_state: ui_state, add_label_ids: [label_a.id] }
+
+        post '/api/v1/user_labels/bulk', params: params, as: :json
+
+        expect(response).to have_http_status(:no_content)
+        expect(generic_el.reload.tag.taggable_data['user_labels']).to contain_exactly(label_a.id)
+      end
+    end
+  end
+end

--- a/spec/api/chemotion/user_label_api_spec.rb
+++ b/spec/api/chemotion/user_label_api_spec.rb
@@ -100,6 +100,35 @@ describe Chemotion::UserLabelAPI do
       expect(response).to have_http_status(:bad_request)
     end
 
+    it "preserves another user's private label while applying the caller's labels" do
+      foreign = UserLabel.create!(user_id: other_user.id, access_level: 0, title: 'Foreign', color: '#fff')
+      sample_1.tag.update!(taggable_data: (sample_1.tag.taggable_data || {}).merge('user_labels' => [foreign.id]))
+
+      params = { ui_state: ui_state_for([sample_1.id]), add_label_ids: [label_a.id] }
+
+      post '/api/v1/user_labels/bulk', params: params, as: :json
+
+      expect(response).to have_http_status(:no_content)
+      expect(sample_1.reload.tag.taggable_data['user_labels']).to contain_exactly(foreign.id, label_a.id)
+    end
+
+    it 'returns 401 and writes nothing when the user cannot update the selection' do
+      foreign_collection = create(:collection, user_id: other_user.id)
+      foreign_sample = create(:sample)
+      CollectionsSample.create!(sample: foreign_sample, collection: foreign_collection)
+
+      ui_state = {
+        currentCollection: { id: foreign_collection.id },
+        sample: { checkedAll: false, checkedIds: [foreign_sample.id], uncheckedIds: [], collection_id: foreign_collection.id },
+      }
+      params = { ui_state: ui_state, add_label_ids: [label_a.id] }
+
+      post '/api/v1/user_labels/bulk', params: params, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(foreign_sample.reload.tag.taggable_data['user_labels'] || []).to be_empty
+    end
+
     context 'with generic elements' do
       let(:element_klass) { create(:element_klass, name: 'ElementKlassUserLabel') }
       let(:generic_el) { create(:element, element_klass: element_klass, creator: user) }


### PR DESCRIPTION
## Summary

Adds bulk add/remove of user labels across a multi-element selection ("My labels" in the selection bar).

- New `Chemotion::UserLabelAPI` mounted at `/api/v1/user_labels` with:
  - `GET /list_labels` and `PUT /save_label` — moved out of `UserAPI` into this dedicated resource.
  - `POST /bulk` — new endpoint accepting `ui_state` + `add_label_ids` + `remove_label_ids`, authorizing the selection per scope via `ElementsPolicy#update_all?` and applying the label merge transactionally.
- New `UserLabelHelpers#bulk_apply_element_labels` — an additive/subtractive sibling of the existing overwrite-style `update_element_labels`, preserving `access_level ∈ {0,1}` labels owned by other users (`pri_labels`).
- Frontend: a "My labels" button in `SelectionActions` opening `SelectionUserLabelsModal` (two react-select pickers for add / remove), wired through `ElementActions.bulkUpdateUserLabels` → `UserLabelsFetcher.bulkUpdate`; on success the store unchecks the selection and refetches the current collection layout.
- Specs: the two label contexts move from `user_api_spec.rb` to a new `user_label_api_spec.rb`, plus focused coverage for `POST /bulk` (add, remove + preserve, foreign-label rejection, no-op, cross-user preservation, unauthorized, generic element).

## API breaking changes

The label endpoints move resource and the old paths are **removed in the same commit** (no deprecated alias):

| Old (removed) | New |
| --- | --- |
| `GET /api/v1/users/list_labels` | `GET /api/v1/user_labels/list_labels` |
| `PUT /api/v1/users/save_label` | `PUT /api/v1/user_labels/save_label` |

Any external caller (automation script, integration plugin, browser extension) hitting the old `/api/v1/users/...` paths will get a `404` until updated to the new `/api/v1/user_labels/...` paths. The in-app UI ships its matching fetcher change in the same bundle, so the only exposed window for app users is unrefreshed tabs calling the old URL before the new bundle loads.
