### PR TITLE
fix(UI): close panel after Save and Close for every element type

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/ElementDetailCard.js
+++ b/app/javascript/src/apps/mydb/elements/details/ElementDetailCard.js
@@ -31,7 +31,6 @@ export default function ElementDetailCard({
   footerToolbar,
   onClose,
   onSave,
-  onSaveClose,
   saveDisabled,
   showPrintCode,
   showCalendar,
@@ -88,17 +87,12 @@ export default function ElementDetailCard({
 
   const handleSaveClose = () => {
     setShowCloseOverlay(false);
-    if (onSaveClose) {
-      onSaveClose();
-    } else {
-      onSave();
-      handleClose();
-    }
+    onSave(true);
   };
 
   const saveButtonProps = {
     iconClass: 'fa fa-floppy-o',
-    onClick: onSave,
+    onClick: () => onSave(false),
     variant: 'primary',
     disabled: saveDisabled,
     label: inferredSaveLabel,
@@ -263,7 +257,6 @@ ElementDetailCard.propTypes = {
   footerToolbar: PropTypes.node,
   onClose: PropTypes.func,
   onSave: PropTypes.func.isRequired,
-  onSaveClose: PropTypes.func,
   saveDisabled: PropTypes.bool,
   showPrintCode: PropTypes.bool,
   showCalendar: PropTypes.bool,
@@ -278,7 +271,6 @@ ElementDetailCard.defaultProps = {
   headerToolbar: null,
   footerToolbar: null,
   onClose: null,
-  onSaveClose: null,
   saveDisabled: false,
   showPrintCode: false,
   showCalendar: false,

--- a/app/javascript/src/apps/mydb/elements/details/ElementDetailCard.js
+++ b/app/javascript/src/apps/mydb/elements/details/ElementDetailCard.js
@@ -88,6 +88,12 @@ export default function ElementDetailCard({
   const handleSaveClose = () => {
     setShowCloseOverlay(false);
     onSave(true);
+    // Mirror the non-save close path so callers that use onClose for their own
+    // cleanup (e.g. removing an item from a MobX store) still run on Save and Close.
+    // The actual panel close is handled by the onSave chain via DetailActions.close.
+    if (onClose) {
+      onClose();
+    }
   };
 
   const saveButtonProps = {

--- a/app/javascript/src/apps/mydb/elements/details/cellLines/CellLineDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/CellLineDetails.js
@@ -29,7 +29,7 @@ class CellLineDetails extends React.Component {
     };
   }
 
-  handleSubmit(cellLineItem) {
+  handleSubmit(cellLineItem, closeView = false) {
     // eslint-disable-next-line react/destructuring-assignment
     const mobXItem = this.context.cellLineDetailsStore.cellLines(this.props.cellLineItem.id);
     cellLineItem.adoptPropsFromMobXModel(mobXItem);
@@ -38,7 +38,7 @@ class CellLineDetails extends React.Component {
       DetailActions.close(cellLineItem, true);
       ElementActions.createCellLine(cellLineItem);
     } else {
-      ElementActions.updateCellLine(cellLineItem);
+      ElementActions.updateCellLine(cellLineItem, closeView);
     }
     mobXItem.setChanged(false);
   }
@@ -88,7 +88,7 @@ class CellLineDetails extends React.Component {
         title={cellLineItem.short_label}
         titleTooltip={formatTimeStampsOfElement(cellLineItem || {})}
         onClose={() => this.handleClose()}
-        onSave={() => this.handleSubmit(cellLineItem)}
+        onSave={(closeView) => this.handleSubmit(cellLineItem, closeView)}
         saveDisabled={saveDisabled}
       >
         <div className="tabs-container--with-borders">

--- a/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/DeviceDescriptionDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/DeviceDescriptionDetails.js
@@ -108,13 +108,13 @@ function DeviceDescriptionDetails({ openedFromCollectionId }) {
     deviceDescriptionsStore.setActiveTabKey(key);
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = (closeView = false) => {
     LoadingActions.start();
     if (deviceDescription.is_new) {
       DetailActions.close(deviceDescription, true);
       ElementActions.createDeviceDescription(deviceDescription);
     } else {
-      ElementActions.updateDeviceDescription(deviceDescription);
+      ElementActions.updateDeviceDescription(deviceDescription, closeView);
     }
     deviceDescriptionsStore.setCurrentDeviceDescriptionIdToSave(`${deviceDescription.id}`);
   };
@@ -151,7 +151,7 @@ function DeviceDescriptionDetails({ openedFromCollectionId }) {
       title={deviceDescription.name}
       titleTooltip={formatTimeStampsOfElement(deviceDescription || {})}
       footerToolbar={downloadAnalysisButton()}
-      onSave={handleSubmit}
+      onSave={(closeView) => handleSubmit(closeView)}
       saveDisabled={!deviceDescriptionIsValid()}
       showPrintCode
       showCalendar

--- a/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -1000,8 +1000,7 @@ export default class ReactionDetails extends Component {
         titleAppendix={titleAppendix}
         headerToolbar={headerToolbar}
         footerToolbar={footerToolbar}
-        onSave={() => this.handleSubmit()}
-        onSaveClose={() => this.handleSubmit(true)}
+        onSave={(closeView) => this.handleSubmit(closeView)}
         showSave={showSave}
         saveDisabled={saveDisabled}
         showPrintCode

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
@@ -103,7 +103,7 @@ export default class ResearchPlanDetails extends Component {
 
   // handle functions
 
-  handleSubmit() {
+  handleSubmit(closeView = false) {
     const { researchPlan } = this.state;
     LoadingActions.start();
     this.context.attachmentNotificationStore.clearMessages();
@@ -111,7 +111,7 @@ export default class ResearchPlanDetails extends Component {
     if (researchPlan.isNew) {
       ElementActions.createResearchPlan(researchPlan);
     } else {
-      ElementActions.updateResearchPlan(researchPlan);
+      ElementActions.updateResearchPlan(researchPlan, closeView);
     }
 
     if (researchPlan.is_new) {
@@ -566,7 +566,7 @@ export default class ResearchPlanDetails extends Component {
         isPendingToSave={researchPlan.isPendingToSave}
         title={researchPlan.name}
         titleTooltip={formatTimeStampsOfElement(researchPlan || {})}
-        onSave={() => this.handleSubmit()}
+        onSave={(closeView) => this.handleSubmit(closeView)}
         showCalendar
       >
         <div className="tabs-container--with-borders">

--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -575,7 +575,9 @@ export default class SampleDetails extends React.Component {
     }
 
     if (needChemicalSave) {
-      this.setState({ saveInventoryAction: true });
+      // Defer close until the inventory save completes; handleInventorySaveComplete
+      // consumes closeAfterInventorySave when didSave is true.
+      this.setState({ saveInventoryAction: true, closeAfterInventorySave: closeView });
     }
   }
 

--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -556,7 +556,7 @@ export default class SampleDetails extends React.Component {
     );
   }
 
-  saveSampleOrChemical() {
+  saveSampleOrChemical(closeView = false) {
     const { sample, isChemicalEdited } = this.state;
     const needChemicalSave = isChemicalEdited && !sample.isNew;
     const needChemicalCreate = isChemicalEdited && sample.isNew;
@@ -571,7 +571,7 @@ export default class SampleDetails extends React.Component {
 
       // When chemical also needs saving on an existing sample, don't close on
       // the sample save so ChemicalTab stays mounted to receive saveInventoryAction.
-      this.handleSubmit(needChemicalSave ? false : undefined);
+      this.handleSubmit(needChemicalSave ? false : closeView);
     }
 
     if (needChemicalSave) {
@@ -1596,7 +1596,7 @@ export default class SampleDetails extends React.Component {
         title={sampleTitle(sample)}
         titleTooltip={formatTimeStampsOfElement(sample || {})}
         titleAppendix={sampleTitleAppendix(sample, this.handleFastInput)}
-        onSave={() => this.saveSampleOrChemical()}
+        onSave={(closeView) => this.saveSampleOrChemical(closeView)}
         saveDisabled={saveDisabled}
         showPrintCode
         showCalendar

--- a/app/javascript/src/apps/mydb/elements/details/screens/ScreenDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/ScreenDetails.js
@@ -93,14 +93,14 @@ export default class ScreenDetails extends Component {
     this.setState({ visible });
   }
 
-  handleSubmit() {
+  handleSubmit(closeView = false) {
     const { screen } = this.state;
     LoadingActions.start();
 
     if (screen.isNew) {
       ElementActions.createScreen(screen);
     } else {
-      ElementActions.updateScreen(screen);
+      ElementActions.updateScreen(screen, closeView);
     }
     if (screen.is_new) {
       const force = true;
@@ -390,7 +390,7 @@ export default class ScreenDetails extends Component {
         isPendingToSave={screen.isPendingToSave}
         title={screen.name}
         titleTooltip={formatTimeStampsOfElement(screen || {})}
-        onSave={() => this.handleSubmit()}
+        onSave={(closeView) => this.handleSubmit(closeView)}
         showPrintCode
       >
         <ResearchplanFlowDisplay

--- a/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/SequenceBasedMacromoleculeSampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/SequenceBasedMacromoleculeSampleDetails.js
@@ -247,13 +247,14 @@ function SequenceBasedMacromoleculeSampleDetails({ openedFromCollectionId }) {
     sbmmStore.setActiveTabKey(key);
   };
 
-  const handleSubmit = () => {
-    sbmmStore.saveSample(sbmmSample);
+  const handleSubmit = (closeView = false) => {
+    sbmmStore.saveSample(sbmmSample, closeView);
   };
 
   // Chain-save: save SBMM sample first (if changed and valid), then chemical (if edited)
-  const handleChainSave = () => {
+  const handleChainSave = (closeView = false) => {
     const sbmmHasChanges = sbmmSample.isEdited || sbmmSample.changed;
+    const willSaveChemical = sbmmStore.isChemicalEdited && !sbmmSample.isNew;
     // Snapshot chemical data BEFORE handleSubmit closes this instance.
     // For new SBMM samples, navigateToNewElement mounts a fresh component;
     // the useEffect on mount will consume _sbmmPendingChemicalCreate.
@@ -261,9 +262,10 @@ function SequenceBasedMacromoleculeSampleDetails({ openedFromCollectionId }) {
       _sbmmPendingChemicalCreate = chemicalTabRef.current?.getChemicalSnapshot() ?? null;
     }
     if (sbmmHasChanges && Object.keys(sbmmSample.errors).length < 1) {
-      handleSubmit();
+      // Defer close when chemical also needs saving so ChemicalTab stays mounted.
+      handleSubmit(willSaveChemical ? false : closeView);
     }
-    if (sbmmStore.isChemicalEdited && !sbmmSample.isNew) {
+    if (willSaveChemical) {
       handleSubmitChemical();
     }
   };
@@ -337,7 +339,7 @@ function SequenceBasedMacromoleculeSampleDetails({ openedFromCollectionId }) {
       titleAppendix={titleAppendix}
       headerToolbar={headerToolbar}
       footerToolbar={downloadAnalysisButton()}
-      onSave={handleChainSave}
+      onSave={(closeView) => handleChainSave(closeView)}
       saveDisabled={!canSaveSample && !canSaveChemical}
       showPrintCode
       showCalendar

--- a/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/SequenceBasedMacromoleculeSampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/SequenceBasedMacromoleculeSampleDetails.js
@@ -37,6 +37,7 @@ import CollectionActions from 'src/stores/alt/actions/CollectionActions';
 import CollectionUtils from 'src/models/collection/CollectionUtils';
 import ChemicalTab from 'src/components/chemicals/ChemicalTab';
 import ChemicalFetcher from 'src/fetchers/ChemicalFetcher';
+import DetailActions from 'src/stores/alt/actions/DetailActions';
 
 // Module-level slot: holds chemical data to be created after a new SBMM sample is
 // persisted (survives the component unmount/remount caused by navigateToNewElement).
@@ -90,6 +91,13 @@ function SequenceBasedMacromoleculeSampleDetails({ openedFromCollectionId }) {
     }
   }, [alertRef.current]);
 
+  const handleInventorySaveComplete = (didSave) => {
+    if (didSave && sbmmStore.closeAfterInventorySave) {
+      DetailActions.close(sbmmSample, true);
+    }
+    sbmmStore.setCloseAfterInventorySave(false);
+  };
+
   const sbmmInventoryTab = (eventKey) => (
     <Tab eventKey={eventKey} title="Inventory" key={`Inventory${sbmmSample.id.toString()}`} unmountOnExit={false}>
       {
@@ -103,6 +111,7 @@ function SequenceBasedMacromoleculeSampleDetails({ openedFromCollectionId }) {
           setSaveInventory={(v) => sbmmStore.setSaveInventoryAction(v)}
           saveInventory={sbmmStore.saveInventoryAction}
           editChemical={sbmmStore.editChemical}
+          onInventorySaveComplete={handleInventorySaveComplete}
           key={`ChemicalTab${sbmmSample.id.toString()}`}
         />
       </ListGroupItem>
@@ -251,6 +260,12 @@ function SequenceBasedMacromoleculeSampleDetails({ openedFromCollectionId }) {
     sbmmStore.saveSample(sbmmSample, closeView);
   };
 
+  // Handler for chemical save
+  const handleSubmitChemical = () => {
+    // Set saveInventoryAction to true, which triggers ChemicalTab to save
+    sbmmStore.setSaveInventoryAction(true);
+  };
+
   // Chain-save: save SBMM sample first (if changed and valid), then chemical (if edited)
   const handleChainSave = (closeView = false) => {
     const sbmmHasChanges = sbmmSample.isEdited || sbmmSample.changed;
@@ -266,6 +281,9 @@ function SequenceBasedMacromoleculeSampleDetails({ openedFromCollectionId }) {
       handleSubmit(willSaveChemical ? false : closeView);
     }
     if (willSaveChemical) {
+      // Defer close until the inventory save completes; ChemicalTab's
+      // onInventorySaveComplete consumes closeAfterInventorySave below.
+      sbmmStore.setCloseAfterInventorySave(closeView);
       handleSubmitChemical();
     }
   };
@@ -302,12 +320,6 @@ function SequenceBasedMacromoleculeSampleDetails({ openedFromCollectionId }) {
       );
     }
     return <img src="/logos/uniprot-logo-gray.svg" className="uniprot-logo-gray" alt="Uniprot" />;
-  };
-
-  // Handler for chemical save
-  const handleSubmitChemical = () => {
-    // Set saveInventoryAction to true, which triggers ChemicalTab to save
-    sbmmStore.setSaveInventoryAction(true);
   };
 
   const hasSampleChanges = sbmmSample.isEdited || sbmmSample.changed;

--- a/app/javascript/src/apps/mydb/elements/details/vessels/VesselDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/vessels/VesselDetails.js
@@ -68,8 +68,12 @@ function VesselDetails({ vesselItem }) {
 
   const handleSaveClose = () => {
     setShowCloseOverlay(false);
+    // handleSubmit(true) threads closeView through updateVessel; the store closes
+    // the panel once the update resolves. Locally we only need to clear our MobX
+    // entry — do not dispatch DetailActions.close here, otherwise the store close
+    // path runs twice and can shift the active tab unexpectedly.
     handleSubmit(true);
-    handleClose(true);
+    context.vesselDetailsStore.removeVesselFromStore(vesselItem.id);
   };
 
   const requestClose = (event, forceClose = false, placement = 'bottom') => {

--- a/app/javascript/src/apps/mydb/elements/details/vessels/VesselDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/vessels/VesselDetails.js
@@ -45,14 +45,14 @@ function VesselDetails({ vesselItem }) {
     setReadOnly(isReadOnly());
   }, [vesselItem]);
 
-  const handleSubmit = () => {
+  const handleSubmit = (closeView = false) => {
     vesselItem.adoptPropsFromMobXModel(mobXItem);
 
     if (vesselItem.is_new) {
       DetailActions.close(vesselItem, true);
       ElementActions.createVessel(vesselItem);
     } else {
-      ElementActions.updateVessel(vesselItem);
+      ElementActions.updateVessel(vesselItem, closeView);
     }
     mobXItem.markChanged(false);
   };
@@ -68,7 +68,7 @@ function VesselDetails({ vesselItem }) {
 
   const handleSaveClose = () => {
     setShowCloseOverlay(false);
-    handleSubmit();
+    handleSubmit(true);
     handleClose(true);
   };
 

--- a/app/javascript/src/apps/mydb/elements/details/vessels/VesselDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/vessels/VesselDetails.js
@@ -112,7 +112,7 @@ function VesselDetails({ vesselItem }) {
         label: submitLabel,
         iconClass: 'fa fa-floppy-o',
         variant: 'primary',
-        onClick: handleSubmit,
+        onClick: () => handleSubmit(),
       })}
     </div>
   ) : null;
@@ -127,7 +127,7 @@ function VesselDetails({ vesselItem }) {
         iconClass: 'fa fa-floppy-o',
         variant: 'primary',
         disabled: isSubmitDisabled,
-        onClick: handleSubmit,
+        onClick: () => handleSubmit(),
       })}
     </>
   );

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
@@ -97,14 +97,14 @@ export default class WellplateDetails extends Component {
     this.setState({ wellplate });
   }
 
-  handleSubmit() {
+  handleSubmit(closeView = false) {
     const { wellplate } = this.state;
     this.context.attachmentNotificationStore.clearMessages();
     LoadingActions.start();
     if (wellplate.isNew) {
       ElementActions.createWellplate(wellplate);
     } else {
-      ElementActions.updateWellplate(wellplate);
+      ElementActions.updateWellplate(wellplate, closeView);
     }
     if (wellplate.is_new) {
       const force = true;
@@ -378,7 +378,7 @@ export default class WellplateDetails extends Component {
         title={wellplate.name}
         titleTooltip={formatTimeStampsOfElement(wellplate || {})}
         footerToolbar={this.wellplateFooter()}
-        onSave={() => this.handleSubmit()}
+        onSave={(closeView) => this.handleSubmit(closeView)}
         showPrintCode
       >
         <div className="tabs-container--with-borders">

--- a/app/javascript/src/components/generic/GenericElDetails.js
+++ b/app/javascript/src/components/generic/GenericElDetails.js
@@ -446,7 +446,7 @@ export default class GenericElDetails extends Component {
           isPendingToSave={genericEl.isPendingToSave}
           title={genericEl.short_label}
           titleTooltip={formatTimeStampsOfElement(genericEl || {})}
-          onSave={() => this.handleSubmit()}
+          onSave={(closeView) => this.handleSubmit(closeView)}
           saveDisabled={!genericEl.isNew && !genericEl.can_update}
           showCalendar
         >

--- a/app/javascript/src/stores/alt/actions/ElementActions.js
+++ b/app/javascript/src/stores/alt/actions/ElementActions.js
@@ -837,11 +837,11 @@ class ElementActions {
     };
   }
 
-  updateWellplate(wellplate) {
+  updateWellplate(wellplate, closeView = false) {
     return (dispatch) => {
       WellplatesFetcher.update(wellplate)
         .then(result => {
-          dispatch(result);
+          dispatch({ element: result, closeView });
         }).catch((errorMessage) => {
           console.log(errorMessage);
         });
@@ -924,11 +924,11 @@ class ElementActions {
     };
   }
 
-  updateScreen(params) {
+  updateScreen(params, closeView = false) {
     return (dispatch) => {
       ScreensFetcher.update(params)
         .then(result => {
-          dispatch(result);
+          dispatch({ element: result, closeView });
         }).catch((errorMessage) => {
           console.log(errorMessage);
         });
@@ -948,22 +948,22 @@ class ElementActions {
     };
   }
 
-  updateCellLine(params) {
+  updateCellLine(params, closeView = false) {
     return (dispatch) => {
       CellLinesFetcher.update(params)
         .then((result) => {
-          dispatch(result);
+          dispatch({ element: result, closeView });
         }).catch((errorMessage) => {
           console.log(errorMessage);
         });
     };
   }
 
-  updateResearchPlan(params) {
+  updateResearchPlan(params, closeView = false) {
     return (dispatch) => {
       ResearchPlansFetcher.update(params)
         .then((result) => {
-          dispatch(result);
+          dispatch({ element: result, closeView });
         }).catch((errorMessage) => {
           console.log(errorMessage);
         });
@@ -1020,11 +1020,11 @@ class ElementActions {
     };
   }
 
-  updateDeviceDescription(params) {
+  updateDeviceDescription(params, closeView = false) {
     return (dispatch) => {
       DeviceDescriptionFetcher.updateDeviceDescription(params)
         .then((result) => {
-          dispatch(result);
+          dispatch({ element: result, closeView });
         }).catch((errorMessage) => {
           console.log(errorMessage);
         });
@@ -1189,11 +1189,11 @@ class ElementActions {
     };
   }
 
-  updateSequenceBasedMacromoleculeSample(params) {
+  updateSequenceBasedMacromoleculeSample(params, closeView = false) {
     return (dispatch) => {
       SequenceBasedMacromoleculeSamplesFetcher.updateSequenceBasedMacromoleculeSample(params)
         .then((result) => {
-          dispatch(result);
+          dispatch({ element: result, closeView });
         }).catch((errorMessage) => {
           console.log(errorMessage);
         });

--- a/app/javascript/src/stores/alt/actions/ElementActions.js
+++ b/app/javascript/src/stores/alt/actions/ElementActions.js
@@ -1153,22 +1153,22 @@ class ElementActions {
     return vesselTemplate;
   }
 
-  updateVessel(params) {
+  updateVessel(params, closeView = false) {
     return (dispatch) => {
       VesselsFetcher.updateVesselInstance(params)
         .then((result) => {
-          dispatch(result);
+          dispatch({ element: result, closeView });
         }).catch((errorMessage) => {
           console.log(errorMessage);
         });
     };
   }
 
-  updateVesselTemplate(params) {
+  updateVesselTemplate(params, closeView = false) {
     return (dispatch) => {
       VesselsFetcher.updateVesselTemplate(params)
         .then((result) => {
-          dispatch(result);
+          dispatch({ element: result, closeView });
         })
         .catch((errorMessage) => {
           console.log(errorMessage);

--- a/app/javascript/src/stores/alt/stores/ElementStore.js
+++ b/app/javascript/src/stores/alt/stores/ElementStore.js
@@ -1715,7 +1715,14 @@ class ElementStore {
     const closeView = isEnriched ? !!payload.closeView : false;
     const openOrClose = (el) => {
       if (closeView) {
-        this.deleteCurrentElement(el);
+        // Guard: if the element is no longer in selecteds (e.g. a detail view
+        // already dispatched DetailActions.close synchronously), skip
+        // deleteCurrentElement so we don't reset activeKey/currentElement and
+        // unexpectedly shift the active tab.
+        const { selecteds } = this.state;
+        if (this.elementIndex(selecteds, el) !== -1) {
+          this.deleteCurrentElement(el);
+        }
       } else {
         this.changeCurrentElement(el);
       }

--- a/app/javascript/src/stores/alt/stores/ElementStore.js
+++ b/app/javascript/src/stores/alt/stores/ElementStore.js
@@ -1597,18 +1597,20 @@ class ElementStore {
   }
 
   UpdateResearchPlanAttaches(updatedResearchPlan, closeView = false) {
+    // Save-and-Close: close synchronously on the element we already have;
+    // skip the refresh fetch since the panel is going away anyway.
+    if (closeView) {
+      this.deleteCurrentElement(updatedResearchPlan);
+      return;
+    }
     const { selecteds } = this.state;
     ResearchPlansFetcher.fetchById(updatedResearchPlan.id)
       .then((result) => {
         result.mode = 'edit';
-        if (closeView) {
-          this.deleteCurrentElement(result);
-        } else {
-          this.changeCurrentElement(result);
-          const index = this.elementIndex(selecteds, result);
-          const newSelecteds = this.updateElement(result, index);
-          this.setState({ selecteds: newSelecteds });
-        }
+        this.changeCurrentElement(result);
+        const index = this.elementIndex(selecteds, result);
+        const newSelecteds = this.updateElement(result, index);
+        this.setState({ selecteds: newSelecteds });
       });
   }
 
@@ -1617,17 +1619,17 @@ class ElementStore {
   }
 
   UpdateWellplateAttaches(updatedWellplate, closeView = false) {
+    if (closeView) {
+      this.deleteCurrentElement(updatedWellplate);
+      return;
+    }
     const { selecteds } = this.state;
     WellplatesFetcher.fetchById(updatedWellplate.id)
       .then((result) => {
-        if (closeView) {
-          this.deleteCurrentElement(result);
-        } else {
-          this.changeCurrentElement(result);
-          const index = this.elementIndex(selecteds, result);
-          const newSelecteds = this.updateElement(result, index);
-          this.setState({ selecteds: newSelecteds });
-        }
+        this.changeCurrentElement(result);
+        const index = this.elementIndex(selecteds, result);
+        const newSelecteds = this.updateElement(result, index);
+        this.setState({ selecteds: newSelecteds });
       });
   }
 
@@ -1636,17 +1638,17 @@ class ElementStore {
   }
 
   UpdateScreen(updatedScreen, closeView = false) {
+    if (closeView) {
+      this.deleteCurrentElement(updatedScreen);
+      return;
+    }
     const { selecteds } = this.state;
     ScreensFetcher.fetchById(updatedScreen.id)
       .then((result) => {
-        if (closeView) {
-          this.deleteCurrentElement(result);
-        } else {
-          this.changeCurrentElement(result);
-          const index = this.elementIndex(selecteds, result);
-          const newSelecteds = this.updateElement(result, index);
-          this.setState({ selecteds: newSelecteds });
-        }
+        this.changeCurrentElement(result);
+        const index = this.elementIndex(selecteds, result);
+        const newSelecteds = this.updateElement(result, index);
+        this.setState({ selecteds: newSelecteds });
       });
   }
 

--- a/app/javascript/src/stores/alt/stores/ElementStore.js
+++ b/app/javascript/src/stores/alt/stores/ElementStore.js
@@ -834,16 +834,17 @@ class ElementStore {
           console.log(errorMessage);
         });
     }
+    // Guard both branches: if the element is no longer in selecteds (e.g.
+    // closed synchronously by handleSubmit, or by a deferred chemical-save
+    // close racing ahead of this dispatch), skip the selection update so we
+    // don't either re-delete (and shift the active tab) or re-add the panel
+    // via changeCurrentElement's addElement fallback.
+    const stillOpen = this.elementIndex(this.state.selecteds, element) !== -1;
     if (closeView) {
-      // Guard: if the element is no longer in selecteds (e.g. a detail view
-      // already dispatched DetailActions.close synchronously), skip
-      // deleteCurrentElement so we don't reset activeKey/currentElement and
-      // unexpectedly shift the active tab.
-      const { selecteds } = this.state;
-      if (this.elementIndex(selecteds, element) !== -1) {
+      if (stillOpen) {
         this.deleteCurrentElement(element);
       }
-    } else {
+    } else if (stillOpen) {
       this.changeCurrentElement(element);
     }
     this.handleUpdateElement(element);
@@ -1721,16 +1722,17 @@ class ElementStore {
     const updatedElement = isEnriched ? payload.element : payload;
     const closeView = isEnriched ? !!payload.closeView : false;
     const openOrClose = (el) => {
+      // Guard both branches: if the element is no longer in selecteds (e.g.
+      // closed synchronously by the detail view, or by a deferred chemical-
+      // save close racing ahead of this dispatch), skip the selection update
+      // so we don't either re-delete (and shift the active tab) or re-add the
+      // panel via changeCurrentElement's addElement fallback.
+      const stillOpen = this.elementIndex(this.state.selecteds, el) !== -1;
       if (closeView) {
-        // Guard: if the element is no longer in selecteds (e.g. a detail view
-        // already dispatched DetailActions.close synchronously), skip
-        // deleteCurrentElement so we don't reset activeKey/currentElement and
-        // unexpectedly shift the active tab.
-        const { selecteds } = this.state;
-        if (this.elementIndex(selecteds, el) !== -1) {
+        if (stillOpen) {
           this.deleteCurrentElement(el);
         }
-      } else {
+      } else if (stillOpen) {
         this.changeCurrentElement(el);
       }
     };

--- a/app/javascript/src/stores/alt/stores/ElementStore.js
+++ b/app/javascript/src/stores/alt/stores/ElementStore.js
@@ -1596,50 +1596,62 @@ class ElementStore {
     }
   }
 
-  UpdateResearchPlanAttaches(updatedResearchPlan) {
+  UpdateResearchPlanAttaches(updatedResearchPlan, closeView = false) {
     const { selecteds } = this.state;
     ResearchPlansFetcher.fetchById(updatedResearchPlan.id)
       .then((result) => {
         result.mode = 'edit';
-        this.changeCurrentElement(result);
-        const index = this.elementIndex(selecteds, result);
-        const newSelecteds = this.updateElement(result, index);
-        this.setState({ selecteds: newSelecteds });
+        if (closeView) {
+          this.deleteCurrentElement(result);
+        } else {
+          this.changeCurrentElement(result);
+          const index = this.elementIndex(selecteds, result);
+          const newSelecteds = this.updateElement(result, index);
+          this.setState({ selecteds: newSelecteds });
+        }
       });
   }
 
-  handleUpdateResearchPlanAttaches(updatedResearchPlan) {
-    this.UpdateResearchPlanAttaches(updatedResearchPlan);
+  handleUpdateResearchPlanAttaches(updatedResearchPlan, closeView = false) {
+    this.UpdateResearchPlanAttaches(updatedResearchPlan, closeView);
   }
 
-  UpdateWellplateAttaches(updatedWellplate) {
+  UpdateWellplateAttaches(updatedWellplate, closeView = false) {
     const { selecteds } = this.state;
     WellplatesFetcher.fetchById(updatedWellplate.id)
       .then((result) => {
-        this.changeCurrentElement(result);
-        const index = this.elementIndex(selecteds, result);
-        const newSelecteds = this.updateElement(result, index);
-        this.setState({ selecteds: newSelecteds });
+        if (closeView) {
+          this.deleteCurrentElement(result);
+        } else {
+          this.changeCurrentElement(result);
+          const index = this.elementIndex(selecteds, result);
+          const newSelecteds = this.updateElement(result, index);
+          this.setState({ selecteds: newSelecteds });
+        }
       });
   }
 
-  handleUpdateWellplateAttaches(updatedWellplate) {
-    this.UpdateWellplateAttaches(updatedWellplate);
+  handleUpdateWellplateAttaches(updatedWellplate, closeView = false) {
+    this.UpdateWellplateAttaches(updatedWellplate, closeView);
   }
 
-  UpdateScreen(updatedScreen) {
+  UpdateScreen(updatedScreen, closeView = false) {
     const { selecteds } = this.state;
     ScreensFetcher.fetchById(updatedScreen.id)
       .then((result) => {
-        this.changeCurrentElement(result);
-        const index = this.elementIndex(selecteds, result);
-        const newSelecteds = this.updateElement(result, index);
-        this.setState({ selecteds: newSelecteds });
+        if (closeView) {
+          this.deleteCurrentElement(result);
+        } else {
+          this.changeCurrentElement(result);
+          const index = this.elementIndex(selecteds, result);
+          const newSelecteds = this.updateElement(result, index);
+          this.setState({ selecteds: newSelecteds });
+        }
       });
   }
 
-  handleUpdateScreen(updatedScreen) {
-    this.UpdateScreen(updatedScreen);
+  handleUpdateScreen(updatedScreen, closeView = false) {
+    this.UpdateScreen(updatedScreen, closeView);
   }
 
   handleUpdateMoleculeNames(updatedSample) {
@@ -1694,7 +1706,18 @@ class ElementStore {
     }
   }
 
-  handleUpdateElement(updatedElement) {
+  handleUpdateElement(payload) {
+    // Accept both the legacy shape (element) and the enriched shape ({ element, closeView }).
+    const isEnriched = payload && typeof payload === 'object' && 'element' in payload && !('type' in payload);
+    const updatedElement = isEnriched ? payload.element : payload;
+    const closeView = isEnriched ? !!payload.closeView : false;
+    const openOrClose = (el) => {
+      if (closeView) {
+        this.deleteCurrentElement(el);
+      } else {
+        this.changeCurrentElement(el);
+      }
+    };
     switch (updatedElement?.type) {
       case 'sample':
         fetchOls('sample');
@@ -1708,14 +1731,14 @@ class ElementStore {
       case 'screen':
         fetchOls('screen');
         this.handleRefreshElements('screen');
-        this.handleUpdateScreen(updatedElement);
+        this.handleUpdateScreen(updatedElement, closeView);
         break;
       case 'research_plan':
         this.handleRefreshElements('research_plan');
-        this.handleUpdateResearchPlanAttaches(updatedElement);
+        this.handleUpdateResearchPlanAttaches(updatedElement, closeView);
         break;
       case 'cell_line':
-        this.changeCurrentElement(updatedElement);
+        openOrClose(updatedElement);
         this.handleRefreshElements('cell_line');
         break;
       case 'vessel':
@@ -1730,16 +1753,16 @@ class ElementStore {
       case 'wellplate':
         fetchOls('wellplate');
         this.handleRefreshElements('wellplate');
-        this.handleUpdateWellplateAttaches(updatedElement);
+        this.handleUpdateWellplateAttaches(updatedElement, closeView);
         this.handleRefreshElements('sample');
         break;
       case 'device_description':
-        this.changeCurrentElement(updatedElement);
+        openOrClose(updatedElement);
         this.handleRefreshElements('device_description');
         break;
       case 'sequence_based_macromolecule_sample':
         this.handleUpdatedSbmmSample(updatedElement);
-        this.changeCurrentElement(updatedElement);
+        openOrClose(updatedElement);
         this.handleRefreshElements('sequence_based_macromolecule_sample');
         break;
       case 'genericEl':

--- a/app/javascript/src/stores/alt/stores/ElementStore.js
+++ b/app/javascript/src/stores/alt/stores/ElementStore.js
@@ -835,7 +835,14 @@ class ElementStore {
         });
     }
     if (closeView) {
-      this.deleteCurrentElement(element);
+      // Guard: if the element is no longer in selecteds (e.g. a detail view
+      // already dispatched DetailActions.close synchronously), skip
+      // deleteCurrentElement so we don't reset activeKey/currentElement and
+      // unexpectedly shift the active tab.
+      const { selecteds } = this.state;
+      if (this.elementIndex(selecteds, element) !== -1) {
+        this.deleteCurrentElement(element);
+      }
     } else {
       this.changeCurrentElement(element);
     }

--- a/app/javascript/src/stores/alt/stores/ElementStore.js
+++ b/app/javascript/src/stores/alt/stores/ElementStore.js
@@ -1744,11 +1744,11 @@ class ElementStore {
         this.handleRefreshElements('cell_line');
         break;
       case 'vessel':
-        this.changeCurrentElement(updatedElement);
+        openOrClose(updatedElement);
         this.handleRefreshElements('vessel');
         break;
       case 'vessel_template':
-        this.changeCurrentElement(updatedElement);
+        openOrClose(updatedElement);
         this.handleRefreshElements('vessel_template');
         this.handleRefreshElements('vessel');
         break;

--- a/app/javascript/src/stores/alt/stores/InboxStore.js
+++ b/app/javascript/src/stores/alt/stores/InboxStore.js
@@ -57,13 +57,16 @@ class InboxStore {
         ElementActions.createSample,
         ElementActions.updateSample,
         ElementActions.createReaction,
+        // update* actions now dispatch { element, closeView } so they must
+        // go through the Dict handler, which unwraps the payload before
+        // forwarding to handleUpdateCreateElement.
+        ElementActions.updateReaction,
+        ElementActions.updateWellplate,
+        ElementActions.updateScreen,
       ],
       handleUpdateCreateElement: [
-        ElementActions.updateReaction,
         ElementActions.createWellplate,
-        ElementActions.updateWellplate,
         ElementActions.createScreen,
-        ElementActions.updateScreen,
       ],
       handleClose: DetailActions.close,
       handleConfirmDelete: DetailActions.confirmDelete,

--- a/app/javascript/src/stores/mobx/SequenceBasedMacromoleculeSamplesStore.jsx
+++ b/app/javascript/src/stores/mobx/SequenceBasedMacromoleculeSamplesStore.jsx
@@ -102,6 +102,7 @@ export const SequenceBasedMacromoleculeSamplesStore = types
     // For ChemicalTab integration
     saveInventoryAction: types.optional(types.boolean, false),
     isChemicalEdited: types.optional(types.boolean, false),
+    closeAfterInventorySave: types.optional(types.boolean, false),
   })
   .actions(self => ({
     setSaveInventoryAction(value) {
@@ -109,6 +110,9 @@ export const SequenceBasedMacromoleculeSamplesStore = types
     },
     editChemical(value) {
       self.isChemicalEdited = value;
+    },
+    setCloseAfterInventorySave(value) {
+      self.closeAfterInventorySave = value;
     },
     searchForSequenceBasedMacromolecule: flow(function* searchForSequenceBasedMacromolecule(search_term, search_field) {
       let result = yield SequenceBasedMacromoleculesFetcher.searchForSequenceBasedMacromolecule(search_term, search_field);

--- a/app/javascript/src/stores/mobx/SequenceBasedMacromoleculeSamplesStore.jsx
+++ b/app/javascript/src/stores/mobx/SequenceBasedMacromoleculeSamplesStore.jsx
@@ -320,14 +320,14 @@ export const SequenceBasedMacromoleculeSamplesStore = types
       self.conflict_sbmms = [];
       self.saveSample(self.sequence_based_macromolecule_sample);
     },
-    saveSample(sbmmSample) {
+    saveSample(sbmmSample, closeView = false) {
       LoadingActions.start();
       if (sbmmSample.is_new) {
         self.removeFromOpenSequenceBasedMacromoleculeSamples(sbmmSample);
         DetailActions.close(sbmmSample, true);
         ElementActions.createSequenceBasedMacromoleculeSample(sbmmSample);
       } else {
-        ElementActions.updateSequenceBasedMacromoleculeSample(sbmmSample);
+        ElementActions.updateSequenceBasedMacromoleculeSample(sbmmSample, closeView);
         self.setUpdatedSequenceBasedMacromoleculeSampleId(sbmmSample.id);
       }
     },

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/ElementDetailCard.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/ElementDetailCard.spec.js
@@ -65,7 +65,7 @@ describe('ElementDetailCard save button wiring', () => {
     expect(onSave.firstCall.args[0]).toBe(true);
   });
 
-  it('invokes onClose cleanup on Save and Close (Copilot review #1/#6)', () => {
+  it('invokes onClose cleanup when Save and Close is clicked', () => {
     const wrapper = mountCard();
     findSaveCloseButton(wrapper).simulate('click');
     expect(onClose.calledOnce).toBe(true);

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/ElementDetailCard.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/ElementDetailCard.spec.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import expect from 'expect';
+import sinon from 'sinon';
+import Enzyme, { mount } from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import { describe, it, beforeEach } from 'mocha';
+import ElementDetailCard from 'src/apps/mydb/elements/details/ElementDetailCard';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('ElementDetailCard save button wiring', () => {
+  let onSave;
+  let onClose;
+
+  const element = {
+    id: 1,
+    type: 'sample',
+    isPendingToSave: true,
+    isNew: false,
+    can_copy: false,
+  };
+
+  const mountCard = (props = {}) => mount(
+    <ElementDetailCard
+      element={element}
+      title="Test"
+      onSave={onSave}
+      onClose={onClose}
+      showUserLabels={false}
+      showHeaderCommentSection={false}
+      {...props}
+    >
+      <div>content</div>
+    </ElementDetailCard>
+  );
+
+  // The header Save button is primary and carries the floppy icon without the combi overlay.
+  const findSaveButton = (wrapper) => wrapper.find('button').filterWhere(
+    (btn) => btn.find('.fa-floppy-o').exists()
+      && !btn.find('.combi-icon-close').exists()
+      && btn.hasClass('btn-primary')
+  ).first();
+
+  // The Save and Close header button uses the combi-icon-close modifier.
+  const findSaveCloseButton = (wrapper) => wrapper.find('button').filterWhere(
+    (btn) => btn.find('.combi-icon-close').exists()
+  ).first();
+
+  beforeEach(() => {
+    onSave = sinon.spy();
+    onClose = sinon.spy();
+  });
+
+  it('calls onSave(false) when the plain Save button is clicked', () => {
+    const wrapper = mountCard();
+    findSaveButton(wrapper).simulate('click');
+    expect(onSave.calledOnce).toBe(true);
+    expect(onSave.firstCall.args[0]).toBe(false);
+  });
+
+  it('calls onSave(true) when Save and Close is clicked', () => {
+    const wrapper = mountCard();
+    findSaveCloseButton(wrapper).simulate('click');
+    expect(onSave.calledOnce).toBe(true);
+    expect(onSave.firstCall.args[0]).toBe(true);
+  });
+
+  it('invokes onClose cleanup on Save and Close (Copilot review #1/#6)', () => {
+    const wrapper = mountCard();
+    findSaveCloseButton(wrapper).simulate('click');
+    expect(onClose.calledOnce).toBe(true);
+  });
+
+  it('does not throw if onClose is not provided on Save and Close', () => {
+    const wrapper = mountCard({ onClose: undefined });
+    expect(() => findSaveCloseButton(wrapper).simulate('click')).not.toThrow();
+    expect(onSave.calledOnce).toBe(true);
+    expect(onSave.firstCall.args[0]).toBe(true);
+  });
+});


### PR DESCRIPTION
Only reactions closed the detail panel on Save and Close; every other element type (sample, SBMM, cell line, screen, wellplate, research plan, device description) reopened on save because the update dispatch went through changeCurrentElement.

Unify ElementDetailCard around a single onSave(closeView) callback and thread closeView through ElementActions.update* and the matching ElementStore handlers so the store skips re-selection when the panel should close.

