### PR TITLE
fix: vessel creation and collection handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,4 @@ public/sprite.png
 *storybook.log
 storybook-static
 public/units_system/units_system.json
+CLAUDE.md

--- a/app/javascript/src/apps/mydb/elements/details/vessels/VesselTemplateDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/vessels/VesselTemplateDetails.js
@@ -6,6 +6,7 @@ import React, {
 import { StoreContext } from 'src/stores/mobx/RootStore';
 import PropTypes from 'prop-types';
 import { toJS } from 'mobx';
+import uuid from 'uuid';
 import {
   Button, Form, Row, Col, Table, InputGroup, Card, Container
 } from 'react-bootstrap';
@@ -99,6 +100,7 @@ function VesselTemplateDetails({ vessels }) {
 
   const handleAddNewInstance = () => {
     setNewInstances([...newInstances, {
+      localId: uuid.v4(),
       vesselInstanceName: '',
       vesselInstanceDescription: '',
       barCode: '',
@@ -412,9 +414,7 @@ function VesselTemplateDetails({ vessels }) {
                 </tr>
               ))}
               {newInstances.map((instance, index) => (
-                <tr
-                  key={`new-${instance.vesselInstanceName || ''}-${instance.barCode || ''}-${instance.qrCode || ''}`}
-                >
+                <tr key={instance.localId}>
                   {['vesselInstanceName', 'vesselInstanceDescription', 'barCode', 'qrCode'].map((field) => (
                     <td key={field} className="p-1">
                       <Form.Control

--- a/app/models/collections_vessel.rb
+++ b/app/models/collections_vessel.rb
@@ -23,4 +23,22 @@ class CollectionsVessel < ApplicationRecord
 
   belongs_to :collection
   belongs_to :vessel
+
+  include Tagging
+  include Collecting
+
+  def self.remove_in_collection(element_ids, collection_ids)
+    delete_in_collection(element_ids, collection_ids)
+    update_tag_by_element_ids(element_ids)
+  end
+
+  def self.move_to_collection(element_ids, from_col_ids, to_col_ids)
+    delete_in_collection(element_ids, from_col_ids)
+    insert_in_collection(element_ids, to_col_ids)
+    update_tag_by_element_ids(element_ids)
+  end
+
+  def self.create_in_collection(element_ids, collection_ids)
+    static_create_in_collection(element_ids, collection_ids)
+  end
 end


### PR DESCRIPTION
## Summary

  Restores `remove_in_collection`, `move_to_collection`, and `create_in_collection` on `CollectionsVessel`, and includes
   the `Tagging` / `Collecting` concerns the join-table relies on.

  Without these methods, "Remove from current collection" raises a `NoMethodError` whenever a vessel is part of the
  selection.

  Because `Usecases::Collections::RemoveElements#remove_elements_from_collection` iterates `ui_state` keys without a
  wrapping transaction, the failure also produces a confusing secondary symptom: any element type processed *before*
  `vessel` (e.g. `sample`) is soft-deleted in the DB, but the API returns 500, so the frontend skips its post-delete
  refresh in `CollectionsStore.removeElementsFromCollection`. The user sees those elements still in the list until a
  hard reload.

  The same gap affects "Add to collection" (`AddElements` calls `create_in_collection`) and the move/transfer flows
  (`move_to_collection`).

  ## Root cause

  This is **not** related to the collection-sharing refactor.
  The methods were *originally written* by the vessel feature author on the long-lived feature branch, but were lost
  when the branch was squashed and merged into main:

  | Commit | Date | What happened |
  | --- | --- | --- |
  | `3835858d6` ("add model tests", `origin/vessel-element`) | 2023-06-29 | `CollectionsVessel` includes `Tagging`/`Collecting` and defines `remove_in_collection`, `move_to_collection`, `create_in_collection`. |
  | `db1cbb180` ("feat(vessel): implement api for vessel and vessel template (#2441)") | 2025-08-04 | Squash-merge of the vessel feature into main. `app/models/collections_vessel.rb` lands as bare `belongs_to`s only — the concerns and three class methods are dropped. |
  | `c7843cfea` ("refactor!: collection sharing - merge shared and sync collections (#2783)") | 2026-03-16 | Left `CollectionsVessel` untouched; preserved the latent bug. |

  ## Fix

  `app/models/collections_vessel.rb` is updated to mirror `CollectionsDeviceDescription` (the simplest sibling without
  sample-cascade logic). Vessels don't have the reaction/wellplate dependency that `CollectionsSample` filters on, so a
  plain `delete_in_collection` / `insert_in_collection` is correct here.

  ## Test plan

  - [ ] Open a collection containing one or more vessels, select them, choose "Remove from current collection" → expect
  204 and the vessels to disappear without a reload.
  - [ ] Mixed selection of a sample and a vessel → both removed, no 500, list refreshes.
  - [ ] Move a vessel between two collections → vessel disappears from source, appears in target, tag updated.
  - [ ] Add a vessel to a different collection from the elements table → vessel shows up in the target.
  
  Also fixed keeping input focus when typing in new vessel instance row.