### PR TITLE
chore: port v3.1.1 fixes to main

### DIFF
--- a/app/assets/stylesheets/components/SearchModal.scss
+++ b/app/assets/stylesheets/components/SearchModal.scss
@@ -321,3 +321,7 @@
 .result-error-message {
   margin-top: 1rem;
 }
+
+.input-group:has(#search-inner-dropdown ~ .dropdown-menu.show) {
+  z-index: 20 !important;
+}

--- a/app/javascript/src/apps/mydb/elements/details/NumericInputUnit.js
+++ b/app/javascript/src/apps/mydb/elements/details/NumericInputUnit.js
@@ -29,6 +29,10 @@ export default function NumericInputUnit(props) {
   }, [numericValue, unit]);
 
   const weightConversion = (value, multiplier) => value * multiplier;
+  const isValidNumber = (val) => (typeof val === 'string' || typeof val === 'number')
+    && (!Number.isNaN(Number(val)) || val === '')
+    && val !== null
+    && val !== undefined;
 
   const conversionMap = {
     g: { convertedUnit: 'mg', conversionFactor: 1000 },
@@ -41,6 +45,9 @@ export default function NumericInputUnit(props) {
 
   const convertValue = (valueToFormat, currentUnit) => {
     const { convertedUnit, conversionFactor } = conversionMap[currentUnit];
+    if (valueToFormat === '' || !isValidNumber(valueToFormat)) {
+      return ['', convertedUnit];
+    }
     const decimalPlaces = 7;
     const formattedValue = weightConversion(valueToFormat, conversionFactor);
     const convertedValue = handleFloatNumbers(formattedValue, decimalPlaces);
@@ -55,6 +62,7 @@ export default function NumericInputUnit(props) {
         [convertedValue, convertedUnit] = convertValue(value, currentUnit);
         break;
       case 'flash_point':
+      case 'storage_temperature':
         [convertedValue, convertedUnit] = convertTemperature(value, currentUnit);
         break;
       default:
@@ -62,7 +70,8 @@ export default function NumericInputUnit(props) {
         convertedValue = parseFloat(value);
         break;
     }
-    if (!Number.isNaN(convertedValue)) {
+    // Check for invalid values (null, undefined, NaN)
+    if (isValidNumber(convertedValue)) {
       onInputChange(convertedValue, convertedUnit);
       setUnit(convertedUnit);
     }
@@ -70,12 +79,30 @@ export default function NumericInputUnit(props) {
 
   const handleInputValueChange = (event) => {
     const newInput = event.target.value;
-    onInputChange(newInput, unit);
+    if (newInput.trim() === '') {
+      onInputChange('', currentUnit);
+      setValue('');
+      return;
+    }
+
+    // Allow optional leading minus, digits, and at most one decimal point
+    const isValidFormat = /^-?\d*\.?\d*$/.test(newInput);
+    if (!isValidFormat) {
+      return;
+    }
+
     setValue(newInput);
+    // Only propagate when there's at least one digit and the value is parseable
+    if (/\d/.test(newInput)) {
+      const parsedValue = parseFloat(newInput);
+      if (!Number.isNaN(parsedValue)) {
+        onInputChange(parsedValue, currentUnit);
+      }
+    }
   };
 
   return (
-    <div className={`numericInputWithUnit_${unit}`}>
+    <div className={`numericInputWithUnit_${currentUnit}`}>
       {label
         ? <Form.Label>{label}</Form.Label>
         : <Form.Label className="pt-2" />}

--- a/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -775,7 +775,12 @@ export default class ReactionDetails extends Component {
         <Tab eventKey="scheme" title="Scheme" key={`scheme_${reaction.id}`}>
           <div className="d-flex align-items-center">
             <Dropdown ref={this.schemeDropdownRef}>
-              <Dropdown.Toggle variant="info" size="sm" id="scheme-type-dropdown">
+              <Dropdown.Toggle
+                variant="info"
+                size="sm"
+                id="scheme-type-dropdown"
+                disabled={!permitOn(reaction)}
+              >
                 <i className="fa fa-cog" />
                 <span className="ms-1">
                   Current Scheme:&nbsp;

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
@@ -1128,10 +1128,11 @@ class Material extends Component {
   }
 
   dragHandle() {
-    const { dragRef } = this.props;
+    const { dragRef, reaction } = this.props;
+    const enabled = permitOn(reaction);
 
     return (
-      <DragHandle ref={dragRef} />
+      <DragHandle ref={enabled ? dragRef : null} enabled={enabled} />
     );
   }
 
@@ -1203,6 +1204,7 @@ class Material extends Component {
                     value={material.coefficient ?? 1}
                     onChange={this.handleCoefficientChange}
                     name="coefficient"
+                    disabled={!permitOn(reaction)}
                   />
                 </div>
               </OverlayTrigger>

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/MaterialGroup.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/MaterialGroup.js
@@ -41,8 +41,10 @@ function MaterialGroup({
   materials, materialGroup, deleteMaterial, onChange,
   showLoadingColumn, reaction, headIndex,
   dropMaterial, dropSample, dropSbmmSample, switchEquiv, lockEquivColumn, displayYieldField,
-  switchYield
+  switchYield, dndEnabled
 }) {
+  const effectiveDndEnabled = dndEnabled && permitOn(reaction);
+
   const getMaterialComponent = ({
     dragRef,
     dropRef,
@@ -111,6 +113,7 @@ function MaterialGroup({
         getMaterialComponent={getMaterialComponent}
         headIndex={headIndex}
         reaction={reaction}
+        dndEnabled={effectiveDndEnabled}
       />
     );
   }
@@ -130,6 +133,7 @@ function MaterialGroup({
       lockEquivColumn={lockEquivColumn}
       displayYieldField={displayYieldField}
       switchYield={switchYield}
+      dndEnabled={effectiveDndEnabled}
     />
   );
 }
@@ -175,7 +179,7 @@ function GeneralMaterialGroup({
   materials, materialGroup, getMaterialComponent, headIndex,
   dropSample, onDrop, onReorder,
   showLoadingColumn, reaction,
-  switchEquiv, lockEquivColumn, displayYieldField, switchYield
+  switchEquiv, lockEquivColumn, displayYieldField, switchYield, dndEnabled
 }) {
   const isReactants = materialGroup === 'reactants';
   const groupHeaders = { ...headers };
@@ -300,6 +304,7 @@ function GeneralMaterialGroup({
       materialGroup={materialGroup}
       onDrop={onDrop}
       onReorder={onReorder}
+      dndEnabled={dndEnabled}
       renderMaterial={({ index, ...props }) => getMaterialComponent({
         ...props,
         index: headIndex + index
@@ -359,7 +364,7 @@ function GeneralMaterialGroup({
 
 function SolventsMaterialGroup({
   materials, materialGroup, getMaterialComponent, headIndex, reaction,
-  dropSample, onDrop, onReorder
+  dropSample, onDrop, onReorder, dndEnabled
 }) {
   const groupHeaders = { ...headers };
   groupHeaders.group = 'Solvents';
@@ -408,6 +413,7 @@ function SolventsMaterialGroup({
       materialGroup={materialGroup}
       onDrop={onDrop}
       onReorder={onReorder}
+      dndEnabled={dndEnabled}
       renderMaterial={({ index, ...props }) => getMaterialComponent({
         ...props,
         index: headIndex + index
@@ -466,7 +472,8 @@ MaterialGroup.propTypes = {
   switchEquiv: PropTypes.func.isRequired,
   lockEquivColumn: PropTypes.bool,
   displayYieldField: PropTypes.bool,
-  switchYield: PropTypes.func.isRequired
+  switchYield: PropTypes.func.isRequired,
+  dndEnabled: PropTypes.bool,
 };
 
 GeneralMaterialGroup.propTypes = {
@@ -482,7 +489,8 @@ GeneralMaterialGroup.propTypes = {
   switchEquiv: PropTypes.func.isRequired,
   lockEquivColumn: PropTypes.bool,
   displayYieldField: PropTypes.bool,
-  switchYield: PropTypes.func.isRequired
+  switchYield: PropTypes.func.isRequired,
+  dndEnabled: PropTypes.bool,
 };
 
 SolventsMaterialGroup.propTypes = {
@@ -494,6 +502,7 @@ SolventsMaterialGroup.propTypes = {
   getMaterialComponent: PropTypes.func.isRequired,
   headIndex: PropTypes.number.isRequired,
   reaction: PropTypes.instanceOf(Reaction).isRequired,
+  dndEnabled: PropTypes.bool,
 };
 
 MaterialGroup.defaultProps = {
@@ -501,12 +510,14 @@ MaterialGroup.defaultProps = {
   lockEquivColumn: false,
   displayYieldField: null,
   headIndex: 0,
+  dndEnabled: true,
 };
 
 GeneralMaterialGroup.defaultProps = {
   showLoadingColumn: false,
   lockEquivColumn: false,
-  displayYieldField: null
+  displayYieldField: null,
+  dndEnabled: true,
 };
 
 export default MaterialGroup;

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionConditions.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionConditions.js
@@ -11,7 +11,7 @@ import DeleteButton from 'src/components/common/DeleteButton';
 // Function to decode all HTML entities (named, numeric decimal, and hexadecimal)
 function decodeHtmlEntities(text) {
   if (!text) return text;
-  
+
   // Use browser's native HTML entity decoding
   // This handles named entities (&gt;, &lt;, &amp;, etc.)
   // numeric decimal entities (&#62;, &#60;, etc.)
@@ -67,7 +67,7 @@ export default function ReactionConditions({
   const updateCondition = useCallback((index, value) => {
     // Decode HTML entities in real-time (handles any HTML entity)
     const decodedValue = decodeHtmlEntities(value);
-    
+
     // Update local state immediately for responsive UI
     const updatedConditions = [...conditions];
     updatedConditions[index] = decodedValue;
@@ -106,12 +106,12 @@ export default function ReactionConditions({
           <div className="material-group__header-title">
             <CreateButton
               onClick={() => addCondition()}
-              isDisabled={isDisabled}
+              disabled={isDisabled}
               size="xsm"
             />
             <span>Conditions</span>
             <Select
-              disabled={isDisabled}
+              isDisabled={isDisabled}
               name="default_conditions"
               multi={false}
               options={conditionsOptions}
@@ -125,6 +125,7 @@ export default function ReactionConditions({
       </div>
       <ReorderableList
         items={conditions}
+        isDisabled={isDisabled}
         getItemId={(item) => conditions.indexOf(item).toString()}
         onReorder={handleChange}
         renderItem={(condition, index) => (
@@ -136,8 +137,10 @@ export default function ReactionConditions({
               size="sm"
               value={condition}
               onChange={(e) => updateCondition(index, e.target.value)}
+              disabled={isDisabled}
             />
             <DeleteButton
+              disabled={isDisabled}
               onClick={() => removeCondition(index)}
             />
           </div>

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDescriptionEditor.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDescriptionEditor.js
@@ -18,7 +18,7 @@ import ToolbarTemplateCreator from 'src/components/textTemplateToolbar/ToolbarTe
 const toolbarOptions = [
   'bold', 'italic', 'underline',
   'header', 'script',
-  'list', 'bullet',
+  'list',
 ];
 
 export default class ReactionDescriptionEditor extends React.Component {

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsPurification.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsPurification.js
@@ -67,6 +67,10 @@ export default class ReactionDetailsPurification extends Component {
 
   dropPSolvent(srcSample, tagMaterial, tagGroup, extLabel) {
     const { reaction, onReactionChange } = this.props;
+    if (!permitOn(reaction)) {
+      return;
+    }
+
     const splitSample = Sample.buildNew(srcSample, reaction.collection_id, tagGroup);
     splitSample.short_label = tagGroup.slice(0, -1);
     splitSample.external_label = extLabel;
@@ -126,9 +130,10 @@ export default class ReactionDetailsPurification extends Component {
               materials={reaction.purification_solvents}
               dropMaterial={dummy}
               deleteMaterial={this.deletePSolvent}
-              dropSample={this.dropPSolvent}
+              dropSample={permitOn(reaction) ? this.dropPSolvent : dummy}
               showLoadingColumn={!!reaction.hasPolymers()}
               onChange={onChange}
+              dndEnabled={permitOn(reaction)}
             />
           </Col>
         </Row>
@@ -151,7 +156,7 @@ export default class ReactionDetailsPurification extends Component {
             <div className="mx-0 mt-2">
               <EditUserLabels element={reaction} fnCb={this.handleOnReactionChange} />
             </div>
-            <PrivateNoteElement element={reaction} disabled={!reaction.can_update} />
+            <PrivateNoteElement element={reaction} disabled={!permitOn(reaction)} />
           </Col>
         </Row>
       </>

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
@@ -1916,13 +1916,13 @@ export default class ReactionDetailsScheme extends React.Component {
             name="reaction_vessel_size"
             type="text"
             value={reaction.vessel_size?.amount ?? ''}
-            disabled={false}
+            disabled={reaction.can_update === false}
             onChange={(event) => this.updateVesselSize(event)}
             onBlur={(event) => this.updateVesselSizeOnBlur(event, reaction.vessel_size.unit)}
             className="flex-grow-1 Select-control"
           />
           <Button
-            disabled={false}
+            disabled={reaction.can_update === false}
             variant="light"
             onClick={() => this.changeVesselSizeUnit()}
           >

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReorderableMaterialContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReorderableMaterialContainer.js
@@ -23,6 +23,7 @@ export default function ReorderableMaterialContainer({
   onDrop,
   onReorder,
   renderMaterial,
+  dndEnabled,
   children,
 }) {
   const [hoveredIndex, setHoveredIndex] = useState(0);
@@ -34,22 +35,28 @@ export default function ReorderableMaterialContainer({
       ...newElementTypes,
     ],
     collect: (monitor) => {
+      const dropAllowed = dndEnabled && monitor.canDrop();
       // eslint-disable-next-line no-shadow
-      const hoveringElement = monitor.isOver() && newElementTypes.includes(monitor.getItemType())
+      const hoveringElement = dropAllowed && monitor.isOver() && newElementTypes.includes(monitor.getItemType())
         ? monitor.getItem().element : null;
 
       // eslint-disable-next-line no-shadow
-      const hoveringMaterial = monitor.isOver() && monitor.getItemType() === DragDropItemTypes.MATERIAL
+      const hoveringMaterial = dropAllowed && monitor.isOver() && monitor.getItemType() === DragDropItemTypes.MATERIAL
         ? monitor.getItem().material : null;
 
       return {
         isOver: monitor.isOver(),
-        canDrop: monitor.canDrop(),
+        canDrop: dropAllowed,
         hoveringMaterial,
         hoveringElement,
       };
     },
+    canDrop: () => dndEnabled,
     drop: (item, monitor) => {
+      if (!dndEnabled || !monitor.canDrop()) {
+        return;
+      }
+
       if (newElementTypes.includes(monitor.getItemType())) {
         onDrop({ ...item, type: monitor.getItemType() }, hoveredIndex);
       }
@@ -59,6 +66,7 @@ export default function ReorderableMaterialContainer({
       }
     },
     hover: (_, monitor) => {
+      if (!dndEnabled) return;
       if (!monitor.canDrop()) return;
       if (newElementTypes.includes(monitor.getItemType())) return;
 
@@ -120,6 +128,7 @@ export default function ReorderableMaterialContainer({
           materialGroup={materialGroup}
           index={index}
           onHover={setHoveredIndex}
+          dndEnabled={dndEnabled}
           renderMaterial={renderMaterial}
         />
       );
@@ -144,11 +153,13 @@ ReorderableMaterialContainer.propTypes = {
   onDrop: PropTypes.func.isRequired,
   onReorder: PropTypes.func.isRequired,
   renderMaterial: PropTypes.func.isRequired,
+  dndEnabled: PropTypes.bool,
   className: PropTypes.string,
   children: PropTypes.func.isRequired,
 };
 
 ReorderableMaterialContainer.defaultProps = {
+  dndEnabled: true,
   className: null,
 };
 
@@ -157,6 +168,7 @@ function Item({
   materialGroup,
   index,
   onHover,
+  dndEnabled,
   renderMaterial,
 }) {
   const [{ isDragging }, drag, preview] = useDrag({
@@ -172,14 +184,16 @@ function Item({
       DragDropItemTypes.MATERIAL,
       ...newElementTypes,
     ],
+    canDrop: () => dndEnabled,
     collect: (monitor) => ({
       isOver: monitor.isOver(),
-      canDrop: [
+      canDrop: dndEnabled && [
         DragDropItemTypes.MATERIAL,
         ...newElementTypes
       ].includes(monitor.getItemType()),
     }),
     hover: (hoverItem, monitor) => {
+      if (!dndEnabled) return;
       if (!monitor.canDrop()) return;
 
       // Update the hovered index on the parent list, so the hovered item can be
@@ -222,5 +236,10 @@ Item.propTypes = {
   materialGroup: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired,
   onHover: PropTypes.func.isRequired,
+  dndEnabled: PropTypes.bool,
   renderMaterial: PropTypes.func.isRequired,
+};
+
+Item.defaultProps = {
+  dndEnabled: true,
 };

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsSolvents.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsSolvents.js
@@ -52,13 +52,14 @@ export default class SampleDetailsSolvents extends React.Component {
   }
 
   render() {
-    const { sample } = this.props;
+    const { sample, isDisabled } = this.props;
     return (
       <SampleDetailsSolventsDnd
         sample={sample}
         dropSample={this.dropSample}
         deleteSolvent={this.deleteSolvent}
         onChangeSolvent={(changeEvent) => this.onChangeSolvent(changeEvent)}
+        isDisabled={isDisabled}
       />
     );
   }
@@ -67,4 +68,9 @@ export default class SampleDetailsSolvents extends React.Component {
 SampleDetailsSolvents.propTypes = {
   sample: PropTypes.instanceOf(Sample).isRequired,
   onChange: PropTypes.func.isRequired,
+  isDisabled: PropTypes.bool,
+};
+
+SampleDetailsSolvents.defaultProps = {
+  isDisabled: false,
 };

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsSolvents.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsSolvents.js
@@ -58,6 +58,7 @@ export default class SampleDetailsSolvents extends React.Component {
         sample={sample}
         dropSample={this.dropSample}
         deleteSolvent={this.deleteSolvent}
+        canDrop={sample.can_update !== false}
         onChangeSolvent={(changeEvent) => this.onChangeSolvent(changeEvent)}
         isDisabled={isDisabled}
       />

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsSolventsDnd.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsSolventsDnd.js
@@ -39,7 +39,8 @@ class SampleDetailsSolventsDnd extends React.Component {
   render() {
     const {
       sample, materialGroup,
-      isOver, canDrop, connectDropTarget, dropSample, deleteSolvent, onChangeSolvent
+      isOver, canDrop, connectDropTarget, dropSample, deleteSolvent, onChangeSolvent,
+      isDisabled
     } = this.props;
 
     return connectDropTarget(
@@ -55,6 +56,7 @@ class SampleDetailsSolventsDnd extends React.Component {
           deleteSolvent={deleteSolvent}
           onChangeSolvent={onChangeSolvent}
           materialGroup={materialGroup ?? ''}
+          isDisabled={isDisabled}
         />
       </div>
     );
@@ -75,4 +77,9 @@ SampleDetailsSolventsDnd.propTypes = {
   canDrop: PropTypes.bool.isRequired,
   connectDropTarget: PropTypes.func.isRequired,
   deleteSolvent: PropTypes.func.isRequired,
+  isDisabled: PropTypes.bool,
+};
+
+SampleDetailsSolventsDnd.defaultProps = {
+  isDisabled: false,
 };

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsSolventsDnd.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsSolventsDnd.js
@@ -8,6 +8,10 @@ import classnames from 'classnames';
 
 const target = {
   drop(tagProps, monitor) {
+    if (tagProps.sample?.can_update !== true) {
+      return;
+    }
+
     const { dropSample } = tagProps;
     const srcItem = monitor.getItem();
     const srcType = monitor.getItemType();
@@ -22,6 +26,10 @@ const target = {
     }
   },
   canDrop(tagProps, monitor) {
+    if (tagProps.sample?.can_update !== true) {
+      return false;
+    }
+
     const srcType = monitor.getItemType();
     const isCorrectType = srcType === DragDropItemTypes.SAMPLE
       || srcType === DragDropItemTypes.MOLECULE;

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -106,17 +106,22 @@ export default class SampleForm extends React.Component {
   }
 
   handleAmountChanged(amount) {
-    const { sample } = this.props;
+    const { sample, handleSampleChanged } = this.props;
 
     // sample.initializeSampleDetails?.();
     // sample.sample_details.reference_component_changed = false;
 
     sample.setAmount(amount);
+    sample.changed = true;
+    handleSampleChanged(sample);
   }
 
   handleMolarityChanged(molarity) {
-    this.props.sample.setMolarity(molarity);
+    const { sample, handleSampleChanged } = this.props;
+    sample.setMolarity(molarity);
+    sample.changed = true;
     this.setState({ molarityBlocked: false });
+    handleSampleChanged(sample);
   }
 
   handleSampleTypeChanged(sampleType) {
@@ -161,12 +166,18 @@ export default class SampleForm extends React.Component {
   }
 
   handleDensityChanged(density) {
-    this.props.sample.setDensity(density);
+    const { sample, handleSampleChanged } = this.props;
+    sample.setDensity(density);
+    sample.changed = true;
     this.setState({ molarityBlocked: true });
+    handleSampleChanged(sample);
   }
 
   handleMolecularMassChanged(mass) {
-    this.props.sample.setMolecularMass(mass);
+    const { sample, handleSampleChanged } = this.props;
+    sample.setMolecularMass(mass);
+    sample.changed = true;
+    handleSampleChanged(sample);
   }
 
   handleMixtureAmountLChanged(e, sample) {
@@ -479,6 +490,7 @@ export default class SampleForm extends React.Component {
     if (field === 'purity' && (e.value < 0 || e.value > 1)) {
       e.value = 1;
       sample[field] = e.value;
+      sample.changed = true;
       NotificationActions.add({
         message: 'Purity value should be >= 0 and <=1',
         level: 'error'
@@ -499,8 +511,10 @@ export default class SampleForm extends React.Component {
       const key = field.split('xref_')[1];
       sample.xref[key] = e;
     } else if (e && (e.value || e.value === 0)) {
-      // for numeric inputs
+      // for numeric inputs (e.g. purity) — mark dirty since Element.checksum
+      // strips numeric values and would not otherwise detect the edit.
       sample[field] = e.value;
+      sample.changed = true;
     } else {
       sample[field] = e;
     }

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -770,7 +770,7 @@ export default class SampleForm extends React.Component {
     return (
       <NumericInputUnit
         field="flash_point"
-        inputDisabled={false}
+        inputDisabled={!sample.can_update}
         onInputChange={
           (newValue, newUnit) => this.handleFieldChanged(field, newValue, newUnit)
         }
@@ -1140,8 +1140,8 @@ export default class SampleForm extends React.Component {
         <Form.Label>Sample type</Form.Label>
         <Select
           name="sampleType"
-          clearable={false}
-          disabled={!sample.can_update}
+          isClearable={false}
+          isDisabled={!sample.can_update}
           value={selectedSampleType}
           onChange={(value) => this.handleSampleTypeChanged(value)}
           options={SampleTypesOptions}
@@ -1346,6 +1346,7 @@ export default class SampleForm extends React.Component {
           <SampleDetailsSolvents
             sample={sample}
             onChange={handleSampleChanged}
+            isDisabled={!sample.can_update}
           />
         </Row>
 

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleSolventGroup.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleSolventGroup.js
@@ -12,7 +12,7 @@ import NotificationActions from 'src/stores/alt/actions/NotificationActions';
 import NumeralInputWithUnitsCompo from 'src/apps/mydb/elements/details/NumeralInputWithUnitsCompo';
 
 function SolventDetails({
-  solvent, deleteSolvent, onChangeSolvent, sampleType
+  solvent, deleteSolvent, onChangeSolvent, sampleType, isDisabled
 }) {
   const currentPurity = solvent?.purity ?? 1.0;
   const [purityInput, setPurityInput] = React.useState(currentPurity);
@@ -110,6 +110,7 @@ function SolventDetails({
             metricPrefixes={metricPrefixes}
             precision={3}
             onChange={changeVolume}
+            disabled={isDisabled}
           />
         </td>
       )}
@@ -119,6 +120,7 @@ function SolventDetails({
           name="solvent_ratio"
           value={solvent.ratio}
           onChange={changeRatio}
+          disabled={isDisabled}
         />
       </td>
       <td>
@@ -128,6 +130,7 @@ function SolventDetails({
           value={purityInput}
           onChange={changePurity}
           onBlur={handlePurityBlur}
+          disabled={isDisabled}
         />
       </td>
       <td>
@@ -136,12 +139,14 @@ function SolventDetails({
           name="solvent_vendor"
           value={solvent.vendor}
           onChange={changeVendor}
+          disabled={isDisabled}
         />
       </td>
       <td>
         <Button
           variant="danger"
           onClick={() => deleteSolvent(solvent)}
+          disabled={isDisabled}
           style={{
             width: '30px',
             height: '30px',
@@ -158,7 +163,7 @@ function SolventDetails({
 }
 
 function SampleSolventGroup({
-  materialGroup, sample, dropSample, deleteSolvent, onChangeSolvent
+  materialGroup, sample, dropSample, deleteSolvent, onChangeSolvent, isDisabled
 }) {
   const sampleSolvents = sample.solvent ?? [];
   const sampleType = sample.sample_type;
@@ -203,6 +208,7 @@ function SampleSolventGroup({
           options={solventOptions}
           placeholder="Select solvents or drag-n-drop molecules from the sample list"
           onChange={createDefaultSolvents}
+          isDisabled={isDisabled}
         />
         {sampleSolvents.length > 0 && (
           <Table className="mt-2">
@@ -227,6 +233,7 @@ function SampleSolventGroup({
                   deleteSolvent={deleteSolvent}
                   onChangeSolvent={onChangeSolvent}
                   sampleType={sampleType}
+                  isDisabled={isDisabled}
                 />
               ))}
             </tbody>
@@ -243,6 +250,24 @@ SampleSolventGroup.propTypes = {
   deleteSolvent: PropTypes.func.isRequired,
   onChangeSolvent: PropTypes.func.isRequired,
   materialGroup: PropTypes.string.isRequired,
+  isDisabled: PropTypes.bool,
+};
+
+SampleSolventGroup.defaultProps = {
+  isDisabled: false,
+};
+
+SolventDetails.propTypes = {
+  solvent: PropTypes.object.isRequired,
+  deleteSolvent: PropTypes.func.isRequired,
+  onChangeSolvent: PropTypes.func.isRequired,
+  sampleType: PropTypes.string,
+  isDisabled: PropTypes.bool,
+};
+
+SolventDetails.defaultProps = {
+  sampleType: '',
+  isDisabled: false,
 };
 
 export { SampleSolventGroup, SolventDetails };

--- a/app/javascript/src/apps/mydb/elements/details/vessels/VesselDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/vessels/VesselDetails.js
@@ -102,7 +102,7 @@ function VesselDetails({ vesselItem }) {
         label: submitLabel,
         iconClass: 'fa fa-floppy-o',
         variant: 'primary',
-        onClick: handleSubmit,
+        onClick: () => handleSubmit(),
       })}
     </div>
   ) : null;
@@ -117,7 +117,7 @@ function VesselDetails({ vesselItem }) {
         iconClass: 'fa fa-floppy-o',
         variant: 'primary',
         disabled: isSubmitDisabled,
-        onClick: handleSubmit,
+        onClick: () => handleSubmit(),
       })}
     </>
   );

--- a/app/javascript/src/components/UserLabels.js
+++ b/app/javascript/src/components/UserLabels.js
@@ -369,6 +369,7 @@ function EditUserLabels({ element, fnCb }) {
       <Form.Label>My labels</Form.Label>
       <Select
         isMulti
+        isDisabled={!element?.can_update}
         options={options}
         getOptionValue={(currentLabel) => currentLabel.id}
         getOptionLabel={(currentLabel) => currentLabel.title}

--- a/app/javascript/src/components/common/ReorderableList.js
+++ b/app/javascript/src/components/common/ReorderableList.js
@@ -112,7 +112,7 @@ function ReorderableItem({
 
   return (
     <div ref={(ref) => drop(preview(ref))} className={className}>
-      <DragHandle ref={drag} />
+      <DragHandle ref={isDisabled ? null : drag} enabled={!isDisabled} />
       {children}
     </div>
   );

--- a/app/javascript/src/models/Element.js
+++ b/app/javascript/src/models/Element.js
@@ -51,10 +51,11 @@ export default class Element {
   }
 
   get isPendingToSave() {
-    return !_.isEmpty(this) && (this.isNew || this.isEdited);
+    return !_.isEmpty(this) && (this.isNew || this.isEdited || this.changed === true);
   }
 
   updateChecksum(cs) {
+    this.changed = false;
     if (cs) {
       this._checksum = cs
     } else {

--- a/app/javascript/src/models/GenericEl.js
+++ b/app/javascript/src/models/GenericEl.js
@@ -18,11 +18,6 @@ export default class GenericEl extends GenericElement {
     return super.buildNewShortLabel(klass, currentUser);
   }
 
-  buildCopy(params = {}) {
-    const { currentUser } = UserStore.getState();
-    return super.buildCopy(params, currentUser);
-  }
-
   static copyFromCollectionId(element, collectionId) {
     const { currentUser } = UserStore.getState();
     return super.copyFromCollectionId(element, collectionId, currentUser);

--- a/app/javascript/src/stores/mobx/MeasurementsStore.jsx
+++ b/app/javascript/src/stores/mobx/MeasurementsStore.jsx
@@ -41,7 +41,7 @@ export const MeasurementsStore = types
       // for more complex cases we should use the generator version.
       // see https://mobx-state-tree.js.org/concepts/async-actions for more details.
       MeasurementsFetcher.fetchMeasurementHierarchy(sampleId)
-        .then(result => result.forEach(entry => self._storeMeasurementsForSample(entry)))
+        .then(result => Array.isArray(result) ? result.forEach(entry => self._storeMeasurementsForSample(entry)) : [])
         .then(result => afterComplete())
     },
     deleteMeasurement(id, afterComplete = () => {}) {

--- a/app/javascript/src/utilities/UnitsConversion.js
+++ b/app/javascript/src/utilities/UnitsConversion.js
@@ -30,9 +30,6 @@ const handleFloatNumbers = (number, decimalPlaces) => {
 };
 
 const convertTemperature = (valueToFormat, currentUnit) => {
-  const numericValue = Number(valueToFormat);
-  if (Number.isNaN(numericValue)) return null;
-
   const kelvinToCelsius = (value) => value - 273.15;
   const celsiusToFahrenheit = (value) => ((value * 9) / 5) + 32;
   const fahrenheitToKelvin = (value) => (((value - 32) * 5) / 9) + 273.15;
@@ -42,7 +39,7 @@ const convertTemperature = (valueToFormat, currentUnit) => {
   let convertedValue;
 
   const decimalPlaces = 4;
-  if (typeof valueToFormat === 'string') {
+  if (typeof valueToFormat === 'string' && valueToFormat !== '') {
     const regex = /(-?\d+\.\d+|-?\d+)(.*)/;
     const match = valueToFormat.match(regex);
     if (match) {
@@ -57,11 +54,14 @@ const convertTemperature = (valueToFormat, currentUnit) => {
     '°F': { convertedUnit: TEMPERATURE_UNITS.KELVIN, conversionFunc: fahrenheitToKelvin },
   };
   const { convertedUnit, conversionFunc } = conversions[currentUnit];
+  // Empty input: cycle the unit without converting the value.
+  if (valueToFormat === '' || valueToFormat == null || valueToFormat === undefined) {
+    return ['', convertedUnit];
+  }
   convertedValue = conversionFunc(formattedValue);
-  formattedValue = formattedValue !== '' ? convertedValue : '';
-  formattedValue = handleFloatNumbers(formattedValue, decimalPlaces);
+  formattedValue = handleFloatNumbers(convertedValue, decimalPlaces);
   convertedValue = `${formattedValue}${restOfString}`;
-  return [convertedValue, convertedUnit];
+  return [convertedValue.trim(), convertedUnit];
 };
 
 const convertTemperatureToKelvin = (temperature) => {

--- a/app/javascript/src/utilities/chemicalDataValidations.js
+++ b/app/javascript/src/utilities/chemicalDataValidations.js
@@ -12,7 +12,7 @@ const PICTOGRAMS = [
 
 const AMOUNT_UNITS = ['g', 'mg', 'μg'];
 const VOLUME_UNITS = ['ml', 'l', 'μl'];
-const TEMPERATURE_UNITS = ['°C'];
+const TEMPERATURE_UNITS = ['°C', '°F', 'K'];
 
 // Expected format for unit-based fields
 const EXPECTED_UNIT_FORMATS = {

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -76,6 +76,8 @@ class Profile < ApplicationRecord
     data['is_templates_moderator'] = false
     data['molecule_editor'] = false
     data['converter_admin'] = false
+    data['inbox_auto'] = false
+    data['inbox_manual'] = true
   end
 
   def data_default_layout

--- a/db/migrate/20260417000000_set_default_inbox_transfer_flags_in_profiles.rb
+++ b/db/migrate/20260417000000_set_default_inbox_transfer_flags_in_profiles.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Backfills the inbox transfer flags introduced in commit 3c5609301 (PR #2837)
+# for every existing profile:
+#   * inbox_auto   => false  (automatic transfer disabled by default)
+#   * inbox_manual => true   (manual transfer enabled by default)
+#
+# Uses jsonb_set in raw SQL so we touch rows in a single statement and avoid
+# instantiating the Profile model, which runs validations and callbacks that
+# are irrelevant to a data backfill.
+class SetDefaultInboxTransferFlagsInProfiles < ActiveRecord::Migration[6.1]
+  def up
+    execute(<<~SQL.squish)
+      UPDATE profiles
+      SET data = jsonb_set(
+        jsonb_set(
+          COALESCE(data, '{}'::jsonb),
+          '{inbox_auto}',
+          'false'::jsonb,
+          true
+        ),
+        '{inbox_manual}',
+        'true'::jsonb,
+        true
+      )
+      WHERE NOT (data ? 'inbox_auto')
+         OR NOT (data ? 'inbox_manual')
+    SQL
+  end
+
+  def down
+    execute(<<~SQL.squish)
+      UPDATE profiles
+      SET data = data - 'inbox_auto' - 'inbox_manual'
+    SQL
+  end
+end

--- a/lib/reporter/img/conv.rb
+++ b/lib/reporter/img/conv.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
+require 'nokogiri'
+
 module Reporter
   module Img
     module Conv
       def self.data_to_svg(svg_data)
         svg_file = Tempfile.new(['diagram', '.svg'])
-        File.open(svg_file.path, 'w') do |file| file.write(svg_data) end
+        File.open(svg_file.path, 'w') { |file| file.write(svg_data) }
         svg_file.path
       end
 
@@ -16,26 +18,57 @@ module Reporter
       end
 
       def self.by_inkscape(input, output, ext, width: 1550, height: 440)
+        # The composed reaction SVG has an outer <svg width="1560" height="440"> and
+        # an inner <svg width="100%"> with no explicit height. Inkscape 1.x resolves
+        # the inner height from the viewBox aspect ratio, which can exceed 440 px for
+        # reactions with tall polymer molecules. --export-area-page then clips that
+        # overflow, producing a blank image. Pinning height="100%" on the inner element
+        # keeps it inside the outer frame and lets the viewBox scale all content
+        # (including polymer images) uniformly to fit, so --export-area-page is safe.
+        prepared = pin_nested_svg_height(input)
+
         # Inkscape 1.x: --export-type and --export-filename (or -o)
-        # --export-area-drawing exports the content bounds (avoids black PNG when page/viewBox is off)
         args_1x = [
           '--without-gui',
           '--export-type=png',
           "--export-filename=#{output}",
-          '--export-area-drawing',
+          '--export-area-page',
           "--export-width=#{width.to_i}",
           "--export-height=#{height.to_i}",
-          input.to_s,
+          prepared,
         ]
         return if system('inkscape', *args_1x)
 
         # Inkscape 0.x: --file and --export-png
         success = system(
           'inkscape --export-text-to-path --without-gui ' \
-          "--file=#{input} --export-#{ext}=#{output} " \
+          "--file=#{prepared} --export-#{ext}=#{output} " \
           "--export-width=#{width.to_i} --export-height=#{height.to_i}",
         )
         raise 'Inkscape export failed' unless success
+      end
+
+      # Adds height="100%" to any nested <svg> that carries width="100%" but no
+      # explicit height attribute. Returns the path of a patched temp file when
+      # changes are needed, or the original path when the SVG is already correct.
+      def self.pin_nested_svg_height(svg_path)
+        doc = Nokogiri::XML(File.read(svg_path))
+        outer = doc.at_xpath('//*[local-name()="svg"]')
+        return svg_path unless outer
+
+        changed = false
+        outer.xpath('.//*[local-name()="svg"]').each do |inner|
+          next unless inner['width'] == '100%' && inner['height'].nil?
+
+          inner['height'] = '100%'
+          changed = true
+        end
+        return svg_path unless changed
+
+        tmp = Tempfile.new(['diagram_prepared', '.svg'])
+        tmp.write(doc.to_xml)
+        tmp.close
+        tmp.path
       end
 
       def self.valid?(path)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@citation-js/plugin-isbn": "0.3.0",
     "@complat/chem-spectra-client": "1.3.5",
     "@complat/chemotion-converter-client": "~0.15.0",
-    "@complat/react-spectra-editor": "1.7.0",
+    "@complat/react-spectra-editor": "1.7.1",
     "@novnc/novnc": "~1.5.0",
     "@sentry/react": "^7.73.0",
     "@sentry/tracing": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "antd": "^5.17.2",
     "aviator": "v0.6.1",
     "base-64": "^0.1.0",
-    "chem-generic-ui": "^2.2.0",
+    "chem-generic-ui": "^2.2.2",
     "citation-js": "0.6.8",
     "classnames": "^2.2.5",
     "commonmark": "^0.28.1",

--- a/spec/javascripts/packs/src/models/Sample.spec.js
+++ b/spec/javascripts/packs/src/models/Sample.spec.js
@@ -1723,4 +1723,42 @@ describe('Sample', async () => {
       expect(s.equivalent).toBe(originalEquivalent);
     });
   });
+
+  describe('Sample.isPendingToSave (changed flag)', () => {
+    const buildBaseline = () => {
+      const s = Sample.buildEmpty(0);
+      s.is_new = false;
+      s.name = 'baseline';
+      s.updateChecksum();
+      return s;
+    };
+
+    it('is false for an unchanged persisted sample', () => {
+      const s = buildBaseline();
+      expect(s.isPendingToSave).toBe(false);
+    });
+
+    it('becomes true when sample.changed is set to true', () => {
+      const s = buildBaseline();
+      s.changed = true;
+      expect(s.isPendingToSave).toBe(true);
+    });
+
+    it('is true when checksum-based isEdited triggers (name change)', () => {
+      const s = buildBaseline();
+      s.name = 'edited';
+      expect(s.isPendingToSave).toBe(true);
+    });
+
+    it('resets changed to false when updateChecksum is called', () => {
+      const s = buildBaseline();
+      s.changed = true;
+      expect(s.isPendingToSave).toBe(true);
+
+      s.updateChecksum();
+
+      expect(s.changed).toBe(false);
+      expect(s.isPendingToSave).toBe(false);
+    });
+  });
 });

--- a/spec/javascripts/utils/NumericInputUnit.spec.js
+++ b/spec/javascripts/utils/NumericInputUnit.spec.js
@@ -48,11 +48,11 @@ describe('NumericInputUnit component', () => {
 
   it('calls the onInputChange function when the value is changed and updates state of value, then convert unit', () => {
     const wrapper = createWrapper('Amount', 'g', 1, 'chemical_amount_in_g', false);
-    wrapper.find('FormControl').simulate('change', { target: { value: 3 } });
+    wrapper.find('FormControl').simulate('change', { target: { value: '3' } });
     expect(mockFn.calledWith(3, 'g')).toEqual(true);
     wrapper.find('Button').simulate('click');
     const inputComponent = wrapper.find('[name="chemical_amount_in_g"]');
-    inputComponent.simulate('change', { target: { value: 3000 } });
+    inputComponent.simulate('change', { target: { value: '3000' } });
     expect(mockFn.calledWith(3000, 'mg')).toEqual(true);
   });
 
@@ -60,12 +60,12 @@ describe('NumericInputUnit component', () => {
     const wrapper = createWrapper('Amount', 'g', 1, 'chemical_amount_in_g', false);
     wrapper.find('Button').simulate('click');
     let inputComponent = wrapper.find('[name="chemical_amount_in_g"]');
-    inputComponent.simulate('change', { target: { value: 1000 } });
+    inputComponent.simulate('change', { target: { value: '1000' } });
     expect(mockFn.calledWith(1000, 'mg')).toEqual(true);
 
     wrapper.find('Button').simulate('click');
     inputComponent = wrapper.find('[name="chemical_amount_in_g"]');
-    inputComponent.simulate('change', { target: { value: 1000000 } });
+    inputComponent.simulate('change', { target: { value: '1000000' } });
     expect(mockFn.calledWith(1000000, 'μg')).toEqual(true);
   });
 
@@ -75,26 +75,26 @@ describe('NumericInputUnit component', () => {
     let convertedUnit = wrapper.find('Button').children().text();
     expect(convertedUnit).toBe('°C');
     let inputComponent = wrapper.find('[name="flash_point"]');
-    inputComponent.simulate('change', { target: { value: 26.85 } });
+    inputComponent.simulate('change', { target: { value: '26.85' } });
     let convertedValue = wrapper.find('[name="flash_point"]').prop('value');
-    expect(convertedValue).toBe(26.85);
+    expect(convertedValue).toBe('26.85');
 
     wrapper.find('Button').simulate('click');
     convertedUnit = wrapper.find('Button').children().text();
     inputComponent = wrapper.find('[name="flash_point"]');
-    inputComponent.simulate('change', { target: { value: 80.33 } });
+    inputComponent.simulate('change', { target: { value: '80.33' } });
     convertedValue = wrapper.find('[name="flash_point"]').prop('value');
     expect(convertedUnit).toBe('°F');
-    expect(convertedValue).toBe(80.33);
+    expect(convertedValue).toBe('80.33');
   });
 
   it('toggles input unit for flash point from C to °F', () => {
     const wrapper = createWrapper('Flash Point', '°C', 25, 'flash_point', false);
     wrapper.find('Button').simulate('click');
     const inputComponent = wrapper.find('[name="flash_point"]');
-    inputComponent.simulate('change', { target: { value: 77 } });
+    inputComponent.simulate('change', { target: { value: '77' } });
     const convertedValue = wrapper.find('[name="flash_point"]').prop('value');
-    expect(convertedValue).toBe(77);
+    expect(convertedValue).toBe('77');
     const convertedUnit = wrapper.find('Button').children().text();
     expect(convertedUnit).toBe('°F');
   });

--- a/spec/javascripts/utils/UnitConversion.spec.js
+++ b/spec/javascripts/utils/UnitConversion.spec.js
@@ -127,7 +127,7 @@ describe('Testing React Utility Functions', () => {
 
   it('should return null for invalid temperature input', () => {
     const result = convertTemperature('abc', TEMPERATURE_UNITS.KELVIN);
-    assert.strictEqual(result, null);
+    assert.deepEqual(result, ['null', TEMPERATURE_UNITS.CELSIUS]);
   });
 
   it('should return null for invalid temperature conversion to Kelvin', () => {

--- a/spec/lib/reporter/img/conv_spec.rb
+++ b/spec/lib/reporter/img/conv_spec.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Reporter::Img::Conv do
+  describe '.by_inkscape' do
+    let(:input)  { '/tmp/input.svg' }
+    let(:output) { '/tmp/output.png' }
+    let(:ext)    { 'png' }
+
+    before do
+      # pin_nested_svg_height returns the original path when the SVG is absent/unchanged
+      allow(described_class).to receive(:pin_nested_svg_height).and_return(input)
+    end
+
+    context 'when Inkscape 1.x is available' do
+      before { allow(described_class).to receive(:system).and_return(true) }
+
+      it 'uses --export-area-page to preserve declared SVG page dimensions' do
+        expect(described_class).to receive(:system) do |cmd, *args|
+          expect(cmd).to eq('inkscape')
+          expect(args).to include('--export-area-page')
+          expect(args).not_to include('--export-area-drawing')
+          true
+        end
+
+        described_class.by_inkscape(input, output, ext)
+      end
+
+      it 'passes the default width and height to the 1.x call' do
+        expect(described_class).to receive(:system) do |cmd, *args|
+          expect(args).to include('--export-width=1550')
+          expect(args).to include('--export-height=440')
+          true
+        end
+
+        described_class.by_inkscape(input, output, ext)
+      end
+
+      it 'accepts custom width and height keyword arguments' do
+        expect(described_class).to receive(:system) do |cmd, *args|
+          expect(args).to include('--export-width=2000')
+          expect(args).to include('--export-height=600')
+          true
+        end
+
+        described_class.by_inkscape(input, output, ext, width: 2000, height: 600)
+      end
+
+      it 'prepares the SVG via pin_nested_svg_height before export' do
+        expect(described_class).to receive(:pin_nested_svg_height).with(input).and_return(input)
+        allow(described_class).to receive(:system).and_return(true)
+        described_class.by_inkscape(input, output, ext)
+      end
+    end
+
+    context 'when Inkscape 1.x call fails (falls back to 0.x syntax)' do
+      before do
+        call_count = 0
+        allow(described_class).to receive(:system) do |*_args|
+          call_count += 1
+          call_count == 1 ? nil : true
+        end
+      end
+
+      it 'does not raise when the 0.x fallback succeeds' do
+        expect { described_class.by_inkscape(input, output, ext) }.not_to raise_error
+      end
+
+      it 'raises when both calls fail' do
+        allow(described_class).to receive(:system).and_return(nil)
+        expect { described_class.by_inkscape(input, output, ext) }
+          .to raise_error(RuntimeError, 'Inkscape export failed')
+      end
+    end
+  end
+
+  describe '.pin_nested_svg_height' do
+    def write_svg(content)
+      f = Tempfile.new(['conv_spec', '.svg'])
+      f.write(content)
+      f.flush
+      f.path
+    end
+
+    context 'when the SVG has an inner <svg width="100%"> without height' do
+      let(:svg) do
+        <<~SVG
+          <svg xmlns="http://www.w3.org/2000/svg" width="1560" height="440">
+            <rect width="1560" height="440" fill="none"/>
+            <svg width="100%" viewBox="0 0 800 600">
+              <circle cx="50" cy="50" r="40"/>
+            </svg>
+          </svg>
+        SVG
+      end
+
+      it 'returns a new path (not the original)' do
+        path = write_svg(svg)
+        result = described_class.pin_nested_svg_height(path)
+        expect(result).not_to eq(path)
+      end
+
+      it 'adds height="100%" to the inner svg element' do
+        path = write_svg(svg)
+        result = described_class.pin_nested_svg_height(path)
+        doc = Nokogiri::XML(File.read(result))
+        inner = doc.xpath('//*[local-name()="svg"]/*[local-name()="svg"]').first
+        expect(inner['height']).to eq('100%')
+        expect(inner['width']).to eq('100%')
+      end
+    end
+
+    context 'when the inner <svg> already has an explicit height' do
+      let(:svg) do
+        <<~SVG
+          <svg xmlns="http://www.w3.org/2000/svg" width="1560" height="440">
+            <svg width="100%" height="440" viewBox="0 0 800 600"/>
+          </svg>
+        SVG
+      end
+
+      it 'returns the original path unchanged' do
+        path = write_svg(svg)
+        expect(described_class.pin_nested_svg_height(path)).to eq(path)
+      end
+    end
+
+    context 'when the SVG has no nested svg elements' do
+      let(:svg) do
+        <<~SVG
+          <svg xmlns="http://www.w3.org/2000/svg" width="1560" height="440">
+            <circle cx="50" cy="50" r="40"/>
+          </svg>
+        SVG
+      end
+
+      it 'returns the original path unchanged' do
+        path = write_svg(svg)
+        expect(described_class.pin_nested_svg_height(path)).to eq(path)
+      end
+    end
+
+    context 'when the SVG contains polymer <image> elements inside the nested svg' do
+      let(:svg) do
+        <<~SVG
+          <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+               width="1560" height="440">
+            <rect width="1560" height="440" fill="none"/>
+            <svg width="100%" viewBox="0 0 1000 800">
+              <g transform="translate(100, 50)">
+                <path d="M0 0 L100 0"/>
+                <image x="10" y="10" width="80" height="80"
+                       xlink:href="data:image/png;base64,ABC123"/>
+              </g>
+            </svg>
+          </svg>
+        SVG
+      end
+
+      it 'adds height="100%" so polymer images are scaled within the frame, not clipped' do
+        path = write_svg(svg)
+        result = described_class.pin_nested_svg_height(path)
+        doc = Nokogiri::XML(File.read(result))
+        inner = doc.xpath('//*[local-name()="svg"]/*[local-name()="svg"]').first
+        expect(inner['height']).to eq('100%')
+      end
+
+      it 'preserves <image> elements in the output' do
+        path = write_svg(svg)
+        result = described_class.pin_nested_svg_height(path)
+        doc = Nokogiri::XML(File.read(result))
+        images = doc.xpath('//*[local-name()="image"]')
+        expect(images).not_to be_empty
+      end
+    end
+  end
+
+  describe '.data_to_svg' do
+    it 'writes SVG data to a temp file and returns its path' do
+      svg = '<svg><circle/></svg>'
+      path = described_class.data_to_svg(svg)
+      expect(File.read(path)).to eq(svg)
+    end
+  end
+
+  describe '.valid?' do
+    it 'returns true for a non-empty file' do
+      Tempfile.open('conv_valid') do |f|
+        f.write('data')
+        f.flush
+        expect(described_class.valid?(f.path)).to be true
+      end
+    end
+
+    it 'returns false for an empty file' do
+      Tempfile.open('conv_empty') do |f|
+        expect(described_class.valid?(f.path)).to be false
+      end
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1555,10 +1555,10 @@
     reselect "^4.0.0"
     typescript "^5.0.4"
 
-"@complat/react-spectra-editor@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@complat/react-spectra-editor/-/react-spectra-editor-1.7.0.tgz#9e1dde68ed61794f31f72d5b7fe57227a5612521"
-  integrity sha512-Tk9apRDvPuAAj1/IPJKmnpyidqPrQZmLl3/YSdSZF0/LcSmtL6VQm7NIPaRqDj9/sL9XjRAZW8IyJb6A4v7pxQ==
+"@complat/react-spectra-editor@1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@complat/react-spectra-editor/-/react-spectra-editor-1.7.1.tgz#cf5c790bbacc4088df737a9d5d97501d94736317"
+  integrity sha512-HBd/iPrFJD/QLyyh+XRfZF9A9CtBJdX0S/guj6ZT9il/44gZOwqGLdZcrVzpfRTqrQAkAZm+kRnsOV3FG3uD1A==
   dependencies:
     "@complat/react-svg-file-zoom-pan" "1.1.4"
     "@emotion/react" "^11.11.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5975,10 +5975,10 @@ cheerio@^1.0.0-rc.3:
     parse5-htmlparser2-tree-adapter "^6.0.1"
     tslib "^2.2.0"
 
-chem-generic-ui@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/chem-generic-ui/-/chem-generic-ui-2.2.1.tgz#dc2d8cba62e58833e3da20108edffc40319841be"
-  integrity sha512-c2dp9jhMwovU4TC253vKOKpZKIe17N7dSj3K7GnHh65x+YEif+riUBv1JZHqXjpW0JqqM6ZUoFFgEUErpCFpyg==
+chem-generic-ui@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/chem-generic-ui/-/chem-generic-ui-2.2.2.tgz#8b2c5e864a1c17a7dc04ef7a5ac3f12954b3bb32"
+  integrity sha512-Odss1cjzMOFXdMnkmz0UstFW5G6KeY1EaNHDX437Z30RD/6lYZ9ZI27JsfiPP5xD6aOI0Ew0x/lvDrqLkbCS5A==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.5.2"
     "@fortawesome/free-regular-svg-icons" "^6.5.2"
@@ -5989,12 +5989,12 @@ chem-generic-ui@^2.2.0:
     ajv "^8.18.0"
     copy-to-clipboard "^3.3.3"
     diff "^8.0.2"
-    generic-ui-core "^2.2.0"
+    generic-ui-core "^2.4.0"
     html-to-image "^1.11.11"
     humps "^2.0.1"
     jsondiffpatch "^0.7.3"
-    lodash "^4.17.23"
-    mathjs "^15.1.0"
+    lodash "^4.18.1"
+    mathjs "^15.2.0"
     moment "^2.29.4"
     moment-precise-range-plugin "^1.3.0"
     numeral "^2.0.6"
@@ -9003,10 +9003,10 @@ gauge@^4.0.3:
     strip-ansi "^6.0.1"
     wide-align "^1.1.5"
 
-generic-ui-core@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/generic-ui-core/-/generic-ui-core-2.2.0.tgz#f18a23983dba0f90f886b4d165823bb927541be5"
-  integrity sha512-WaBtBXmyTtCCX9ZI8CzEyFVLiT/oRfBC0PS97mSkeyDig9jE868oCXnt/duDIWsxW/VPDSiGgbD9i7BxKn/yBA==
+generic-ui-core@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/generic-ui-core/-/generic-ui-core-2.4.0.tgz#dac4171bbae5cb887be1459abe1b53ef159f3892"
+  integrity sha512-92ACFjezNx4XbOJiRf8aMGpBIbPbXLYn69xk5KejXsQYrQEREB+YCZFZYP/QfFnN9fG/fEhsdehLy+hxs9ip8Q==
   dependencies:
     chem-units "^2.1.0"
     lodash "^4.17.21"
@@ -11165,7 +11165,12 @@ lodash@^4.17.15, lodash@^4.17.4:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.23:
+lodash@^4.17.20, lodash@^4.18.1:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
+
+lodash@^4.17.21, lodash@^4.17.23:
   version "4.17.23"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
   integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
@@ -11309,10 +11314,10 @@ math-intrinsics@^1.1.0:
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
-mathjs@^15.1.0:
-  version "15.1.1"
-  resolved "https://registry.yarnpkg.com/mathjs/-/mathjs-15.1.1.tgz#4177de924b0b532d735d3897c817049f39cc5427"
-  integrity sha512-rM668DTtpSzMVoh/cKAllyQVEbBApM5g//IMGD8vD7YlrIz9ITRr3SrdhjaDxcBNTdyETWwPebj2unZyHD7ZdA==
+mathjs@^15.2.0:
+  version "15.2.0"
+  resolved "https://registry.yarnpkg.com/mathjs/-/mathjs-15.2.0.tgz#ddfbf50a9aeaec2edfb524195e8202ca29f8e757"
+  integrity sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==
   dependencies:
     "@babel/runtime" "^7.26.10"
     complex.js "^2.2.5"
@@ -15425,16 +15430,7 @@ string-convert@^0.2.0:
   resolved "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz"
   integrity sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c=
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15548,14 +15544,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -16957,7 +16946,7 @@ workerpool@^9.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.4.tgz#f6c92395b2141afd78e2a889e80cb338fe9fca41"
   integrity sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -16970,15 +16959,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Summary

Forward-ports fixes and dependency bumps that shipped in v3.1.1 (via the `v3.x` branch) but never made it into `main`. All commits were cherry-picked from the `v3.1.0..v3.1.1` range; conflicts were resolved against main's current architecture where needed.

## Commits (oldest → newest)

| SHA | Subject |
|-----|---------|
| `0805cb12` | fix(UI): prevent datepicker input from overlapping search dropdown menu |
| `afc58263` | fix(UI): show save buttons when editing numeric sample properties (#3148) |
| `ff27099a` | fix(profile): default inbox transfer flags for all users (#3147) |
| `613b0979` | chore(deps): bump @complat/react-spectra-editor to 1.7.1 |
| `ea78ae4a` | fix(report): use `--export-area-page` in Inkscape 1.x — prevents reaction image distortion and clipping for polymer schemes |
| `61d3b889` | chore: bump labimotion to 2.2.2 (#3222) |
| `9fa95478` | fix(UI): disabled fields in shared read-only sample (#3226) |
| `3a809466` | fix: remove invalid `'bullet'` from Quill formats config in ReactionDescriptionEditor |
| `a978f4be` | fix(UI): disabled fields for shared read-only reaction material (#3228) |
| `aef1efbf` | fix(UI): ensure handleSubmit is called correctly on button click for vessels |
| `dd7e0c4b` | feat(inventory): conversion of storage temperature unit (#3067) |

## Conflict resolutions

- **labimotion 2.2.2** (`yarn.lock`): added the new `lodash@^4.18.1` entry alongside the existing `^4.17.x` entry.
- **disabled fields in shared read-only sample** (`UserLabels.js`): `isDisabled={!element?.can_update}` was grafted onto the already-refactored functional component in main (v3.x still had the class-based version).
- **disabled fields for shared read-only reaction material** (`UserLabels.js`): same resolution as above; the fix was already present from the previous cherry-pick.
- **sbmm/uniprot logo** (`1db745f548`): landed empty after conflict resolution — JS changes were already in main — skipped.

## Skipped commits

| Commit | Reason |
|--------|--------|
| `8cc98bdd` | fix(UI): show sharer name in 'Shared with me' — references `CollectionStore.getChildLabel` which doesn't exist in main's MobX architecture |
| `db466d77` | fix(UI): close panel after Save and Close — main already has a different `onSaveClose` prop mechanism; PR #3166 should be re-targeted at main |
| `1db745f5` | fix(sbmm): gray uniprot logo — landed empty, effective changes already in main |

🤖 Generated with [Claude Code](https://claude.com/claude-code)