### PR TITLE
fix: cell line close

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/cellLines/CellLineDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/cellLines/CellLineDetails.js
@@ -46,6 +46,7 @@ class CellLineDetails extends React.Component {
     const { cellLineItem } = this.props;
     const { cellLineDetailsStore } = this.context;
     cellLineDetailsStore.removeCellLineFromStore(cellLineItem.id);
+    DetailActions.close(cellLineItem, true);
   }
 
   handleTabChange(eventKey) {


### PR DESCRIPTION
Cell Lines cannot be closed since:
https://github.com/ComPlat/chemotion_ELN/pull/3063/changes#diff-43fa55d928abcbd344ec9d9b6626942f50cc6608108fdbbd2a5c32ff37250952
Readded missing DetailAction.close