### PR TITLE
fix(UI): Disable sample window link on sample analysis tab when not active

### DIFF
--- a/app/assets/stylesheets/legacy/miscellaneous.scss
+++ b/app/assets/stylesheets/legacy/miscellaneous.scss
@@ -68,13 +68,23 @@ label.required:after {
   border-color: $gray-700;
 }
 
-span.pseudo-link {
+.pseudo-link {
   cursor: pointer;
   color: $link-color;
 }
 
-span.pseudo-link:hover {
+.pseudo-link:hover {
   text-decoration: underline;
+}
+
+.pseudo-link.disabled {
+  text-decoration: none;
+  pointer-events: none;
+  cursor: default;
+}
+
+.pseudo-link.disabled:hover {
+  text-decoration: none;
 }
 
 .nav-tabs > li > a {

--- a/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -59,13 +59,16 @@ const productLink = (product, active) => (
     {active && "Sample Analysis:"}
     <span
       aria-hidden="true"
-      className="pseudo-link"
-      onClick={() => aviatorNavigation('sample', product.id, true, true)}
-      title="Open sample window"
+      className={`pseudo-link ${!active ? "disabled" : ""}`}
+      onClick={
+        active
+          ? () => aviatorNavigation('sample', product.id, true, true)
+          : undefined
+      }
+      title={active ? "Open sample window" : undefined}
     >
       <i className="icon-sample mx-1" />
       {product.title()}
-      hah
     </span>
   </span>
 );


### PR DESCRIPTION
- Under the reaction analysis tab, when a sample is not active, disable the sample window link. This is to prevent users from accidentally opening the sample window when they only want to switch to the sample analysis tab.
- Add styles for disabled pseudo-link.

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
