### PR TITLE
fix: support comma as decimal separator in numeric parsing

### DIFF
--- a/app/models/sum_formula.rb
+++ b/app/models/sum_formula.rb
@@ -2,7 +2,7 @@
 
 class SumFormula < Hash
   ELEMENT_REGEXP = /\A[A-Z][a-z]*\z/.freeze
-  NUMBER_REGEXP = /\d+(?:\.\d+)?/.freeze
+  NUMBER_REGEXP = /\d+(?:[.,]\d+)?/.freeze
 
   def initialize(formula = '')
     super()
@@ -294,7 +294,9 @@ class SumFormula < Hash
   end
 
   def self.parse_numeric_token(token)
-    token.include?('.') ? token.to_f : token.to_i
+    return token.tr(',', '.').to_f if token.match?(/[.,]/)
+
+    token.to_i
   end
 
   private_class_method :decimal_dot?, :hydrate_dot?, :previous_top_level_separator_index,

--- a/spec/models/sum_formula_spec.rb
+++ b/spec/models/sum_formula_spec.rb
@@ -43,6 +43,11 @@ RSpec.describe SumFormula do
       expect(parsed).to include('C' => 12.3, 'H' => 3.5, 'O' => 2.556)
     end
 
+    it 'parses decimal atom counts with comma as decimal separator' do
+      parsed = described_class.new('C12,3H3,5O2,556')
+      expect(parsed).to include('C' => 12.3, 'H' => 3.5, 'O' => 2.556)
+    end
+
     it 'parses a single decimal atom count without splitting on dot' do
       parsed = described_class.new('C1.5H2')
       expect(parsed).to include('C' => 1.5, 'H' => 2)


### PR DESCRIPTION
- Updated NUMBER_REGEXP to recognize both dot and comma as decimal separators.
- Enhanced parse_numeric_token method to convert tokens with commas to floats.
- Added a test case to verify parsing of atom counts using commas.

Relates to https://github.com/ComPlat/chemotion_ELN/issues/2950