### PR TITLE
fix: Strip image embeds from ReactQuill to prevent reaction details crash

### DIFF
--- a/app/javascript/src/components/QuillEditor.js
+++ b/app/javascript/src/components/QuillEditor.js
@@ -7,10 +7,12 @@ import Delta from 'quill-delta';
 
 import _ from 'lodash';
 import { Dropdown, DropdownButton, OverlayTrigger, Popover, Button } from 'react-bootstrap';
+import { stripImages } from 'src/utilities/quillFormat';
 
 const toolbarOptions = [
   ['bold', 'italic', 'underline'],
   [{ list: 'ordered' }, { list: 'bullet' }],
+  [{ indent: '-1' }, { indent: '+1' }],
   [{ script: 'sub' }, { script: 'super' }],
   [{ header: [1, 2, 3, 4, 5, 6, false] }],
   [{
@@ -25,7 +27,6 @@ const toolbarOptions = [
   // ['α', 'β', 'π'],
   // ['blockquote', 'code-block'],
   // [{ 'header': 1 }, { 'header': 2 }],
-  // [{ 'indent': '-1'}, { 'indent': '+1' }],
   // [{ 'direction': 'rtl' }],
   // [{ 'size': ['small', false, 'large', 'huge'] }],
   // [{ 'align': [] }],
@@ -94,7 +95,7 @@ export default class QuillEditor extends React.Component {
 
     this.setState({ value });
     const sel = this.editor.getSelection();
-    this.editor.setContents(value);
+    this.editor.setContents(stripImages(value));
     if (sel) this.editor.setSelection(sel);
   }
 
@@ -174,6 +175,7 @@ export default class QuillEditor extends React.Component {
             }
           }
         },
+        formats: ['bold', 'italic', 'underline', 'header', 'script', 'list', 'indent'],
         theme: this.theme,
         readOnly: this.readOnly,
       };
@@ -181,7 +183,7 @@ export default class QuillEditor extends React.Component {
       // init Quill
       this.editor = new Quill(quillEditor, quillOptions);
       const { value } = this.state;
-      if (value) this.editor.setContents(value);
+      if (value) this.editor.setContents(stripImages(value));
 
       // Resolve compability with Grammarly Chrome add-on
       // Fromm https://github.com/quilljs/quill/issues/574

--- a/app/javascript/src/components/QuillViewer.js
+++ b/app/javascript/src/components/QuillViewer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Quill from 'quill';
 import _ from 'lodash';
 
-import { keepSupSub } from 'src/utilities/quillFormat';
+import { keepSupSub, stripImages } from 'src/utilities/quillFormat';
 
 export default class QuillViewer extends React.Component {
   constructor(props) {
@@ -19,7 +19,7 @@ export default class QuillViewer extends React.Component {
   componentDidUpdate(prevProps) {
     const { value } = this.props;
     if (value && prevProps.value && value !== prevProps.value) {
-      this.viewer.setContents(value);
+      this.viewer.setContents(stripImages(value));
     }
   }
 
@@ -27,6 +27,7 @@ export default class QuillViewer extends React.Component {
     if (!this.viewer) {
       const { quillViewer } = this;
       const defaultOptions = {
+        formats: ['bold', 'italic', 'underline', 'header', 'script', 'list', 'indent'],
         theme: this.theme,
         readOnly: this.readOnly,
       };
@@ -34,7 +35,7 @@ export default class QuillViewer extends React.Component {
       this.viewer = new Quill(quillViewer, defaultOptions);
       const oriValue = this.props.value;
       const value = this.props.preview ? keepSupSub(oriValue) : oriValue;
-      this.viewer.setContents(value);
+      this.viewer.setContents(stripImages(value));
     }
   }
 

--- a/app/javascript/src/components/reactQuill/ReactQuill.js
+++ b/app/javascript/src/components/reactQuill/ReactQuill.js
@@ -10,6 +10,8 @@ import isEqual from 'lodash/isEqual';
 
 import Quill from 'quill';
 
+import { stripImages } from 'src/utilities/quillFormat';
+
 function postpone(fn) {
   Promise.resolve().then(fn);
 }
@@ -255,9 +257,10 @@ export default class ReactQuill extends React.Component {
     const sel = this.getEditorSelection();
 
     if (typeof value === 'string') {
-      editor.setContents(editor.clipboard.convert(value));
+      const converted = editor.clipboard.convert(value);
+      editor.setContents(stripImages(converted));
     } else {
-      editor.setContents(value);
+      editor.setContents(stripImages(value));
     }
 
     postpone(() => this.setEditorSelection(editor, sel));

--- a/app/javascript/src/utilities/quillFormat.js
+++ b/app/javascript/src/utilities/quillFormat.js
@@ -36,6 +36,15 @@ const keepSupSub = (value) => {
   return content;
 };
 
+const isImageOp = op => op && op.insert && typeof op.insert === 'object' && op.insert.image;
+
+const stripImages = (value) => {
+  if (!value) return value;
+  if (Array.isArray(value)) return value.filter(op => !isImageOp(op));
+  if (value.ops) return { ...value, ops: value.ops.filter(op => !isImageOp(op)) };
+  return value;
+};
+
 const rmRedundantSpaceBreak = (target) => {
   return target.replace(/\n/g, '').replace(/\s\s+/g, ' ');
 };
@@ -80,4 +89,5 @@ export {
   rmOpsRedundantSpaceBreak,
   rmRedundantSpaceBreak,
   frontBreak,
+  stripImages,
 };

--- a/spec/javascripts/packs/src/utilities/quillFormat.spec.js
+++ b/spec/javascripts/packs/src/utilities/quillFormat.spec.js
@@ -1,0 +1,52 @@
+// eslint-disable-next-line import/no-unresolved
+import { stripImages } from 'src/utilities/quillFormat';
+import expect from 'expect';
+import { describe, it } from 'mocha';
+
+describe('quillFormat.stripImages', () => {
+  it('drops object-form image inserts from a delta object', () => {
+    const input = {
+      ops: [
+        { insert: 'hello ' },
+        { insert: { image: 'data:image/png;base64,AAA' } },
+        { insert: 'world' },
+      ],
+    };
+    expect(stripImages(input)).toEqual({
+      ops: [
+        { insert: 'hello ' },
+        { insert: 'world' },
+      ],
+    });
+  });
+
+  it('drops object-form image inserts from a bare ops array', () => {
+    const input = [
+      { insert: { image: 'x' } },
+      { insert: 'kept' },
+    ];
+    expect(stripImages(input)).toEqual([{ insert: 'kept' }]);
+  });
+
+  it('preserves non-image embeds and attributed text', () => {
+    const input = {
+      ops: [
+        { insert: 'bold', attributes: { bold: true } },
+        { insert: { video: 'x' } },
+        { insert: { image: 'x' } },
+      ],
+    };
+    expect(stripImages(input)).toEqual({
+      ops: [
+        { insert: 'bold', attributes: { bold: true } },
+        { insert: { video: 'x' } },
+      ],
+    });
+  });
+
+  it('returns empty/null inputs unchanged', () => {
+    expect(stripImages(null)).toBe(null);
+    expect(stripImages(undefined)).toBe(undefined);
+    expect(stripImages({})).toEqual({});
+  });
+});


### PR DESCRIPTION
PR resolves:  Image blot issues with quillEditor

---------------

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
