### PR TITLE
fix(API): expose temp_svg from molecules SMILES endpoint

### DIFF
--- a/app/api/chemotion/molecule_api.rb
+++ b/app/api/chemotion/molecule_api.rb
@@ -80,9 +80,8 @@ module Chemotion
               end
             end
           end
-          molecule.attributes.merge(temp_svg: File.exist?(svg_process[:svg_file_path]) && svg_process[:svg_file_name], ob_log: babel_info[:ob_log])
-
-          present molecule, with: Entities::MoleculeEntity
+          temp_svg = File.exist?(svg_process[:svg_file_path]) ? svg_process[:svg_file_name] : nil
+          Entities::MoleculeEntity.represent(molecule, temp_svg: temp_svg, ob_log: babel_info[:ob_log])
         end
       end
 


### PR DESCRIPTION
## Summary

- The `molecules#smiles` Grape endpoint built a `temp_svg` value but discarded it via `Hash#merge` and called `present molecule, with: MoleculeEntity` without passing `temp_svg` as an option
- Since `Entities::MoleculeEntity` reads `temp_svg` from `options[:temp_svg]`, the field was always absent from the SMILES response, so samples created via **fast input** (SMILES/CAS) had no `sample_svg_file` after save
- The frontend `Sample#set molecule()` setter already auto-populates `sample_svg_file` from `result.temp_svg`. Once the backend actually sends `temp_svg`, the rest of the chain (`Sample#attach_svg` `before_save` hook → SVG persistence → label preview) works as designed
- Mirrors the pattern already used by the `molecules#molfile` endpoint (`MoleculeEntity.represent` with explicit `temp_svg`/`ob_log` options) — which is why the structure-editor flow always worked


## Test plan

- [ ] Create a sample via fast input (enter a SMILES or CAS, do not open the structure editor)
- [ ] Save the sample
- [ ] Open the label print preview — structure image should appear
- [ ] Verify the structure-editor flow still works (regression check: it uses the `molfile` endpoint, untouched here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)