### PR TITLE
fix(report): use real-first amount precedence for solvents in reaction docx

### DIFF
--- a/lib/reporter/docx/detail_reaction.rb
+++ b/lib/reporter/docx/detail_reaction.rb
@@ -742,9 +742,9 @@ module Reporter
         if solvents.present?
           solvents.map do |solvent|
             s = OpenStruct.new(solvent)
-            volume = if s.target_amount_value
-                       " (#{valid_digit(s.amount_ml, digit)}ml)"
-                     elsif s.real_amount_value
+            volume = if s.real_amount_value && s.real_amount_value != 0
+                       " (#{valid_digit(s.real_amount_ml, digit)}ml)"
+                     elsif s.target_amount_value && s.target_amount_value != 0
                        " (#{valid_digit(s.amount_ml, digit)}ml)"
                      end
             "#{s.preferred_label}#{volume}" if s.preferred_label

--- a/spec/lib/reporter/docx/detail_reaction_spec.rb
+++ b/spec/lib/reporter/docx/detail_reaction_spec.rb
@@ -324,6 +324,57 @@ describe 'Reporter::Docx::DetailReaction' do
       )
     end
 
+    context 'when building displayed_solvents' do
+      let(:solvent_real_only) do
+        {
+          preferred_label: 'DCM',
+          target_amount_value: 0,
+          real_amount_value: 5.0,
+          amount_ml: 0.0,
+          real_amount_ml: 5.0,
+        }
+      end
+      let(:solvent_target_only) do
+        {
+          preferred_label: 'EtOH',
+          target_amount_value: 3.0,
+          real_amount_value: nil,
+          amount_ml: 3.0,
+          real_amount_ml: 0.0,
+        }
+      end
+      let(:solvent_both) do
+        {
+          preferred_label: 'THF',
+          target_amount_value: 2.0,
+          real_amount_value: 4.5,
+          amount_ml: 2.0,
+          real_amount_ml: 4.5,
+        }
+      end
+
+      def detail_for(solvents)
+        Reporter::Docx::DetailReaction.new(
+          reaction: OpenStruct.new(solvents: solvents),
+          mol_serials: [],
+          index: prev_index,
+          si_rxn_settings: all_si_rxn_settings,
+        )
+      end
+
+      it 'uses real_amount_ml when only real amount is set' do
+        expect(detail_for([solvent_real_only]).send(:displayed_solvents)).to eq('DCM (5.00ml)')
+      end
+
+      it 'falls back to target amount_ml when real amount is zero/nil' do
+        expect(detail_for([solvent_target_only]).send(:displayed_solvents)).to eq('EtOH (3.00ml)')
+      end
+
+      it 'prefers real over target when both are set' do
+        expect(detail_for([solvent_both]).send(:displayed_solvents)).to eq('THF (4.50ml)')
+      end
+    end
+
     context 'when calculating_amount_mmol' do
       let(:valid_vessel_size) { { 'amount' => 10, 'unit' => 'ml' } }
       let!(:reaction_with_valid_vessel_size) { create(:reaction, vessel_size: valid_vessel_size) }


### PR DESCRIPTION
Aligns displayed_solvents with the real-first default applied across the rest of the reporter (and the codebase) so a solvent with only the real amount set no longer renders as "0ml". Also fixes a latent dead-arm bug where both branches printed the target-derived `amount_ml`.

refs: #2921


