### PR TITLE
fix(report): escape HTML special chars in Quill delta converter

### DIFF
--- a/lib/reporter/delta.rb
+++ b/lib/reporter/delta.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module Reporter
   # Delta class to convert Quill delta format to HTML
   class Delta
@@ -113,7 +115,7 @@ module Reporter
     end
 
     def buildDeltaOps(op)
-      return op["insert"] if (!op["attributes"]) && (!(op && op["insert"].is_a?(Hash) && op["insert"]["image"]))
+      return CGI.escapeHTML(op["insert"]) if (!op["attributes"]) && (!(op && op["insert"].is_a?(Hash) && op["insert"]["image"]))
 
       styles = []
       tags = []
@@ -152,7 +154,7 @@ module Reporter
 
     def html_with_tags_style(op, tags, styles)
       style = styles.count > 0 ? " style=\"#{styles.join(";")}\"" : ""
-      html = "<span#{style}>#{op["insert"]}</span>"
+      html = "<span#{style}>#{CGI.escapeHTML(op["insert"])}</span>"
 
       tags.each { |tag| html = "<#{tag}>#{html}</#{tag}>" }
       html


### PR DESCRIPTION
## Summary

- `Reporter::Delta#buildDeltaOps` and `#html_with_tags_style` interpolated raw user text (`op["insert"]`) directly into HTML strings without escaping special characters.
- A Reaction Description containing `<a` (or any `<`) produced malformed HTML (e.g. `<span><a</span>`), which Sablon embedded in the `.docx` template, causing the report download to fail with a browser "site not available" error.
- Fix: apply `CGI.escapeHTML` to `op["insert"]` at both injection points so `<`, `>`, `&`, and `"` are safely encoded before insertion into generated markup.

> **Note:** This is a latent defect present since the Delta class was first introduced in Dec 2016 — not a regression from a recent change.


## Test plan

- [ ] Add `<a` (without a space) somewhere in a Reaction Description
- [ ] Click **Generate Report** — report should download successfully
- [ ] Verify the downloaded `.docx` renders `<a` as literal text (not a broken tag)
- [ ] Repeat with `>`, `&`, and `"` in the description to confirm all special chars are handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)