### PR TITLE
fix: Quill editor bullet styles

### DIFF
--- a/app/assets/stylesheets/components/QuillEditor.scss
+++ b/app/assets/stylesheets/components/QuillEditor.scss
@@ -52,7 +52,7 @@
 .ql-editor h6 {
   margin: 0;
   padding: 0;
-  counter-reset: list-1 list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9;
+  counter-reset: list-1 list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9 list-num;
 }
 .ql-editor ol,
 .ql-editor ul {
@@ -65,7 +65,6 @@
 .ql-editor ul > li::before,
 .ql-editor li[data-list="bullet"]::before {
   content: '\25CF';
-  counter-increment: none;
 }
 .ql-editor li::before {
   display: inline-block;

--- a/app/assets/stylesheets/components/QuillEditor.scss
+++ b/app/assets/stylesheets/components/QuillEditor.scss
@@ -62,8 +62,10 @@
 .ql-editor ul > li {
   list-style-type: none;
 }
-.ql-editor ul > li::before {
+.ql-editor ul > li::before,
+.ql-editor li[data-list="bullet"]::before {
   content: '\25CF';
+  counter-increment: none;
 }
 .ql-editor li::before {
   display: inline-block;
@@ -79,11 +81,17 @@
 .ql-editor ul li {
   padding-left: 1.5em;
 }
-.ql-editor ol li {
+.ql-editor ol li,
+.ql-editor li[data-list="ordered"] {
   counter-reset: list-1 list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9;
   counter-increment: list-num;
 }
-.ql-editor ol li:before {
+.ql-editor li[data-list="bullet"] {
+  counter-reset: none;
+  counter-increment: none;
+}
+.ql-editor ol li:before,
+.ql-editor li[data-list="ordered"]:before {
   content: counter(list-num, decimal) '. ';
 }
 .ql-editor ol li.ql-indent-1 {

--- a/app/assets/stylesheets/components/QuillEditor.scss
+++ b/app/assets/stylesheets/components/QuillEditor.scss
@@ -63,7 +63,9 @@
   list-style-type: none;
 }
 .ql-editor ul > li::before,
-.ql-editor li[data-list="bullet"]::before {
+.ql-editor li[data-list="bullet"]::before,
+.ql-editor ol li[data-list="bullet"][class*="ql-indent-"]:before,
+.ql-editor ul li[data-list="bullet"][class*="ql-indent-"]:before {
   content: '\25CF';
 }
 .ql-editor li::before {
@@ -96,6 +98,7 @@
 .ql-editor ol li.ql-indent-1 {
   counter-increment: list-1;
 }
+.ql-editor ol li[data-list="ordered"].ql-indent-1:before,
 .ql-editor ol li.ql-indent-1:before {
   content: counter(list-1, lower-alpha) '. ';
 }
@@ -105,6 +108,7 @@
 .ql-editor ol li.ql-indent-2 {
   counter-increment: list-2;
 }
+.ql-editor ol li[data-list="ordered"].ql-indent-2:before,
 .ql-editor ol li.ql-indent-2:before {
   content: counter(list-2, lower-roman) '. ';
 }
@@ -114,6 +118,7 @@
 .ql-editor ol li.ql-indent-3 {
   counter-increment: list-3;
 }
+.ql-editor ol li[data-list="ordered"].ql-indent-3:before,
 .ql-editor ol li.ql-indent-3:before {
   content: counter(list-3, decimal) '. ';
 }
@@ -123,6 +128,7 @@
 .ql-editor ol li.ql-indent-4 {
   counter-increment: list-4;
 }
+.ql-editor ol li[data-list="ordered"].ql-indent-4:before,
 .ql-editor ol li.ql-indent-4:before {
   content: counter(list-4, lower-alpha) '. ';
 }
@@ -132,6 +138,7 @@
 .ql-editor ol li.ql-indent-5 {
   counter-increment: list-5;
 }
+.ql-editor ol li[data-list="ordered"].ql-indent-5:before,
 .ql-editor ol li.ql-indent-5:before {
   content: counter(list-5, lower-roman) '. ';
 }
@@ -141,6 +148,7 @@
 .ql-editor ol li.ql-indent-6 {
   counter-increment: list-6;
 }
+.ql-editor ol li[data-list="ordered"].ql-indent-6:before,
 .ql-editor ol li.ql-indent-6:before {
   content: counter(list-6, decimal) '. ';
 }
@@ -150,6 +158,7 @@
 .ql-editor ol li.ql-indent-7 {
   counter-increment: list-7;
 }
+.ql-editor ol li[data-list="ordered"].ql-indent-7:before,
 .ql-editor ol li.ql-indent-7:before {
   content: counter(list-7, lower-alpha) '. ';
 }
@@ -159,6 +168,7 @@
 .ql-editor ol li.ql-indent-8 {
   counter-increment: list-8;
 }
+.ql-editor ol li[data-list="ordered"].ql-indent-8:before,
 .ql-editor ol li.ql-indent-8:before {
   content: counter(list-8, lower-roman) '. ';
 }
@@ -168,6 +178,7 @@
 .ql-editor ol li.ql-indent-9 {
   counter-increment: list-9;
 }
+.ql-editor ol li[data-list="ordered"].ql-indent-9:before,
 .ql-editor ol li.ql-indent-9:before {
   content: counter(list-9, decimal) '. ';
 }

--- a/app/javascript/src/components/QuillEditor.js
+++ b/app/javascript/src/components/QuillEditor.js
@@ -410,7 +410,7 @@ export default class QuillEditor extends React.Component {
 }
 
 QuillEditor.propTypes = {
-  value: PropTypes.object,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   customToolbar: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   toolbarSymbol: PropTypes.array,
   toolbarDropdown: PropTypes.arrayOf(PropTypes.object),


### PR DESCRIPTION
PR resolve: style for bullet points in the Quill editor.

----------------

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
