### PR TITLE
feat(comment): add element URL path for notifications

### DIFF
--- a/app/api/helpers/comment_helpers.rb
+++ b/app/api/helpers/comment_helpers.rb
@@ -22,26 +22,39 @@ module CommentHelpers
   end
 
   def notify_collection_owners(current_user, element)
-    element.collections.find_each do |collection|
-      recipient = collection.user.send(:user_ids) - [current_user.id]
-      next if recipient.blank?
+    recipients = collect_collection_recipients(element) - [current_user.id]
+    return if recipients.blank?
 
-      data_args = {
-        commented_by: current_user.name,
-        element_type: element.class.to_s,
-        element_name: element_name(element),
-      }
+    data_args = {
+      commented_by: current_user.name,
+      element_type: element.class.to_s,
+      element_name: element_name(element),
+    }
 
-      Message.create_msg_notification(
-        channel_subject: Channel::COMMENT_ON_MY_COLLECTION,
-        message_from: current_user.id,
-        message_to: recipient,
-        data_args: data_args,
-        level: 'info',
-        url: element_url_path(element),
-        urlTitle: "View #{element.class} #{element_name(element)}",
-      )
+    Message.create_msg_notification(
+      channel_subject: Channel::COMMENT_ON_MY_COLLECTION,
+      message_from: current_user.id,
+      message_to: recipients,
+      data_args: data_args,
+      level: 'info',
+      url: element_url_path(element),
+      urlTitle: "View #{element.class} #{element_name(element)}",
+    )
+  end
+
+  # Collects all users with access to the element across its collections —
+  # both the collection owners and anyone the collection is shared with —
+  # expanding any group recipients to their member ids and de-duplicating.
+  def collect_collection_recipients(element)
+    ids = element.collections.includes(:user, collection_shares: :shared_with).flat_map do |collection|
+      [
+        *collection.user&.send(:user_ids),
+        *collection.collection_shares.flat_map do |share|
+          share.shared_with&.send(:user_ids)
+        end,
+      ]
     end
+    ids.compact.uniq
   end
 
   def notify_comment_resolved(comment, current_user)

--- a/app/api/helpers/comment_helpers.rb
+++ b/app/api/helpers/comment_helpers.rb
@@ -13,6 +13,14 @@ module CommentHelpers
     end
   end
 
+  # Returns the in-app URL path for a given element so it can be embedded in
+  # notifications as a clickable deep link.  The path matches the Aviator
+  # client-side routes defined in routes.js (e.g. /mydb/sample/42).
+  def element_url_path(element)
+    type_slug = element.class.to_s.underscore
+    "/mydb/#{type_slug}/#{element.id}"
+  end
+
   def notify_collection_owners(current_user, element)
     element.collections.find_each do |collection|
       recipient = collection.user.send(:user_ids) - [current_user.id]
@@ -30,6 +38,8 @@ module CommentHelpers
         message_to: recipient,
         data_args: data_args,
         level: 'info',
+        url: element_url_path(element),
+        urlTitle: "View #{element.class} #{element_name(element)}",
       )
     end
   end
@@ -40,11 +50,14 @@ module CommentHelpers
 
     Message.create_msg_notification(
       channel_subject: Channel::COMMENT_RESOLVED,
-      message_from: current_user.id, message_to: [comment.created_by],
+      message_from: current_user.id,
+      message_to: [comment.created_by],
       data_args: { resolved_by: current_user.name,
                    element_type: commentable_type,
                    element_name: element_name(commentable) },
-      level: 'info'
+      level: 'info',
+      url: element_url_path(commentable),
+      urlTitle: "View #{commentable_type} #{element_name(commentable)}",
     )
   end
 end


### PR DESCRIPTION
Introduces a new method `element_url_path` to generate in-app URL paths for elements, enabling clickable deep links in notifications. Updates notification data to include these URLs and their titles for better user navigation.

Closes https://github.com/ComPlat/chemotion_ELN/issues/2975