### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/app/api/chemotion/icon_nmr_api.rb
+++ b/app/api/chemotion/icon_nmr_api.rb
@@ -2,6 +2,10 @@ module Chemotion
   class IconNmrAPI < Grape::API
     resource :icon_nmr do
       namespace :config do
+        before do
+          error!(401) unless current_user.matrix_check_by_name("iconNmr")
+        end
+
         desc "Create config file and send to SFTP Server"
         params do
           requires :data, type: Array

--- a/app/api/helpers/sample_helpers.rb
+++ b/app/api/helpers/sample_helpers.rb
@@ -2,7 +2,7 @@ module SampleHelpers
   extend Grape::API::Helpers
 
   def db_exec_detail_level_for_sample(user_id, sample_id)
-    sql = "select detail_level_sample, detail_level_wellplate from detail_level_for_sample(#{user_id},#{sample_id})"
-    ActiveRecord::Base.connection.exec_query(sql)
+    sql = 'SELECT detail_level_sample, detail_level_wellplate FROM detail_level_for_sample($1, $2)'
+    ActiveRecord::Base.connection.exec_query(sql, 'detail_level_for_sample', [[nil, user_id], [nil, sample_id]])
   end
 end


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Critical` | **File**: `app/api/helpers/sample_helpers.rb:L9`

The db_exec_detail_level_for_sample method directly interpolates user_id and sample_id into SQL string without parameterization. This allows SQL injection attacks if these values come from user input.

## Solution

Use parameterized queries with ActiveRecord::Base.connection.exec_query with proper bind variables: sql = 'SELECT detail_level_sample, detail_level_wellplate FROM detail_level_for_sample($1, $2)'; ActiveRecord::Base.connection.exec_query(sql, 'detail_level_for_sample', [[nil, user_id], [nil, sample_id]])

## Changes

- `app/api/helpers/sample_helpers.rb` (modified)
- `app/api/chemotion/icon_nmr_api.rb` (modified)