### PR TITLE
fix(UI): correct react-select portal dropdown positioning in modals

### DIFF
--- a/app/javascript/src/components/common/Select.js
+++ b/app/javascript/src/components/common/Select.js
@@ -82,6 +82,7 @@ function buildWrappedComponent(name, BaseComponent) {
         ref={ref}
         menuPortalTarget={document.body}
         menuPlacement="auto"
+        menuPosition="fixed"
         unstyled
         styles={stylesWithOverrides}
         components={mergedComponents}


### PR DESCRIPTION
## Summary

- Adds `menuPosition="fixed"` to all `Select`, `AsyncSelect`, and `CreatableSelect` instances that already use `menuPortalTarget={document.body}`
- With `menuPortalTarget`, the portal CSS is forced to `position: fixed`, but `menuPosition` defaulted to `'absolute'`, causing react-select to add `window.pageYOffset` to the calculated top offset
- This made dropdowns appear detached (too low) when the page was scrolled — most visibly in the admin device modal

## Test plan

- [ ] Open a modal that contains a react-select dropdown (e.g. admin device modal)
- [ ] Scroll the page down before opening the modal
- [ ] Confirm the dropdown opens aligned with its control, not offset by the scroll position
- [ ] Verify other Select/AsyncSelect/CreatableSelect instances throughout the app are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)