### PR TITLE
feat(sample): enhance melting/boiling point range input with decomposed toggle

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -46,6 +46,7 @@
 @import "components/ReorderableList";
 @import "components/SampleName";
 @import "components/SearchInput";
+@import "components/TextRangeWithAddon";
 @import "components/SearchModal";
 @import "components/SearchResult";
 @import "components/SelectionActions";

--- a/app/assets/stylesheets/components/TextRangeWithAddon.scss
+++ b/app/assets/stylesheets/components/TextRangeWithAddon.scss
@@ -1,0 +1,8 @@
+.text-range-alternative-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.85em;
+  line-height: 1.2;
+  margin-bottom: 0;
+}

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -434,10 +434,10 @@ export default class SampleForm extends React.Component {
     );
   }
 
-  handleRangeChanged(field, lower, upper) {
-    const { sample } = this.props;
-    sample.updateRange(field, lower, upper);
-    this.props.handleSampleChanged(sample);
+  handleRangeChanged(field, lower, upper, label) {
+    const { sample, handleSampleChanged } = this.props;
+    sample.updateRange(field, lower, upper, label);
+    handleSampleChanged(sample);
   }
 
   // Toggle the "Decomposed" state for melting point. When checked, the numeric
@@ -447,7 +447,7 @@ export default class SampleForm extends React.Component {
     const { sample, handleSampleChanged } = this.props;
     sample.xref = { ...(sample.xref || {}), melting_point_decomposed: !!checked };
     if (checked) {
-      sample.updateRange('melting_point', '', '');
+      sample.updateRange('melting_point', '', '', '');
     }
     handleSampleChanged(sample);
   }
@@ -1276,7 +1276,7 @@ export default class SampleForm extends React.Component {
                     value={sample.melting_point_display}
                     disabled={polyDisabled}
                     onChange={this.handleRangeChanged}
-                    tipOnText="Use space-separated value to input a Temperature range"
+                    tipOnText='Examples: "65", "65-68", "65 68", ">300", "<200"'
                     alternativeActive={!!(sample.xref && sample.xref.melting_point_decomposed)}
                     alternativeLabel="Decomposed"
                     alternativeToggleLabel="Decomposed"
@@ -1293,7 +1293,7 @@ export default class SampleForm extends React.Component {
                     value={sample.boiling_point_display}
                     disabled={polyDisabled}
                     onChange={this.handleRangeChanged}
-                    tipOnText="Use space-separated value to input a Temperature range"
+                    tipOnText='Examples: "65", "65-68", "65 68", ">300", "<200"'
                   />
                 </Col>
                 <Col>{this.inputWithUnit(sample, 'xref_flash_point', 'Flash point')}</Col>

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -48,6 +48,7 @@ export default class SampleForm extends React.Component {
     this.updateStereoRel = this.updateStereoRel.bind(this);
     this.addMolName = this.addMolName.bind(this);
     this.handleRangeChanged = this.handleRangeChanged.bind(this);
+    this.handleMeltingPointDecomposedChanged = this.handleMeltingPointDecomposedChanged.bind(this);
     this.handleMetricsChange = this.handleMetricsChange.bind(this);
     this.fetchNextInventoryLabel = this.fetchNextInventoryLabel.bind(this);
     this.matchSelectedCollection = this.matchSelectedCollection.bind(this);
@@ -437,6 +438,18 @@ export default class SampleForm extends React.Component {
     const { sample } = this.props;
     sample.updateRange(field, lower, upper);
     this.props.handleSampleChanged(sample);
+  }
+
+  // Toggle the "Decomposed" state for melting point. When checked, the numeric
+  // range is cleared because the substance decomposes before melting and no
+  // temperature can be measured.
+  handleMeltingPointDecomposedChanged(checked) {
+    const { sample, handleSampleChanged } = this.props;
+    sample.xref = { ...(sample.xref || {}), melting_point_decomposed: !!checked };
+    if (checked) {
+      sample.updateRange('melting_point', '', '');
+    }
+    handleSampleChanged(sample);
   }
 
   /* eslint-disable camelcase */
@@ -1254,7 +1267,7 @@ export default class SampleForm extends React.Component {
                 <Col>{this.textInput(sample, 'xref_color', 'Color')}</Col>
                 <Col>{this.textInput(sample, 'xref_solubility', 'Soluble in')}</Col>
               </Row>
-              <Row className="align-items-end mb-4">
+              <Row className="align-items-start mb-4">
                 <Col>
                   <TextRangeWithAddon
                     field="melting_point"
@@ -1264,6 +1277,11 @@ export default class SampleForm extends React.Component {
                     disabled={polyDisabled}
                     onChange={this.handleRangeChanged}
                     tipOnText="Use space-separated value to input a Temperature range"
+                    alternativeActive={!!(sample.xref && sample.xref.melting_point_decomposed)}
+                    alternativeLabel="Decomposed"
+                    alternativeToggleLabel="Decomposed"
+                    alternativeToggleTooltip="Substance decomposes before melting; no temperature can be measured"
+                    onAlternativeToggle={this.handleMeltingPointDecomposedChanged}
                   />
                 </Col>
 

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/TextRangeWithAddon.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/TextRangeWithAddon.js
@@ -118,6 +118,10 @@ export default class TextRangeWithAddon extends Component {
         position: 'tc',
         autoDismiss: 8,
       });
+      // handleInputChange has been syncing the raw keystrokes into the model on every keypress.
+      // Clear both the input and the model fields so an invalid value isn't persisted.
+      this.input.value = '';
+      onChange(field, '', '', '');
       return;
     }
 

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/TextRangeWithAddon.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/TextRangeWithAddon.js
@@ -54,24 +54,45 @@ export default class TextRangeWithAddon extends Component {
 
   render() {
     const {
-      addon, disabled, label, tipOnText, value
+      addon, disabled, label, tipOnText, value,
+      alternativeActive, alternativeLabel, alternativeToggleLabel,
+      alternativeToggleTooltip, onAlternativeToggle, field
     } = this.props;
+
+    const showAlternative = Boolean(alternativeActive);
+    const inputValue = showAlternative ? alternativeLabel : value;
+    const inputDisabled = disabled || showAlternative;
+
     return (
       <Form.Group size="sm">
         <Form.Label>{label}</Form.Label>
         <InputGroup data-cy={"cy_"+label}>
           <Form.Control
-            title={tipOnText}
+            title={showAlternative ? alternativeLabel : tipOnText}
             type="text"
-            disabled={disabled}
-            value={value}
+            disabled={inputDisabled}
+            value={inputValue}
             ref={(ref) => { this.input = ref; }}
             onChange={(event) => this.handleInputChange(event)}
             onFocus={() => this.handleInputFocus()}
             onBlur={() => this.handleInputBlur()}
           />
-          <InputGroup.Text>{addon}</InputGroup.Text>
+          {!showAlternative && <InputGroup.Text>{addon}</InputGroup.Text>}
         </InputGroup>
+        {alternativeToggleLabel && onAlternativeToggle && (
+          <div className="mt-1">
+            <Form.Check
+              type="checkbox"
+              id={`alt_toggle_${field}`}
+              checked={showAlternative}
+              disabled={disabled}
+              label={alternativeToggleLabel}
+              title={alternativeToggleTooltip || alternativeToggleLabel}
+              onChange={(e) => onAlternativeToggle(e.target.checked)}
+              className="text-range-alternative-checkbox"
+            />
+          </div>
+        )}
       </Form.Group>
     );
   }
@@ -84,7 +105,12 @@ TextRangeWithAddon.propTypes = {
   addon: PropTypes.string,
   disabled: PropTypes.bool,
   onChange: PropTypes.func,
-  tipOnText: PropTypes.string
+  tipOnText: PropTypes.string,
+  alternativeActive: PropTypes.bool,
+  alternativeLabel: PropTypes.string,
+  alternativeToggleLabel: PropTypes.string,
+  alternativeToggleTooltip: PropTypes.string,
+  onAlternativeToggle: PropTypes.func,
 };
 
 TextRangeWithAddon.defaultProps = {
@@ -93,5 +119,10 @@ TextRangeWithAddon.defaultProps = {
   addon: '',
   disabled: false,
   onChange: () => {},
-  tipOnText: ''
+  tipOnText: '',
+  alternativeActive: false,
+  alternativeLabel: '',
+  alternativeToggleLabel: '',
+  alternativeToggleTooltip: '',
+  onAlternativeToggle: null,
 };

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/TextRangeWithAddon.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/TextRangeWithAddon.js
@@ -1,25 +1,103 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { InputGroup, Form } from 'react-bootstrap';
+import NotificationActions from 'src/stores/alt/actions/NotificationActions';
+
+const ALLOWED_INPUT_CHARS = /[-+0-9.,\s><=≥≤–]/;
+const NUMBER_REGEX = /-?\d+(?:\.\d+)?/g;
+const COMPARISON_PREFIX_REGEX = /^\s*(>=|<=|≥|≤|>|<)\s*(-?\d+(?:\.\d+)?)\s*$/;
+
+const humanizeFieldName = (field) => field
+  .replace(/_/g, ' ')
+  .replace(/\b\w/g, (m) => m.toUpperCase());
+
+// Parse the user input into structured bounds + a canonical label.
+// Returns null if the input cannot be parsed as a valid range.
+export const parseRangeInput = (rawInput) => {
+  const trimmed = (rawInput || '').trim();
+
+  if (trimmed === '') {
+    return {
+      lower: '', upper: '', label: '', kind: 'empty',
+    };
+  }
+
+  const comparisonMatch = trimmed.match(COMPARISON_PREFIX_REGEX);
+  if (comparisonMatch) {
+    const operator = comparisonMatch[1];
+    const number = Number.parseFloat(comparisonMatch[2]);
+    if (Number.isNaN(number)) return null;
+
+    if (operator === '>' || operator === '>=' || operator === '≥') {
+      return {
+        lower: number,
+        upper: Number.POSITIVE_INFINITY,
+        label: `${operator}${number}`,
+        kind: 'open-upper',
+      };
+    }
+    return {
+      lower: Number.NEGATIVE_INFINITY,
+      upper: number,
+      label: `${operator}${number}`,
+      kind: 'open-lower',
+    };
+  }
+
+  // Normalize common range separators to spaces so the parser can extract numbers.
+  // A dash is only treated as a separator when it is *directly* preceded by a digit
+  // (e.g. "65-68", "1.5-2.5"); a dash preceded by whitespace or beginning a number
+  // ("-65", "65 -68") is left intact as a negative sign.  The Unicode en-dash
+  // (used in our display format "65 – 68") is always treated as a separator.
+  const normalized = trimmed
+    .replace(/(\d)-(?=\s*-?\d)/g, '$1 ')
+    .replace(/\s*–\s*/g, ' ')
+    .replace(/\.{2,3}/g, ' ')
+    .replace(/,/g, ' ');
+
+  const numberMatches = normalized.match(NUMBER_REGEX);
+  if (!numberMatches || numberMatches.length === 0) return null;
+
+  const numbers = numberMatches
+    .map((s) => Number.parseFloat(s))
+    .filter((n) => !Number.isNaN(n));
+
+  if (numbers.length === 0) return null;
+
+  if (numbers.length === 1) {
+    const value = numbers[0];
+    return {
+      lower: value, upper: value, label: `${value}`, kind: 'single',
+    };
+  }
+
+  const lower = numbers[0];
+  const upper = numbers[numbers.length - 1];
+  if (upper < lower) return null;
+
+  return {
+    lower,
+    upper,
+    label: `${lower} – ${upper}`,
+    kind: 'range',
+  };
+};
 
 export default class TextRangeWithAddon extends Component {
   handleInputChange(e) {
+    const { onChange, field } = this.props;
     const input = e.target;
     input.focus();
     const { value, selectionStart } = input;
-    let newValue = value;
     const lastChar = value[selectionStart - 1] || '';
-    if (lastChar !== '' && !lastChar.match(/-|\d|\.| |(,)/)) {
-      const reg = new RegExp(lastChar, 'g');
-      newValue = newValue.replace(reg, '');
-      this.input.value = newValue;
+    if (lastChar !== '' && !lastChar.match(ALLOWED_INPUT_CHARS)) {
+      const reg = new RegExp(lastChar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
+      this.input.value = value.replace(reg, '');
       return;
     }
-    newValue = newValue.replace(/--/g, '');
-    newValue = newValue.replace(/,/g, '.');
-    newValue = newValue.replace(/\.+\./g, '.');
-    newValue = newValue.replace(/ - /g, ' ');
-    this.props.onChange(this.props.field, newValue, newValue);
+    // Don't pass a label argument here so we don't pollute xref on every keystroke;
+    // the canonical label is committed on blur.
+    onChange(field, value, value);
   }
 
   handleInputFocus() {
@@ -27,29 +105,30 @@ export default class TextRangeWithAddon extends Component {
   }
 
   handleInputBlur() {
-    const value = this.input.value.trim();
-    const result = value.match(/[-.0-9]+|[0-9]/g);
-    if (result) {
-      // eslint-disable-next-line no-restricted-globals
-      const nums = result.filter(r => !isNaN(r));
-      if (nums.length > 0) {
-        let lower = null;
-        let upper = null;
-        if (nums.length === 1) {
-          lower = nums.shift();
-          upper = lower;
-        } else {
-          lower = nums.shift();
-          upper = nums.pop();
-        }
-        this.props.onChange(this.props.field, Number.parseFloat(lower), Number.parseFloat(upper));
-      } else {
-        this.input.value = '';
-        this.props.onChange(this.props.field, '', '');
-      }
-    } else {
-      this.props.onChange(this.props.field, '', '');
+    const { onChange, field } = this.props;
+    const rawValue = this.input.value;
+    const parsed = parseRangeInput(rawValue);
+
+    if (parsed === null) {
+      const fieldLabel = humanizeFieldName(field);
+      NotificationActions.add({
+        title: `Invalid ${fieldLabel}`,
+        message: `Could not parse "${rawValue.trim()}". Use formats like "65", "65-68", "65 68", ">300", or "<200".`,
+        level: 'error',
+        position: 'tc',
+        autoDismiss: 8,
+      });
+      return;
     }
+
+    if (parsed.kind === 'empty') {
+      this.input.value = '';
+      onChange(field, '', '', '');
+      return;
+    }
+
+    this.input.value = parsed.label;
+    onChange(field, parsed.lower, parsed.upper, parsed.label);
   }
 
   render() {

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/TextRangeWithAddon.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/TextRangeWithAddon.js
@@ -4,8 +4,8 @@ import { InputGroup, Form } from 'react-bootstrap';
 import NotificationActions from 'src/stores/alt/actions/NotificationActions';
 
 const ALLOWED_INPUT_CHARS = /[-+0-9.,\s><=≥≤–]/;
-const NUMBER_REGEX = /-?\d+(?:\.\d+)?/g;
-const COMPARISON_PREFIX_REGEX = /^\s*(>=|<=|≥|≤|>|<)\s*(-?\d+(?:\.\d+)?)\s*$/;
+const NUMBER_REGEX = /-?(?:\d+(?:\.\d+)?|\.\d+)/g;
+const COMPARISON_PREFIX_REGEX = /^\s*(>=|<=|≥|≤|>|<)\s*(-?(?:\d+(?:\.\d+)?|\.\d+))\s*$/;
 
 const humanizeFieldName = (field) => field
   .replace(/_/g, ' ')
@@ -53,7 +53,7 @@ export const parseRangeInput = (rawInput) => {
     .replace(/(\d)-(?=\s*-?\d)/g, '$1 ')
     .replace(/\s*–\s*/g, ' ')
     .replace(/\.{2,3}/g, ' ')
-    .replace(/,/g, ' ');
+    .replace(/,/g, '.');
 
   const numberMatches = normalized.match(NUMBER_REGEX);
   if (!numberMatches || numberMatches.length === 0) return null;

--- a/app/javascript/src/models/Sample.js
+++ b/app/javascript/src/models/Sample.js
@@ -35,11 +35,21 @@ const prepareRangeBound = (args = {}, field) => {
     if (!args[`${field}_lowerbound`]) {
       argsNew[`${field}_lowerbound`] = Number.NEGATIVE_INFINITY === Number(bounds[0]) ? null : Number(bounds[0]);
     }
-    if (argsNew[`${field}_upperbound`] == null || argsNew[`${field}_upperbound`] == null) {
-      argsNew[`${field}_display`] = (argsNew[`${field}_lowerbound`] || '').toString().trim();
+
+    const xrefLabel = args.xref && args.xref[`${field}_label`];
+    const lower = argsNew[`${field}_lowerbound`];
+    const upper = argsNew[`${field}_upperbound`];
+
+    if (xrefLabel) {
+      argsNew[`${field}_display`] = xrefLabel;
+    } else if (lower == null && upper == null) {
+      argsNew[`${field}_display`] = '';
+    } else if (lower == null) {
+      argsNew[`${field}_display`] = `<${upper}`;
+    } else if (upper == null) {
+      argsNew[`${field}_display`] = lower.toString().trim();
     } else {
-      argsNew[`${field}_display`] = ((argsNew[`${field}_lowerbound`] || '')
-        .toString().concat(' – ', argsNew[`${field}_upperbound`])).trim();
+      argsNew[`${field}_display`] = `${lower} – ${upper}`.trim();
     }
   }
   return argsNew;
@@ -644,20 +654,67 @@ export default class Sample extends Element {
     this._imported_readout = imported_readout;
   }
 
-  updateRange(field, lower, upper) {
-    this[`${field}_lowerbound`] = lower;
-    this[`${field}_upperbound`] = upper;
-    if (lower === '' && upper === '') {
-      this[`${field}_display`] = lower.toString();
-      this[field] = lower.toString();
-    } else if (lower === upper) {
-      this[`${field}_upperbound`] = '';
-      this[`${field}_display`] = lower.toString();
-      this[field] = lower.toString().concat('...', Number.POSITIVE_INFINITY);
+  // Returns true when a bound value represents an open (unbounded) end of a range.
+  static isOpenBound(value) {
+    return value === '' || value == null
+      || value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY
+      || value === '-Infinity' || value === 'Infinity';
+  }
+
+  // Persists or removes the human-readable label in xref so it survives a reload.
+  updateRangeLabel(field, label) {
+    this.xref = { ...(this.xref || {}) };
+    if (label === '' || label == null) {
+      delete this.xref[`${field}_label`];
     } else {
-      this[`${field}_display`] = (lower.toString().concat(' – ', upper)).trim();
-      this[field] = lower.toString().concat('..', upper);
+      this.xref[`${field}_label`] = label;
     }
+  }
+
+  // Derives the display string shown in the UI input from the normalised bounds.
+  static rangeDisplayText(lowerForApi, upperForApi, isOpenLower, isOpenUpper, label) {
+    if (label) return label;
+
+    if (isOpenLower && isOpenUpper) return '';
+
+    if (isOpenLower) return `<${upperForApi}`;
+    if (isOpenUpper) return lowerForApi.toString();
+
+    if (lowerForApi === upperForApi) return lowerForApi.toString();
+
+    return `${lowerForApi} – ${upperForApi}`.trim();
+  }
+
+  // Serializes the bounds into the Ruby range literal stored on the model
+  // and sent to the API (e.g. "65..68", "65...Infinity", "-Infinity..200").
+  static rangeSerialised(lowerForApi, upperForApi, isOpenLower, isOpenUpper) {
+    if (isOpenLower && isOpenUpper) return '';
+    if (isOpenLower) return `-Infinity..${upperForApi}`;
+    if (isOpenUpper || lowerForApi === upperForApi) return `${lowerForApi}...${Number.POSITIVE_INFINITY}`;
+
+    return `${lowerForApi}..${upperForApi}`;
+  }
+
+  updateRange(field, lower, upper, label = undefined) {
+    const isOpenLower = Sample.isOpenBound(lower);
+    const isOpenUpper = Sample.isOpenBound(upper);
+
+    const lowerForApi = isOpenLower ? '' : lower;
+    const upperForApi = isOpenUpper ? '' : upper;
+
+    this[`${field}_lowerbound`] = lowerForApi;
+    this[`${field}_upperbound`] = upperForApi;
+
+    if (label !== undefined) this.updateRangeLabel(field, label);
+
+    const displayText = Sample.rangeDisplayText(lowerForApi, upperForApi, isOpenLower, isOpenUpper, label);
+    // When both bounds are equal treat it as a single-value entry (no upper stored).
+    if (!isOpenLower && !isOpenUpper && lowerForApi === upperForApi) {
+      this[`${field}_upperbound`] = '';
+    }
+
+    this[`${field}_display`] = displayText;
+    this[field] = Sample.rangeSerialised(lowerForApi, upperForApi, isOpenLower, isOpenUpper);
   }
 
   /**

--- a/app/javascript/src/models/Sample.js
+++ b/app/javascript/src/models/Sample.js
@@ -705,7 +705,9 @@ export default class Sample extends Element {
     this[`${field}_lowerbound`] = lowerForApi;
     this[`${field}_upperbound`] = upperForApi;
 
-    if (label !== undefined) this.updateRangeLabel(field, label);
+    // Always synchronize the persisted xref label with the current update so
+    // stale labels do not survive calls that only change/clear the bounds.
+    this.updateRangeLabel(field, label === undefined ? '' : label);
 
     const displayText = Sample.rangeDisplayText(lowerForApi, upperForApi, isOpenLower, isOpenUpper, label);
     // When both bounds are equal treat it as a single-value entry (no upper stored).

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/samples/propertiesTab/TextRangeWithAddon.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/samples/propertiesTab/TextRangeWithAddon.spec.js
@@ -128,10 +128,15 @@ describe('parseRangeInput', () => {
     expect(parseRangeInput('  65 - 68  ').lower).toBe(65);
   });
 
-  it('tolerates a comma as a decimal/range separator', () => {
-    const result = parseRangeInput('65,68');
-    expect(result.kind).toBe('range');
-    expect(result.lower).toBe(65);
-    expect(result.upper).toBe(68);
+  it('parses decimal-comma input as numeric values', () => {
+    const singleValueResult = parseRangeInput('65,5');
+    expect(singleValueResult.kind).toBe('single');
+    expect(singleValueResult.lower).toBe(65.5);
+    expect(singleValueResult.upper).toBe(65.5);
+
+    const rangeResult = parseRangeInput('1,5-2,5');
+    expect(rangeResult.kind).toBe('range');
+    expect(rangeResult.lower).toBe(1.5);
+    expect(rangeResult.upper).toBe(2.5);
   });
 });

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/samples/propertiesTab/TextRangeWithAddon.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/samples/propertiesTab/TextRangeWithAddon.spec.js
@@ -1,0 +1,137 @@
+/* global describe, it */
+
+import expect from 'expect';
+import { parseRangeInput } from 'src/apps/mydb/elements/details/samples/propertiesTab/TextRangeWithAddon';
+
+describe('parseRangeInput', () => {
+  it('treats an empty string as an empty range', () => {
+    const result = parseRangeInput('');
+    expect(result).toEqual({
+      lower: '', upper: '', label: '', kind: 'empty',
+    });
+  });
+
+  it('treats whitespace-only input as an empty range', () => {
+    expect(parseRangeInput('   ').kind).toBe('empty');
+  });
+
+  it('parses a single positive number', () => {
+    const result = parseRangeInput('65');
+    expect(result.kind).toBe('single');
+    expect(result.lower).toBe(65);
+    expect(result.upper).toBe(65);
+    expect(result.label).toBe('65');
+  });
+
+  it('parses a single negative number', () => {
+    const result = parseRangeInput('-65');
+    expect(result.kind).toBe('single');
+    expect(result.lower).toBe(-65);
+    expect(result.upper).toBe(-65);
+  });
+
+  it('parses a decimal value', () => {
+    const result = parseRangeInput('65.5');
+    expect(result.lower).toBe(65.5);
+    expect(result.upper).toBe(65.5);
+  });
+
+  it('parses a dash-separated range "65-68"', () => {
+    const result = parseRangeInput('65-68');
+    expect(result.kind).toBe('range');
+    expect(result.lower).toBe(65);
+    expect(result.upper).toBe(68);
+    expect(result.label).toBe('65 – 68');
+  });
+
+  it('parses a space-separated range "65 68"', () => {
+    const result = parseRangeInput('65 68');
+    expect(result.kind).toBe('range');
+    expect(result.lower).toBe(65);
+    expect(result.upper).toBe(68);
+  });
+
+  it('parses an en-dash range "65 – 68"', () => {
+    const result = parseRangeInput('65 – 68');
+    expect(result.kind).toBe('range');
+    expect(result.lower).toBe(65);
+    expect(result.upper).toBe(68);
+  });
+
+  it('parses a two-dot separated range "65..68"', () => {
+    const result = parseRangeInput('65..68');
+    expect(result.kind).toBe('range');
+    expect(result.lower).toBe(65);
+    expect(result.upper).toBe(68);
+  });
+
+  it('parses a range with decimals "1.5-2.5"', () => {
+    const result = parseRangeInput('1.5-2.5');
+    expect(result.kind).toBe('range');
+    expect(result.lower).toBe(1.5);
+    expect(result.upper).toBe(2.5);
+  });
+
+  it('parses a range of negative numbers separated by spaces', () => {
+    const result = parseRangeInput('-65 -60');
+    expect(result.kind).toBe('range');
+    expect(result.lower).toBe(-65);
+    expect(result.upper).toBe(-60);
+  });
+
+  it('parses ">300" as an open-upper range', () => {
+    const result = parseRangeInput('>300');
+    expect(result.kind).toBe('open-upper');
+    expect(result.lower).toBe(300);
+    expect(result.upper).toBe(Number.POSITIVE_INFINITY);
+    expect(result.label).toBe('>300');
+  });
+
+  it('parses ">=300" as an open-upper range', () => {
+    const result = parseRangeInput('>=300');
+    expect(result.kind).toBe('open-upper');
+    expect(result.lower).toBe(300);
+    expect(result.label).toBe('>=300');
+  });
+
+  it('parses "≥300" as an open-upper range', () => {
+    const result = parseRangeInput('≥300');
+    expect(result.kind).toBe('open-upper');
+    expect(result.lower).toBe(300);
+  });
+
+  it('parses "<200" as an open-lower range', () => {
+    const result = parseRangeInput('<200');
+    expect(result.kind).toBe('open-lower');
+    expect(result.lower).toBe(Number.NEGATIVE_INFINITY);
+    expect(result.upper).toBe(200);
+    expect(result.label).toBe('<200');
+  });
+
+  it('parses "<=200" as an open-lower range', () => {
+    const result = parseRangeInput('<=200');
+    expect(result.kind).toBe('open-lower');
+    expect(result.upper).toBe(200);
+  });
+
+  it('returns null for non-numeric input', () => {
+    expect(parseRangeInput('abc')).toBeNull();
+  });
+
+  it('returns null when upper bound is below lower bound', () => {
+    expect(parseRangeInput('100 50')).toBeNull();
+    expect(parseRangeInput('100-50')).toBeNull();
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseRangeInput('  65  ').lower).toBe(65);
+    expect(parseRangeInput('  65 - 68  ').lower).toBe(65);
+  });
+
+  it('tolerates a comma as a decimal/range separator', () => {
+    const result = parseRangeInput('65,68');
+    expect(result.kind).toBe('range');
+    expect(result.lower).toBe(65);
+    expect(result.upper).toBe(68);
+  });
+});

--- a/spec/javascripts/packs/src/models/Sample.spec.js
+++ b/spec/javascripts/packs/src/models/Sample.spec.js
@@ -991,6 +991,56 @@ describe('Sample', async () => {
       expect(sample.boiling_point_upperbound).toBe('');
       expect(sample.boiling_point_display).toBe('100');
     });
+
+    it('should treat positive infinity upper bound as open-ended', () => {
+      const sample = new Sample();
+      sample.updateRange('melting_point', 300, Number.POSITIVE_INFINITY, '>300');
+      expect(sample.melting_point_lowerbound).toBe(300);
+      expect(sample.melting_point_upperbound).toBe('');
+      expect(sample.melting_point_display).toBe('>300');
+      expect(sample.xref.melting_point_label).toBe('>300');
+    });
+
+    it('should treat negative infinity lower bound as open-ended', () => {
+      const sample = new Sample();
+      sample.updateRange('boiling_point', Number.NEGATIVE_INFINITY, 50, '<50');
+      expect(sample.boiling_point_lowerbound).toBe('');
+      expect(sample.boiling_point_upperbound).toBe(50);
+      expect(sample.boiling_point_display).toBe('<50');
+      expect(sample.xref.boiling_point_label).toBe('<50');
+    });
+
+    it('should remove the xref label when an empty label is supplied', () => {
+      const sample = new Sample();
+      sample.xref = { melting_point_label: '>300' };
+      sample.updateRange('melting_point', '', '', '');
+      expect(sample.xref.melting_point_label).toBeUndefined();
+      expect(sample.melting_point_display).toBe('');
+    });
+  });
+
+  describe('Sample.prepareRangeBound (via constructor)', () => {
+    it('uses xref label as display when present', () => {
+      const sample = new Sample({
+        melting_point: '300..Infinity',
+        xref: { melting_point_label: '>300' },
+      });
+      expect(sample.melting_point_display).toBe('>300');
+    });
+
+    it('formats open-upper bound without xref label as bare number', () => {
+      const sample = new Sample({ melting_point: '300..Infinity' });
+      expect(sample.melting_point_lowerbound).toBe(300);
+      expect(sample.melting_point_upperbound).toBeNull();
+      expect(sample.melting_point_display).toBe('300');
+    });
+
+    it('formats open-lower bound without xref label using "<" notation', () => {
+      const sample = new Sample({ melting_point: '-Infinity..200' });
+      expect(sample.melting_point_lowerbound).toBeNull();
+      expect(sample.melting_point_upperbound).toBe(200);
+      expect(sample.melting_point_display).toBe('<200');
+    });
   });
 
   describe('Sample.applyMixturePropertiesToSample()', () => {


### PR DESCRIPTION
This PR enhances sample melting/boiling point range entry by adding richer parsing, comparison-style labels, and a “Decomposed” toggle for melting points.
- Introduced a new `TextRangeWithAddon` component with styling for alternative checkbox.
- Updated `SampleForm` to include a toggle for the "Decomposed" state of melting point, clearing the numeric range when checked.
- Integrated the new component into the sample form, enhancing user interaction for melting point input.
- Enhance `SampleForm` and `TextRangeWithAddon` for improved range handling

Closes https://github.com/ComPlat/chemotion_ELN/issues/1151 and https://github.com/ComPlat/chemotion_ELN/issues/1725