### PR TITLE
fix(UI): show save buttons when editing Amount, Density, Molarity, or Molecular Mass

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -106,17 +106,22 @@ export default class SampleForm extends React.Component {
   }
 
   handleAmountChanged(amount) {
-    const { sample } = this.props;
+    const { sample, handleSampleChanged } = this.props;
 
     // sample.initializeSampleDetails?.();
     // sample.sample_details.reference_component_changed = false;
 
     sample.setAmount(amount);
+    sample.changed = true;
+    handleSampleChanged(sample);
   }
 
   handleMolarityChanged(molarity) {
-    this.props.sample.setMolarity(molarity);
+    const { sample, handleSampleChanged } = this.props;
+    sample.setMolarity(molarity);
+    sample.changed = true;
     this.setState({ molarityBlocked: false });
+    handleSampleChanged(sample);
   }
 
   handleSampleTypeChanged(sampleType) {
@@ -161,12 +166,18 @@ export default class SampleForm extends React.Component {
   }
 
   handleDensityChanged(density) {
-    this.props.sample.setDensity(density);
+    const { sample, handleSampleChanged } = this.props;
+    sample.setDensity(density);
+    sample.changed = true;
     this.setState({ molarityBlocked: true });
+    handleSampleChanged(sample);
   }
 
   handleMolecularMassChanged(mass) {
-    this.props.sample.setMolecularMass(mass);
+    const { sample, handleSampleChanged } = this.props;
+    sample.setMolecularMass(mass);
+    sample.changed = true;
+    handleSampleChanged(sample);
   }
 
   handleMixtureAmountLChanged(e, sample) {
@@ -479,6 +490,7 @@ export default class SampleForm extends React.Component {
     if (field === 'purity' && (e.value < 0 || e.value > 1)) {
       e.value = 1;
       sample[field] = e.value;
+      sample.changed = true;
       NotificationActions.add({
         message: 'Purity value should be >= 0 and <=1',
         level: 'error'
@@ -499,8 +511,10 @@ export default class SampleForm extends React.Component {
       const key = field.split('xref_')[1];
       sample.xref[key] = e;
     } else if (e && (e.value || e.value === 0)) {
-      // for numeric inputs
+      // for numeric inputs (e.g. purity) — mark dirty since Element.checksum
+      // strips numeric values and would not otherwise detect the edit.
       sample[field] = e.value;
+      sample.changed = true;
     } else {
       sample[field] = e;
     }

--- a/app/javascript/src/models/Element.js
+++ b/app/javascript/src/models/Element.js
@@ -51,10 +51,11 @@ export default class Element {
   }
 
   get isPendingToSave() {
-    return !_.isEmpty(this) && (this.isNew || this.isEdited);
+    return !_.isEmpty(this) && (this.isNew || this.isEdited || this.changed === true);
   }
 
   updateChecksum(cs) {
+    this.changed = false;
     if (cs) {
       this._checksum = cs
     } else {

--- a/spec/javascripts/packs/src/models/Sample.spec.js
+++ b/spec/javascripts/packs/src/models/Sample.spec.js
@@ -1723,4 +1723,42 @@ describe('Sample', async () => {
       expect(s.equivalent).toBe(originalEquivalent);
     });
   });
+
+  describe('Sample.isPendingToSave (changed flag)', () => {
+    const buildBaseline = () => {
+      const s = Sample.buildEmpty(0);
+      s.is_new = false;
+      s.name = 'baseline';
+      s.updateChecksum();
+      return s;
+    };
+
+    it('is false for an unchanged persisted sample', () => {
+      const s = buildBaseline();
+      expect(s.isPendingToSave).toBe(false);
+    });
+
+    it('becomes true when sample.changed is set to true', () => {
+      const s = buildBaseline();
+      s.changed = true;
+      expect(s.isPendingToSave).toBe(true);
+    });
+
+    it('is true when checksum-based isEdited triggers (name change)', () => {
+      const s = buildBaseline();
+      s.name = 'edited';
+      expect(s.isPendingToSave).toBe(true);
+    });
+
+    it('resets changed to false when updateChecksum is called', () => {
+      const s = buildBaseline();
+      s.changed = true;
+      expect(s.isPendingToSave).toBe(true);
+
+      s.updateChecksum();
+
+      expect(s.changed).toBe(false);
+      expect(s.isPendingToSave).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
