### PR TITLE
fix(spectra): editor refresh simulation payload

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/ViewSpectra.js
+++ b/app/javascript/src/apps/mydb/elements/details/ViewSpectra.js
@@ -660,10 +660,13 @@ class ViewSpectra extends React.Component {
   }
 
   refreshOp(params) {
-    const refreshPayloads = this.getSavePayloads(params, { simulatenmr: true });
+    const hasSpectraList = Array.isArray(params?.spectra_list) && params.spectra_list.length > 0;
+    const spectraList = hasSpectraList
+      ? this.getSavePayloads(params, { simulatenmr: true })
+      : [{ ...params, simulatenmr: true }];
     this.saveOp({
       ...params,
-      spectra_list: refreshPayloads,
+      spectra_list: spectraList,
     });
   }
 


### PR DESCRIPTION
## Problem
After the save flow was refactored to use `spectra_list`, the **Refresh simulation** button in Chemspectra still called `refreshCb` with a flat payload (no `spectra_list`). `refreshOp` then built an empty list, `saveOp` exited early, and **no HTTP request** was sent, NMR simulation stayed empty (`nmrSimPeaks`).

## Change
In `ViewSpectra.refreshOp`, if `spectra_list` is missing or empty, wrap the flat callback payload in a single-item array with `simulatenmr: true`, matching the one-curve save shape.

## Testing
- Open Spectra Editor for a ¹H NMR with a molecule, click **Refresh simulation** → confirm `POST .../save_spectrum` with `simulatenmr: true` and simulation peaks appear / Predict can be used after assigning multiplets.