### PR TITLE
fix: prevent GC from deleting Tempfile during CDXML conversion for reports

### DIFF
--- a/lib/chemotion/open_babel_service.rb
+++ b/lib/chemotion/open_babel_service.rb
@@ -498,8 +498,11 @@ M  END
     mf = mofile_clear_coord_bonds(molfile)
     mol = mf || molfile
     # `obabel -imol #{file_name} -ocdxml`
-    input = Tempfile.new(["input", ".mol"]).path
-    output = output_path || Tempfile.new(["output", ".mol"]).path
+    # Keep Tempfile references alive until after File.read; GC finalizers delete the files.
+    input_tf = Tempfile.new(["input", ".mol"])
+    output_tf = output_path ? nil : Tempfile.new(["output", ".mol"])
+    input = input_tf.path
+    output = output_path || output_tf.path
     File.write(input, mol)
 
     c = OpenBabel::OBConversion.new
@@ -509,7 +512,10 @@ M  END
 
     orig_cdxml = File.read(output)
     shifted_cdxml, geometry = Cdxml::Shifter.new({orig_cdxml: orig_cdxml, shifter: shifter}).convey
-    return { content: shifted_cdxml, geometry: geometry, path: output }
+    { content: shifted_cdxml, geometry: geometry, path: output }
+  ensure
+    input_tf&.close!
+    output_tf&.close!
   end
 
   def self.smi_to_svg(smi)


### PR DESCRIPTION
## Summary

- `get_cdxml_from_molfile` in `lib/chemotion/open_babel_service.rb` called `Tempfile.new(...).path` without storing the object reference, making the Tempfile immediately eligible for GC.
- Ruby's Tempfile finalizer deletes the underlying file when the object is collected. Under memory pressure (e.g. in a long-running `delayed_job` process), GC can fire between `c.convert` writing the output and `File.read(output)` consuming it, causing `Errno::ENOENT` and a failed report job.
- The bug has been present since commit `4125a4a` (Dec 15, 2016) when the method was first introduced.

## Fix

Store both `Tempfile` objects in local variables so they stay live through `File.read`, then explicitly `close!` them in an `ensure` block.

## Test plan

- [ ] Generate a DOCX report for a reaction with starting materials, reactants, and products — confirm it completes without error.
- [ ] Verify no temp files are leaked in `/tmp` after report generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)