### PR TITLE
fix: reactants search regex improvements

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/MaterialGroup.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/MaterialGroup.js
@@ -200,13 +200,20 @@ function GeneralMaterialGroup({
         });
     };
 
+    const filterReagents = (option, inputValue) => {
+      if (!inputValue) return true;
+      const normalizedInput = inputValue.replace(/\s+/g, '');
+      const normalizedLabel = option.label.replace(/\s+/g, '');
+      return normalizedLabel.toLowerCase().includes(normalizedInput.toLowerCase());
+    };
+
     reagentDd = (
       <Select
         isDisabled={!permitOn(reaction)}
-        value={null}
         options={reagentList}
         placeholder="Add"
         onChange={createReagentForReaction}
+        filterOption={filterReagents}
         size="xsm"
         styles={{
           menu: (base) => ({
@@ -388,6 +395,13 @@ function SolventsMaterialGroup({
     }
   }), defaultMultiSolventsSmilesOptions);
 
+  const filterSolvents = (option, inputValue) => {
+    if (!inputValue) return true;
+    const normalizedInput = inputValue.replace(/\s+/g, '');
+    const normalizedLabel = option.label.replace(/\s+/g, '');
+    return normalizedLabel.toLowerCase().includes(normalizedInput.toLowerCase());
+  };
+
   return (
     <ReorderableMaterialContainer
       materials={materials}
@@ -416,11 +430,11 @@ function SolventsMaterialGroup({
                 {addSampleButton}
                 {groupHeaders.group}
                 <Select
-                  value={null}
                   isDisabled={!permitOn(reaction)}
                   options={solventOptions}
                   placeholder="Add"
                   onChange={createDefaultSolventsForReaction}
+                  filterOption={filterSolvents}
                   size="xsm"
                 />
               </div>

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionConditions.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionConditions.js
@@ -92,6 +92,13 @@ export default function ReactionConditions({
     handleChange(conditions.filter((_, i) => i !== index));
   }, [conditions, handleChange]);
 
+  const filterConditions = useCallback((option, inputValue) => {
+    if (!inputValue) return true;
+    const normalizedInput = inputValue.replace(/\s+/g, '');
+    const normalizedLabel = option.label.replace(/\s+/g, '');
+    return normalizedLabel.toLowerCase().includes(normalizedInput.toLowerCase());
+  }, []);
+
   return (
     <div className="material-group">
       <div className="pseudo-table__row pseudo-table__row-header">
@@ -109,6 +116,7 @@ export default function ReactionConditions({
               multi={false}
               options={conditionsOptions}
               onChange={({ value }) => addCondition(value)}
+              filterOption={filterConditions}
               size="xsm"
               placeholder="Add"
             />


### PR DESCRIPTION
PR resolves: reactants search in a reaction regex improved for spacing

### before(with spaces not there):
<img width="570" height="157" alt="image" src="https://github.com/user-attachments/assets/f10b09e0-4a29-4ad5-b5f8-75c499dc2274" />

### after (both including with or without space):
<img width="267" height="150" alt="image" src="https://github.com/user-attachments/assets/a0484c59-bd67-4eaa-ad93-76f15adc5a74" />

-------------------


- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
