### PR TITLE
feat: admin-configurable Info & Support links

### DIFF
--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -196,6 +196,7 @@ class API < Grape::API
   mount Chemotion::MessageAPI
   mount Chemotion::AdminAPI
   mount Chemotion::AdminUserAPI
+  mount Chemotion::AdminInfoSupportAPI
   mount Chemotion::EditorAPI
   mount Chemotion::UiAPI
   mount Chemotion::OlsTermsAPI

--- a/app/api/chemotion/admin_info_support_api.rb
+++ b/app/api/chemotion/admin_info_support_api.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Chemotion
+  class AdminInfoSupportAPI < Grape::API
+    resource :admin do
+      before do
+        error!('401 Unauthorized', 401) unless current_user.is_a?(Admin)
+      end
+
+      resource :info_support_links do
+        desc 'List all info & support links (admin)'
+        get do
+          present InfoSupportLink.all, with: Entities::InfoSupportLinkEntity
+        end
+
+        desc 'Create an info & support link'
+        params do
+          requires :label, type: String
+          requires :url, type: String
+          optional :position, type: Integer, default: 0
+          optional :enabled, type: Boolean, default: true
+        end
+        post do
+          link = InfoSupportLink.new(declared(params, include_missing: false))
+          if link.save
+            present link, with: Entities::InfoSupportLinkEntity
+          else
+            error!({ errors: link.errors.full_messages }, 422)
+          end
+        end
+
+        route_param :id, type: Integer do
+          desc 'Update an info & support link'
+          params do
+            optional :label, type: String
+            optional :url, type: String
+            optional :position, type: Integer
+            optional :enabled, type: Boolean
+          end
+          put do
+            link = InfoSupportLink.find(params[:id])
+            updates = declared(params, include_missing: false).except(:id)
+            if link.update(updates)
+              present link, with: Entities::InfoSupportLinkEntity
+            else
+              error!({ errors: link.errors.full_messages }, 422)
+            end
+          end
+
+          desc 'Delete an info & support link'
+          delete do
+            InfoSupportLink.find(params[:id]).destroy!
+            status 204
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/api/entities/info_support_link_entity.rb
+++ b/app/api/entities/info_support_link_entity.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Entities
+  class InfoSupportLinkEntity < ApplicationEntity
+    expose :id
+    expose :label
+    expose :url
+    expose :position
+    expose :enabled
+
+    expose_timestamps
+  end
+end

--- a/app/javascript/src/apps/admin/AdminHome.js
+++ b/app/javascript/src/apps/admin/AdminHome.js
@@ -14,6 +14,7 @@ import ChemSpectraLayouts from 'src/apps/admin/ChemSpectraLayouts';
 import DevicesList from 'src/apps/admin/devices/DevicesList';
 // import TemplateManagement from 'src/apps/admin/TemplateManagement';
 import ThirdPartyApp from 'src/apps/admin/ThirdPartyApp';
+import InfoSupportLinks from 'src/apps/admin/InfoSupportLinks';
 
 class AdminHome extends React.Component {
   constructor(props) {
@@ -45,6 +46,7 @@ class AdminHome extends React.Component {
       case 13: return <DelayedJobs />;
       case 14: return <ChemSpectraLayouts />;
       case 15: return <ThirdPartyApp />;
+      case 16: return <InfoSupportLinks />;
       default: return null;
     }
   }
@@ -89,6 +91,9 @@ class AdminHome extends React.Component {
         </NavItem>
         <NavItem>
           <Nav.Link eventKey={15}>Third Party Apps</Nav.Link>
+        </NavItem>
+        <NavItem>
+          <Nav.Link eventKey={16}>Info &amp; Support Links</Nav.Link>
         </NavItem>
       </Nav>
     );

--- a/app/javascript/src/apps/admin/InfoSupportLinks.js
+++ b/app/javascript/src/apps/admin/InfoSupportLinks.js
@@ -1,0 +1,259 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Table, Button, Modal, Form, InputGroup, OverlayTrigger, Tooltip,
+} from 'react-bootstrap';
+import uuid from 'uuid';
+import InfoSupportLinksFetcher from 'src/fetchers/InfoSupportLinksFetcher';
+import NotificationActions from 'src/stores/alt/actions/NotificationActions';
+
+const notify = ({ title, msg, lvl = 'info' }) => NotificationActions.add({
+  title,
+  message: msg,
+  level: lvl,
+  position: 'tc',
+  dismissible: 'button',
+  uid: uuid.v4(),
+});
+
+const emptyDraft = {
+  id: null, label: '', url: '', position: 0, enabled: true,
+};
+
+function LinkFormModal({
+  show, draft, onChange, onClose, onSave, isNew,
+}) {
+  return (
+    <Modal centered show={show} onHide={onClose} backdrop="static">
+      <Modal.Header closeButton>
+        <Modal.Title>{isNew ? 'New Info & Support Link' : 'Edit Info & Support Link'}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Form className="d-flex flex-column gap-3">
+          <Form.Group>
+            <InputGroup>
+              <InputGroup.Text>Label</InputGroup.Text>
+              <Form.Control
+                type="text"
+                value={draft.label}
+                onChange={(e) => onChange({ ...draft, label: e.target.value })}
+                placeholder="e.g. Local RDM team"
+              />
+            </InputGroup>
+          </Form.Group>
+          <Form.Group>
+            <InputGroup>
+              <InputGroup.Text>URL</InputGroup.Text>
+              <Form.Control
+                type="text"
+                value={draft.url}
+                onChange={(e) => onChange({ ...draft, url: e.target.value })}
+                placeholder="https://…"
+              />
+            </InputGroup>
+          </Form.Group>
+          <Form.Group>
+            <InputGroup>
+              <InputGroup.Text>Position</InputGroup.Text>
+              <Form.Control
+                type="number"
+                value={draft.position ?? 0}
+                onChange={(e) => onChange({ ...draft, position: Number(e.target.value) })}
+              />
+            </InputGroup>
+          </Form.Group>
+          <Form.Check
+            type="checkbox"
+            checked={!!draft.enabled}
+            onChange={(e) => onChange({ ...draft, enabled: e.target.checked })}
+            label="Enabled (shown to users)"
+          />
+        </Form>
+      </Modal.Body>
+      <Modal.Footer className="modal-footer border-0">
+        <Button variant="warning" onClick={onClose} className="me-1">Cancel</Button>
+        <Button variant="primary" onClick={onSave}>
+          {isNew ? 'Create' : 'Update'}
+          <i className="fa fa-save ms-1" />
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}
+
+LinkFormModal.propTypes = {
+  show: PropTypes.bool.isRequired,
+  draft: PropTypes.shape({
+    id: PropTypes.number,
+    label: PropTypes.string,
+    url: PropTypes.string,
+    position: PropTypes.number,
+    enabled: PropTypes.bool,
+  }).isRequired,
+  onChange: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
+  isNew: PropTypes.bool.isRequired,
+};
+
+export default class InfoSupportLinks extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      links: [],
+      showModal: false,
+      draft: emptyDraft,
+      isNew: true,
+    };
+    this.openNew = this.openNew.bind(this);
+    this.openEdit = this.openEdit.bind(this);
+    this.close = this.close.bind(this);
+    this.handleChange = this.handleChange.bind(this);
+    this.handleSave = this.handleSave.bind(this);
+    this.handleDelete = this.handleDelete.bind(this);
+  }
+
+  componentDidMount() {
+    this.fetchLinks();
+  }
+
+  fetchLinks() {
+    InfoSupportLinksFetcher.fetchAdmin()
+      .then((result) => {
+        const links = Array.isArray(result) ? result : [];
+        this.setState({ links });
+      })
+      .catch(() => notify({ title: 'Info & Support Links', msg: 'Failed to load links', lvl: 'error' }));
+  }
+
+  openNew() {
+    this.setState({ showModal: true, isNew: true, draft: { ...emptyDraft } });
+  }
+
+  openEdit(link) {
+    this.setState({ showModal: true, isNew: false, draft: { ...link } });
+  }
+
+  close() {
+    this.setState({ showModal: false });
+  }
+
+  handleChange(draft) {
+    this.setState({ draft });
+  }
+
+  validate(draft) {
+    if (!draft.label || !draft.label.trim()) return 'Label is required';
+    if (!draft.url || !draft.url.trim()) return 'URL is required';
+    if (!/^https?:\/\/.+/i.test(draft.url.trim())) return 'URL must start with http:// or https://';
+    return null;
+  }
+
+  handleSave() {
+    const { draft, isNew } = this.state;
+    const err = this.validate(draft);
+    if (err) {
+      notify({ title: 'Info & Support Links', msg: err, lvl: 'error' });
+      return;
+    }
+    const payload = {
+      label: draft.label.trim(),
+      url: draft.url.trim(),
+      position: Number(draft.position) || 0,
+      enabled: !!draft.enabled,
+    };
+    const promise = isNew
+      ? InfoSupportLinksFetcher.create(payload)
+      : InfoSupportLinksFetcher.update(draft.id, payload);
+    promise
+      .then((result) => {
+        if (result && result.errors) {
+          notify({ title: 'Info & Support Links', msg: result.errors.join(', '), lvl: 'error' });
+          return;
+        }
+        notify({ title: 'Info & Support Links', msg: isNew ? 'Created' : 'Updated' });
+        this.setState({ showModal: false });
+        this.fetchLinks();
+      })
+      .catch(() => notify({ title: 'Info & Support Links', msg: 'Save failed', lvl: 'error' }));
+  }
+
+  handleDelete(link) {
+    // eslint-disable-next-line no-alert
+    if (!window.confirm(`Delete link "${link.label}"?`)) return;
+    InfoSupportLinksFetcher.delete(link.id)
+      .then(() => {
+        notify({ title: 'Info & Support Links', msg: 'Deleted' });
+        this.fetchLinks();
+      })
+      .catch(() => notify({ title: 'Info & Support Links', msg: 'Delete failed', lvl: 'error' }));
+  }
+
+  renderRows() {
+    const { links } = this.state;
+    return links.map((link, idx) => (
+      <tr key={link.id}>
+        <td>{idx + 1}</td>
+        <td>
+          <OverlayTrigger placement="bottom" overlay={<Tooltip id={`edit-${link.id}`}>Edit</Tooltip>}>
+            <Button size="sm" variant="info" onClick={() => this.openEdit(link)} className="me-1">
+              <i className="fa fa-pencil-square-o" />
+            </Button>
+          </OverlayTrigger>
+          <OverlayTrigger placement="bottom" overlay={<Tooltip id={`del-${link.id}`}>Delete</Tooltip>}>
+            <Button size="sm" variant="danger" onClick={() => this.handleDelete(link)}>
+              <i className="fa fa-trash-o" />
+            </Button>
+          </OverlayTrigger>
+        </td>
+        <td>{link.position}</td>
+        <td>{link.label}</td>
+        <td>
+          <a href={link.url} target="_blank" rel="noopener noreferrer">{link.url}</a>
+        </td>
+        <td>{link.enabled ? 'yes' : 'no'}</td>
+      </tr>
+    ));
+  }
+
+  render() {
+    const {
+      showModal, draft, isNew,
+    } = this.state;
+    return (
+      <div>
+        <div className="d-flex align-items-center justify-content-between mb-2">
+          <h4 className="m-0">Info &amp; Support Links</h4>
+          <Button variant="primary" onClick={this.openNew}>
+            <i className="fa fa-plus me-1" />
+            New link
+          </Button>
+        </div>
+        <p className="text-muted">
+          These links appear in the user-facing &quot;Info &amp; Support&quot; dropdown, below the Chemotion defaults.
+        </p>
+        <Table responsive hover className="border">
+          <thead>
+            <tr className="bg-gray-200">
+              <th>#</th>
+              <th>Actions</th>
+              <th>Position</th>
+              <th>Label</th>
+              <th>URL</th>
+              <th>Enabled</th>
+            </tr>
+          </thead>
+          <tbody>{this.renderRows()}</tbody>
+        </Table>
+        <LinkFormModal
+          show={showModal}
+          draft={draft}
+          isNew={isNew}
+          onChange={this.handleChange}
+          onClose={this.close}
+          onSave={this.handleSave}
+        />
+      </div>
+    );
+  }
+}

--- a/app/javascript/src/components/navigation/NavHead.js
+++ b/app/javascript/src/components/navigation/NavHead.js
@@ -3,6 +3,8 @@ import { NavDropdown, Navbar, Dropdown } from 'react-bootstrap';
 
 function NavHead() {
   const isOnMydb = window.location.href.match(/\/mydb/);
+  const customLinks = Array.isArray(window.__INFO_SUPPORT_LINKS__) ? window.__INFO_SUPPORT_LINKS__ : [];
+
   return (
     <Navbar.Brand className="fs-5">
       <NavDropdown title="Chemotion">
@@ -32,6 +34,20 @@ function NavHead() {
           {' '}
           <i className="fa fa-external-link" aria-hidden="true" />
         </NavDropdown.Item>
+
+        {customLinks.length > 0 && <Dropdown.Divider />}
+        {customLinks.map((link) => (
+          <NavDropdown.Item
+            key={link.id}
+            as="a"
+            href={link.url}
+            target="_blank"
+          >
+            {link.label}
+            <i className="fa fa-external-link float-end" aria-hidden="true" />
+          </NavDropdown.Item>
+        ))}
+
         <Dropdown.Divider />
         <NavDropdown.Item as="a" eventKey="16" href={isOnMydb ? '/home' : '/mydb'} target="_self">
           {isOnMydb ? 'Home' : 'ELN'}

--- a/app/javascript/src/components/navigation/SupportMenuButton.js
+++ b/app/javascript/src/components/navigation/SupportMenuButton.js
@@ -24,12 +24,15 @@ ExternalItem.propTypes = {
 
 export default function SupportMenuButton({ linkToEln, variant }) {
   const [version, setVersion] = useState({});
+  const customLinks = Array.isArray(window.__INFO_SUPPORT_LINKS__) ? window.__INFO_SUPPORT_LINKS__ : [];
+
   useEffect(() => {
     const onUiStoreChange = (state) => setVersion(state.version);
     UIStore.listen(onUiStoreChange);
     onUiStoreChange(UIStore.getState());
     return () => UIStore.unlisten(onUiStoreChange);
   }, []);
+
   const hasVersions = version && Object.keys(version).length > 1;
 
   return (
@@ -45,6 +48,12 @@ export default function SupportMenuButton({ linkToEln, variant }) {
         <ExternalItem title="Search documentation" href="https://chemotion.net/search" />
         <ExternalItem title="Helpdesk - Contact Us" href="https://chemotion.net/helpdesk" />
         <ExternalItem title="Report an issue on Github" href="https://github.com/ComPlat/chemotion_ELN/issues" />
+
+        {customLinks.length > 0 && <Dropdown.Divider />}
+        {customLinks.map((link) => (
+          <ExternalItem key={link.id} title={link.label} href={link.url} />
+        ))}
+
         <Dropdown.Divider />
 
         {linkToEln

--- a/app/javascript/src/fetchers/InfoSupportLinksFetcher.js
+++ b/app/javascript/src/fetchers/InfoSupportLinksFetcher.js
@@ -1,0 +1,39 @@
+import 'whatwg-fetch';
+
+const jsonHeaders = {
+  Accept: 'application/json',
+  'Content-Type': 'application/json',
+};
+
+export default class InfoSupportLinksFetcher {
+  static fetchAdmin() {
+    return fetch('/api/v1/admin/info_support_links', {
+      credentials: 'same-origin',
+    }).then((response) => response.json());
+  }
+
+  static create(params) {
+    return fetch('/api/v1/admin/info_support_links', {
+      credentials: 'same-origin',
+      method: 'POST',
+      headers: jsonHeaders,
+      body: JSON.stringify(params),
+    }).then((response) => response.json());
+  }
+
+  static update(id, params) {
+    return fetch(`/api/v1/admin/info_support_links/${id}`, {
+      credentials: 'same-origin',
+      method: 'PUT',
+      headers: jsonHeaders,
+      body: JSON.stringify(params),
+    }).then((response) => response.json());
+  }
+
+  static delete(id) {
+    return fetch(`/api/v1/admin/info_support_links/${id}`, {
+      credentials: 'same-origin',
+      method: 'DELETE',
+    });
+  }
+}

--- a/app/models/info_support_link.rb
+++ b/app/models/info_support_link.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: info_support_links
+#
+#  id         :bigint           not null, primary key
+#  enabled    :boolean          default(TRUE), not null
+#  label      :string           not null
+#  position   :integer          default(0), not null
+#  url        :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class InfoSupportLink < ApplicationRecord
+  URL_FORMAT = %r{\Ahttps?://.+}i.freeze
+
+  validates :label, presence: true, length: { maximum: 255 }
+  validates :url, presence: true, length: { maximum: 2048 }, format: { with: URL_FORMAT }
+
+  scope :enabled, -> { where(enabled: true) }
+  scope :ordered, -> { order(:position, :id) }
+
+  default_scope { ordered }
+end

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -4,6 +4,8 @@
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title #{ENV['APPLICATION_TITLE'].presence || 'Chemotion'}
     = stylesheet_link_tag 'application', media: 'all'
+    - info_support_links_json = InfoSupportLink.enabled.ordered.map { |l| { id: l.id, label: l.label, url: l.url } }.to_json
+    = javascript_tag "window.__INFO_SUPPORT_LINKS__ = #{raw json_escape(info_support_links_json)};", nonce: content_security_policy_nonce
     = javascript_pack_tag 'application', nonce: content_security_policy_nonce
     = csrf_meta_tags
   %body

--- a/db/migrate/20260417101400_create_info_support_links.rb
+++ b/db/migrate/20260417101400_create_info_support_links.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateInfoSupportLinks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :info_support_links do |t|
+      t.string  :label, null: false
+      t.string  :url, null: false
+      t.integer :position, null: false, default: 0
+      t.boolean :enabled, null: false, default: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_03_25_085008) do
+ActiveRecord::Schema.define(version: 2026_04_17_101400) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -783,6 +783,15 @@ ActiveRecord::Schema.define(version: 2026_03_25_085008) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.time "deleted_at"
+  end
+
+  create_table "info_support_links", force: :cascade do |t|
+    t.string "label", null: false
+    t.string "url", null: false
+    t.integer "position", default: 0, null: false
+    t.boolean "enabled", default: true, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "inventories", force: :cascade do |t|

--- a/spec/api/chemotion/admin_info_support_api_spec.rb
+++ b/spec/api/chemotion/admin_info_support_api_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe Chemotion::AdminInfoSupportAPI do
+  let!(:admin) { create(:admin) }
+  let!(:person) { create(:person) }
+  let(:warden_instance) { instance_double(WardenAuthentication) }
+
+  describe 'when the current user is an admin' do
+    before do
+      allow(WardenAuthentication).to receive(:new).and_return(warden_instance)
+      allow(warden_instance).to receive(:current_user).and_return(admin)
+    end
+
+    describe 'GET /api/v1/admin/info_support_links' do
+      let!(:enabled_link) { create(:info_support_link, label: 'Local RDM', url: 'https://rdm.example.org', enabled: true) }
+      let!(:disabled_link) { create(:info_support_link, enabled: false) }
+
+      it 'returns all links including disabled ones' do
+        get '/api/v1/admin/info_support_links'
+        expect(response).to have_http_status(:ok)
+        labels = parsed_json_response.pluck('label')
+        expect(labels).to include(enabled_link.label, disabled_link.label)
+      end
+    end
+
+    describe 'POST /api/v1/admin/info_support_links' do
+      it 'creates a link with valid params' do
+        expect do
+          post '/api/v1/admin/info_support_links',
+               params: { label: 'Local RDM', url: 'https://rdm.example.org', position: 1 }
+        end.to change(InfoSupportLink, :count).by(1)
+
+        expect(response).to have_http_status(:created).or have_http_status(:ok)
+        expect(parsed_json_response['label']).to eq('Local RDM')
+      end
+
+      it 'returns 422 for an invalid url' do
+        post '/api/v1/admin/info_support_links', params: { label: 'Bad', url: 'not-a-url' }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    describe 'PUT /api/v1/admin/info_support_links/:id' do
+      let!(:link) { create(:info_support_link, label: 'Old', enabled: true) }
+
+      it 'updates fields' do
+        put "/api/v1/admin/info_support_links/#{link.id}", params: { label: 'New', enabled: false }
+        expect(response).to have_http_status(:ok)
+        expect(link.reload.label).to eq('New')
+        expect(link.reload.enabled).to be(false)
+      end
+    end
+
+    describe 'DELETE /api/v1/admin/info_support_links/:id' do
+      let!(:link) { create(:info_support_link) }
+
+      it 'deletes the link' do
+        expect do
+          delete "/api/v1/admin/info_support_links/#{link.id}"
+        end.to change(InfoSupportLink, :count).by(-1)
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+  end
+
+  describe 'when the current user is not an admin' do
+    before do
+      allow(WardenAuthentication).to receive(:new).and_return(warden_instance)
+      allow(warden_instance).to receive(:current_user).and_return(person)
+    end
+
+    it 'rejects GET with 401' do
+      get '/api/v1/admin/info_support_links'
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'rejects POST with 401' do
+      post '/api/v1/admin/info_support_links', params: { label: 'X', url: 'https://x.example.org' }
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/factories/info_support_links.rb
+++ b/spec/factories/info_support_links.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :info_support_link, class: 'InfoSupportLink' do
+    sequence(:label) { |n| "Local resource #{n}" }
+    sequence(:url) { |n| "https://example.org/resource-#{n}" }
+    position { 0 }
+    enabled { true }
+  end
+end

--- a/spec/models/info_support_link_spec.rb
+++ b/spec/models/info_support_link_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: info_support_links
+#
+#  id         :bigint           not null, primary key
+#  enabled    :boolean          default(TRUE), not null
+#  label      :string           not null
+#  position   :integer          default(0), not null
+#  url        :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+RSpec.describe InfoSupportLink, type: :model do
+  describe 'validations' do
+    it 'requires a label' do
+      link = described_class.new(url: 'https://example.org')
+      expect(link).not_to be_valid
+      expect(link.errors[:label]).to be_present
+    end
+
+    it 'requires a url' do
+      link = described_class.new(label: 'Local RDM')
+      expect(link).not_to be_valid
+      expect(link.errors[:url]).to be_present
+    end
+
+    it 'rejects urls without http(s) scheme' do
+      link = described_class.new(label: 'Bad', url: 'ftp://nope.org')
+      expect(link).not_to be_valid
+      expect(link.errors[:url]).to be_present
+    end
+
+    it 'accepts https urls' do
+      link = described_class.new(label: 'Local RDM', url: 'https://rdm.example.org')
+      expect(link).to be_valid
+    end
+  end
+
+  describe 'scopes' do
+    let!(:enabled_link) { create(:info_support_link, enabled: true, position: 2) }
+    let!(:disabled_link) { create(:info_support_link, enabled: false, position: 1) }
+    let!(:other_enabled_link) { create(:info_support_link, enabled: true, position: 1) }
+
+    it '.enabled returns only enabled rows' do
+      expect(described_class.enabled).to contain_exactly(enabled_link, other_enabled_link)
+      expect(described_class.enabled).not_to include(disabled_link)
+    end
+
+    it '.ordered sorts by position then id' do
+      ordered = described_class.ordered.to_a
+      expect(ordered.index(other_enabled_link)).to be < ordered.index(enabled_link)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds an admin UI under **Admin → Info & Support Links** to manage a list of custom links that appear in two user-facing menus, alongside the hardcoded chemotion.net entries:

- The **"Chemotion"** dropdown in the top navbar (`NavHead`).
- The **"Support"** menu (`SupportMenuButton`).

Each link has a label, URL, position, and an enabled flag. Disabled links stay in the admin list but are not shown to users.

Use case: local instances can surface their own RDM team, helpdesk, intranet docs, etc. without needing a fork or a deployment-time config change.

Closes #3079.

## How it works

- A new `info_support_links` table backs an `InfoSupportLink` model that validates `https?://` URLs and exposes `enabled` / `ordered` scopes (default-ordered by `position`, then `id`).
- Admin CRUD is served by a new admin-gated Grape resource at `/api/v1/admin/info_support_links`.
- On every page load, `application.haml` injects the enabled links (label + URL only) into `window.__INFO_SUPPORT_LINKS__` via a nonce'd `<script>` tag; both menus read that global and render the links below a divider, after the built-in entries.
