### PR TITLE
fix: checkbox mutual exclusion and label display

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -66,7 +66,6 @@ const productLink = (product, active) => (
     >
       <i className="icon-sample mx-1" />
       {product.title()}
-      hah
     </span>
   </span>
 );

--- a/app/javascript/src/apps/mydb/elements/list/ElementsTableSettings.js
+++ b/app/javascript/src/apps/mydb/elements/list/ElementsTableSettings.js
@@ -53,6 +53,7 @@ export default class ElementsTableSettings extends React.Component {
     this.handleToggleScheme = this.handleToggleScheme.bind(this);
     this.onChangeUser = this.onChangeUser.bind(this);
     this.onChangeUI = this.onChangeUI.bind(this);
+    this._saveLabelTimeout = null;
   }
 
   componentDidMount() {
@@ -65,6 +66,15 @@ export default class ElementsTableSettings extends React.Component {
   componentWillUnmount() {
     UserStore.unlisten(this.onChangeUser);
     UIStore.unlisten(this.onChangeUI);
+    if (this._saveLabelTimeout) {
+      clearTimeout(this._saveLabelTimeout);
+      const { showSampleExternalLabel, showSampleShortLabel, showSampleName } = this.state;
+      UserActions.updateUserProfile({
+        show_external_name: showSampleExternalLabel,
+        show_sample_short_label: showSampleShortLabel,
+        show_sample_name: showSampleName,
+      });
+    }
   }
 
   componentDidUpdate(prevProps) {
@@ -89,11 +99,11 @@ export default class ElementsTableSettings extends React.Component {
 
   onChangeUser(state) {
     let { currentType } = this.state;
-    if (state && state.profile) {
+    if (state && state.profile && !this._saveLabelTimeout) {
       this.setState({
-        showSampleExternalLabel: state.profile.show_external_name,
-        showSampleName: state.profile.show_sample_name,
-        showSampleShortLabel: state.profile.show_sample_short_label
+        showSampleExternalLabel: !!state.profile.show_external_name,
+        showSampleName: !!state.profile.show_sample_name,
+        showSampleShortLabel: !!state.profile.show_sample_short_label
       });
     }
     if (state && (currentType !== state.currentType)) {
@@ -103,6 +113,9 @@ export default class ElementsTableSettings extends React.Component {
 
   onToggleTabLayoutContainer(show) {
     if (!show) {
+      clearTimeout(this._saveLabelTimeout);
+      this._saveLabelTimeout = null;
+
       this.updateLayout();
 
       if (this.state.currentType == "sample" || this.state.currentType == "reaction") {
@@ -112,14 +125,6 @@ export default class ElementsTableSettings extends React.Component {
           UIActions.toggleShowPreviews(cur_previews);
         }
       }
-
-      const { showSampleExternalLabel, showSampleShortLabel, showSampleName } = this.state;
-
-      UserActions.updateUserProfile({
-        show_external_name: showSampleExternalLabel,
-        show_sample_short_label: showSampleShortLabel,
-        show_sample_name: showSampleName
-      });
     }
   }
 
@@ -128,37 +133,45 @@ export default class ElementsTableSettings extends React.Component {
     this.setState({ tableSchemePreviews: !tableSchemePreviews });
   }
 
+  scheduleSaveLabels() {
+    clearTimeout(this._saveLabelTimeout);
+    this._saveLabelTimeout = setTimeout(() => {
+      const { showSampleExternalLabel, showSampleShortLabel, showSampleName } = this.state;
+      UserActions.updateUserProfile({
+        show_external_name: showSampleExternalLabel,
+        show_sample_short_label: showSampleShortLabel,
+        show_sample_name: showSampleName,
+      });
+    }, 300);
+  }
+
   handleToggleSampleExt() {
-    const { showSampleExternalLabel } = this.state;
-    this.setState({
-      showSampleExternalLabel: !showSampleExternalLabel,
-      showSampleShortLabel: false,
-      showSampleName: false
-    });
+    this.setState(
+      ({ showSampleExternalLabel }) => ({ showSampleExternalLabel: !showSampleExternalLabel }),
+      this.scheduleSaveLabels
+    );
   }
 
   handleToggleSampleShortLabel() {
-    const { showSampleShortLabel } = this.state;
-    this.setState({
-      showSampleShortLabel: !showSampleShortLabel,
-      showSampleExternalLabel: false,
-      showSampleName: false
-    });
+    this.setState(
+      ({ showSampleShortLabel }) => ({ showSampleShortLabel: !showSampleShortLabel }),
+      this.scheduleSaveLabels
+    );
   }
 
   handleToggleSampleName() {
-    const { showSampleName } = this.state;
-    this.setState({
-      showSampleName: !showSampleName,
-      showSampleExternalLabel: false,
-      showSampleShortLabel: false
-    });
+    this.setState(
+      ({ showSampleName }) => ({ showSampleName: !showSampleName }),
+      this.scheduleSaveLabels
+    );
   }
 
   updateLayout() {
-    const { visible, hidden } = this.state;
-    const layout = {};
+    const { visible, hidden, showSampleExternalLabel, showSampleShortLabel, showSampleName } = this.state;
+    const userProfile = UserStore.getState().profile;
+    if (!userProfile) return;
 
+    const layout = {};
     visible.forEach((value, index) => {
       layout[value] = (index + 1);
     });
@@ -166,9 +179,13 @@ export default class ElementsTableSettings extends React.Component {
       layout[value] = (- index - 1);
     });
 
-    const userProfile = UserStore.getState().profile;
-    userProfile.data.layout = layout;
-    UserActions.updateUserProfile(userProfile);
+    UserActions.updateUserProfile({
+      ...userProfile,
+      data: { ...(userProfile.data || {}), layout },
+      show_external_name: showSampleExternalLabel,
+      show_sample_short_label: showSampleShortLabel,
+      show_sample_name: showSampleName,
+    });
   }
 
   render() {
@@ -183,6 +200,10 @@ export default class ElementsTableSettings extends React.Component {
     } = this.state;
 
     const showSettings = (currentType === 'sample' || currentType === 'reaction');
+    const isSample = currentType === 'sample';
+    const otherLabelChecked = showSampleExternalLabel || showSampleName;
+    const shortLabelDisabled = !otherLabelChecked;
+    const shortLabelChecked = shortLabelDisabled ? true : showSampleShortLabel;
     const popoverSettings = (
       <Popover className="d-flex popover-multi">
         {showSettings && (
@@ -196,24 +217,29 @@ export default class ElementsTableSettings extends React.Component {
                   checked={tableSchemePreviews}
                   label="Show schemes images"
                 />
-                <Form.Check
-                  type="checkbox"
-                  onChange={this.handleToggleSampleExt}
-                  checked={showSampleExternalLabel}
-                  label="Show sample external name on title"
-                />
-                <Form.Check
-                  type="checkbox"
-                  onChange={this.handleToggleSampleShortLabel}
-                  checked={showSampleShortLabel}
-                  label="Show sample short label"
-                />
-                <Form.Check
-                  type="checkbox"
-                  onChange={this.handleToggleSampleName}
-                  checked={showSampleName}
-                  label="Show sample name"
-                />
+                {isSample && (
+                  <>
+                    <Form.Check
+                      type="checkbox"
+                      onChange={this.handleToggleSampleExt}
+                      checked={showSampleExternalLabel}
+                      label="Show sample external name on title"
+                    />
+                    <Form.Check
+                      type="checkbox"
+                      onChange={this.handleToggleSampleShortLabel}
+                      checked={shortLabelChecked}
+                      disabled={shortLabelDisabled}
+                      label="Show sample short label"
+                    />
+                    <Form.Check
+                      type="checkbox"
+                      onChange={this.handleToggleSampleName}
+                      checked={showSampleName}
+                      label="Show sample name"
+                    />
+                  </>
+                )}
               </Form>
             </Popover.Body>
           </div>

--- a/app/javascript/src/apps/mydb/elements/list/ElementsTableSettings.js
+++ b/app/javascript/src/apps/mydb/elements/list/ElementsTableSettings.js
@@ -68,6 +68,7 @@ export default class ElementsTableSettings extends React.Component {
     UIStore.unlisten(this.onChangeUI);
     if (this._saveLabelTimeout) {
       clearTimeout(this._saveLabelTimeout);
+      this._saveLabelTimeout = null;
       const { showSampleExternalLabel, showSampleShortLabel, showSampleName } = this.state;
       UserActions.updateUserProfile({
         show_external_name: showSampleExternalLabel,
@@ -136,6 +137,7 @@ export default class ElementsTableSettings extends React.Component {
   scheduleSaveLabels() {
     clearTimeout(this._saveLabelTimeout);
     this._saveLabelTimeout = setTimeout(() => {
+      this._saveLabelTimeout = null;
       const { showSampleExternalLabel, showSampleShortLabel, showSampleName } = this.state;
       UserActions.updateUserProfile({
         show_external_name: showSampleExternalLabel,

--- a/app/javascript/src/models/Sample.js
+++ b/app/javascript/src/models/Sample.js
@@ -489,17 +489,31 @@ export default class Sample extends Element {
     const { profile } = UserStore.getState();
     const show_external_name = profile ? profile.show_external_name : false;
     const show_sample_name = profile ? profile.show_sample_name : false;
-    const { external_label } = this;
+    const show_sample_short_label = profile ? profile.show_sample_short_label : false;
+    const { external_label, name, short_label } = this;
     const extLabelClass = 'label--bold';
-    const { name } = this;
-    const { short_label } = this;
 
-    if (show_external_name) {
-      return (external_label ? <span className={extLabelClass}>{external_label}</span> : short_label);
-    } if (show_sample_name) {
-      return (name ? <span className={extLabelClass}>{name}</span> : short_label);
-    }
-    return short_label;
+    const otherChecked = show_external_name || show_sample_name;
+    const showShortLabel = !otherChecked || show_sample_short_label;
+
+    const parts = [];
+    if (showShortLabel) parts.push(<span key="short">{short_label}</span>);
+    if (show_sample_name && name) parts.push(<span key="name" className={extLabelClass}>{name}</span>);
+    if (show_external_name && external_label) parts.push(<span key="ext" className={extLabelClass}>{external_label}</span>);
+
+    if (parts.length === 0) return short_label;
+    if (parts.length === 1) return parts[0];
+
+    return (
+      <span className="d-flex gap-1 align-items-center">
+        {parts.map((part, i) => (
+          <React.Fragment key={i}>
+            {i > 0 && <span className="text-muted">|</span>}
+            {part}
+          </React.Fragment>
+        ))}
+      </span>
+    );
   }
 
   get molecule_name_label() {


### PR DESCRIPTION
- Fix checkbox mutual exclusion for sample label options. Each checkbox now toggles independently                                                                            
- Fix label selections being lost on settings interaction. All three label values saved together on each toggle to prevent partial API updates.
- Short label checkbox is locked when no other label option is selected (always visible fallback)
- Label checkboxes now restricted to the sample list only
- Multiple selected labels shown inline with `|` separator in sample title     

Closes: #3015, #2681 
Test Instance: https://az-label.deploy.chemdev.scc.kit.edu/

----------------------------
- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
