### PR TITLE
feat(chemicals): editable safety phrases (H/P codes, pictograms) in inventory tab

### DIFF
--- a/app/javascript/src/components/chemicals/ChemicalTab.js
+++ b/app/javascript/src/components/chemicals/ChemicalTab.js
@@ -9,13 +9,13 @@ import {
 import AppModal from 'src/components/common/AppModal';
 import { Select } from 'src/components/common/Select';
 import { chemicalStatusOptions } from 'src/components/staticDropdownOptions/options';
-import SVG from 'react-inlinesvg';
 import ChemicalFetcher from 'src/fetchers/ChemicalFetcher';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
 import Sample from 'src/models/Sample';
 import NumericInputUnit from 'src/apps/mydb/elements/details/NumericInputUnit';
 import ButtonGroupToggleButton from 'src/components/common/ButtonGroupToggleButton';
 import SDSAttachmentModal from 'src/components/chemicals/SDSAttachmentModal';
+import SafetyPhrasesEditor from 'src/components/chemicals/SafetyPhrasesEditor';
 import Chemical from 'src/models/Chemical';
 import NotificationActions from 'src/stores/alt/actions/NotificationActions';
 
@@ -31,7 +31,6 @@ export default class ChemicalTab extends React.Component {
       vendorValue: 'Merck',
       queryOption: 'CAS',
       safetySheetLanguage: 'en',
-      safetyPhrases: '',
       warningMessage: '',
       loadingQuerySafetySheets: false,
       loadingSaveSafetySheets: {},
@@ -337,42 +336,8 @@ export default class ChemicalTab extends React.Component {
     });
   };
 
-  // eslint-disable-next-line class-methods-use-this
-  stylePhrases = (str) => {
-    const HazardPhrases = [];
-    if (str && str.h_statements && str.h_statements.length !== 0) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const [key, value] of Object.entries(str.h_statements)) {
-        // eslint-disable-next-line react/jsx-one-expression-per-line
-        const st = <p key={key}> {key}:{value} </p>;
-        HazardPhrases.push(st);
-      }
-    }
-
-    const precautionaryPhrases = [];
-    if (str && str.p_statements && str?.p_statements?.length !== 0) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const [key, value] of Object.entries(str?.p_statements || {})) {
-        // eslint-disable-next-line react/jsx-one-expression-per-line
-        const st = <p key={key}>{key}:{value}</p>;
-        precautionaryPhrases.push(st);
-      }
-    }
-
-    const pictogramsArray = str.pictograms?.map((i) => (
-      i !== null ? <SVG key={`ghs${i}`} src={`/images/ghs/${i}.svg`} /> : null));
-
-    return (
-      <div>
-        <p className="fw-bold">Pictograms: </p>
-        {(str.pictograms !== undefined && str.pictograms.length !== 0)
-          ? pictogramsArray : <p>Could not find pictograms</p>}
-        <p className="fw-bold mt-3">Hazard Statements: </p>
-        {HazardPhrases}
-        <p className="fw-bold">Precautionary Statements: </p>
-        {precautionaryPhrases}
-      </div>
-    );
+  handleSafetyPhrasesChange = (next) => {
+    this.handleFieldChanged('safetyPhrases', next);
   };
 
   isSavedSds = () => {
@@ -432,7 +397,6 @@ export default class ChemicalTab extends React.Component {
       } else if (result === 'Could not find H and P phrases') {
         this.setState({ warningMessage: result });
       } else {
-        this.setState({ safetyPhrases: this.stylePhrases(result) });
         this.handleFieldChanged('safetyPhrases', result);
       }
     }).catch((errorMessage) => {
@@ -1446,16 +1410,13 @@ export default class ChemicalTab extends React.Component {
   };
 
   renderSafetyPhrases = () => {
-    const { chemical, safetyPhrases } = this.state;
-    let fetchedSafetyPhrases;
-    if (chemical && chemical._chemical_data !== undefined && chemical._chemical_data.length !== 0) {
-      const phrases = chemical._chemical_data[0].safetyPhrases;
-      fetchedSafetyPhrases = (phrases !== undefined) ? this.stylePhrases(phrases) : '';
-    }
+    const { chemical } = this.state;
+    const phrases = chemical?._chemical_data?.[0]?.safetyPhrases;
     return (
-      <div className="pt-2 w-100">
-        {safetyPhrases === '' ? fetchedSafetyPhrases : safetyPhrases}
-      </div>
+      <SafetyPhrasesEditor
+        value={phrases}
+        onChange={this.handleSafetyPhrasesChange}
+      />
     );
   };
 

--- a/app/javascript/src/components/chemicals/SafetyPhrasesEditor.js
+++ b/app/javascript/src/components/chemicals/SafetyPhrasesEditor.js
@@ -18,6 +18,10 @@ const formatStatementValue = (text) => {
 
 const prettyPictogramName = (file) => trim(file).replace(/\.[A-Za-z0-9]+$/, '').replace(/_/g, ' ');
 
+// Only allow known GHS pictogram codes (GHS01–GHS09). This guards against path-traversal
+// and XSS via the /images/ghs/${code}.svg interpolation in PictogramCard.
+const VALID_PICTOGRAM_CODE_RE = /^GHS\d{2}$/;
+
 export const normalizeSafetyPhrases = (value) => {
   const source = value && typeof value === 'object' && !Array.isArray(value) ? value : {};
   const h = source.h_statements && typeof source.h_statements === 'object' && !Array.isArray(source.h_statements)
@@ -25,7 +29,7 @@ export const normalizeSafetyPhrases = (value) => {
   const p = source.p_statements && typeof source.p_statements === 'object' && !Array.isArray(source.p_statements)
     ? source.p_statements : {};
   const pictograms = Array.isArray(source.pictograms)
-    ? source.pictograms.filter((c) => typeof c === 'string') : [];
+    ? source.pictograms.filter((c) => typeof c === 'string' && VALID_PICTOGRAM_CODE_RE.test(c)) : [];
   return { h_statements: h, p_statements: p, pictograms };
 };
 

--- a/app/javascript/src/components/chemicals/SafetyPhrasesEditor.js
+++ b/app/javascript/src/components/chemicals/SafetyPhrasesEditor.js
@@ -3,23 +3,11 @@ import PropTypes from 'prop-types';
 import { Button } from 'react-bootstrap';
 import SVG from 'react-inlinesvg';
 import { Select } from 'src/components/common/Select';
-
-const PHRASE_FILES = {
-  hazard: '/json/hazardPhrases.json',
-  precautionary: '/json/precautionaryPhrases.json',
-  pictograms: '/json/pictograms.json',
-};
-
-const phraseCache = {};
-
-const fetchPhraseFile = (key) => {
-  if (phraseCache[key]) return phraseCache[key];
-  phraseCache[key] = fetch(PHRASE_FILES[key], { credentials: 'same-origin' })
-    .then((res) => (res && res.ok ? res.json() : {}))
-    .then((d) => (d && typeof d === 'object' ? d : {}))
-    .catch(() => ({}));
-  return phraseCache[key];
-};
+import {
+  loadHazardPhrases,
+  loadPrecautionaryPhrases,
+  loadPictograms,
+} from 'src/utilities/chemicalDataValidations';
 
 const trim = (v) => (typeof v === 'string' ? v.trim() : '');
 
@@ -31,9 +19,11 @@ const formatStatementValue = (text) => {
 const prettyPictogramName = (file) => trim(file).replace(/\.[A-Za-z0-9]+$/, '').replace(/_/g, ' ');
 
 export const normalizeSafetyPhrases = (value) => {
-  const source = value && typeof value === 'object' ? value : {};
-  const h = source.h_statements && typeof source.h_statements === 'object' ? source.h_statements : {};
-  const p = source.p_statements && typeof source.p_statements === 'object' ? source.p_statements : {};
+  const source = value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+  const h = source.h_statements && typeof source.h_statements === 'object' && !Array.isArray(source.h_statements)
+    ? source.h_statements : {};
+  const p = source.p_statements && typeof source.p_statements === 'object' && !Array.isArray(source.p_statements)
+    ? source.p_statements : {};
   const pictograms = Array.isArray(source.pictograms)
     ? source.pictograms.filter((c) => typeof c === 'string') : [];
   return { h_statements: h, p_statements: p, pictograms };
@@ -78,7 +68,7 @@ PhraseListItem.propTypes = {
 
 const itemShape = PropTypes.shape({
   code: PropTypes.string.isRequired,
-  text: PropTypes.string,
+  text: PropTypes.string.isRequired,
   onDelete: PropTypes.func.isRequired,
 });
 
@@ -232,9 +222,9 @@ function SafetyPhrasesEditor({ value, onChange }) {
   useEffect(() => {
     let mounted = true;
     Promise.all([
-      fetchPhraseFile('hazard'),
-      fetchPhraseFile('precautionary'),
-      fetchPhraseFile('pictograms'),
+      loadHazardPhrases(),
+      loadPrecautionaryPhrases(),
+      loadPictograms(),
     ]).then(([h, p, g]) => {
       if (!mounted) return;
       setHazardDict(h);

--- a/app/javascript/src/components/chemicals/SafetyPhrasesEditor.js
+++ b/app/javascript/src/components/chemicals/SafetyPhrasesEditor.js
@@ -273,8 +273,9 @@ function SafetyPhrasesEditor({ value, onChange }) {
   };
 
   const handleAddPictogram = (option) => {
-    if (!option || !option.value || data.pictograms.includes(option.value)) return;
-    emit({ ...data, pictograms: [...data.pictograms, option.value] });
+    const code = trim(option && option.value);
+    if (!code || !VALID_PICTOGRAM_CODE_RE.test(code) || data.pictograms.includes(code)) return;
+    emit({ ...data, pictograms: [...data.pictograms, code] });
   };
 
   const handleRemovePictogram = (code) => {

--- a/app/javascript/src/components/chemicals/SafetyPhrasesEditor.js
+++ b/app/javascript/src/components/chemicals/SafetyPhrasesEditor.js
@@ -20,7 +20,7 @@ const prettyPictogramName = (file) => trim(file).replace(/\.[A-Za-z0-9]+$/, '').
 
 // Only allow known GHS pictogram codes (GHS01–GHS09). This guards against path-traversal
 // and XSS via the /images/ghs/${code}.svg interpolation in PictogramCard.
-const VALID_PICTOGRAM_CODE_RE = /^GHS\d{2}$/;
+const VALID_PICTOGRAM_CODE_RE = /^GHS0[1-9]$/;
 
 export const normalizeSafetyPhrases = (value) => {
   const source = value && typeof value === 'object' && !Array.isArray(value) ? value : {};

--- a/app/javascript/src/components/chemicals/SafetyPhrasesEditor.js
+++ b/app/javascript/src/components/chemicals/SafetyPhrasesEditor.js
@@ -1,0 +1,376 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Button } from 'react-bootstrap';
+import SVG from 'react-inlinesvg';
+import { Select } from 'src/components/common/Select';
+
+const PHRASE_FILES = {
+  hazard: '/json/hazardPhrases.json',
+  precautionary: '/json/precautionaryPhrases.json',
+  pictograms: '/json/pictograms.json',
+};
+
+const phraseCache = {};
+
+const fetchPhraseFile = (key) => {
+  if (phraseCache[key]) return phraseCache[key];
+  phraseCache[key] = fetch(PHRASE_FILES[key], { credentials: 'same-origin' })
+    .then((res) => (res && res.ok ? res.json() : {}))
+    .then((d) => (d && typeof d === 'object' ? d : {}))
+    .catch(() => ({}));
+  return phraseCache[key];
+};
+
+const trim = (v) => (typeof v === 'string' ? v.trim() : '');
+
+const formatStatementValue = (text) => {
+  const t = trim(text);
+  return t ? ` ${t}` : '';
+};
+
+const prettyPictogramName = (file) => trim(file).replace(/\.[A-Za-z0-9]+$/, '').replace(/_/g, ' ');
+
+export const normalizeSafetyPhrases = (value) => {
+  const source = value && typeof value === 'object' ? value : {};
+  const h = source.h_statements && typeof source.h_statements === 'object' ? source.h_statements : {};
+  const p = source.p_statements && typeof source.p_statements === 'object' ? source.p_statements : {};
+  const pictograms = Array.isArray(source.pictograms)
+    ? source.pictograms.filter((c) => typeof c === 'string') : [];
+  return { h_statements: h, p_statements: p, pictograms };
+};
+
+const buildOptions = (dictionary, excluded, formatLabel) => (
+  Object.entries(dictionary || {})
+    .filter(([code]) => !excluded.has(code))
+    .map(([code, v]) => ({ value: code, text: trim(v), label: formatLabel(code, v) }))
+);
+
+function PhraseListItem({ code, text, onDelete }) {
+  return (
+    <li
+      className="list-group-item d-flex align-items-center gap-2 py-1"
+      data-component="SafetyPhraseRow"
+      data-code={code}
+    >
+      <div className="me-auto text-break">
+        <strong>{`${code}:`}</strong>
+        {` ${text}`}
+      </div>
+      <Button
+        size="xsm"
+        variant="danger"
+        onClick={onDelete}
+        title={`Remove ${code}`}
+        aria-label={`Remove ${code}`}
+        data-action="remove"
+      >
+        <i className="fa fa-trash-o" />
+      </Button>
+    </li>
+  );
+}
+
+PhraseListItem.propTypes = {
+  code: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
+  onDelete: PropTypes.func.isRequired,
+};
+
+const itemShape = PropTypes.shape({
+  code: PropTypes.string.isRequired,
+  text: PropTypes.string,
+  onDelete: PropTypes.func.isRequired,
+});
+
+const optionShape = PropTypes.shape({
+  value: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  text: PropTypes.string,
+});
+
+function PhraseSection({
+  title, idPrefix, options, items, emptyText, onAdd, disabled,
+}) {
+  return (
+    <div className="mb-4" data-component={idPrefix}>
+      <h6 className="text-primary mb-2">{title}</h6>
+      <Select
+        inputId={`${idPrefix}-select`}
+        classNamePrefix={`${idPrefix}-select`}
+        placeholder={disabled ? 'Loading…' : `Search and add ${title.toLowerCase()}`}
+        options={options}
+        value={null}
+        isDisabled={disabled}
+        isClearable
+        onChange={onAdd}
+        noOptionsMessage={() => 'No matching items'}
+      />
+      {items.length === 0 ? (
+        <p className="text-muted small fst-italic ms-1 mt-1 mb-0">{emptyText}</p>
+      ) : (
+        <ol className="list-group list-group-numbered mt-2" data-component={`${idPrefix}-list`}>
+          {items.map((item) => (
+            <PhraseListItem
+              key={item.code}
+              code={item.code}
+              text={item.text}
+              onDelete={item.onDelete}
+            />
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+PhraseSection.propTypes = {
+  title: PropTypes.string.isRequired,
+  idPrefix: PropTypes.string.isRequired,
+  options: PropTypes.arrayOf(optionShape).isRequired,
+  items: PropTypes.arrayOf(itemShape).isRequired,
+  emptyText: PropTypes.string.isRequired,
+  onAdd: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+};
+
+PhraseSection.defaultProps = { disabled: false };
+
+function PictogramCard({ code, name, onDelete }) {
+  return (
+    <div
+      className="d-flex flex-column align-items-center border rounded p-2 position-relative bg-body-secondary"
+      data-component="SafetyPhraseRow"
+      data-code={code}
+      style={{ width: '100px', minHeight: '110px' }}
+    >
+      <Button
+        size="xsm"
+        variant="danger"
+        onClick={onDelete}
+        title={`Remove ${code}`}
+        aria-label={`Remove ${code}`}
+        data-action="remove"
+        className="position-absolute top-0 end-0 m-1"
+      >
+        <i className="fa fa-trash-o" />
+      </Button>
+      <SVG
+        src={`/images/ghs/${code}.svg`}
+        style={{ width: 70, height: 70, marginTop: '18px' }}
+      />
+      <small className="fw-bold text-center mt-1" style={{ fontSize: '0.7rem' }}>{code}</small>
+      <small className="text-center text-muted" style={{ fontSize: '0.65rem', lineHeight: '1.1' }}>
+        {name}
+      </small>
+    </div>
+  );
+}
+
+PictogramCard.propTypes = {
+  code: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  onDelete: PropTypes.func.isRequired,
+};
+
+function PictogramSection({
+  options, items, onAdd, disabled,
+}) {
+  return (
+    <div className="mb-2" data-component="safety-pictograms">
+      <h6 className="text-primary mb-2">Pictograms</h6>
+      <Select
+        inputId="safety-pictograms-select"
+        classNamePrefix="safety-pictograms-select"
+        placeholder={disabled ? 'Loading…' : 'Search and add pictograms'}
+        options={options}
+        value={null}
+        isDisabled={disabled}
+        isClearable
+        onChange={onAdd}
+        noOptionsMessage={() => 'No matching items'}
+      />
+      {items.length === 0 ? (
+        <p className="text-muted small fst-italic ms-1 mt-1 mb-0">No pictograms added yet.</p>
+      ) : (
+        <div
+          className="d-flex flex-wrap gap-2 mt-2"
+          data-component="safety-pictograms-list"
+        >
+          {items.map((item) => (
+            <PictogramCard
+              key={item.code}
+              code={item.code}
+              name={item.text}
+              onDelete={item.onDelete}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+PictogramSection.propTypes = {
+  options: PropTypes.arrayOf(optionShape).isRequired,
+  items: PropTypes.arrayOf(PropTypes.shape({
+    code: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+    onDelete: PropTypes.func.isRequired,
+  })).isRequired,
+  onAdd: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+};
+
+PictogramSection.defaultProps = { disabled: false };
+
+function SafetyPhrasesEditor({ value, onChange }) {
+  const [hazardDict, setHazardDict] = useState({});
+  const [precautionaryDict, setPrecautionaryDict] = useState({});
+  const [pictogramDict, setPictogramDict] = useState({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    Promise.all([
+      fetchPhraseFile('hazard'),
+      fetchPhraseFile('precautionary'),
+      fetchPhraseFile('pictograms'),
+    ]).then(([h, p, g]) => {
+      if (!mounted) return;
+      setHazardDict(h);
+      setPrecautionaryDict(p);
+      setPictogramDict(g);
+      setLoading(false);
+    });
+    return () => { mounted = false; };
+  }, []);
+
+  // `data` identity changes whenever any phrase field changes — useMemo deps below
+  // intentionally use `data` (not data.h_statements) so that item lists always
+  // capture a fresh handler closure even when an unrelated section changes.
+  const data = useMemo(() => normalizeSafetyPhrases(value), [value]);
+
+  const emit = (next) => {
+    if (typeof onChange === 'function') onChange(next);
+  };
+
+  const handleAddH = (option) => {
+    if (!option || !option.value) return;
+    const text = option.text || trim(hazardDict[option.value]);
+    emit({ ...data, h_statements: { ...data.h_statements, [option.value]: formatStatementValue(text) } });
+  };
+
+  const handleRemoveH = (code) => {
+    const next = { ...data.h_statements };
+    delete next[code];
+    emit({ ...data, h_statements: next });
+  };
+
+  const handleAddP = (option) => {
+    if (!option || !option.value) return;
+    const text = option.text || trim(precautionaryDict[option.value]);
+    emit({ ...data, p_statements: { ...data.p_statements, [option.value]: formatStatementValue(text) } });
+  };
+
+  const handleRemoveP = (code) => {
+    const next = { ...data.p_statements };
+    delete next[code];
+    emit({ ...data, p_statements: next });
+  };
+
+  const handleAddPictogram = (option) => {
+    if (!option || !option.value || data.pictograms.includes(option.value)) return;
+    emit({ ...data, pictograms: [...data.pictograms, option.value] });
+  };
+
+  const handleRemovePictogram = (code) => {
+    emit({ ...data, pictograms: data.pictograms.filter((c) => c !== code) });
+  };
+
+  // Use `data` (not data.h_statements) as the key dep so that onDelete closures
+  // are always fresh — avoids stale-closure cascade-delete bug when an unrelated
+  // section is mutated and data identity changes but the sub-key does not.
+  const hazardItems = useMemo(() => (
+    Object.entries(data.h_statements).map(([code, text]) => ({
+      code,
+      text: trim(text) || trim(hazardDict[code]),
+      onDelete: () => handleRemoveH(code),
+    }))
+  ), [data, hazardDict]);
+
+  const precautionaryItems = useMemo(() => (
+    Object.entries(data.p_statements).map(([code, text]) => ({
+      code,
+      text: trim(text) || trim(precautionaryDict[code]),
+      onDelete: () => handleRemoveP(code),
+    }))
+  ), [data, precautionaryDict]);
+
+  const pictogramItems = useMemo(() => (
+    data.pictograms.map((code) => ({
+      code,
+      text: prettyPictogramName(pictogramDict[code]) || code,
+      onDelete: () => handleRemovePictogram(code),
+    }))
+  ), [data, pictogramDict]);
+
+  const hazardOptions = useMemo(() => (
+    buildOptions(hazardDict, new Set(Object.keys(data.h_statements)), (code, text) => `${code}: ${trim(text)}`)
+  ), [hazardDict, data.h_statements]);
+
+  const precautionaryOptions = useMemo(() => (
+    buildOptions(precautionaryDict, new Set(Object.keys(data.p_statements)), (code, text) => `${code}: ${trim(text)}`)
+  ), [precautionaryDict, data.p_statements]);
+
+  const pictogramOptions = useMemo(() => (
+    buildOptions(pictogramDict, new Set(data.pictograms), (code, file) => `${code}: ${prettyPictogramName(file)}`)
+  ), [pictogramDict, data.pictograms]);
+
+  return (
+    <div
+      className="border rounded p-3 mt-3 w-100 bg-body"
+      data-component="SafetyPhrasesEditor"
+      style={{ maxHeight: '500px', overflow: 'auto' }}
+    >
+      <PhraseSection
+        title="Hazard Statements"
+        idPrefix="safety-h-phrases"
+        options={hazardOptions}
+        items={hazardItems}
+        emptyText="No hazard statements added yet."
+        onAdd={handleAddH}
+        disabled={loading}
+      />
+      <PhraseSection
+        title="Precautionary Statements"
+        idPrefix="safety-p-phrases"
+        options={precautionaryOptions}
+        items={precautionaryItems}
+        emptyText="No precautionary statements added yet."
+        onAdd={handleAddP}
+        disabled={loading}
+      />
+      <PictogramSection
+        options={pictogramOptions}
+        items={pictogramItems}
+        onAdd={handleAddPictogram}
+        disabled={loading}
+      />
+    </div>
+  );
+}
+
+SafetyPhrasesEditor.propTypes = {
+  value: PropTypes.shape({
+    h_statements: PropTypes.objectOf(PropTypes.string),
+    p_statements: PropTypes.objectOf(PropTypes.string),
+    pictograms: PropTypes.arrayOf(PropTypes.string),
+  }),
+  onChange: PropTypes.func.isRequired,
+};
+
+SafetyPhrasesEditor.defaultProps = {
+  value: null,
+};
+
+export default SafetyPhrasesEditor;

--- a/app/javascript/src/utilities/chemicalDataValidations.js
+++ b/app/javascript/src/utilities/chemicalDataValidations.js
@@ -54,9 +54,10 @@ export const defaultChemicalSchemaValidation = {
   safetyPhrases: { type: 'object' } // Complex object with pictograms, h_statements, p_statements
 };
 
-// Cache for hazard and precautionary phrases - will be loaded on demand
+// Cache for hazard, precautionary phrases and pictograms - will be loaded on demand
 let hazardPhrasesCache = null;
 let precautionaryPhrasesCache = null;
+let pictogramsCache = null;
 
 /**
  * Loads hazard phrases from the JSON file
@@ -92,6 +93,25 @@ export const loadPrecautionaryPhrases = async () => {
     return precautionaryPhrasesCache;
   } catch (error) {
     console.error('Failed to load precautionary phrases:', error);
+    return {};
+  }
+};
+
+/**
+ * Loads pictogram codes and their filenames from the JSON file
+ * @returns {Promise<Object>} - Promise resolving to an object mapping pictogram codes to filenames
+ */
+export const loadPictograms = async () => {
+  if (pictogramsCache) {
+    return pictogramsCache;
+  }
+
+  try {
+    const response = await fetch('/json/pictograms.json');
+    pictogramsCache = await response.json();
+    return pictogramsCache;
+  } catch (error) {
+    console.error('Failed to load pictograms:', error);
     return {};
   }
 };

--- a/lib/chemotion/chemicals_service.rb
+++ b/lib/chemotion/chemicals_service.rb
@@ -268,7 +268,8 @@ module Chemotion
       pictogram_text.to_s.split(',').map(&:strip).reject(&:empty?)
     end
 
-    private_class_method :extract_h_text_from_array, :extract_p_text_from_array, :extract_pictograms_from_array
+    private_class_method :extract_h_text_from_array, :extract_p_text_from_array, :extract_pictograms_from_array,
+                         :names_properties_merck
 
     def self.safety_phrases_merck(product_link)
       safety_section = safety_section(product_link)

--- a/lib/chemotion/chemicals_service.rb
+++ b/lib/chemotion/chemicals_service.rb
@@ -268,13 +268,7 @@ module Chemotion
       pictogram_text.to_s.split(',').map(&:strip).reject(&:empty?)
     end
 
-    def self.names_properties_merck(properties)
-      properties.search('div.MuiGrid-grid-sm-3')
-                .css('span').map(&:text).map { |str| str.tr(' ', '_').downcase }
-    end
-
-    private_class_method :extract_h_text_from_array, :extract_p_text_from_array, :extract_pictograms_from_array,
-                         :names_properties_merck
+    private_class_method :extract_h_text_from_array, :extract_p_text_from_array, :extract_pictograms_from_array
 
     def self.safety_phrases_merck(product_link)
       safety_section = safety_section(product_link)

--- a/lib/chemotion/chemicals_service.rb
+++ b/lib/chemotion/chemicals_service.rb
@@ -268,6 +268,11 @@ module Chemotion
       pictogram_text.to_s.split(',').map(&:strip).reject(&:empty?)
     end
 
+    def self.names_properties_merck(properties)
+      properties.search('div.MuiGrid-grid-sm-3')
+                .css('span').map(&:text).map { |str| str.tr(' ', '_').downcase }
+    end
+
     private_class_method :extract_h_text_from_array, :extract_p_text_from_array, :extract_pictograms_from_array,
                          :names_properties_merck
 
@@ -302,11 +307,6 @@ module Chemotion
       chem_properties_alfa(properties)
     rescue StandardError
       'Could not find additional chemical properties'
-    end
-
-    def self.names_properties_merck(properties)
-      properties.search('div.MuiGrid-grid-sm-3')
-                .css('span').map(&:text).map { |str| str.tr(' ', '_').downcase }
     end
 
     def self.clean_property_name(property_name)

--- a/spec/javascripts/packs/src/components/chemicals/ChemicalTab.spec.js
+++ b/spec/javascripts/packs/src/components/chemicals/ChemicalTab.spec.js
@@ -270,7 +270,7 @@ describe('ChemicalTab component', () => {
       handleRemoveSpy.restore();
     });
 
-    it('calls stylePhrases() when state of safetyPhrases is defined ', () => {
+    it('renders the SafetyPhrasesEditor with chemical safetyPhrases data', () => {
       const chemicalData = [{
         safetySheetPath: [
           {
@@ -279,12 +279,12 @@ describe('ChemicalTab component', () => {
         ],
         safetyPhrases: {
           h_statements: {
-            H315: 'Causes skin irritation',
-            H319: 'Causes serious eye irritation'
+            H315: ' Causes skin irritation',
+            H319: ' Causes serious eye irritation'
           },
           p_statements: {
-            P264: 'Wash skin thoroughly after handling',
-            P280: 'Wear protective gloves/protective clothing/eye protection/face protection'
+            P264: ' Wash skin thoroughly after handling',
+            P280: ' Wear protective gloves/protective clothing/eye protection/face protection'
           },
           pictograms: ['GHS07']
         }
@@ -294,11 +294,24 @@ describe('ChemicalTab component', () => {
       instance.setState({ chemical: newChemical, displayWell: true });
       wrapper.update();
 
-      const stylePhrasesSpy = sinon.spy(instance, 'stylePhrases');
-      // Trigger rendering of safety phrases which internally calls stylePhrases
-      instance.renderSafetyPhrases();
-      expect(stylePhrasesSpy.called).toBe(true);
-      stylePhrasesSpy.restore();
+      const editor = instance.renderSafetyPhrases();
+      expect(editor).not.toBeNull();
+      expect(editor.props.value).toEqual(chemicalData[0].safetyPhrases);
+      expect(typeof editor.props.onChange).toBe('function');
+    });
+
+    it('handleSafetyPhrasesChange persists into chemical_data via handleFieldChanged', () => {
+      const chemicalData = [{}];
+      const newChemical = createChemical(chemicalData, '7681-82-5');
+      instance.setState({ chemical: newChemical });
+
+      const handleFieldChangedSpy = sinon.spy(instance, 'handleFieldChanged');
+      const next = { h_statements: { H200: ' Unstable explosive' }, p_statements: {}, pictograms: [] };
+      instance.handleSafetyPhrasesChange(next);
+
+      expect(handleFieldChangedSpy.calledWith('safetyPhrases', next)).toBe(true);
+      expect(wrapper.state().chemical.chemical_data[0].safetyPhrases).toEqual(next);
+      handleFieldChangedSpy.restore();
     });
 
     it('should call saveSafetySheetsButton with expected arguments', () => {

--- a/spec/javascripts/packs/src/components/chemicals/SafetyPhrasesEditor.spec.js
+++ b/spec/javascripts/packs/src/components/chemicals/SafetyPhrasesEditor.spec.js
@@ -1,0 +1,197 @@
+import React from 'react';
+import { configure, shallow } from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import expect from 'expect';
+import sinon from 'sinon';
+import {
+  describe, it, beforeEach, afterEach,
+} from 'mocha';
+import SafetyPhrasesEditor, { normalizeSafetyPhrases } from 'src/components/chemicals/SafetyPhrasesEditor';
+
+configure({ adapter: new Adapter() });
+
+const buildResponse = (data) => ({
+  ok: true,
+  json: () => Promise.resolve(data),
+});
+
+const sectionWithPrefix = (wrapper, idPrefix) => (
+  wrapper.findWhere((n) => n.name() === 'PhraseSection' && n.prop('idPrefix') === idPrefix).first()
+);
+
+const pictogramSection = (wrapper) => (
+  wrapper.findWhere((n) => n.name() === 'PictogramSection').first()
+);
+
+describe('normalizeSafetyPhrases', () => {
+  it('returns empty defaults for null/undefined input', () => {
+    expect(normalizeSafetyPhrases(null)).toEqual({ h_statements: {}, p_statements: {}, pictograms: [] });
+    expect(normalizeSafetyPhrases(undefined)).toEqual({ h_statements: {}, p_statements: {}, pictograms: [] });
+  });
+
+  it('preserves valid statements and pictograms', () => {
+    const value = {
+      h_statements: { H200: ' Unstable explosive' },
+      p_statements: { P102: ' Keep out of reach of children.' },
+      pictograms: ['GHS01'],
+    };
+    expect(normalizeSafetyPhrases(value)).toEqual(value);
+  });
+
+  it('coerces malformed shapes safely', () => {
+    const value = { h_statements: 'not-an-object', p_statements: null, pictograms: 'GHS01' };
+    expect(normalizeSafetyPhrases(value)).toEqual({ h_statements: {}, p_statements: {}, pictograms: [] });
+  });
+
+  it('drops non-string pictogram entries', () => {
+    expect(normalizeSafetyPhrases({ pictograms: ['GHS01', 42, null] })).toEqual({
+      h_statements: {}, p_statements: {}, pictograms: ['GHS01'],
+    });
+  });
+});
+
+describe('SafetyPhrasesEditor', () => {
+  beforeEach(() => {
+    const fetchStub = sinon.stub(global, 'fetch');
+    fetchStub.withArgs('/json/hazardPhrases.json', sinon.match.any)
+      .resolves(buildResponse({ H200: 'Unstable explosive', H315: 'Causes skin irritation' }));
+    fetchStub.withArgs('/json/precautionaryPhrases.json', sinon.match.any)
+      .resolves(buildResponse({ P102: 'Keep out of reach of children.' }));
+    fetchStub.withArgs('/json/pictograms.json', sinon.match.any)
+      .resolves(buildResponse({ GHS01: 'Explosive.gif', GHS07: 'Harmful_Irritant.gif' }));
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('renders H, P, and pictogram sections', () => {
+    const wrapper = shallow(
+      React.createElement(SafetyPhrasesEditor, { value: null, onChange: sinon.spy() })
+    );
+    expect(sectionWithPrefix(wrapper, 'safety-h-phrases').exists()).toBe(true);
+    expect(sectionWithPrefix(wrapper, 'safety-p-phrases').exists()).toBe(true);
+    expect(pictogramSection(wrapper).exists()).toBe(true);
+  });
+
+  it('passes existing phrases through as section items', () => {
+    const value = {
+      h_statements: { H315: ' Causes skin irritation' },
+      p_statements: { P102: ' Keep out of reach of children.' },
+      pictograms: ['GHS07'],
+    };
+    const wrapper = shallow(
+      React.createElement(SafetyPhrasesEditor, { value, onChange: sinon.spy() })
+    );
+
+    const hItems = sectionWithPrefix(wrapper, 'safety-h-phrases').prop('items');
+    expect(hItems).toHaveLength(1);
+    expect(hItems[0].code).toEqual('H315');
+    expect(hItems[0].text).toEqual('Causes skin irritation');
+
+    const pItems = sectionWithPrefix(wrapper, 'safety-p-phrases').prop('items');
+    expect(pItems[0].code).toEqual('P102');
+
+    const gItems = pictogramSection(wrapper).prop('items');
+    expect(gItems[0].code).toEqual('GHS07');
+  });
+
+  it('emits onChange with leading-space text when adding an H phrase', () => {
+    const onChange = sinon.spy();
+    const wrapper = shallow(
+      React.createElement(SafetyPhrasesEditor, { value: null, onChange })
+    );
+    sectionWithPrefix(wrapper, 'safety-h-phrases').prop('onAdd')({
+      value: 'H200',
+      text: 'Unstable explosive',
+    });
+    expect(onChange.calledOnce).toBe(true);
+    expect(onChange.firstCall.args[0]).toEqual({
+      h_statements: { H200: ' Unstable explosive' },
+      p_statements: {},
+      pictograms: [],
+    });
+  });
+
+  it('deletion of H phrase preserves P phrases and pictograms', () => {
+    const onChange = sinon.spy();
+    const value = {
+      h_statements: { H315: ' Causes skin irritation' },
+      p_statements: { P102: ' Keep out of reach of children.' },
+      pictograms: ['GHS07'],
+    };
+    const wrapper = shallow(
+      React.createElement(SafetyPhrasesEditor, { value, onChange })
+    );
+    const items = sectionWithPrefix(wrapper, 'safety-h-phrases').prop('items');
+    items[0].onDelete();
+    expect(onChange.calledOnce).toBe(true);
+    const emitted = onChange.firstCall.args[0];
+    expect(emitted.h_statements).toEqual({});
+    expect(emitted.p_statements).toEqual(value.p_statements);
+    expect(emitted.pictograms).toEqual(value.pictograms);
+  });
+
+  it('deletion of P phrase preserves H phrases and pictograms', () => {
+    const onChange = sinon.spy();
+    const value = {
+      h_statements: { H315: ' Causes skin irritation' },
+      p_statements: { P102: ' Keep out of reach of children.' },
+      pictograms: ['GHS07'],
+    };
+    const wrapper = shallow(
+      React.createElement(SafetyPhrasesEditor, { value, onChange })
+    );
+    const items = sectionWithPrefix(wrapper, 'safety-p-phrases').prop('items');
+    items[0].onDelete();
+    expect(onChange.calledOnce).toBe(true);
+    const emitted = onChange.firstCall.args[0];
+    expect(emitted.p_statements).toEqual({});
+    expect(emitted.h_statements).toEqual(value.h_statements);
+    expect(emitted.pictograms).toEqual(value.pictograms);
+  });
+
+  it('emits onChange when adding a pictogram and ignores duplicates', () => {
+    const onChange = sinon.spy();
+    const wrapper = shallow(
+      React.createElement(SafetyPhrasesEditor, {
+        value: { h_statements: {}, p_statements: {}, pictograms: ['GHS01'] },
+        onChange,
+      })
+    );
+    pictogramSection(wrapper).prop('onAdd')({ value: 'GHS01' });
+    expect(onChange.called).toBe(false);
+
+    pictogramSection(wrapper).prop('onAdd')({ value: 'GHS07' });
+    expect(onChange.calledOnce).toBe(true);
+    expect(onChange.firstCall.args[0].pictograms).toEqual(['GHS01', 'GHS07']);
+  });
+
+  it('emits onChange when pictogram delete handler runs, preserving other sections', () => {
+    const onChange = sinon.spy();
+    const value = {
+      h_statements: { H315: ' Causes skin irritation' },
+      p_statements: { P102: ' note' },
+      pictograms: ['GHS01', 'GHS07'],
+    };
+    const wrapper = shallow(
+      React.createElement(SafetyPhrasesEditor, { value, onChange })
+    );
+    const items = pictogramSection(wrapper).prop('items');
+    items[0].onDelete();
+    expect(onChange.calledOnce).toBe(true);
+    const emitted = onChange.firstCall.args[0];
+    expect(emitted.pictograms).toEqual(['GHS07']);
+    expect(emitted.h_statements).toEqual(value.h_statements);
+    expect(emitted.p_statements).toEqual(value.p_statements);
+  });
+
+  it('ignores onAdd invocations with null (cleared select)', () => {
+    const onChange = sinon.spy();
+    const wrapper = shallow(
+      React.createElement(SafetyPhrasesEditor, { value: null, onChange })
+    );
+    sectionWithPrefix(wrapper, 'safety-h-phrases').prop('onAdd')(null);
+    expect(onChange.called).toBe(false);
+  });
+});

--- a/spec/javascripts/packs/src/components/chemicals/SafetyPhrasesEditor.spec.js
+++ b/spec/javascripts/packs/src/components/chemicals/SafetyPhrasesEditor.spec.js
@@ -59,11 +59,11 @@ describe('normalizeSafetyPhrases', () => {
 describe('SafetyPhrasesEditor', () => {
   beforeEach(() => {
     const fetchStub = sinon.stub(global, 'fetch');
-    fetchStub.withArgs('/json/hazardPhrases.json', sinon.match.any)
+    fetchStub.withArgs('/json/hazardPhrases.json')
       .resolves(buildResponse({ H200: 'Unstable explosive', H315: 'Causes skin irritation' }));
-    fetchStub.withArgs('/json/precautionaryPhrases.json', sinon.match.any)
+    fetchStub.withArgs('/json/precautionaryPhrases.json')
       .resolves(buildResponse({ P102: 'Keep out of reach of children.' }));
-    fetchStub.withArgs('/json/pictograms.json', sinon.match.any)
+    fetchStub.withArgs('/json/pictograms.json')
       .resolves(buildResponse({ GHS01: 'Explosive.gif', GHS07: 'Harmful_Irritant.gif' }));
   });
 

--- a/spec/javascripts/packs/src/components/chemicals/SafetyPhrasesEditor.spec.js
+++ b/spec/javascripts/packs/src/components/chemicals/SafetyPhrasesEditor.spec.js
@@ -173,6 +173,18 @@ describe('SafetyPhrasesEditor', () => {
     expect(onChange.firstCall.args[0].pictograms).toEqual(['GHS01', 'GHS07']);
   });
 
+  it('ignores invalid pictogram values before emitting onChange', () => {
+    const onChange = sinon.spy();
+    const wrapper = shallow(
+      React.createElement(SafetyPhrasesEditor, { value: null, onChange })
+    );
+
+    pictogramSection(wrapper).prop('onAdd')({ value: '../evil' });
+    pictogramSection(wrapper).prop('onAdd')({ value: 'GHS99' });
+
+    expect(onChange.called).toBe(false);
+  });
+
   it('emits onChange when pictogram delete handler runs, preserving other sections', () => {
     const onChange = sinon.spy();
     const value = {

--- a/spec/javascripts/packs/src/components/chemicals/SafetyPhrasesEditor.spec.js
+++ b/spec/javascripts/packs/src/components/chemicals/SafetyPhrasesEditor.spec.js
@@ -49,8 +49,8 @@ describe('normalizeSafetyPhrases', () => {
     });
   });
 
-  it('strips pictogram codes that do not match the GHS\\d{2} whitelist (XSS/path-traversal guard)', () => {
-    expect(normalizeSafetyPhrases({ pictograms: ['GHS01', '../evil', 'GHS09', 'javascript:alert(1)', 'ghs01'] })).toEqual({
+  it('strips pictogram codes outside the GHS01-GHS09 whitelist', () => {
+    expect(normalizeSafetyPhrases({ pictograms: ['GHS01', '../evil', 'GHS09', 'GHS99', 'ghs01'] })).toEqual({
       h_statements: {}, p_statements: {}, pictograms: ['GHS01', 'GHS09'],
     });
   });

--- a/spec/javascripts/packs/src/components/chemicals/SafetyPhrasesEditor.spec.js
+++ b/spec/javascripts/packs/src/components/chemicals/SafetyPhrasesEditor.spec.js
@@ -48,6 +48,12 @@ describe('normalizeSafetyPhrases', () => {
       h_statements: {}, p_statements: {}, pictograms: ['GHS01'],
     });
   });
+
+  it('strips pictogram codes that do not match the GHS\\d{2} whitelist (XSS/path-traversal guard)', () => {
+    expect(normalizeSafetyPhrases({ pictograms: ['GHS01', '../evil', 'GHS09', 'javascript:alert(1)', 'ghs01'] })).toEqual({
+      h_statements: {}, p_statements: {}, pictograms: ['GHS01', 'GHS09'],
+    });
+  });
 });
 
 describe('SafetyPhrasesEditor', () => {


### PR DESCRIPTION
**Problem:** 

- Users cannot manually edit or add safety phrases (hazard statements, precautionary statements, pictograms)
- Safety phrases are read-only and sourced only from external APIs

**Motivation:**
- Enable users to manually add or modify safety phrases directly in the inventory tab 
- Provide a better UX for managing safety information with searchable dropdowns and individual delete options
- Give users full control over chemical safety data without depending entirely on external sources

**Result / behavior:**
- New SafetyPhrasesEditor component in the chemical tab with three searchable phrase sections:
  - Hazard Statements (H-codes) - searchable dropdown to add, list items with delete buttons
  - Precautionary Statements (P-codes) - searchable dropdown to add, list items with delete buttons
  - Pictograms - searchable dropdown with GHS icon preview, add/remove functionality
- Users can search and add phrases from JSON dictionaries, and remove individual entries
- Manual edits persist via handleSafetyPhrasesChange() callback
- Refactored ChemicalTab to delegate phrase rendering to the new component
- Rest coverage for the new component

<img width="1184" height="558" alt="image" src="https://github.com/user-attachments/assets/401d95fb-3475-47bb-ad11-8a81eb1fa859" />
_______________________________________________________________________________________________________________________________

- [ ] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [x] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
