### PR TITLE
fix(report): coerce Quill op["insert"] to String before CGI.escapeHTML

### DIFF
--- a/lib/reporter/delta.rb
+++ b/lib/reporter/delta.rb
@@ -115,7 +115,7 @@ module Reporter
     end
 
     def buildDeltaOps(op)
-      return CGI.escapeHTML(op["insert"]) if (!op["attributes"]) && (!(op && op["insert"].is_a?(Hash) && op["insert"]["image"]))
+      return CGI.escapeHTML(op["insert"].to_s) if (!op["attributes"]) && (!(op && op["insert"].is_a?(Hash) && op["insert"]["image"]))
 
       styles = []
       tags = []
@@ -154,7 +154,7 @@ module Reporter
 
     def html_with_tags_style(op, tags, styles)
       style = styles.count > 0 ? " style=\"#{styles.join(";")}\"" : ""
-      html = "<span#{style}>#{CGI.escapeHTML(op["insert"])}</span>"
+      html = "<span#{style}>#{CGI.escapeHTML(op["insert"].to_s)}</span>"
 
       tags.each { |tag| html = "<#{tag}>#{html}</#{tag}>" }
       html


### PR DESCRIPTION
CGI.escapeHTML raises TypeError on non-String input, so reports whose Quill deltas contain numeric or nil inserts crashed with "no implicit conversion of Integer into String" at delta.rb:157. The previous string-interpolation form silently called .to_s; restore that tolerance by calling .to_s explicitly before escaping, at both call sites.

refs: d27ac4ae69 , #3209



