### PR TITLE
fix(ketcher): skip onTemplateMove on ADD_BOND

### DIFF
--- a/app/javascript/src/components/structureEditor/KetcherEditor.js
+++ b/app/javascript/src/components/structureEditor/KetcherEditor.js
@@ -236,7 +236,7 @@ const KetcherEditor = forwardRef((props, ref) => {
       }
     },
     [EventNames.ADD_BOND]: async () => {
-      if (editor && editor.structureDef) {
+      if (editor && editor.structureDef && (imagesList.length > 0 || textList.length > 0)) {
         await onTemplateMove(editor);
       }
     }


### PR DESCRIPTION
 when no images/labels present

Every bond draw was unconditionally triggering a getKet→setMolecule round-trip via onTemplateMove. The async setMolecule from bond N competed with Ketcher's own ctab rebuild for bond N+1, widening the window where ctab.visibleBonds and ctab.atoms are out of sync and making a Ketcher internal crash (TypeError on bond hit-test) consistently reproducible.

Guard the ADD_BOND handler to only run onTemplateMove when polymer images or text labels are actually present — the only case where repositioning is needed. Fixes 
