### PR TITLE
fix(inbox): samples matching improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,4 @@ public/sprite.png
 *storybook.log
 storybook-static
 public/units_system/units_system.json
+CLAUDE.md

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -284,6 +284,9 @@ class Attachment < ApplicationRecord
     return [reactions.first, variation] if samples.empty? && reactions.one?
     return [samples.first, nil]         if reactions.empty? && samples.one?
 
+    product_samples = samples.select { |s| s.reactions_samples.any? { |rs| rs.type == 'ReactionsProductSample' } }
+    return [product_samples.first, nil] if reactions.empty? && product_samples.one?
+
     [nil, nil]
   end
 

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -142,7 +142,7 @@ class Sample < ApplicationRecord
       .where('molecule_names.name ILIKE ?', "%#{sanitize_sql_like(query)}%")
   }
   scope :by_exact_name, lambda { |query|
-                          sanitized_query = "^([a-zA-Z0-9]+-)?#{sanitize_sql_like(query)}(-?[a-zA-Z])$"
+                          sanitized_query = "^([a-zA-Z0-9]+-)?#{sanitize_sql_like(query)}(-?[a-zA-Z])?$"
                           where('lower(samples.name) ~* lower(?) or lower(samples.external_label) ~* lower(?)',
                                 sanitized_query, sanitized_query)
                         }
@@ -721,7 +721,6 @@ class Sample < ApplicationRecord
       elemental_compositions << ElementalComposition.new(attrs)
     end
   end
-
 
   def set_loading_from_ea
     return unless residues.first

--- a/spec/api/chemotion/inbox_api_spec.rb
+++ b/spec/api/chemotion/inbox_api_spec.rb
@@ -17,6 +17,10 @@ describe Chemotion::InboxAPI do
       let(:sample_short) { create(:sample, name: 'JB-R581-A', creator: user, collections: [collection]) }
       let(:sample_exact_a) { create(:sample, name: 'JB-R23-A', creator: user, collections: [collection]) }
       let(:sample_exact_b) { create(:sample, name: 'JB-R23-B', creator: user, collections: [collection]) }
+      let(:sample_no_suffix) { create(:sample, name: 'JB-R23', creator: user, collections: [collection]) }
+      let(:sample_external_digit) do
+        create(:sample, name: 'unrelated', external_label: 'JB-R23', creator: user, collections: [collection])
+      end
 
       before do
         sample_short
@@ -31,6 +35,34 @@ describe Chemotion::InboxAPI do
 
         it 'return fitting samples' do
           expect(JSON.parse(response.body)['samples'].size).to eq(2)
+        end
+      end
+
+      describe 'get samples by sample name ending with a digit' do
+        let(:search_string) { 'R23.pdf' }
+
+        before do
+          sample_no_suffix
+          get "/api/v1/inbox/samples?search_string=#{search_string}"
+        end
+
+        it 'returns samples whose name ends with a digit' do
+          names = JSON.parse(response.body)['samples'].pluck('name')
+          expect(names).to include('JB-R23')
+        end
+      end
+
+      describe 'get samples by external label ending with a digit' do
+        let(:search_string) { 'R23.pdf' }
+
+        before do
+          sample_external_digit
+          get "/api/v1/inbox/samples?search_string=#{search_string}"
+        end
+
+        it 'returns samples whose external_label ends with a digit' do
+          ids = JSON.parse(response.body)['samples'].pluck('id')
+          expect(ids).to include(sample_external_digit.id)
         end
       end
 

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -846,6 +846,123 @@ RSpec.describe Attachment do
       end
     end
   end
+
+  describe '#resolve_unique_match' do
+    let(:user) { create(:person) }
+    let(:collection) { create(:collection, user: user) }
+    let(:attachment) do
+      create(:attachment, :with_pdf, filename: 'JB-R23.pdf').tap do |a|
+        a.update_columns(created_for: user.id) # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+
+    context 'when exactly one reaction matches and no samples match' do
+      let!(:reaction) do
+        create(:reaction, name: 'JB-R23', creator: user).tap do |r|
+          CollectionsReaction.create!(reaction: r, collection: collection)
+        end
+      end
+
+      it 'auto-transfers to the reaction' do
+        match, variation = attachment.resolve_unique_match
+        expect(match).to eq(reaction)
+        expect(variation).to be_nil
+      end
+    end
+
+    context 'when filename includes a variation suffix and one reaction matches' do
+      let(:attachment) do
+        create(:attachment, :with_pdf, filename: 'JB-R23-v2.pdf').tap do |a|
+          a.update_columns(created_for: user.id) # rubocop:disable Rails/SkipsModelValidations
+        end
+      end
+      let!(:reaction) do
+        create(:reaction, name: 'JB-R23', creator: user).tap do |r|
+          CollectionsReaction.create!(reaction: r, collection: collection)
+        end
+      end
+
+      it 'auto-transfers to the reaction with extracted variation' do
+        match, variation = attachment.resolve_unique_match
+        expect(match).to eq(reaction)
+        expect(variation).to eq('2')
+      end
+    end
+
+    context 'when multiple reactions match' do
+      before do
+        [create(:reaction, name: 'JB-R23-A', creator: user),
+         create(:reaction, name: 'JB-R23-B', creator: user)].each do |r|
+          CollectionsReaction.create!(reaction: r, collection: collection)
+        end
+      end
+
+      it 'does not auto-transfer (ambiguous)' do
+        expect(attachment.resolve_unique_match).to eq([nil, nil])
+      end
+    end
+
+    context 'when no reactions match and multiple samples match but only one is a product' do
+      let(:product_sample) { create(:sample, name: 'JB-R23-A', creator: user, collections: [collection]) }
+      let(:reactant_sample) { create(:sample, name: 'JB-R23-B', creator: user, collections: [collection]) }
+      let(:reaction) { create(:reaction, name: 'unrelated reaction', creator: user) }
+
+      before do
+        CollectionsReaction.create!(reaction: reaction, collection: collection)
+        create(:reactions_product_sample, reaction: reaction, sample: product_sample)
+        create(:reactions_reactant_sample, reaction: reaction, sample: reactant_sample)
+      end
+
+      it 'auto-transfers to the product sample' do
+        match, variation = attachment.resolve_unique_match
+        expect(match).to eq(product_sample)
+        expect(variation).to be_nil
+      end
+    end
+
+    context 'when no reactions match and multiple samples match and multiple are products' do
+      let(:product_a) { create(:sample, name: 'JB-R23-A', creator: user, collections: [collection]) }
+      let(:product_b) { create(:sample, name: 'JB-R23-B', creator: user, collections: [collection]) }
+      let(:reaction) { create(:reaction, name: 'unrelated reaction', creator: user) }
+
+      before do
+        CollectionsReaction.create!(reaction: reaction, collection: collection)
+        create(:reactions_product_sample, reaction: reaction, sample: product_a)
+        create(:reactions_product_sample, reaction: reaction, sample: product_b)
+      end
+
+      it 'does not auto-transfer (ambiguous)' do
+        expect(attachment.resolve_unique_match).to eq([nil, nil])
+      end
+    end
+
+    context 'when no reactions match and multiple samples match but none is a product' do
+      before do
+        create(:sample, name: 'JB-R23-A', creator: user, collections: [collection])
+        create(:sample, name: 'JB-R23-B', creator: user, collections: [collection])
+      end
+
+      it 'does not auto-transfer' do
+        expect(attachment.resolve_unique_match).to eq([nil, nil])
+      end
+    end
+
+    context 'when a reaction also matches alongside a single product sample' do
+      let(:product_sample) { create(:sample, name: 'JB-R23-A', creator: user, collections: [collection]) }
+      let(:reactant_sample) { create(:sample, name: 'JB-R23-B', creator: user, collections: [collection]) }
+      let(:matching_reaction) { create(:reaction, name: 'JB-R23', creator: user) }
+
+      before do
+        CollectionsReaction.create!(reaction: matching_reaction, collection: collection)
+        create(:reactions_product_sample, reaction: matching_reaction, sample: product_sample)
+        create(:reactions_reactant_sample, reaction: matching_reaction, sample: reactant_sample)
+      end
+
+      it 'does not auto-transfer (reaction precedence preserved)' do
+        expect(attachment.resolve_unique_match).to eq([nil, nil])
+      end
+    end
+  end
 end
 
 # rubocop:enable RSpec/NestedGroups


### PR DESCRIPTION
- Finds sample if it ends with a digit.
- When no reaction matches and multiple samples match, if exactly one of those is a ReactionsProductSample,
  auto-transfer to it
- Added tests