### PR TITLE
fix: validating data on import sample using column mapping feature

### DIFF
--- a/app/javascript/src/apps/mydb/collections/ValidationComponent.js
+++ b/app/javascript/src/apps/mydb/collections/ValidationComponent.js
@@ -274,15 +274,14 @@ const ValidationComponent = React.forwardRef(({
 
     // Update the currentRowData with validation results and conversions
     setCurrentRowData(allRows);
-    onRowDataChange(allRows);
-
     gridApi.refreshCells();
     onValidate(invalid, allRows);
   };
 
   useImperativeHandle(ref, () => ({
-    validateData
-  }), [validateData]);
+    validateData,
+    getRowData: () => currentRowData,
+  }), [validateData, currentRowData]);
 
   const addNewRow = () => {
     // Generate a user-friendly row ID based on current data length

--- a/app/javascript/src/apps/mydb/collections/importSamples/ModalImport.js
+++ b/app/javascript/src/apps/mydb/collections/importSamples/ModalImport.js
@@ -336,7 +336,7 @@ export default class ModalImport extends React.Component {
     });
   }
 
-  handleValidation(invalidRows, rowsData) {
+  static handleValidation(invalidRows) {
     if (invalidRows.length > 0) {
       // if some rows have validation errors, show notification but keep the modal open
       NotificationActions.add({
@@ -345,25 +345,6 @@ export default class ModalImport extends React.Component {
         level: 'error',
         dismissible: true,
       });
-    } else {
-      // Get the current valid data from the grid
-      const validData = rowsData.filter((row) => !row.delete && (row.valid !== false));
-
-      // Prepare data for backend
-      const cleanedData = validData.map((row) => {
-        const cleanRow = { ...row };
-        if (cleanRow.molfile !== undefined && cleanRow.molfile !== null) {
-          cleanRow.molfile = `\n${cleanRow.molfile}\n`;
-        }
-        // Remove UI-specific properties
-        delete cleanRow.id;
-        delete cleanRow.valid;
-        delete cleanRow.errors;
-        delete cleanRow.delete;
-        return cleanRow;
-      });
-
-      this.setState({ rowData: cleanedData });
     }
   }
 
@@ -397,14 +378,28 @@ export default class ModalImport extends React.Component {
   handleImportData() {
     const { onHide } = this.props;
     const {
-      importAsChemical, fileFormat, rowData, targetCollectionId
+      importAsChemical, fileFormat, targetCollectionId
     } = this.state;
 
-    // For Excel and other formats, send the cleaned data directly
+    const liveRows = this.validationComponentRef.current?.getRowData() ?? [];
+    const cleanedData = liveRows
+      .filter((row) => !row.delete && row.valid !== false)
+      .map((row) => {
+        const cleanRow = { ...row };
+        if (cleanRow.molfile != null) {
+          cleanRow.molfile = `\n${cleanRow.molfile}\n`;
+        }
+        delete cleanRow.id;
+        delete cleanRow.valid;
+        delete cleanRow.errors;
+        delete cleanRow.delete;
+        return cleanRow;
+      });
+
     const params = {
       currentCollectionId: targetCollectionId,
       type: importAsChemical ? 'chemical' : 'sample',
-      data: rowData,
+      data: cleanedData,
       originalFormat: fileFormat
     };
 
@@ -1112,7 +1107,7 @@ export default class ModalImport extends React.Component {
               rowData={rowData || []}
               onRowDataChange={(data) => this.setState({ rowData: data })}
               columnDefs={columnDefs || []}
-              onValidate={(invalidRows, rowsData) => this.handleValidation(invalidRows, rowsData)}
+              onValidate={(invalidRows) => ModalImport.handleValidation(invalidRows)}
               onValidationStateChange={this.handleValidationStateChange}
             />
           )}


### PR DESCRIPTION
**Fix validation feedback loop & column-mapping import**

**Problem:** Clicking "Validate Data" does not show the success/error UI, and the import flow could not proceed — validation ran, but the modal immediately reverted to an un-validated state, so the footer never changed to allow import. Originating from [PR#3146 Consolidate design for modals](https://github.com/ComPlat/chemotion_ELN/pull/3146)

**Cause:** A feedback loop between the grid and the parent modal: the validator updated parent state with the validated rows, the parent passed that state back as initial data, and the grid's prop-change effect reset validation flags before results could render.

**Fix:** Break the circular update and make data flow pull-based:
- Stop updating parent row state from inside the validator during validation.
- Expose an imperative getter on the validator so the parent reads final validated rows only when needed.
- Parent reads cleaned/filtered rows from the validator on import, performs UI-only cleanup (strip IDs/errors, pad molfile), and sends the payload.

**Result / behavior after fix**: Validation now shows errors or a success alert correctly; when valid, the primary button switches to "Import" and the parent uploads a cleaned payload (no UI-only fields).

<img width="876" height="749" alt="image" src="https://github.com/user-attachments/assets/d22f0848-15f3-415a-aad4-d383e3b2d8c9" />

____________________________________________________________________________________
- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release