### PR TITLE
Feat/combine samples

### DIFF
--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -645,6 +645,47 @@ module Chemotion
           sample.destroy
         end
       end
+
+      namespace :merge do
+        desc 'Merge one product or reactant sample into another within the same reaction'
+        params do
+          requires :source_sample_id, type: Integer
+          requires :target_sample_id, type: Integer
+          requires :reaction_id,      type: Integer
+        end
+        post do
+          target = SampleMergeService.new(current_user: current_user).merge!(
+            source_id: params[:source_sample_id],
+            target_id: params[:target_sample_id],
+            reaction_id: params[:reaction_id],
+          )
+          present target, with: Entities::SampleEntity, root: :sample,
+                          policy: ElementPolicy.new(current_user, target)
+        rescue SampleMergeService::MergeError => e
+          error!(e.message, e.http_status)
+        rescue ActiveRecord::RecordInvalid => e
+          error!(e.message, 422)
+        rescue ActiveRecord::RecordNotFound => e
+          error!(e.message, 404)
+        end
+
+        route_param :id, type: Integer do
+          desc 'Unmerge a previously merged source from its target'
+          delete do
+            target = SampleMergeService.new(current_user: current_user).unmerge!(
+              merge_id: params[:id],
+            )
+            present target, with: Entities::SampleEntity, root: :sample,
+                            policy: ElementPolicy.new(current_user, target)
+          rescue SampleMergeService::MergeError => e
+            error!(e.message, e.http_status)
+          rescue ActiveRecord::RecordInvalid => e
+            error!(e.message, 422)
+          rescue ActiveRecord::RecordNotFound => e
+            error!(e.message, 404)
+          end
+        end
+      end
     end
   end
 end

--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -592,6 +592,47 @@ module Chemotion
           sample.destroy
         end
       end
+
+      namespace :merge do
+        desc 'Merge one product or reactant sample into another within the same reaction'
+        params do
+          requires :source_sample_id, type: Integer
+          requires :target_sample_id, type: Integer
+          requires :reaction_id,      type: Integer
+        end
+        post do
+          target = SampleMergeService.new(current_user: current_user).merge!(
+            source_id: params[:source_sample_id],
+            target_id: params[:target_sample_id],
+            reaction_id: params[:reaction_id],
+          )
+          present target, with: Entities::SampleEntity, root: :sample,
+                          policy: ElementPolicy.new(current_user, target)
+        rescue SampleMergeService::MergeError => e
+          error!(e.message, e.http_status)
+        rescue ActiveRecord::RecordInvalid => e
+          error!(e.message, 422)
+        rescue ActiveRecord::RecordNotFound => e
+          error!(e.message, 404)
+        end
+
+        route_param :id, type: Integer do
+          desc 'Unmerge a previously merged source from its target'
+          delete do
+            target = SampleMergeService.new(current_user: current_user).unmerge!(
+              merge_id: params[:id],
+            )
+            present target, with: Entities::SampleEntity, root: :sample,
+                            policy: ElementPolicy.new(current_user, target)
+          rescue SampleMergeService::MergeError => e
+            error!(e.message, e.http_status)
+          rescue ActiveRecord::RecordInvalid => e
+            error!(e.message, 422)
+          rescue ActiveRecord::RecordNotFound => e
+            error!(e.message, 404)
+          end
+        end
+      end
     end
   end
 end

--- a/app/api/entities/merged_source_entity.rb
+++ b/app/api/entities/merged_source_entity.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Entities
+  class MergedSourceEntity < Grape::Entity
+    expose :id
+    expose :short_label
+    expose :name
+    expose :merge_id do |sample|
+      sample.outgoing_merge&.id
+    end
+  end
+end

--- a/app/api/entities/reaction_entity.rb
+++ b/app/api/entities/reaction_entity.rb
@@ -82,7 +82,7 @@ module Entities
     end
 
     def products
-      displayed_in_list? ? [] : object.reactions_product_samples
+      displayed_in_list? ? [] : object.reactions_product_samples.includes(sample: { incoming_merges: :source_sample })
     end
 
     def purification_solvents
@@ -90,7 +90,7 @@ module Entities
     end
 
     def reactants
-      displayed_in_list? ? [] : object.reactions_reactant_samples
+      displayed_in_list? ? [] : object.reactions_reactant_samples.includes(sample: { incoming_merges: :source_sample })
     end
 
     def reactant_sbmm_samples

--- a/app/api/entities/reaction_entity.rb
+++ b/app/api/entities/reaction_entity.rb
@@ -80,7 +80,7 @@ module Entities
     end
 
     def products
-      displayed_in_list? ? [] : object.reactions_product_samples
+      displayed_in_list? ? [] : object.reactions_product_samples.includes(sample: { incoming_merges: :source_sample })
     end
 
     def purification_solvents
@@ -88,7 +88,7 @@ module Entities
     end
 
     def reactants
-      displayed_in_list? ? [] : object.reactions_reactant_samples
+      displayed_in_list? ? [] : object.reactions_reactant_samples.includes(sample: { incoming_merges: :source_sample })
     end
 
     def reactant_sbmm_samples

--- a/app/api/entities/sample_entity.rb
+++ b/app/api/entities/sample_entity.rb
@@ -77,6 +77,8 @@ module Entities
       expose! :sample_type
       expose! :sample_details
       expose! :components,              unless: :displayed_in_list, anonymize_with: [],   using: 'Entities::ComponentEntity'
+      expose! :is_legacy,                                           anonymize_with: false
+      expose! :merged_sources,          unless: :displayed_in_list, anonymize_with: [],   using: 'Entities::MergedSourceEntity'
     end
     # rubocop:enable Layout/ExtraSpacing, Metrics/BlockLength
 
@@ -150,6 +152,10 @@ module Entities
 
     def weight_percentage
       object.reactions_samples.pick(:weight_percentage)
+    end
+
+    def merged_sources
+      object.merged_sources
     end
   end
 end

--- a/app/api/entities/sample_entity.rb
+++ b/app/api/entities/sample_entity.rb
@@ -80,6 +80,8 @@ module Entities
       expose! :sample_type
       expose! :sample_details,                                      anonymize_with: nil
       expose! :components,              unless: :displayed_in_list, anonymize_with: [],   using: 'Entities::ComponentEntity'
+      expose! :is_legacy,                                           anonymize_with: false
+      expose! :merged_sources,          unless: :displayed_in_list, anonymize_with: [],   using: 'Entities::MergedSourceEntity'
     end
     # rubocop:enable Layout/ExtraSpacing, Metrics/BlockLength
 
@@ -162,6 +164,10 @@ module Entities
       return @reactions_sample if defined?(@reactions_sample)
 
       @reactions_sample = object.reactions_samples.first
+    end
+
+    def merged_sources
+      object.merged_sources
     end
   end
 end

--- a/app/assets/stylesheets/components/ReactionMaterial.scss
+++ b/app/assets/stylesheets/components/ReactionMaterial.scss
@@ -304,3 +304,11 @@ $rm-columns: (
     }
   }
 }
+
+.merged-source-link {
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
@@ -91,6 +91,7 @@ class Material extends Component {
 
     this.state = {
       showComponents: false,
+      showMergedSources: true,
       mixtureComponents: [],
       mixtureComponentsLoading: false,
       fieldToShow: 'molar mass',
@@ -155,6 +156,22 @@ class Material extends Component {
       sample.updateChecksum();
       ElementActions.showReactionMaterial({ sample, reaction });
     }
+  }
+
+  handleUnmergeSample(mergedSource) {
+    const { onUnmerge } = this.props;
+    if (onUnmerge && mergedSource.merge_id) {
+      onUnmerge(mergedSource.merge_id);
+    }
+  }
+
+  handleMergedSourceClick(mergedSource) {
+    const { reaction } = this.props;
+    aviatorNavigation('sample', mergedSource.id, true, false);
+    ElementActions.showReactionMaterial({
+      sample: { id: mergedSource.id },
+      reaction,
+    });
   }
 
   materialLoading(material, showLoadingColumn) {
@@ -1206,7 +1223,7 @@ class Material extends Component {
       metric = material.metrics[0];
     }
 
-    const { showComponents, mixtureComponentsLoading } = this.state;
+    const { showComponents, showMergedSources, mixtureComponentsLoading } = this.state;
     const isMixture = material.isMixture && material.isMixture();
     // Always get fresh components from material, syncing with state
     const existingComponents = Array.isArray(material.components) ? material.components : [];
@@ -1291,9 +1308,62 @@ class Material extends Component {
       </div>
     );
 
+    const mergedSources = material.merged_sources || [];
+
     return (
       <>
         {materialRow}
+
+        {(materialGroup === 'products' || materialGroup === 'reactants') && mergedSources.length > 0 && (
+          <div className="border-top">
+            <button
+              type="button"
+              className="d-flex align-items-center gap-2 px-3 py-1 small text-muted user-select-none w-100 bg-transparent border-0 text-start"
+              onClick={() => this.setState((s) => ({ showMergedSources: !s.showMergedSources }))}
+              title={showMergedSources ? 'Collapse merged sources' : 'Expand merged sources'}
+            >
+              <i className={`fa fa-chevron-${showMergedSources ? 'down' : 'right'}`} />
+              <span>{`Merged with (${mergedSources.length} ${mergedSources.length === 1 ? 'sample' : 'samples'})`}</span>
+            </button>
+            {showMergedSources && (
+            <div>
+              {mergedSources.map((src) => (
+                <div key={src.id} className="d-flex align-items-center gap-2 ps-4 pe-3 py-1 small border-top">
+                  <span className="text-muted">•</span>
+                  <span
+                    className="merged-source-link text-primary fw-semibold"
+                    role="link"
+                    tabIndex={0}
+                    onClick={() => this.handleMergedSourceClick(src)}
+                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') this.handleMergedSourceClick(src); }}
+                  >
+                    {src.short_label}
+                  </span>
+                  <span
+                    className="merged-source-link text-primary flex-grow-1"
+                    role="link"
+                    tabIndex={0}
+                    onClick={() => this.handleMergedSourceClick(src)}
+                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') this.handleMergedSourceClick(src); }}
+                  >
+                    {src.name}
+                  </span>
+                  <div className="ms-auto">
+                    <Button
+                      variant="outline-danger"
+                      size="sm"
+                      onClick={() => this.handleUnmergeSample(src)}
+                      title="Unmerge this sample from the target"
+                    >
+                      Unmerge
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+            )}
+          </div>
+        )}
 
         {isMixture && hasComponents && (
           <Accordion
@@ -1611,6 +1681,9 @@ class Material extends Component {
                 {materialName}
               </div>
             </OverlayTrigger>
+            {material.merged_sources?.length > 0 && (
+              <span className="badge bg-success ms-1">MERGED TARGET</span>
+            )}
           </div>
           {moleculeIupacName !== '' && (
             <div className="reaction-material__iupac-name">
@@ -1789,6 +1862,7 @@ Material.propTypes = {
   isOver: PropTypes.bool.isRequired,
   canDrop: PropTypes.bool.isRequired,
   isDragging: PropTypes.bool.isRequired,
+  onUnmerge: PropTypes.func,
 };
 
 Material.defaultProps = {
@@ -1797,4 +1871,5 @@ Material.defaultProps = {
   isDragging: false,
   canDrop: false,
   isOver: false,
+  onUnmerge: null,
 };

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
@@ -91,6 +91,7 @@ class Material extends Component {
 
     this.state = {
       showComponents: false,
+      showMergedSources: true,
       mixtureComponents: [],
       mixtureComponentsLoading: false,
       fieldToShow: 'molar mass',
@@ -155,6 +156,22 @@ class Material extends Component {
       sample.updateChecksum();
       ElementActions.showReactionMaterial({ sample, reaction });
     }
+  }
+
+  handleUnmergeSample(mergedSource) {
+    const { onUnmerge } = this.props;
+    if (onUnmerge && mergedSource.merge_id) {
+      onUnmerge(mergedSource.merge_id);
+    }
+  }
+
+  handleMergedSourceClick(mergedSource) {
+    const { reaction } = this.props;
+    aviatorNavigation('sample', mergedSource.id, true, false);
+    ElementActions.showReactionMaterial({
+      sample: { id: mergedSource.id },
+      reaction,
+    });
   }
 
   materialLoading(material, showLoadingColumn) {
@@ -1214,7 +1231,7 @@ class Material extends Component {
       metric = material.metrics[0];
     }
 
-    const { showComponents, mixtureComponentsLoading } = this.state;
+    const { showComponents, showMergedSources, mixtureComponentsLoading } = this.state;
     const isMixture = material.isMixture && material.isMixture();
     // Always get fresh components from material, syncing with state
     const existingComponents = Array.isArray(material.components) ? material.components : [];
@@ -1299,9 +1316,62 @@ class Material extends Component {
       </div>
     );
 
+    const mergedSources = material.merged_sources || [];
+
     return (
       <>
         {materialRow}
+
+        {(materialGroup === 'products' || materialGroup === 'reactants') && mergedSources.length > 0 && (
+          <div className="border-top">
+            <button
+              type="button"
+              className="d-flex align-items-center gap-2 px-3 py-1 small text-muted user-select-none w-100 bg-transparent border-0 text-start"
+              onClick={() => this.setState((s) => ({ showMergedSources: !s.showMergedSources }))}
+              title={showMergedSources ? 'Collapse merged sources' : 'Expand merged sources'}
+            >
+              <i className={`fa fa-chevron-${showMergedSources ? 'down' : 'right'}`} />
+              <span>{`Merged with (${mergedSources.length} ${mergedSources.length === 1 ? 'sample' : 'samples'})`}</span>
+            </button>
+            {showMergedSources && (
+            <div>
+              {mergedSources.map((src) => (
+                <div key={src.id} className="d-flex align-items-center gap-2 ps-4 pe-3 py-1 small border-top">
+                  <span className="text-muted">•</span>
+                  <span
+                    className="merged-source-link text-primary fw-semibold"
+                    role="link"
+                    tabIndex={0}
+                    onClick={() => this.handleMergedSourceClick(src)}
+                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') this.handleMergedSourceClick(src); }}
+                  >
+                    {src.short_label}
+                  </span>
+                  <span
+                    className="merged-source-link text-primary flex-grow-1"
+                    role="link"
+                    tabIndex={0}
+                    onClick={() => this.handleMergedSourceClick(src)}
+                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') this.handleMergedSourceClick(src); }}
+                  >
+                    {src.name}
+                  </span>
+                  <div className="ms-auto">
+                    <Button
+                      variant="outline-danger"
+                      size="sm"
+                      onClick={() => this.handleUnmergeSample(src)}
+                      title="Unmerge this sample from the target"
+                    >
+                      Unmerge
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+            )}
+          </div>
+        )}
 
         {isMixture && hasComponents && (
           <Accordion
@@ -1619,6 +1689,9 @@ class Material extends Component {
                 {materialName}
               </div>
             </OverlayTrigger>
+            {material.merged_sources?.length > 0 && (
+              <span className="badge bg-success ms-1">MERGED TARGET</span>
+            )}
           </div>
           {moleculeIupacName !== '' && (
             <div className="reaction-material__iupac-name">
@@ -1797,6 +1870,7 @@ Material.propTypes = {
   isOver: PropTypes.bool.isRequired,
   canDrop: PropTypes.bool.isRequired,
   isDragging: PropTypes.bool.isRequired,
+  onUnmerge: PropTypes.func,
 };
 
 Material.defaultProps = {
@@ -1805,4 +1879,5 @@ Material.defaultProps = {
   isDragging: false,
   canDrop: false,
   isOver: false,
+  onUnmerge: null,
 };

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/MaterialGroup.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/MaterialGroup.js
@@ -14,6 +14,7 @@ import { defaultMultiSolventsSmilesOptions } from 'src/components/staticDropdown
 import { ionic_liquids } from 'src/components/staticDropdownOptions/ionic_liquids';
 import { reagents_kombi } from 'src/components/staticDropdownOptions/reagents_kombi';
 import { permitOn } from 'src/components/common/uis';
+import { isSbmmSample } from 'src/utilities/ElementUtils';
 import ToggleButton from 'src/components/common/ToggleButton';
 import { DragDropItemTypes } from 'src/utilities/DndConst';
 import ReorderableMaterialContainer
@@ -43,7 +44,7 @@ const MaterialGroup = ({
   materials, materialGroup, deleteMaterial, onChange,
   showLoadingColumn, reaction, headIndex,
   dropMaterial, dropSample, dropSbmmSample, switchEquiv, lockEquivColumn, displayYieldField,
-  switchYield, dndEnabled
+  switchYield, dndEnabled, onInitiateMerge, onUnmerge,
 }) => {
   const { notifications } = useContext(StoreContext);
   const effectiveDndEnabled = dndEnabled && permitOn(reaction);
@@ -73,6 +74,7 @@ const MaterialGroup = ({
       isOver={isOver}
       canDrop={canDrop}
       isDragging={isDragging}
+      onUnmerge={onUnmerge}
     />
   );
 
@@ -98,8 +100,43 @@ const MaterialGroup = ({
     }
   };
 
+  const MERGEABLE_GROUPS = ['products', 'reactants'];
+
   const onReorder = (item, index) => {
-    dropMaterial(item.material, item.materialGroup, materials.at(index), materialGroup);
+    const target = materials.at(index);
+
+    if (
+      MERGEABLE_GROUPS.includes(materialGroup)
+      && item.materialGroup === materialGroup
+      && target
+      && item.material.id !== target.id
+      && !isSbmmSample(item.material)
+      && !isSbmmSample(target)
+    ) {
+      if (item.material.is_legacy) {
+        NotificationActions.add({
+          message: 'This sample has already been merged.',
+          level: 'warning',
+          position: 'tr',
+        });
+        return;
+      }
+      if (item.material.is_new || target.is_new) {
+        NotificationActions.add({
+          message: 'Save the reaction before merging materials.',
+          level: 'warning',
+          position: 'tr',
+        });
+        return;
+      }
+      // Show modal instead of pendingMerge confirmation row
+      if (onInitiateMerge) {
+        onInitiateMerge(item.material, target, materialGroup);
+      }
+      return;
+    }
+
+    dropMaterial(item.material, item.materialGroup, target, materialGroup);
   };
 
   if (materialGroup === 'solvents'
@@ -618,6 +655,8 @@ MaterialGroup.propTypes = {
   displayYieldField: PropTypes.bool,
   switchYield: PropTypes.func.isRequired,
   dndEnabled: PropTypes.bool,
+  onInitiateMerge: PropTypes.func,
+  onUnmerge: PropTypes.func,
 };
 
 GeneralMaterialGroup.propTypes = {
@@ -659,6 +698,8 @@ MaterialGroup.defaultProps = {
   displayYieldField: null,
   headIndex: 0,
   dndEnabled: true,
+  onInitiateMerge: null,
+  onUnmerge: null,
 };
 
 GeneralMaterialGroup.defaultProps = {
@@ -666,6 +707,8 @@ GeneralMaterialGroup.defaultProps = {
   lockEquivColumn: false,
   displayYieldField: null,
   dndEnabled: true,
+  onInitiateMerge: null,
+  onUnmerge: null,
 };
 
 export default MaterialGroup;

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
@@ -7,7 +7,9 @@ import {
 import { Select } from 'src/components/common/Select';
 import Delta from 'quill-delta';
 import MaterialGroup from 'src/apps/mydb/elements/details/reactions/schemeTab/MaterialGroup';
+import MergeSampleModal from 'src/components/common/MergeSampleModal';
 import Sample from 'src/models/Sample';
+import SamplesFetcher from 'src/fetchers/SamplesFetcher';
 import Reaction from 'src/models/Reaction';
 import Molecule from 'src/models/Molecule';
 import { isSbmmSample } from 'src/utilities/ElementUtils';
@@ -58,6 +60,10 @@ export default class ReactionDetailsScheme extends React.Component {
       lockEquivColumn,
       displayYieldField: null,
       reactionDescTemplate: textTemplate.toJS(),
+      showMergeModal: false,
+      sourceProduct: null,
+      targetProduct: null,
+      mergeGroup: null,
     };
 
     this.reactQuillRef = React.createRef();
@@ -73,6 +79,11 @@ export default class ReactionDetailsScheme extends React.Component {
     this.dropSbmmSample = this.dropSbmmSample.bind(this);
     this.switchEquiv = this.switchEquiv.bind(this);
     this.switchYield = this.switchYield.bind(this);
+    this.handleMergeConfirm = this.handleMergeConfirm.bind(this);
+    this.handleUnmerge = this.handleUnmerge.bind(this);
+    this.showMergeModal = this.showMergeModal.bind(this);
+    this.handleReorderProducts = this.handleReorderProducts.bind(this);
+    this.handleMergeModalClose = this.handleMergeModalClose.bind(this);
     this.updateTextTemplates = this.updateTextTemplates.bind(this);
     this.reactionVesselSize = this.reactionVesselSize.bind(this);
     this.updateVesselSize = this.updateVesselSize.bind(this);
@@ -434,6 +445,62 @@ export default class ReactionDetailsScheme extends React.Component {
 
     reaction.moveMaterial(srcMat, actualSrcGroup, tagMat, actualTagGroup);
     onReactionChange(reaction, { updateGraphic: true });
+  }
+
+  handleMergeConfirm(source, target) {
+    const { reaction, onReactionChange } = this.props;
+    const group = this.state.mergeGroup;
+
+    return SamplesFetcher.mergeSamples({
+      sourceSampleId: source.id,
+      targetSampleId: target.id,
+      reactionId: reaction.id,
+    }).then(() => {
+      reaction[group] = reaction[group].filter((p) => p.id !== source.id);
+      onReactionChange(reaction, { updateGraphic: true });
+      ElementActions.fetchReactionById(reaction.id);
+    }).catch((err) => {
+      NotificationActions.add({
+        title: 'Merge failed', message: err.message, level: 'error', position: 'tr',
+      });
+      throw err;
+    });
+  }
+
+  handleUnmerge(mergeId) {
+    const { reaction, onReactionChange } = this.props;
+
+    SamplesFetcher.unmergeSample(mergeId).then(() => {
+      onReactionChange(reaction, { updateGraphic: true });
+      ElementActions.fetchReactionById(reaction.id);
+    }).catch((err) => {
+      NotificationActions.add({
+        title: 'Unmerge failed', message: err.message, level: 'error', position: 'tr',
+      });
+    });
+  }
+
+  showMergeModal(sourceProduct, targetProduct, mergeGroup) {
+    this.setState({
+      showMergeModal: true,
+      sourceProduct,
+      targetProduct,
+      mergeGroup,
+    });
+  }
+
+  handleMergeModalClose() {
+    this.setState({
+      showMergeModal: false,
+      sourceProduct: null,
+      targetProduct: null,
+      mergeGroup: null,
+    });
+  }
+
+  handleReorderProducts(sourceProduct, targetProduct) {
+    const group = this.state.mergeGroup;
+    this.dropMaterial(sourceProduct, group, targetProduct, group);
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -2506,7 +2573,7 @@ export default class ReactionDetailsScheme extends React.Component {
           <MaterialGroup
             reaction={reaction}
             materialGroup="reactants"
-            materials={reaction.reactantsWithSbmm}
+            materials={reaction.reactantsWithSbmm.filter((r) => !r.is_legacy)}
             dropMaterial={this.dropMaterial}
             deleteMaterial={
               (material, materialGroup) => this.deleteMaterial(material, materialGroup)
@@ -2518,6 +2585,8 @@ export default class ReactionDetailsScheme extends React.Component {
             switchEquiv={this.switchEquiv}
             lockEquivColumn={lockEquivColumn}
             headIndex={reaction.starting_materials.length ?? 0}
+            onInitiateMerge={this.showMergeModal}
+            onUnmerge={this.handleUnmerge}
           />
           <MaterialGroup
             reaction={reaction}
@@ -2536,7 +2605,7 @@ export default class ReactionDetailsScheme extends React.Component {
           <MaterialGroup
             reaction={reaction}
             materialGroup="products"
-            materials={reaction.products}
+            materials={reaction.products.filter((p) => !p.is_legacy)}
             dropMaterial={this.dropMaterial}
             deleteMaterial={
               (material, materialGroup) => this.deleteMaterial(material, materialGroup)
@@ -2548,6 +2617,8 @@ export default class ReactionDetailsScheme extends React.Component {
             lockEquivColumn={this.state.lockEquivColumn}
             switchYield={this.switchYield}
             displayYieldField={displayYieldField}
+            onInitiateMerge={this.showMergeModal}
+            onUnmerge={this.handleUnmerge}
           />
           {!isInteractionReaction && (
             <ReactionConditions
@@ -2629,6 +2700,15 @@ export default class ReactionDetailsScheme extends React.Component {
           additionQuillRef={this.additionQuillRef}
           onChange={(event) => this.handleMaterialsChange(event)}
           isInteractionReaction={isInteractionReaction}
+        />
+
+        <MergeSampleModal
+          show={this.state.showMergeModal}
+          onHide={this.handleMergeModalClose}
+          sourceProduct={this.state.sourceProduct}
+          targetProduct={this.state.targetProduct}
+          onMerge={this.handleMergeConfirm}
+          onReorder={this.handleReorderProducts}
         />
       </>
     );

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
@@ -7,7 +7,9 @@ import {
 import { Select } from 'src/components/common/Select';
 import Delta from 'quill-delta';
 import MaterialGroup from 'src/apps/mydb/elements/details/reactions/schemeTab/MaterialGroup';
+import MergeSampleModal from 'src/components/common/MergeSampleModal';
 import Sample from 'src/models/Sample';
+import SamplesFetcher from 'src/fetchers/SamplesFetcher';
 import Reaction from 'src/models/Reaction';
 import Molecule from 'src/models/Molecule';
 import { isSbmmSample } from 'src/utilities/ElementUtils';
@@ -58,6 +60,10 @@ export default class ReactionDetailsScheme extends React.Component {
       lockEquivColumn,
       displayYieldField: null,
       reactionDescTemplate: textTemplate.toJS(),
+      showMergeModal: false,
+      sourceProduct: null,
+      targetProduct: null,
+      mergeGroup: null,
     };
 
     this.reactQuillRef = React.createRef();
@@ -73,6 +79,11 @@ export default class ReactionDetailsScheme extends React.Component {
     this.dropSbmmSample = this.dropSbmmSample.bind(this);
     this.switchEquiv = this.switchEquiv.bind(this);
     this.switchYield = this.switchYield.bind(this);
+    this.handleMergeConfirm = this.handleMergeConfirm.bind(this);
+    this.handleUnmerge = this.handleUnmerge.bind(this);
+    this.showMergeModal = this.showMergeModal.bind(this);
+    this.handleReorderProducts = this.handleReorderProducts.bind(this);
+    this.handleMergeModalClose = this.handleMergeModalClose.bind(this);
     this.updateTextTemplates = this.updateTextTemplates.bind(this);
     this.reactionVesselSize = this.reactionVesselSize.bind(this);
     this.updateVesselSize = this.updateVesselSize.bind(this);
@@ -434,6 +445,62 @@ export default class ReactionDetailsScheme extends React.Component {
 
     reaction.moveMaterial(srcMat, actualSrcGroup, tagMat, actualTagGroup);
     onReactionChange(reaction, { updateGraphic: true });
+  }
+
+  handleMergeConfirm(source, target) {
+    const { reaction, onReactionChange } = this.props;
+    const group = this.state.mergeGroup;
+
+    return SamplesFetcher.mergeSamples({
+      sourceSampleId: source.id,
+      targetSampleId: target.id,
+      reactionId: reaction.id,
+    }).then(() => {
+      reaction[group] = reaction[group].filter((p) => p.id !== source.id);
+      onReactionChange(reaction, { updateGraphic: true });
+      ElementActions.fetchReactionById(reaction.id);
+    }).catch((err) => {
+      NotificationActions.add({
+        title: 'Merge failed', message: err.message, level: 'error', position: 'tr',
+      });
+      throw err;
+    });
+  }
+
+  handleUnmerge(mergeId) {
+    const { reaction, onReactionChange } = this.props;
+
+    SamplesFetcher.unmergeSample(mergeId).then(() => {
+      onReactionChange(reaction, { updateGraphic: true });
+      ElementActions.fetchReactionById(reaction.id);
+    }).catch((err) => {
+      NotificationActions.add({
+        title: 'Unmerge failed', message: err.message, level: 'error', position: 'tr',
+      });
+    });
+  }
+
+  showMergeModal(sourceProduct, targetProduct, mergeGroup) {
+    this.setState({
+      showMergeModal: true,
+      sourceProduct,
+      targetProduct,
+      mergeGroup,
+    });
+  }
+
+  handleMergeModalClose() {
+    this.setState({
+      showMergeModal: false,
+      sourceProduct: null,
+      targetProduct: null,
+      mergeGroup: null,
+    });
+  }
+
+  handleReorderProducts(sourceProduct, targetProduct) {
+    const group = this.state.mergeGroup;
+    this.dropMaterial(sourceProduct, group, targetProduct, group);
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -2547,7 +2614,7 @@ export default class ReactionDetailsScheme extends React.Component {
           <MaterialGroup
             reaction={reaction}
             materialGroup="reactants"
-            materials={reaction.reactantsWithSbmm}
+            materials={reaction.reactantsWithSbmm.filter((r) => !r.is_legacy)}
             dropMaterial={this.dropMaterial}
             deleteMaterial={
               (material, materialGroup) => this.deleteMaterial(material, materialGroup)
@@ -2559,6 +2626,8 @@ export default class ReactionDetailsScheme extends React.Component {
             switchEquiv={this.switchEquiv}
             lockEquivColumn={lockEquivColumn}
             headIndex={reaction.starting_materials.length ?? 0}
+            onInitiateMerge={this.showMergeModal}
+            onUnmerge={this.handleUnmerge}
           />
           <MaterialGroup
             reaction={reaction}
@@ -2577,7 +2646,7 @@ export default class ReactionDetailsScheme extends React.Component {
           <MaterialGroup
             reaction={reaction}
             materialGroup="products"
-            materials={reaction.products}
+            materials={reaction.products.filter((p) => !p.is_legacy)}
             dropMaterial={this.dropMaterial}
             deleteMaterial={
               (material, materialGroup) => this.deleteMaterial(material, materialGroup)
@@ -2589,6 +2658,8 @@ export default class ReactionDetailsScheme extends React.Component {
             lockEquivColumn={this.state.lockEquivColumn}
             switchYield={this.switchYield}
             displayYieldField={displayYieldField}
+            onInitiateMerge={this.showMergeModal}
+            onUnmerge={this.handleUnmerge}
           />
           {!isInteractionReaction && (
             <ReactionConditions
@@ -2670,6 +2741,15 @@ export default class ReactionDetailsScheme extends React.Component {
           additionQuillRef={this.additionQuillRef}
           onChange={(event) => this.handleMaterialsChange(event)}
           isInteractionReaction={isInteractionReaction}
+        />
+
+        <MergeSampleModal
+          show={this.state.showMergeModal}
+          onHide={this.handleMergeModalClose}
+          sourceProduct={this.state.sourceProduct}
+          targetProduct={this.state.targetProduct}
+          onMerge={this.handleMergeConfirm}
+          onReorder={this.handleReorderProducts}
         />
       </>
     );

--- a/app/javascript/src/components/common/MergeSampleModal.js
+++ b/app/javascript/src/components/common/MergeSampleModal.js
@@ -1,0 +1,137 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { Button } from 'react-bootstrap';
+import AppModal from 'src/components/common/AppModal';
+
+export default function MergeSampleModal({
+  show,
+  onHide,
+  sourceProduct,
+  targetProduct,
+  onMerge,
+  onReorder,
+}) {
+  const [step, setStep] = useState('choose');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!show) {
+      setStep('choose');
+      setLoading(false);
+    }
+  }, [show]);
+
+  const materialLabel = (material, fallback) => {
+    if (!material) return fallback;
+    const label = material.short_label || fallback;
+    return material.name ? `${label} (${material.name})` : label;
+  };
+
+  const sourceLabel = materialLabel(sourceProduct, 'Source');
+  const targetLabel = materialLabel(targetProduct, 'Target');
+
+  const handleReorder = () => {
+    if (onReorder) onReorder(sourceProduct, targetProduct);
+    onHide();
+  };
+
+  const handleMergeConfirm = () => {
+    if (!onMerge) {
+      onHide();
+      return;
+    }
+    setLoading(true);
+    Promise.resolve(onMerge(sourceProduct, targetProduct))
+      .then(() => onHide())
+      .catch(() => setLoading(false));
+  };
+
+  if (step === 'choose') {
+    return (
+      <AppModal
+        show={show}
+        onHide={onHide}
+        title="Move or Merge?"
+        primaryActionLabel="Merge"
+        onPrimaryAction={() => setStep('confirm')}
+        extendedFooter={(
+          <Button variant="secondary" onClick={handleReorder}>
+            Reorder
+          </Button>
+        )}
+      >
+        <p>
+          <strong>{sourceLabel}</strong>
+          {' was dropped onto '}
+          <strong>{targetLabel}</strong>
+          .
+        </p>
+        <p className="text-muted small mb-0">
+          Choose <strong>Reorder</strong> to change the position, or <strong>Merge</strong> to combine the amounts.
+        </p>
+      </AppModal>
+    );
+  }
+
+  return (
+    <AppModal
+      show={show}
+      onHide={onHide}
+      onRequestClose={(_, source) => {
+        if (loading) return;
+        if (source === 'footer') setStep('choose');
+        else onHide();
+      }}
+      title="Confirm Merge"
+      closeLabel="Back"
+      primaryActionLabel={loading ? 'Merging…' : 'Confirm Merge'}
+      primaryActionDisabled={loading}
+      onPrimaryAction={handleMergeConfirm}
+    >
+      <p>
+        {'Merge '}
+        <strong>{sourceLabel}</strong>
+        {' into '}
+        <strong>{targetLabel}</strong>
+        ?
+      </p>
+      <ul className="mb-0">
+        <li>
+          {'The real amount of '}
+          <strong>{sourceLabel}</strong>
+          {' will be added to '}
+          <strong>{targetLabel}</strong>
+          .
+        </li>
+        <li>
+          <strong>{sourceLabel}</strong>
+          {' will be marked as Legacy and removed from the materials list.'}
+        </li>
+      </ul>
+    </AppModal>
+  );
+}
+
+MergeSampleModal.propTypes = {
+  show: PropTypes.bool.isRequired,
+  onHide: PropTypes.func.isRequired,
+  sourceProduct: PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    short_label: PropTypes.string,
+    name: PropTypes.string,
+  }),
+  targetProduct: PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    short_label: PropTypes.string,
+    name: PropTypes.string,
+  }),
+  onMerge: PropTypes.func,
+  onReorder: PropTypes.func,
+};
+
+MergeSampleModal.defaultProps = {
+  sourceProduct: null,
+  targetProduct: null,
+  onMerge: null,
+  onReorder: null,
+};

--- a/app/javascript/src/fetchers/SamplesFetcher.js
+++ b/app/javascript/src/fetchers/SamplesFetcher.js
@@ -180,4 +180,33 @@ export default class SamplesFetcher {
     }
     return sample;
   }
+
+  static mergeSamples({ sourceSampleId, targetSampleId, reactionId }) {
+    return fetch('/api/v1/samples/merge', {
+      credentials: 'same-origin',
+      method: 'POST',
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        source_sample_id: sourceSampleId,
+        target_sample_id: targetSampleId,
+        reaction_id: reactionId,
+      }),
+    }).then(async (response) => {
+      const json = await response.json().catch(() => null);
+      if (!response.ok) throw new Error(json?.error || `Merge failed (${response.status})`);
+      return new Sample(json.sample);
+    });
+  }
+
+  static unmergeSample(mergeId) {
+    return fetch(`/api/v1/samples/merge/${mergeId}`, {
+      credentials: 'same-origin',
+      method: 'DELETE',
+      headers: { Accept: 'application/json' },
+    }).then(async (response) => {
+      const json = await response.json().catch(() => null);
+      if (!response.ok) throw new Error(json?.error || `Unmerge failed (${response.status})`);
+      return new Sample(json.sample);
+    });
+  }
 }

--- a/app/javascript/src/fetchers/SamplesFetcher.js
+++ b/app/javascript/src/fetchers/SamplesFetcher.js
@@ -152,4 +152,33 @@ export default class SamplesFetcher {
     }
     return sample;
   }
+
+  static mergeSamples({ sourceSampleId, targetSampleId, reactionId }) {
+    return fetch('/api/v1/samples/merge', {
+      credentials: 'same-origin',
+      method: 'POST',
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        source_sample_id: sourceSampleId,
+        target_sample_id: targetSampleId,
+        reaction_id: reactionId,
+      }),
+    }).then(async (response) => {
+      const json = await response.json().catch(() => null);
+      if (!response.ok) throw new Error(json?.error || `Merge failed (${response.status})`);
+      return new Sample(json.sample);
+    });
+  }
+
+  static unmergeSample(mergeId) {
+    return fetch(`/api/v1/samples/merge/${mergeId}`, {
+      credentials: 'same-origin',
+      method: 'DELETE',
+      headers: { Accept: 'application/json' },
+    }).then(async (response) => {
+      const json = await response.json().catch(() => null);
+      if (!response.ok) throw new Error(json?.error || `Unmerge failed (${response.status})`);
+      return new Sample(json.sample);
+    });
+  }
 }

--- a/app/javascript/src/models/Sample.js
+++ b/app/javascript/src/models/Sample.js
@@ -74,6 +74,8 @@ export default class Sample extends Element {
     argsNew = prepareRangeBound(argsNew, 'boiling_point');
     argsNew = prepareRangeBound(argsNew, 'melting_point');
     super(argsNew);
+    this.is_legacy = argsNew.is_legacy || false;
+    this.merged_sources = argsNew.merged_sources || [];
   }
 
   cleanBoilingMelting() {

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -161,6 +161,8 @@ class Reaction < ApplicationRecord
   has_many :products, through: :reactions_product_samples, source: :sample
   has_many :product_molecules, through: :products, source: :molecule
 
+  has_many :sample_merges, dependent: :destroy
+
   has_many :literals, as: :element, dependent: :destroy
   has_many :literatures, through: :literals
 

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -19,6 +19,7 @@
 #  imported_readout    :string
 #  impurities          :string           default("")
 #  inventory_sample    :boolean          default(FALSE)
+#  is_legacy           :boolean          default(FALSE), not null
 #  is_top_secret       :boolean          default(FALSE)
 #  location            :string           default("")
 #  melting_point       :numrange
@@ -55,6 +56,7 @@
 #  index_samples_on_deleted_at        (deleted_at)
 #  index_samples_on_identifier        (identifier)
 #  index_samples_on_inventory_sample  (inventory_sample)
+#  index_samples_on_is_legacy         (is_legacy) WHERE (is_legacy = true)
 #  index_samples_on_molecule_name_id  (molecule_name_id)
 #  index_samples_on_sample_id         (molecule_id)
 #  index_samples_on_short_label       (short_label)
@@ -228,6 +230,8 @@ class Sample < ApplicationRecord
   before_create :check_molecule_name
   before_create :set_boiling_melting_points
   after_create :create_root_container
+  before_destroy :prevent_destroy_with_incoming_merges, prepend: true
+  before_destroy :prevent_destroy_when_merged_source, prepend: true
   after_save :update_counter
   after_save :update_equivalent_for_reactions
   after_save :update_gas_material
@@ -258,6 +262,20 @@ class Sample < ApplicationRecord
   has_many :comments, as: :commentable, dependent: :destroy
 
   has_many :components, dependent: :destroy
+
+  has_one  :outgoing_merge,
+           class_name: 'SampleMerge',
+           foreign_key: :source_sample_id,
+           inverse_of: :source_sample,
+           dependent: :destroy
+  has_many :incoming_merges,
+           class_name: 'SampleMerge',
+           foreign_key: :target_sample_id,
+           inverse_of: :target_sample,
+           dependent: :destroy
+  has_many :merged_sources,
+           through: :incoming_merges,
+           source: :source_sample
 
   belongs_to :fingerprint, optional: true
   belongs_to :user, optional: true
@@ -292,6 +310,20 @@ class Sample < ApplicationRecord
   delegate :inchikey, to: :molecule, prefix: true, allow_nil: true
 
   attr_writer :skip_reaction_svg_update
+
+  def prevent_destroy_when_merged_source
+    return if outgoing_merge.nil?
+
+    errors.add(:base, 'Cannot delete a merged sample. Unmerge it first.')
+    throw :abort
+  end
+
+  def prevent_destroy_with_incoming_merges
+    return unless incoming_merges.exists?
+
+    errors.add(:base, 'Cannot delete a sample that has merged sources. Unmerge them first.')
+    throw :abort
+  end
 
   def self.rebuild_pg_search_documents
     find_each(&:update_pg_search_document)

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -19,6 +19,7 @@
 #  imported_readout    :string
 #  impurities          :string           default("")
 #  inventory_sample    :boolean          default(FALSE)
+#  is_legacy           :boolean          default(FALSE), not null
 #  is_top_secret       :boolean          default(FALSE)
 #  location            :string           default("")
 #  melting_point       :numrange
@@ -55,6 +56,7 @@
 #  index_samples_on_deleted_at        (deleted_at)
 #  index_samples_on_identifier        (identifier)
 #  index_samples_on_inventory_sample  (inventory_sample)
+#  index_samples_on_is_legacy         (is_legacy) WHERE (is_legacy = true)
 #  index_samples_on_molecule_name_id  (molecule_name_id)
 #  index_samples_on_sample_id         (molecule_id)
 #  index_samples_on_short_label       (short_label)
@@ -231,6 +233,8 @@ class Sample < ApplicationRecord
   before_create :check_molecule_name
   before_create :set_boiling_melting_points
   after_create :create_root_container
+  before_destroy :prevent_destroy_with_incoming_merges, prepend: true
+  before_destroy :prevent_destroy_when_merged_source, prepend: true
   after_save :update_counter
   after_save :update_equivalent_for_reactions
   after_save :update_gas_material
@@ -261,6 +265,20 @@ class Sample < ApplicationRecord
   has_many :comments, as: :commentable, dependent: :destroy
 
   has_many :components, dependent: :destroy
+
+  has_one  :outgoing_merge,
+           class_name: 'SampleMerge',
+           foreign_key: :source_sample_id,
+           inverse_of: :source_sample,
+           dependent: :destroy
+  has_many :incoming_merges,
+           class_name: 'SampleMerge',
+           foreign_key: :target_sample_id,
+           inverse_of: :target_sample,
+           dependent: :destroy
+  has_many :merged_sources,
+           through: :incoming_merges,
+           source: :source_sample
 
   belongs_to :fingerprint, optional: true
   belongs_to :user, optional: true
@@ -295,6 +313,20 @@ class Sample < ApplicationRecord
   delegate :inchikey, to: :molecule, prefix: true, allow_nil: true
 
   attr_writer :skip_reaction_svg_update
+
+  def prevent_destroy_when_merged_source
+    return if outgoing_merge.nil?
+
+    errors.add(:base, 'Cannot delete a merged sample. Unmerge it first.')
+    throw :abort
+  end
+
+  def prevent_destroy_with_incoming_merges
+    return unless incoming_merges.exists?
+
+    errors.add(:base, 'Cannot delete a sample that has merged sources. Unmerge them first.')
+    throw :abort
+  end
 
   def self.rebuild_pg_search_documents
     find_each(&:update_pg_search_document)

--- a/app/models/sample_merge.rb
+++ b/app/models/sample_merge.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: sample_merges
+#
+#  id                                 :bigint           not null, primary key
+#  source_amount_mol                  :float            not null
+#  source_reaction_sample_attributes  :jsonb
+#  target_molecule_id_before          :integer
+#  target_real_amount_unit_before     :string
+#  target_real_amount_value_before    :float
+#  created_at                         :datetime
+#  updated_at                         :datetime
+#  reaction_id                        :integer          not null
+#  source_sample_id                   :integer          not null
+#  target_sample_id                   :integer          not null
+#
+# Indexes
+#
+#  index_sample_merges_on_source_sample_id     (source_sample_id) UNIQUE
+#  index_sample_merges_on_target_and_reaction  (target_sample_id,reaction_id)
+#
+# Foreign Keys
+#
+#  fk_sample_merges_reaction  (reaction_id => reactions.id)
+#  fk_sample_merges_source    (source_sample_id => samples.id)
+#  fk_sample_merges_target    (target_sample_id => samples.id)
+#
+class SampleMerge < ApplicationRecord
+  belongs_to :source_sample, class_name: 'Sample', inverse_of: :outgoing_merge
+  belongs_to :target_sample, class_name: 'Sample', inverse_of: :incoming_merges
+  belongs_to :reaction, inverse_of: :sample_merges
+
+  validates :source_sample_id, uniqueness: true
+  validate  :source_and_target_differ
+  validate  :source_amount_mol_non_negative
+
+  private
+
+  def source_and_target_differ
+    errors.add(:source_sample_id, 'cannot equal target') if source_sample_id == target_sample_id
+  end
+
+  def source_amount_mol_non_negative
+    errors.add(:source_amount_mol, 'must be >= 0') if source_amount_mol&.negative?
+  end
+end

--- a/app/services/sample_merge_service.rb
+++ b/app/services/sample_merge_service.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+class SampleMergeService
+  class MergeError < StandardError
+    attr_reader :http_status
+
+    def initialize(message = nil, http_status: 422)
+      super(message)
+      @http_status = http_status
+    end
+  end
+
+  DUMMY_INCHIKEY = 'DUMMY'
+  MERGEABLE_GROUPS = %i[reactions_product_samples reactions_reactant_samples].freeze
+
+  def initialize(current_user:)
+    @user = current_user
+  end
+
+  def merge!(source_id:, target_id:, reaction_id:)
+    source   = Sample.find(source_id)
+    target   = Sample.find(target_id)
+    reaction = Reaction.find(reaction_id)
+
+    validate_merge!(source, target, reaction)
+    ActiveRecord::Base.transaction { apply_merge!(source, target, reaction) }
+    target.reload
+  end
+
+  def unmerge!(merge_id:)
+    merge  = SampleMerge.find(merge_id)
+    source = merge.source_sample
+    target = merge.target_sample
+
+    authorized = can_update?(source) && can_update?(target) && can_update?(merge.reaction)
+    raise MergeError.new('Unauthorized', http_status: 401) unless authorized
+    raise MergeError, 'cannot unmerge from a sample that has itself been merged upstream' if target.is_legacy
+
+    ActiveRecord::Base.transaction { apply_unmerge!(merge, source, target) }
+    target.reload
+  end
+
+  private
+
+  def apply_merge!(source, target, reaction)
+    snapshot               = original_target_snapshot(target)
+    target_molecule_before = target.molecule_id
+
+    reconcile_molecule!(source, target)
+    target.reload if target.molecule_id != target_molecule_before
+
+    reference_mw = molecular_weight(target) || molecular_weight(source)
+    source_mol   = sample_mol(source, reference_mw)
+    target_mol   = sample_mol(target, reference_mw)
+
+    target.update!(real_amount_value: source_mol + target_mol, real_amount_unit: 'mol')
+    rps_attributes = destroy_source_reaction_sample!(source, reaction)
+    source.update!(is_legacy: true)
+
+    SampleMerge.create!(
+      source_sample: source,
+      target_sample: target,
+      reaction: reaction,
+      source_amount_mol: source_mol,
+      target_real_amount_value_before: snapshot[:value],
+      target_real_amount_unit_before: snapshot[:unit],
+      target_molecule_id_before: target_molecule_before,
+      source_reaction_sample_attributes: rps_attributes,
+    )
+  end
+
+  def apply_unmerge!(merge, source, target)
+    is_last_merge = target.incoming_merges.where.not(id: merge.id).none?
+    restore_or_subtract!(merge, target, is_last_merge)
+    restore_target_molecule!(merge, target, is_last_merge)
+    source.update!(is_legacy: false)
+    restore_source_reaction_sample!(merge, source)
+    merge.destroy!
+  end
+
+  def original_target_snapshot(target)
+    { value: target.real_amount_value, unit: target.real_amount_unit }
+  end
+
+  def restore_or_subtract!(merge, target, is_last_merge)
+    if is_last_merge
+      target.update!(
+        real_amount_value: merge.target_real_amount_value_before,
+        real_amount_unit: merge.target_real_amount_unit_before,
+      )
+    else
+      current_mol = sample_mol(target, molecular_weight(target))
+      new_value   = current_mol - merge.source_amount_mol
+      raise MergeError, 'unmerge would yield negative amount' if new_value.negative?
+
+      target.update!(real_amount_value: new_value, real_amount_unit: 'mol')
+    end
+  end
+
+  def reconcile_molecule!(source, target)
+    return unless no_molecule?(target)
+    return if no_molecule?(source)
+
+    target.update!(molecule_id: source.molecule_id)
+  end
+
+  def restore_target_molecule!(merge, target, is_last_merge)
+    return unless is_last_merge
+    return if merge.target_molecule_id_before == target.molecule_id
+
+    target.update!(molecule_id: merge.target_molecule_id_before)
+  end
+
+  def destroy_source_reaction_sample!(source, reaction)
+    group = mergeable_group(reaction, source.id)
+    return nil unless group
+
+    scope = reaction.public_send(group).where(sample_id: source.id)
+    raise MergeError, 'source has multiple reaction associations' if scope.many?
+
+    rps = scope.first
+    return nil unless rps
+
+    attrs = rps.attributes.except('id', 'created_at', 'updated_at')
+    rps.destroy!
+    attrs
+  end
+
+  def restore_source_reaction_sample!(merge, source)
+    return if merge.reaction.reactions_samples.exists?(sample_id: source.id)
+
+    attrs = (merge.source_reaction_sample_attributes || {}).merge(
+      'reaction_id' => merge.reaction_id,
+      'sample_id' => source.id,
+    )
+    ReactionsSample.create!(attrs)
+  end
+
+  def validate_merge!(source, target, reaction)
+    validate_distinct_samples!(source, target)
+    validate_legacy_state!(source, target)
+    validate_authorization!(source, target, reaction)
+    validate_reaction_membership!(source, target, reaction)
+    validate_molecule_compatibility!(source, target)
+  end
+
+  def validate_distinct_samples!(source, target)
+    raise MergeError, 'source equals target' if source.id == target.id
+  end
+
+  def validate_legacy_state!(source, target)
+    raise MergeError, 'source already merged' if source.is_legacy
+    raise MergeError, 'target is legacy' if target.is_legacy
+  end
+
+  def validate_authorization!(source, target, reaction)
+    authorized = can_update?(source) && can_update?(target) && can_update?(reaction)
+    raise MergeError.new('Unauthorized', http_status: 401) unless authorized
+  end
+
+  def validate_reaction_membership!(source, target, reaction)
+    source_group = mergeable_group(reaction, source.id)
+    target_group = mergeable_group(reaction, target.id)
+    raise MergeError, 'source must be a product or reactant of this reaction' unless source_group
+    raise MergeError, 'target must be in the same material group as source' unless source_group == target_group
+  end
+
+  def mergeable_group(reaction, sample_id)
+    MERGEABLE_GROUPS.find { |group| reaction.public_send(group).exists?(sample_id: sample_id) }
+  end
+
+  def validate_molecule_compatibility!(source, target)
+    return if no_molecule?(source) || no_molecule?(target)
+    return if source.molecule_inchikey == target.molecule_inchikey
+
+    raise MergeError, 'source and target have different structures'
+  end
+
+  def no_molecule?(sample)
+    key = sample.molecule_inchikey
+    key.blank? || key == DUMMY_INCHIKEY
+  end
+
+  def molecular_weight(sample)
+    mw = sample.molecule&.molecular_weight.to_f
+    mw.positive? ? mw : nil
+  end
+
+  def sample_mol(sample, fallback_mw)
+    return 0.0 if real_amount_blank?(sample)
+
+    mol = sample.amount_mol
+    return mol.to_f unless mol.nil?
+
+    value = sample.real_amount_value.to_f
+    unit  = sample.real_amount_unit
+    return value if unit == 'mol'
+
+    unless fallback_mw.to_f.positive? && unit == 'g'
+      raise MergeError,
+            "cannot convert sample #{sample.id} amount (#{unit.inspect}) to mol: " \
+            'missing molecular weight or unsupported unit'
+    end
+
+    (value * sample.purity.to_f) / fallback_mw.to_f
+  end
+
+  def real_amount_blank?(sample)
+    sample.real_amount_value.nil? || sample.real_amount_value.to_f.zero?
+  end
+
+  def can_update?(record)
+    ElementPolicy.new(@user, record).update?
+  end
+end

--- a/app/usecases/reactions/update_materials.rb
+++ b/app/usecases/reactions/update_materials.rb
@@ -62,7 +62,7 @@ end
 
 module Usecases
   module Reactions
-    class UpdateMaterials
+    class UpdateMaterials # rubocop:disable Metrics/ClassLength
       include ContainerHelpers
       include Reactable
       attr_reader :current_user
@@ -268,8 +268,10 @@ module Usecases
         end
       end
 
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       def update_existing_sample(sample, fixed_label, target_amount = nil)
         existing_sample = Sample.find(sample.id)
+        return existing_sample if existing_sample.is_legacy
 
         update_gas_material = @reaction.vessel_size && @vessel_size && (
           @reaction.vessel_size['amount'] != @vessel_size['amount'] ||
@@ -304,6 +306,7 @@ module Usecases
         existing_sample.save!
         existing_sample
       end
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
       def associate_sample_with_reaction(sample, modified_sample, material_group)
         reactions_sample_klass = "Reactions#{material_group.camelize}Sample"

--- a/app/usecases/reactions/update_materials.rb
+++ b/app/usecases/reactions/update_materials.rb
@@ -269,8 +269,10 @@ module Usecases
         end
       end
 
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       def update_existing_sample(sample, fixed_label, target_amount = nil)
         existing_sample = Sample.find(sample.id)
+        return existing_sample if existing_sample.is_legacy
 
         update_gas_material = @reaction.vessel_size && @vessel_size && (
           @reaction.vessel_size['amount'] != @vessel_size['amount'] ||
@@ -306,7 +308,6 @@ module Usecases
         existing_sample
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength -- pre-existing size, out of scope for this PR
       def associate_sample_with_reaction(sample, modified_sample, material_group)
         reactions_sample_klass = "Reactions#{material_group.camelize}Sample"
         existing_association = ReactionsSample.find_by(sample_id: modified_sample.id)
@@ -347,7 +348,7 @@ module Usecases
           )
         end
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
       def destroy_unused_samples(modified_sample_ids)
         current_sample_ids = @reaction.reactions_samples.pluck(:sample_id)

--- a/db/migrate/20260504000001_add_is_legacy_to_samples.rb
+++ b/db/migrate/20260504000001_add_is_legacy_to_samples.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddIsLegacyToSamples < ActiveRecord::Migration[6.1]
+  def up
+    add_column :samples, :is_legacy, :boolean, default: false, null: false
+    add_index :samples, :is_legacy, name: 'index_samples_on_is_legacy', where: 'is_legacy = TRUE'
+  end
+
+  def down
+    remove_index :samples, name: 'index_samples_on_is_legacy'
+    remove_column :samples, :is_legacy
+  end
+end

--- a/db/migrate/20260504000002_create_sample_merges.rb
+++ b/db/migrate/20260504000002_create_sample_merges.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class CreateSampleMerges < ActiveRecord::Migration[6.1]
+  def up
+    create_table :sample_merges do |t|
+      t.integer :source_sample_id,               null: false
+      t.integer :target_sample_id,               null: false
+      t.integer :reaction_id,                    null: false
+      t.float   :source_amount_mol,              null: false
+      t.float   :target_real_amount_value_before
+      t.string  :target_real_amount_unit_before
+      t.integer :target_molecule_id_before
+      t.jsonb   :source_reaction_sample_attributes
+      t.datetime :created_at
+      t.datetime :updated_at
+    end
+
+    # Unique: a source can only be actively merged into one target at a time
+    add_index :sample_merges, :source_sample_id,
+              unique: true,
+              name: 'index_sample_merges_on_source_sample_id'
+
+    add_index :sample_merges, %i[target_sample_id reaction_id],
+              name: 'index_sample_merges_on_target_and_reaction'
+
+    add_foreign_key :sample_merges, :samples,
+                    column: :source_sample_id,
+                    name: 'fk_sample_merges_source'
+    add_foreign_key :sample_merges, :samples,
+                    column: :target_sample_id,
+                    name: 'fk_sample_merges_target'
+    add_foreign_key :sample_merges, :reactions,
+                    name: 'fk_sample_merges_reaction'
+  end
+
+  def down
+    remove_foreign_key :sample_merges, name: 'fk_sample_merges_source'
+    remove_foreign_key :sample_merges, name: 'fk_sample_merges_target'
+    remove_foreign_key :sample_merges, name: 'fk_sample_merges_reaction'
+    drop_table :sample_merges
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1379,6 +1379,21 @@ ActiveRecord::Schema.define(version: 2026_07_09_140001) do
     t.index ["sample_id"], name: "index_residues_on_sample_id"
   end
 
+  create_table "sample_merges", force: :cascade do |t|
+    t.integer "source_sample_id", null: false
+    t.integer "target_sample_id", null: false
+    t.integer "reaction_id", null: false
+    t.float "source_amount_mol", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.float "target_real_amount_value_before"
+    t.string "target_real_amount_unit_before"
+    t.integer "target_molecule_id_before"
+    t.jsonb "source_reaction_sample_attributes"
+    t.index ["source_sample_id"], name: "index_sample_merges_on_source_sample_id", unique: true
+    t.index ["target_sample_id", "reaction_id"], name: "index_sample_merges_on_target_and_reaction"
+  end
+
   create_table "sample_tasks", force: :cascade do |t|
     t.float "result_value"
     t.string "result_unit", default: "g", null: false
@@ -1437,10 +1452,12 @@ ActiveRecord::Schema.define(version: 2026_07_09_140001) do
     t.string "sample_type", default: "Micromolecule"
     t.jsonb "sample_details"
     t.jsonb "log_data"
+    t.boolean "is_legacy", default: false, null: false
     t.index ["ancestry"], name: "index_samples_on_ancestry", opclass: :varchar_pattern_ops, where: "(deleted_at IS NULL)"
     t.index ["deleted_at"], name: "index_samples_on_deleted_at"
     t.index ["identifier"], name: "index_samples_on_identifier"
     t.index ["inventory_sample"], name: "index_samples_on_inventory_sample"
+    t.index ["is_legacy"], name: "index_samples_on_is_legacy", where: "(is_legacy = true)"
     t.index ["molecule_id"], name: "index_samples_on_sample_id"
     t.index ["molecule_name_id"], name: "index_samples_on_molecule_name_id"
     t.index ["short_label"], name: "index_samples_on_short_label"
@@ -1882,6 +1899,9 @@ ActiveRecord::Schema.define(version: 2026_07_09_140001) do
   add_foreign_key "reactions_reactant_sbmm_samples", "reactions"
   add_foreign_key "reactions_reactant_sbmm_samples", "sequence_based_macromolecule_samples"
   add_foreign_key "report_templates", "attachments"
+  add_foreign_key "sample_merges", "reactions", name: "fk_sample_merges_reaction"
+  add_foreign_key "sample_merges", "samples", column: "source_sample_id", name: "fk_sample_merges_source"
+  add_foreign_key "sample_merges", "samples", column: "target_sample_id", name: "fk_sample_merges_target"
   add_foreign_key "sample_tasks", "samples"
   add_foreign_key "sample_tasks", "users", column: "creator_id"
   add_foreign_key "sequence_based_macromolecule_samples", "sequence_based_macromolecules"

--- a/spec/api/chemotion/sample_api_merge_spec.rb
+++ b/spec/api/chemotion/sample_api_merge_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Chemotion::SampleAPI do
+  include_context 'api request authorization context'
+
+  let(:collection) { create(:collection, user: user) }
+  let(:reaction) { create(:reaction, collections: [collection]) }
+  let(:molecule) { create(:molecule) }
+
+  # Creates a product sample, places it in a collection, and links it to a reaction.
+  def product(real_value, real_unit, mol, in_collection: collection, in_reaction: reaction)
+    sample = create(
+      :sample,
+      collections: [in_collection],
+      molecule: mol,
+      purity: 1.0,
+      real_amount_value: real_value,
+      real_amount_unit: real_unit,
+    )
+    create(:reactions_product_sample, reaction: in_reaction, sample: sample)
+    sample
+  end
+
+  describe 'POST /api/v1/samples/merge' do
+    let(:source) { product(2.0, 'mol', molecule) }
+    let(:target) { product(3.0, 'mol', molecule) }
+
+    def merge_request(source_id: source.id, target_id: target.id, reaction_id: reaction.id)
+      post '/api/v1/samples/merge',
+           params: { source_sample_id: source_id, target_sample_id: target_id, reaction_id: reaction_id },
+           as: :json
+    end
+
+    it 'merges and returns the updated target' do
+      merge_request
+
+      expect(response).to have_http_status(:created)
+      expect(JSON.parse(response.body)['sample']['id']).to eq(target.id)
+    end
+
+    context 'when merging reactants' do
+      def reactant(real_value, real_unit, mol)
+        sample = create(
+          :sample,
+          collections: [collection],
+          molecule: mol,
+          purity: 1.0,
+          real_amount_value: real_value,
+          real_amount_unit: real_unit,
+        )
+        create(:reactions_reactant_sample, reaction: reaction, sample: sample)
+        sample
+      end
+
+      let(:source) { reactant(2.0, 'mol', molecule) }
+      let(:target) { reactant(3.0, 'mol', molecule) }
+
+      it 'merges and returns the updated target' do
+        merge_request
+
+        expect(response).to have_http_status(:created)
+        expect(JSON.parse(response.body)['sample']['id']).to eq(target.id)
+      end
+    end
+
+    it 'returns 422 when the structures differ' do
+      different_source = product(1.0, 'mol', create(:molecule))
+      merge_request(source_id: different_source.id)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'returns 404 when a sample is missing' do
+      merge_request(source_id: 0)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns 401 when the user cannot access the reaction' do
+      foreign_collection = create(:collection, user: create(:person))
+      foreign_reaction = create(:reaction, collections: [foreign_collection])
+      foreign_source = product(1.0, 'mol', molecule, in_collection: foreign_collection, in_reaction: foreign_reaction)
+      foreign_target = product(1.0, 'mol', molecule, in_collection: foreign_collection, in_reaction: foreign_reaction)
+
+      post '/api/v1/samples/merge',
+           params: {
+             source_sample_id: foreign_source.id,
+             target_sample_id: foreign_target.id,
+             reaction_id: foreign_reaction.id,
+           },
+           as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'DELETE /api/v1/samples/merge/:id' do
+    let(:source) { product(2.0, 'mol', molecule) }
+    let(:target) { product(3.0, 'mol', molecule) }
+
+    before do
+      SampleMergeService.new(current_user: user).merge!(
+        source_id: source.id, target_id: target.id, reaction_id: reaction.id,
+      )
+    end
+
+    it 'unmerges and revives the source' do
+      delete "/api/v1/samples/merge/#{SampleMerge.last.id}", as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(source.reload.is_legacy).to be false
+    end
+
+    it 'returns 404 for an unknown merge id' do
+      delete '/api/v1/samples/merge/0', as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/models/sample_merge_spec.rb
+++ b/spec/models/sample_merge_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: sample_merges
+#
+#  id                                 :bigint           not null, primary key
+#  source_amount_mol                  :float            not null
+#  source_reaction_sample_attributes  :jsonb
+#  target_molecule_id_before          :integer
+#  target_real_amount_unit_before     :string
+#  target_real_amount_value_before    :float
+#  created_at                         :datetime
+#  updated_at                         :datetime
+#  reaction_id                        :integer          not null
+#  source_sample_id                   :integer          not null
+#  target_sample_id                   :integer          not null
+#
+# Indexes
+#
+#  index_sample_merges_on_source_sample_id     (source_sample_id) UNIQUE
+#  index_sample_merges_on_target_and_reaction  (target_sample_id,reaction_id)
+#
+# Foreign Keys
+#
+#  fk_sample_merges_reaction  (reaction_id => reactions.id)
+#  fk_sample_merges_source    (source_sample_id => samples.id)
+#  fk_sample_merges_target    (target_sample_id => samples.id)
+#
+require 'rails_helper'
+
+describe SampleMerge do
+  let(:user) { create(:user) }
+  let(:collection) { create(:collection, user: user) }
+  let(:reaction) { create(:reaction, collections: [collection]) }
+  let(:sample_a) { create(:sample, collections: [collection]) }
+  let(:sample_b) { create(:sample, collections: [collection]) }
+
+  def build_merge(**overrides)
+    described_class.new(
+      { source_sample: sample_a, target_sample: sample_b, reaction: reaction, source_amount_mol: 1.0 }
+        .merge(overrides),
+    )
+  end
+
+  it 'is valid with a distinct source and target' do
+    expect(build_merge).to be_valid
+  end
+
+  it 'rejects a source equal to the target' do
+    expect(build_merge(target_sample: sample_a)).not_to be_valid
+  end
+
+  it 'rejects a negative source amount' do
+    expect(build_merge(source_amount_mol: -1.0)).not_to be_valid
+  end
+
+  it 'enforces uniqueness of the source sample' do
+    build_merge.save!
+    duplicate = build_merge(target_sample: create(:sample, collections: [collection]))
+    expect(duplicate).not_to be_valid
+  end
+end

--- a/spec/models/sample_spec.rb
+++ b/spec/models/sample_spec.rb
@@ -19,6 +19,7 @@
 #  imported_readout    :string
 #  impurities          :string           default("")
 #  inventory_sample    :boolean          default(FALSE)
+#  is_legacy           :boolean          default(FALSE), not null
 #  is_top_secret       :boolean          default(FALSE)
 #  location            :string           default("")
 #  melting_point       :numrange
@@ -55,6 +56,7 @@
 #  index_samples_on_deleted_at        (deleted_at)
 #  index_samples_on_identifier        (identifier)
 #  index_samples_on_inventory_sample  (inventory_sample)
+#  index_samples_on_is_legacy         (is_legacy) WHERE (is_legacy = true)
 #  index_samples_on_molecule_name_id  (molecule_name_id)
 #  index_samples_on_sample_id         (molecule_id)
 #  index_samples_on_short_label       (short_label)
@@ -512,6 +514,41 @@ RSpec.describe Sample do
         result = sample.send(:valid_molecular_weight?)
         expect(result).to be false
       end
+    end
+  end
+
+  describe 'merge destroy guards' do
+    let(:user) { create(:user) }
+    let(:source) { merge_product(1.0) }
+    let(:target) { merge_product(2.0) }
+    let(:collection) { create(:collection, user: user) }
+    let(:reaction) { create(:reaction, collections: [collection]) }
+    let(:molecule) { create(:molecule) }
+
+    def merge_product(value)
+      sample = create(
+        :sample,
+        collections: [collection],
+        molecule: molecule,
+        real_amount_value: value,
+        real_amount_unit: 'mol',
+      )
+      create(:reactions_product_sample, reaction: reaction, sample: sample)
+      sample
+    end
+
+    before do
+      SampleMergeService.new(current_user: user).merge!(
+        source_id: source.id, target_id: target.id, reaction_id: reaction.id,
+      )
+    end
+
+    it 'prevents deleting a merged source' do
+      expect(source.reload.destroy).to be false
+    end
+
+    it 'prevents deleting a merge target' do
+      expect(target.reload.destroy).to be false
     end
   end
 end

--- a/spec/models/sample_spec.rb
+++ b/spec/models/sample_spec.rb
@@ -19,6 +19,7 @@
 #  imported_readout    :string
 #  impurities          :string           default("")
 #  inventory_sample    :boolean          default(FALSE)
+#  is_legacy           :boolean          default(FALSE), not null
 #  is_top_secret       :boolean          default(FALSE)
 #  location            :string           default("")
 #  melting_point       :numrange
@@ -55,6 +56,7 @@
 #  index_samples_on_deleted_at        (deleted_at)
 #  index_samples_on_identifier        (identifier)
 #  index_samples_on_inventory_sample  (inventory_sample)
+#  index_samples_on_is_legacy         (is_legacy) WHERE (is_legacy = true)
 #  index_samples_on_molecule_name_id  (molecule_name_id)
 #  index_samples_on_sample_id         (molecule_id)
 #  index_samples_on_short_label       (short_label)
@@ -586,6 +588,41 @@ RSpec.describe Sample do
         result = sample.send(:valid_molecular_weight?)
         expect(result).to be false
       end
+    end
+  end
+
+  describe 'merge destroy guards' do
+    let(:user) { create(:user) }
+    let(:source) { merge_product(1.0) }
+    let(:target) { merge_product(2.0) }
+    let(:collection) { create(:collection, user: user) }
+    let(:reaction) { create(:reaction, collections: [collection]) }
+    let(:molecule) { create(:molecule) }
+
+    def merge_product(value)
+      sample = create(
+        :sample,
+        collections: [collection],
+        molecule: molecule,
+        real_amount_value: value,
+        real_amount_unit: 'mol',
+      )
+      create(:reactions_product_sample, reaction: reaction, sample: sample)
+      sample
+    end
+
+    before do
+      SampleMergeService.new(current_user: user).merge!(
+        source_id: source.id, target_id: target.id, reaction_id: reaction.id,
+      )
+    end
+
+    it 'prevents deleting a merged source' do
+      expect(source.reload.destroy).to be false
+    end
+
+    it 'prevents deleting a merge target' do
+      expect(target.reload.destroy).to be false
     end
   end
 

--- a/spec/services/sample_merge_service_spec.rb
+++ b/spec/services/sample_merge_service_spec.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SampleMergeService do
+  subject(:service) { described_class.new(current_user: user) }
+
+  let(:user) { create(:user) }
+  let(:collection) { create(:collection, user: user) }
+  let(:reaction) { create(:reaction, collections: [collection]) }
+  let(:molecule) { create(:molecule) }
+
+  # Creates a product sample, places it in the user's collection, and links it
+  # to the reaction as a ReactionsProductSample.
+  def build_product(real_value:, real_unit:, molecule:)
+    build_material(:reactions_product_sample, real_value: real_value, real_unit: real_unit, molecule: molecule)
+  end
+
+  # Same as build_product, but linked to the reaction as a ReactionsReactantSample.
+  def build_reactant(real_value:, real_unit:, molecule:)
+    build_material(:reactions_reactant_sample, real_value: real_value, real_unit: real_unit, molecule: molecule)
+  end
+
+  def build_material(factory, real_value:, real_unit:, molecule:)
+    sample = create(
+      :sample,
+      collections: [collection],
+      molecule: molecule,
+      purity: 1.0,
+      real_amount_value: real_value,
+      real_amount_unit: real_unit,
+    )
+    create(factory, reaction: reaction, sample: sample)
+    sample
+  end
+
+  describe '#merge!' do
+    context 'when both products share the same molecule (mol units)' do
+      let(:source) { build_product(real_value: 2.0, real_unit: 'mol', molecule: molecule) }
+      let(:target) { build_product(real_value: 3.0, real_unit: 'mol', molecule: molecule) }
+
+      it 'adds the source amount into the target' do
+        result = service.merge!(source_id: source.id, target_id: target.id, reaction_id: reaction.id)
+
+        expect(result.real_amount_value).to eq(5.0)
+        expect(result.real_amount_unit).to eq('mol')
+      end
+
+      it 'marks the source as legacy and removes its product row' do
+        service.merge!(source_id: source.id, target_id: target.id, reaction_id: reaction.id)
+
+        expect(source.reload.is_legacy).to be true
+        expect(reaction.reactions_product_samples.exists?(sample_id: source.id)).to be false
+      end
+
+      it 'records the merge with the source amount and the target snapshot' do
+        expect do
+          service.merge!(source_id: source.id, target_id: target.id, reaction_id: reaction.id)
+        end.to change(SampleMerge, :count).by(1)
+
+        merge = SampleMerge.last
+        expect(merge.source_amount_mol).to eq(2.0)
+        expect(merge.target_real_amount_value_before).to eq(3.0)
+      end
+    end
+
+    context 'when amounts are in grams' do
+      let(:source) { build_product(real_value: molecule.molecular_weight, real_unit: 'g', molecule: molecule) }
+      let(:target) { build_product(real_value: molecule.molecular_weight * 2, real_unit: 'g', molecule: molecule) }
+
+      it 'converts grams to mol before adding' do
+        result = service.merge!(source_id: source.id, target_id: target.id, reaction_id: reaction.id)
+
+        expect(result.real_amount_value).to be_within(1e-6).of(3.0)
+        expect(result.real_amount_unit).to eq('mol')
+      end
+    end
+
+    context 'when the products have different structures' do
+      let(:source) { build_product(real_value: 1.0, real_unit: 'mol', molecule: create(:molecule)) }
+      let(:target) { build_product(real_value: 1.0, real_unit: 'mol', molecule: create(:molecule)) }
+
+      it 'raises a MergeError' do
+        expect do
+          service.merge!(source_id: source.id, target_id: target.id, reaction_id: reaction.id)
+        end.to raise_error(SampleMergeService::MergeError, /different structures/)
+      end
+    end
+
+    context 'when the source has no recorded real amount (n.d)' do
+      let(:source) { build_product(real_value: 0.0, real_unit: nil, molecule: molecule) }
+      let(:target) { build_product(real_value: 3.0, real_unit: 'mol', molecule: molecule) }
+
+      it 'treats the source as 0 mol and merges without error' do
+        result = service.merge!(source_id: source.id, target_id: target.id, reaction_id: reaction.id)
+
+        expect(result.real_amount_value).to eq(3.0)
+        expect(result.real_amount_unit).to eq('mol')
+      end
+    end
+
+    context 'when an amount uses an unconvertible unit' do
+      let(:source) { build_product(real_value: 5.0, real_unit: 'ml', molecule: molecule) }
+      let(:target) { build_product(real_value: 1.0, real_unit: 'mol', molecule: molecule) }
+
+      it 'raises instead of silently losing mass' do
+        expect do
+          service.merge!(source_id: source.id, target_id: target.id, reaction_id: reaction.id)
+        end.to raise_error(SampleMergeService::MergeError, /cannot convert/)
+      end
+    end
+
+    context 'when the source is already merged' do
+      let(:source) { build_product(real_value: 1.0, real_unit: 'mol', molecule: molecule) }
+      let(:target) { build_product(real_value: 1.0, real_unit: 'mol', molecule: molecule) }
+
+      before { source.update!(is_legacy: true) }
+
+      it 'raises a MergeError' do
+        expect do
+          service.merge!(source_id: source.id, target_id: target.id, reaction_id: reaction.id)
+        end.to raise_error(SampleMergeService::MergeError, /already merged/)
+      end
+    end
+
+    context 'when the user cannot access the reaction' do
+      let(:source) { build_product(real_value: 1.0, real_unit: 'mol', molecule: molecule) }
+      let(:target) { build_product(real_value: 1.0, real_unit: 'mol', molecule: molecule) }
+      let(:other_user) { create(:user) }
+
+      it 'raises a MergeError with http_status 401' do
+        expect do
+          described_class.new(current_user: other_user)
+                         .merge!(source_id: source.id, target_id: target.id, reaction_id: reaction.id)
+        end.to raise_error(SampleMergeService::MergeError) { |e| expect(e.http_status).to eq(401) }
+      end
+    end
+
+    context 'when both reactants share the same molecule' do
+      let(:source) { build_reactant(real_value: 2.0, real_unit: 'mol', molecule: molecule) }
+      let(:target) { build_reactant(real_value: 3.0, real_unit: 'mol', molecule: molecule) }
+
+      it 'adds the source amount into the target' do
+        result = service.merge!(source_id: source.id, target_id: target.id, reaction_id: reaction.id)
+
+        expect(result.real_amount_value).to eq(5.0)
+        expect(result.real_amount_unit).to eq('mol')
+      end
+
+      it 'marks the source as legacy and removes its reactant row' do
+        service.merge!(source_id: source.id, target_id: target.id, reaction_id: reaction.id)
+
+        expect(source.reload.is_legacy).to be true
+        expect(reaction.reactions_reactant_samples.exists?(sample_id: source.id)).to be false
+      end
+    end
+
+    context 'when source is a product and target is a reactant' do
+      let(:source) { build_product(real_value: 1.0, real_unit: 'mol', molecule: molecule) }
+      let(:target) { build_reactant(real_value: 1.0, real_unit: 'mol', molecule: molecule) }
+
+      it 'raises a MergeError' do
+        expect do
+          service.merge!(source_id: source.id, target_id: target.id, reaction_id: reaction.id)
+        end.to raise_error(SampleMergeService::MergeError, /same material group/)
+      end
+    end
+  end
+
+  describe '#unmerge!' do
+    let(:source) { build_product(real_value: 2.0, real_unit: 'mol', molecule: molecule) }
+    let(:target) { build_product(real_value: 3.0, real_unit: 'mol', molecule: molecule) }
+
+    before { service.merge!(source_id: source.id, target_id: target.id, reaction_id: reaction.id) }
+
+    it 'restores the target amount and revives the source' do
+      service.unmerge!(merge_id: SampleMerge.last.id)
+
+      expect(target.reload.real_amount_value).to eq(3.0)
+      expect(source.reload.is_legacy).to be false
+      expect(reaction.reactions_product_samples.exists?(sample_id: source.id)).to be true
+    end
+
+    it 'removes the merge record' do
+      expect { service.unmerge!(merge_id: SampleMerge.last.id) }.to change(SampleMerge, :count).by(-1)
+    end
+
+    context 'when the merged pair are reactants' do
+      let(:source) { build_reactant(real_value: 2.0, real_unit: 'mol', molecule: molecule) }
+      let(:target) { build_reactant(real_value: 3.0, real_unit: 'mol', molecule: molecule) }
+
+      it 'restores the target amount and revives the source as a reactant' do
+        service.unmerge!(merge_id: SampleMerge.last.id)
+
+        expect(target.reload.real_amount_value).to eq(3.0)
+        expect(source.reload.is_legacy).to be false
+        expect(reaction.reactions_reactant_samples.exists?(sample_id: source.id)).to be true
+      end
+    end
+
+    context 'when the target has itself been merged upstream (chained merge)' do
+      let(:outer_target) { build_product(real_value: 5.0, real_unit: 'mol', molecule: molecule) }
+
+      before { service.merge!(source_id: target.id, target_id: outer_target.id, reaction_id: reaction.id) }
+
+      it 'raises a MergeError and does not corrupt the outer target' do
+        inner_merge_id = SampleMerge.find_by(source_sample_id: source.id).id
+
+        expect do
+          service.unmerge!(merge_id: inner_merge_id)
+        end.to raise_error(SampleMergeService::MergeError, /merged upstream/)
+
+        # outer_target was 5 + (2+3) = 10 after both merges; guard must leave it untouched
+        expect(outer_target.reload.real_amount_value).to eq(10.0)
+      end
+    end
+  end
+end


### PR DESCRIPTION

## Summary
- Add merge/unmerge for reaction **products**: combine two same-structure product samples' real amounts into one, mark the merged-away sample as legacy, with full unmerge support
- Extend the same merge/unmerge capability to **reactants**
- New "Move or Merge?" modal when dragging one product/reactant onto another of the same group
- `is_legacy` samples are hidden from the material list but preserved (not deleted) so unmerge can restore them



https://az-combinesamples.deploy.chemdev.scc.kit.edu/


---------------------------
- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
