### PR TITLE
fix: bulk print label

### DIFF
--- a/app/api/chemotion/code_log_api.rb
+++ b/app/api/chemotion/code_log_api.rb
@@ -5,6 +5,48 @@ module Chemotion
     helpers ParamsHelpers
     helpers CollectionHelpers
 
+    PRINTABLE_ELEMENT_TYPES = %w[
+      sample reaction wellplate screen device_description sequence_based_macromolecule_sample
+    ].freeze
+
+    helpers do
+      # Returns the AR class corresponding to the +element_type+ request param.
+      # @return [Class] e.g. Sample, Reaction, ...
+      def element_class
+        params[:element_type].classify.constantize
+      end
+
+      # Translates the request params into the option hash accepted by
+      # {CodePdf#initialize}.
+      # @return [Hash]
+      def code_pdf_options
+        {
+          width: params[:width],
+          element_type: params[:element_type],
+          code_type: params[:code_type],
+          code_image_size: params[:code_image_size],
+          display_sample: params[:displaySample],
+          name: params[:name],
+          short_label: params[:short_label],
+          external_label: params[:external_label],
+          molecule_name: params[:molecule_name],
+          code_log: params[:code_log],
+          text_position: params[:text_position],
+        }
+      end
+
+      # Sets the HTTP envelope and returns the rendered PDF body.
+      # @param elements [ActiveRecord::Relation]
+      # @return [String] rendered PDF body
+      def render_print_codes_pdf(elements)
+        content_type('application/pdf')
+        header 'Content-Disposition',
+               "attachment; filename*=UTF-8''#{params[:element_type]}_codes_#{params[:size]}.pdf"
+        env['api.format'] = :binary
+        CodePdf.new(elements, **code_pdf_options).render
+      end
+    end
+
     resource :code_logs do
       rescue_from ActiveRecord::RecordNotFound do |_error|
         message = 'Could not find code log'
@@ -50,43 +92,9 @@ module Chemotion
       end
 
       namespace :print_codes do
-        helpers do
-          # Translates the request params into the option hash accepted by
-          # {CodePdf#initialize}.
-          # @return [Hash]
-          def code_pdf_options
-            {
-              width: params[:width],
-              element_type: params[:element_type],
-              code_type: params[:code_type],
-              code_image_size: params[:code_image_size],
-              display_sample: params[:displaySample],
-              name: params[:name],
-              short_label: params[:short_label],
-              external_label: params[:external_label],
-              molecule_name: params[:molecule_name],
-              code_log: params[:code_log],
-              text_position: params[:text_position],
-            }
-          end
-
-          # Sets the HTTP envelope and returns the rendered PDF body.
-          # @param elements [ActiveRecord::Relation]
-          # @return [String] rendered PDF body
-          def render_print_codes_pdf(elements)
-            content_type('application/pdf')
-            header 'Content-Disposition',
-                   "attachment; filename*=UTF-8''#{params[:element_type]}_codes_#{params[:size]}.pdf"
-            env['api.format'] = :binary
-            CodePdf.new(elements, **code_pdf_options).render
-          end
-        end
-
         desc 'Build PDF with element bar & qr code'
         params do
-          requires(:element_type, type: String, values: %w[
-                     sample reaction wellplate screen device_description sequence_based_macromolecule_sample
-                   ])
+          requires :element_type, type: String, values: PRINTABLE_ELEMENT_TYPES
           # TODO: check coerce with  type Array[Integer] not working with before do
           requires :ids, type: Array # , coerce_with: ->(val) { val.split(/,/).map(&:to_i) }
           requires :width, type: Integer
@@ -102,17 +110,12 @@ module Chemotion
         before do
           # TODO: vide supra
           ids = params[:ids][0]&.split(',')&.map(&:to_i)
-          error!('401 Unauthorized', 401) unless ElementsPolicy.new(
-            current_user,
-            params[:element_type].classify.constantize.where(id: ids),
-          ).read?
+          @print_code_elements = element_class.where(id: ids)
+          error!('401 Unauthorized', 401) unless ElementsPolicy.new(current_user, @print_code_elements).read?
         end
 
         get do
-          # TODO: vide supra
-          ids = params[:ids][0]&.split(',')&.map(&:to_i)
-          elements = params[:element_type].classify.constantize.where(id: ids)
-          body render_print_codes_pdf(elements)
+          body render_print_codes_pdf(@print_code_elements)
         end
       end
 
@@ -123,9 +126,7 @@ module Chemotion
       namespace :print_codes_by_ui_state do
         desc 'Build PDF with element bar & qr code from ui_state'
         params do
-          requires(:element_type, type: String, values: %w[
-                     sample reaction wellplate screen device_description sequence_based_macromolecule_sample
-                   ])
+          requires :element_type, type: String, values: PRINTABLE_ELEMENT_TYPES
           requires(:ui_state, type: Hash) do
             use :ui_state_params
           end
@@ -142,7 +143,7 @@ module Chemotion
         end
 
         before do
-          klass = params[:element_type].classify.constantize
+          klass = element_class
           cid = fetch_collection_id_w_current_user(
             params[:ui_state][:collection_id],
             params[:ui_state][:is_sync_to_me],
@@ -161,25 +162,20 @@ module Chemotion
       namespace :print_analyses_codes do
         desc 'Build PDF with analyses codes of one analysis type'
         params do
-          requires(:element_type, type: String, values: %w[
-                     sample reaction wellplate screen device_description sequence_based_macromolecule_sample
-                   ])
+          requires :element_type, type: String, values: PRINTABLE_ELEMENT_TYPES
           requires :id, type: Integer, desc: 'Element id'
           requires :analyses_ids, type: [String]
           requires :size, type: String, values: %w[small big]
         end
 
         before do
-          error!('401 Unauthorized', 401) unless ElementPolicy.new(
-            current_user,
-            params[:element_type].classify.constantize.find(params[:id]),
-          ).read?
+          @print_analyses_element = element_class.find(params[:id])
+          error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, @print_analyses_element).read?
         end
 
         get do
-          element = params[:element_type].classify.constantize.find(params[:id])
           # TODO: check that analyses is defined for all element type
-          analyses = element.analyses.where(id: params[:analyses_ids])
+          analyses = @print_analyses_element.analyses.where(id: params[:analyses_ids])
 
           content_type('application/pdf')
           header 'Content-Disposition', "attachment; filename*=UTF-8''analysis_codes_#{params[:size]}.pdf"
@@ -189,7 +185,7 @@ module Chemotion
           # when "nmr_analysis"
           #   body AnalysisNmrPdf.new(elements).render
           # when "analysis"
-          body AnalysisPdf.new(element, analyses, params[:size]).render
+          body AnalysisPdf.new(@print_analyses_element, analyses, params[:size]).render
           # else
           #   error!("Analysis with #{params[:type]} not defined", 500)
           # end

--- a/app/api/chemotion/code_log_api.rb
+++ b/app/api/chemotion/code_log_api.rb
@@ -2,6 +2,9 @@
 
 module Chemotion
   class CodeLogAPI < Grape::API
+    helpers ParamsHelpers
+    helpers CollectionHelpers
+
     resource :code_logs do
       rescue_from ActiveRecord::RecordNotFound do |_error|
         message = 'Could not find code log'
@@ -47,6 +50,38 @@ module Chemotion
       end
 
       namespace :print_codes do
+        helpers do
+          # Translates the request params into the option hash accepted by
+          # {CodePdf#initialize}.
+          # @return [Hash]
+          def code_pdf_options
+            {
+              width: params[:width],
+              element_type: params[:element_type],
+              code_type: params[:code_type],
+              code_image_size: params[:code_image_size],
+              display_sample: params[:displaySample],
+              name: params[:name],
+              short_label: params[:short_label],
+              external_label: params[:external_label],
+              molecule_name: params[:molecule_name],
+              code_log: params[:code_log],
+              text_position: params[:text_position],
+            }
+          end
+
+          # Sets the HTTP envelope and returns the rendered PDF body.
+          # @param elements [ActiveRecord::Relation]
+          # @return [String] rendered PDF body
+          def render_print_codes_pdf(elements)
+            content_type('application/pdf')
+            header 'Content-Disposition',
+                   "attachment; filename*=UTF-8''#{params[:element_type]}_codes_#{params[:size]}.pdf"
+            env['api.format'] = :binary
+            CodePdf.new(elements, **code_pdf_options).render
+          end
+        end
+
         desc 'Build PDF with element bar & qr code'
         params do
           requires(:element_type, type: String, values: %w[
@@ -77,23 +112,49 @@ module Chemotion
           # TODO: vide supra
           ids = params[:ids][0]&.split(',')&.map(&:to_i)
           elements = params[:element_type].classify.constantize.where(id: ids)
+          body render_print_codes_pdf(elements)
+        end
+      end
 
-          content_type('application/pdf')
-          header 'Content-Disposition',
-                 "attachment; filename*=UTF-8''#{params[:element_type]}_codes_#{params[:size]}.pdf"
-          env['api.format'] = :binary
-          body CodePdf.new(elements,
-                           width: params[:width],
-                           element_type: params[:element_type],
-                           code_type: params[:code_type],
-                           code_image_size: params[:code_image_size],
-                           display_sample: params[:displaySample],
-                           name: params[:name],
-                           short_label: params[:short_label],
-                           external_label: params[:external_label],
-                           molecule_name: params[:molecule_name],
-                           code_log: params[:code_log],
-                           text_position: params[:text_position]).render
+      # POST variant of print_codes that accepts a ui_state payload so that
+      # "select all pages" (checkedAll + uncheckedIds) and large selections can
+      # be resolved server-side against the current collection scope, and
+      # rendered into a single multi-page PDF instead of N per-id requests.
+      namespace :print_codes_by_ui_state do
+        desc 'Build PDF with element bar & qr code from ui_state'
+        params do
+          requires(:element_type, type: String, values: %w[
+                     sample reaction wellplate screen device_description sequence_based_macromolecule_sample
+                   ])
+          requires(:ui_state, type: Hash) do
+            use :ui_state_params
+          end
+          requires :width, type: Integer
+          requires :displaySample, type: Boolean
+          requires :name, type: Boolean
+          requires :short_label, type: Boolean
+          requires :external_label, type: Boolean
+          requires :molecule_name, type: Boolean
+          requires :code_log, type: Boolean
+          requires :code_type, type: String
+          optional :code_image_size, type: Integer
+          optional :text_position, type: String
+        end
+
+        before do
+          klass = params[:element_type].classify.constantize
+          cid = fetch_collection_id_w_current_user(
+            params[:ui_state][:collection_id],
+            params[:ui_state][:is_sync_to_me],
+          )
+          scope = klass.by_collection_id(cid).by_ui_state(params[:ui_state])
+          scope = scope.for_user(current_user.id) if klass.respond_to?(:for_user)
+          @print_code_elements = scope
+          error!('401 Unauthorized', 401) unless ElementsPolicy.new(current_user, @print_code_elements).read?
+        end
+
+        post do
+          body render_print_codes_pdf(@print_code_elements)
         end
       end
 

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionGenerateButton.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionGenerateButton.js
@@ -24,11 +24,12 @@ export default class SelectionGenerateButton extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      // Map of element type -> Immutable.List of checked IDs, including every
-      // printable type with at least one selection (selections persist across
-      // tab switches in UIStore, so the user may have selections on multiple
-      // tabs simultaneously — print all of them).
+      // Snapshot of ui_state per printable element type that has any active
+      // selection ({checkedAll, checkedIds, uncheckedIds}). Mirrors UIStore so
+      // we can build the ui_state payload that the print_codes_by_ui_state
+      // endpoint expects.
       selectionsByType: {},
+      currentCollection: null,
       json: {},
       matrix: null,
       enableComputedProps: null,
@@ -81,63 +82,70 @@ export default class SelectionGenerateButton extends React.Component {
     }
   }
 
-  // Collects checked IDs for every printable element type from UIStore so we
-  // can print labels for selections across all tabs in one go.
+  // Collects ui_state per printable element type from UIStore so we can print
+  // labels for selections across all tabs (including "All pages" via
+  // checkedAll) in a single batch.
   syncFromStores() {
     const uiState = UIStore.getState() || {};
     const next = {};
-    let changed = false;
-    const { selectionsByType: prev } = this.state;
 
     PRINTABLE_ELEMENT_TYPES.forEach((t) => {
-      const ids = uiState[t]?.checkedIds;
-      if (ids && ids.size > 0) {
-        next[t] = ids;
-        if (prev[t] !== ids) changed = true;
-      } else if (prev[t]) {
-        changed = true;
-      }
+      const typeState = uiState[t];
+      if (!typeState) return;
+      const hasSelection = typeState.checkedAll
+        || (typeState.checkedIds && typeState.checkedIds.size > 0);
+      if (!hasSelection) return;
+      next[t] = {
+        checkedAll: !!typeState.checkedAll,
+        checkedIds: typeState.checkedIds ? typeState.checkedIds.toArray() : [],
+        uncheckedIds: typeState.uncheckedIds ? typeState.uncheckedIds.toArray() : [],
+      };
     });
 
-    if (changed || Object.keys(next).length !== Object.keys(prev).length) {
-      this.setState({ selectionsByType: next });
-    }
+    this.setState({
+      selectionsByType: next,
+      currentCollection: uiState.currentCollection || null,
+    });
   }
 
   async downloadPrintCodesPDF(selectedConfig) {
-    const { json, selectionsByType } = this.state;
+    const { json, selectionsByType, currentCollection } = this.state;
+    if (!currentCollection || Object.keys(selectionsByType).length === 0) return;
+
     const configParams = json[selectedConfig] || {};
-    const baseQuery = Object.entries(configParams)
-      .map(([key, value]) => `${key}=${value}`)
-      .join('&');
-
-    const requests = [];
-    Object.entries(selectionsByType).forEach(([elementType, idsList]) => {
-      idsList.forEach((id) => {
-        const params = `element_type=${elementType}&ids[]=${id}`;
-        const url = baseQuery
-          ? `/api/v1/code_logs/print_codes?${params}&${baseQuery}`
-          : `/api/v1/code_logs/print_codes?${params}`;
-        requests.push(url);
-      });
-    });
-
-    if (requests.length === 0) return;
 
     try {
       const mergedPdf = await PDFDocument.create();
-      const pdfPromises = requests.map(async (url) => {
-        const pdfBytes = await PrintCodeFetcher.fetchMergedPrintCodes(url);
+      const requests = Object.entries(selectionsByType).map(([elementType, selection]) => {
+        const payload = {
+          element_type: elementType,
+          ui_state: {
+            checkedAll: selection.checkedAll,
+            checkedIds: selection.checkedIds,
+            uncheckedIds: selection.uncheckedIds,
+            collection_id: currentCollection.id,
+            is_sync_to_me: !!currentCollection.is_sync_to_me,
+          },
+          ...configParams,
+        };
+        return PrintCodeFetcher.fetchPrintCodesByUIState(payload);
+      });
+
+      const pdfBuffers = await Promise.all(requests);
+      // Append each PDF sequentially — mergedPdf mutations aren't safe to
+      // interleave even though JS is single-threaded, because copyPages and
+      // addPage share internal state on the merged document.
+      await pdfBuffers.reduce(async (chain, pdfBytes) => {
+        await chain;
+        if (!pdfBytes || pdfBytes.byteLength === 0) return;
         const pdfToMerge = await PDFDocument.load(pdfBytes);
         const copiedPages = await mergedPdf.copyPages(pdfToMerge, pdfToMerge.getPageIndices());
         copiedPages.forEach((page) => mergedPdf.addPage(page));
-      });
+      }, Promise.resolve());
 
-      await Promise.all(pdfPromises);
       const mergedPdfBytes = await mergedPdf.save();
       const blob = new Blob([mergedPdfBytes], { type: 'application/pdf' });
       const url = URL.createObjectURL(blob);
-
       Utils.downloadFile({ contents: url, name: 'print_codes_merged.pdf' });
     } catch (err) {
       console.error('Failed to generate print codes PDF', err);
@@ -146,11 +154,11 @@ export default class SelectionGenerateButton extends React.Component {
 
   render() {
     const {
-      json, selectionsByType, enableComputedProps, enableReactionPredict
+      json, selectionsByType, currentCollection,
+      enableComputedProps, enableReactionPredict,
     } = this.state;
-    const totalSelected = Object.values(selectionsByType)
-      .reduce((sum, list) => sum + list.size, 0);
-    const disabledPrint = totalSelected === 0;
+    const hasSelection = Object.keys(selectionsByType).length > 0;
+    const disabledPrint = !currentCollection || !hasSelection;
     const pdfMenuItems = Object.entries(json).map(([key]) => ({ key, name: key }));
 
     return (

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionGenerateButton.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionGenerateButton.js
@@ -26,13 +26,14 @@ export default class SelectionGenerateButton extends React.Component {
     super(props);
     this.state = {
       checkedIds: List(),
-      elementType: 'sample',
+      elementType: null,
       json: {},
       matrix: null,
       enableComputedProps: null,
       enableReactionPredict: null,
     };
 
+    this.syncFromStores = this.syncFromStores.bind(this);
     this.onUIStoreChange = this.onUIStoreChange.bind(this);
     this.onUserStoreChange = this.onUserStoreChange.bind(this);
     this.downloadPrintCodesPDF = this.downloadPrintCodesPDF.bind(this);
@@ -41,8 +42,8 @@ export default class SelectionGenerateButton extends React.Component {
   async componentDidMount() {
     UIStore.listen(this.onUIStoreChange);
     UserStore.listen(this.onUserStoreChange);
-    this.onUIStoreChange(UIStore.getState());
     this.onUserStoreChange(UserStore.getState());
+    this.syncFromStores();
 
     // Import the PDF configuration when the component mounts
     try {
@@ -62,13 +63,36 @@ export default class SelectionGenerateButton extends React.Component {
     UserStore.unlisten(this.onUserStoreChange);
   }
 
-  onUIStoreChange(state) {
+  onUIStoreChange() {
+    this.syncFromStores();
+  }
+
+  onUserStoreChange(state) {
+    const { matrix: storeMatrix } = state?.currentUser || {};
+    const { matrix } = this.state;
+    if (matrix !== storeMatrix) {
+      this.setState({
+        matrix: storeMatrix,
+        enableComputedProps: MatrixCheck(storeMatrix, 'computedProp'),
+        enableReactionPredict: MatrixCheck(storeMatrix, 'reactionPrediction'),
+      });
+    }
+    this.syncFromStores();
+  }
+
+  // Picks the active element type from UserStore (the currently selected tab)
+  // and reads the matching checkedIds from UIStore. Scanning UIStore for the
+  // first non-empty selection instead would pick up stale selections left
+  // over from other tabs.
+  syncFromStores() {
+    const { currentType } = UserStore.getState() || {};
+    const uiState = UIStore.getState() || {};
+    const isPrintable = PRINTABLE_ELEMENT_TYPES.includes(currentType);
+    const typeState = isPrintable ? uiState[currentType] : null;
+    const nextCheckedIds = (typeState && typeState.checkedIds) || List();
+    const nextElementType = isPrintable ? currentType : null;
+
     const { checkedIds, elementType } = this.state;
-    const activeType = PRINTABLE_ELEMENT_TYPES.find(
-      (t) => state[t] && state[t].checkedIds && state[t].checkedIds.size > 0
-    );
-    const nextCheckedIds = activeType ? state[activeType].checkedIds : List();
-    const nextElementType = activeType || 'sample';
     if (nextCheckedIds !== checkedIds || nextElementType !== elementType) {
       this.setState({
         checkedIds: nextCheckedIds,
@@ -77,49 +101,42 @@ export default class SelectionGenerateButton extends React.Component {
     }
   }
 
-  onUserStoreChange(state) {
-    const { matrix: storeMatrix } = state?.currentUser || {};
-    if (this.state.matrix !== storeMatrix) {
-      this.setState({
-        matrix: storeMatrix,
-        enableComputedProps: MatrixCheck(storeMatrix, 'computedProp'),
-        enableReactionPredict: MatrixCheck(storeMatrix, 'reactionPrediction'),
-      });
-    }
-  }
-
   async downloadPrintCodesPDF(ids, selectedConfig) {
     const { json, elementType } = this.state;
-    if (!ids || ids.length === 0) return;
+    if (!elementType || !ids || ids.length === 0) return;
 
-    const mergedPdf = await PDFDocument.create();
     const configParams = json[selectedConfig] || {};
 
-    const pdfPromises = ids.map(async (id) => {
-      let url = `/api/v1/code_logs/print_codes?element_type=${elementType}&ids[]=${id}`;
-      Object.entries(configParams).forEach(([key, value]) => {
-        url += `&${key}=${value}`;
+    try {
+      const mergedPdf = await PDFDocument.create();
+      const pdfPromises = ids.map(async (id) => {
+        let url = `/api/v1/code_logs/print_codes?element_type=${elementType}&ids[]=${id}`;
+        Object.entries(configParams).forEach(([key, value]) => {
+          url += `&${key}=${value}`;
+        });
+        const pdfBytes = await PrintCodeFetcher.fetchMergedPrintCodes(url);
+        const pdfToMerge = await PDFDocument.load(pdfBytes);
+        const copiedPages = await mergedPdf.copyPages(pdfToMerge, pdfToMerge.getPageIndices());
+        copiedPages.forEach((page) => mergedPdf.addPage(page));
       });
-      const pdfBytes = await PrintCodeFetcher.fetchMergedPrintCodes(url);
-      const pdfToMerge = await PDFDocument.load(pdfBytes);
-      const copiedPages = await mergedPdf.copyPages(pdfToMerge, pdfToMerge.getPageIndices());
-      copiedPages.forEach((page) => mergedPdf.addPage(page));
-    });
 
-    await Promise.all(pdfPromises);
-    const mergedPdfBytes = await mergedPdf.save();
-    const blob = new Blob([mergedPdfBytes], { type: 'application/pdf' });
-    const url = URL.createObjectURL(blob);
+      await Promise.all(pdfPromises);
+      const mergedPdfBytes = await mergedPdf.save();
+      const blob = new Blob([mergedPdfBytes], { type: 'application/pdf' });
+      const url = URL.createObjectURL(blob);
 
-    Utils.downloadFile({ contents: url, name: 'print_codes_merged.pdf' });
+      Utils.downloadFile({ contents: url, name: 'print_codes_merged.pdf' });
+    } catch (err) {
+      console.error('Failed to generate print codes PDF', err);
+    }
   }
 
   render() {
     const {
-      json, checkedIds, enableComputedProps, enableReactionPredict
+      json, checkedIds, elementType, enableComputedProps, enableReactionPredict
     } = this.state;
     const ids = checkedIds.toArray();
-    const disabledPrint = !(ids.length > 0);
+    const disabledPrint = !elementType || ids.length === 0;
     const pdfMenuItems = Object.entries(json).map(([key]) => ({ key, name: key }));
 
     return (

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionGenerateButton.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionGenerateButton.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { List } from 'immutable';
 import { Dropdown } from 'react-bootstrap';
 import PrintCodeFetcher from 'src/fetchers/PrintCodeFetcher';
 import UIStore from 'src/stores/alt/stores/UIStore';
@@ -9,11 +10,23 @@ import { PDFDocument } from 'pdf-lib';
 import Utils from 'src/utilities/Functions';
 import 'whatwg-fetch';
 
+// Element types accepted by the /api/v1/code_logs/print_codes endpoint
+// (see app/api/chemotion/code_log_api.rb).
+const PRINTABLE_ELEMENT_TYPES = [
+  'sample',
+  'reaction',
+  'wellplate',
+  'screen',
+  'device_description',
+  'sequence_based_macromolecule_sample',
+];
+
 export default class SelectionGenerateButton extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      checkedIds: UIStore.getState().sample.checkedIds,
+      checkedIds: List(),
+      elementType: 'sample',
       json: {},
       matrix: null,
       enableComputedProps: null,
@@ -50,9 +63,16 @@ export default class SelectionGenerateButton extends React.Component {
   }
 
   onUIStoreChange(state) {
-    if (state.sample.checkedIds !== this.state.checkedIds) {
+    const { checkedIds, elementType } = this.state;
+    const activeType = PRINTABLE_ELEMENT_TYPES.find(
+      (t) => state[t] && state[t].checkedIds && state[t].checkedIds.size > 0
+    );
+    const nextCheckedIds = activeType ? state[activeType].checkedIds : List();
+    const nextElementType = activeType || 'sample';
+    if (nextCheckedIds !== checkedIds || nextElementType !== elementType) {
       this.setState({
-        checkedIds: state.sample.checkedIds
+        checkedIds: nextCheckedIds,
+        elementType: nextElementType,
       });
     }
   }
@@ -68,20 +88,21 @@ export default class SelectionGenerateButton extends React.Component {
     }
   }
 
-  async downloadPrintCodesPDF(ids, template) {
-    const { json } = this.state;
-    const fetchedData = await PrintCodeFetcher.fetchPrintCodes(ids.length > 0 ? ids : null, template, json);
-
-    if (!Array.isArray(fetchedData) || fetchedData.length === 0) {
-      console.error('No data received or data is not in expected format');
-      return;
-    }
+  async downloadPrintCodesPDF(ids, selectedConfig) {
+    const { json, elementType } = this.state;
+    if (!ids || ids.length === 0) return;
 
     const mergedPdf = await PDFDocument.create();
-    const pdfPromises = fetchedData.map(async (base64String) => {
-      const pdfBytes = Uint8Array.from(atob(base64String), (c) => c.charCodeAt(0));
-      const pdf = await PDFDocument.load(pdfBytes);
-      const copiedPages = await mergedPdf.copyPages(pdf, pdf.getPageIndices());
+    const configParams = json[selectedConfig] || {};
+
+    const pdfPromises = ids.map(async (id) => {
+      let url = `/api/v1/code_logs/print_codes?element_type=${elementType}&ids[]=${id}`;
+      Object.entries(configParams).forEach(([key, value]) => {
+        url += `&${key}=${value}`;
+      });
+      const pdfBytes = await PrintCodeFetcher.fetchMergedPrintCodes(url);
+      const pdfToMerge = await PDFDocument.load(pdfBytes);
+      const copiedPages = await mergedPdf.copyPages(pdfToMerge, pdfToMerge.getPageIndices());
       copiedPages.forEach((page) => mergedPdf.addPage(page));
     });
 

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionGenerateButton.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionGenerateButton.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { List } from 'immutable';
 import { Dropdown } from 'react-bootstrap';
 import PrintCodeFetcher from 'src/fetchers/PrintCodeFetcher';
 import UIStore from 'src/stores/alt/stores/UIStore';
@@ -25,8 +24,11 @@ export default class SelectionGenerateButton extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      checkedIds: List(),
-      elementType: null,
+      // Map of element type -> Immutable.List of checked IDs, including every
+      // printable type with at least one selection (selections persist across
+      // tab switches in UIStore, so the user may have selections on multiple
+      // tabs simultaneously — print all of them).
+      selectionsByType: {},
       json: {},
       matrix: null,
       enableComputedProps: null,
@@ -77,43 +79,54 @@ export default class SelectionGenerateButton extends React.Component {
         enableReactionPredict: MatrixCheck(storeMatrix, 'reactionPrediction'),
       });
     }
-    this.syncFromStores();
   }
 
-  // Picks the active element type from UserStore (the currently selected tab)
-  // and reads the matching checkedIds from UIStore. Scanning UIStore for the
-  // first non-empty selection instead would pick up stale selections left
-  // over from other tabs.
+  // Collects checked IDs for every printable element type from UIStore so we
+  // can print labels for selections across all tabs in one go.
   syncFromStores() {
-    const { currentType } = UserStore.getState() || {};
     const uiState = UIStore.getState() || {};
-    const isPrintable = PRINTABLE_ELEMENT_TYPES.includes(currentType);
-    const typeState = isPrintable ? uiState[currentType] : null;
-    const nextCheckedIds = (typeState && typeState.checkedIds) || List();
-    const nextElementType = isPrintable ? currentType : null;
+    const next = {};
+    let changed = false;
+    const { selectionsByType: prev } = this.state;
 
-    const { checkedIds, elementType } = this.state;
-    if (nextCheckedIds !== checkedIds || nextElementType !== elementType) {
-      this.setState({
-        checkedIds: nextCheckedIds,
-        elementType: nextElementType,
-      });
+    PRINTABLE_ELEMENT_TYPES.forEach((t) => {
+      const ids = uiState[t]?.checkedIds;
+      if (ids && ids.size > 0) {
+        next[t] = ids;
+        if (prev[t] !== ids) changed = true;
+      } else if (prev[t]) {
+        changed = true;
+      }
+    });
+
+    if (changed || Object.keys(next).length !== Object.keys(prev).length) {
+      this.setState({ selectionsByType: next });
     }
   }
 
-  async downloadPrintCodesPDF(ids, selectedConfig) {
-    const { json, elementType } = this.state;
-    if (!elementType || !ids || ids.length === 0) return;
-
+  async downloadPrintCodesPDF(selectedConfig) {
+    const { json, selectionsByType } = this.state;
     const configParams = json[selectedConfig] || {};
+    const baseQuery = Object.entries(configParams)
+      .map(([key, value]) => `${key}=${value}`)
+      .join('&');
+
+    const requests = [];
+    Object.entries(selectionsByType).forEach(([elementType, idsList]) => {
+      idsList.forEach((id) => {
+        const params = `element_type=${elementType}&ids[]=${id}`;
+        const url = baseQuery
+          ? `/api/v1/code_logs/print_codes?${params}&${baseQuery}`
+          : `/api/v1/code_logs/print_codes?${params}`;
+        requests.push(url);
+      });
+    });
+
+    if (requests.length === 0) return;
 
     try {
       const mergedPdf = await PDFDocument.create();
-      const pdfPromises = ids.map(async (id) => {
-        let url = `/api/v1/code_logs/print_codes?element_type=${elementType}&ids[]=${id}`;
-        Object.entries(configParams).forEach(([key, value]) => {
-          url += `&${key}=${value}`;
-        });
+      const pdfPromises = requests.map(async (url) => {
         const pdfBytes = await PrintCodeFetcher.fetchMergedPrintCodes(url);
         const pdfToMerge = await PDFDocument.load(pdfBytes);
         const copiedPages = await mergedPdf.copyPages(pdfToMerge, pdfToMerge.getPageIndices());
@@ -133,10 +146,11 @@ export default class SelectionGenerateButton extends React.Component {
 
   render() {
     const {
-      json, checkedIds, elementType, enableComputedProps, enableReactionPredict
+      json, selectionsByType, enableComputedProps, enableReactionPredict
     } = this.state;
-    const ids = checkedIds.toArray();
-    const disabledPrint = !elementType || ids.length === 0;
+    const totalSelected = Object.values(selectionsByType)
+      .reduce((sum, list) => sum + list.size, 0);
+    const disabledPrint = totalSelected === 0;
     const pdfMenuItems = Object.entries(json).map(([key]) => ({ key, name: key }));
 
     return (
@@ -155,7 +169,7 @@ export default class SelectionGenerateButton extends React.Component {
               onClick={(event) => {
                 event.stopPropagation();
                 if (!disabledPrint) {
-                  this.downloadPrintCodesPDF(ids, e.name);
+                  this.downloadPrintCodesPDF(e.name);
                 }
               }}
             >

--- a/app/javascript/src/fetchers/PrintCodeFetcher.js
+++ b/app/javascript/src/fetchers/PrintCodeFetcher.js
@@ -33,4 +33,25 @@ export default class PrintCodeFetcher {
       })
       .then((result) => result.arrayBuffer());
   }
+
+  // POST a ui_state-style payload to the print_codes_by_ui_state endpoint so
+  // the server can resolve "select all pages" semantics (checkedAll +
+  // uncheckedIds) and return a single multi-page PDF for the resolved set.
+  // @param {object} payload - { element_type, ui_state: { checkedAll, checkedIds, uncheckedIds, collection_id, is_sync_to_me }, ...printConfig }
+  // @returns {Promise<ArrayBuffer>}
+  static fetchPrintCodesByUIState(payload) {
+    return fetch('/api/v1/code_logs/print_codes_by_ui_state', {
+      credentials: 'same-origin',
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Print code request failed: ${response.status} ${response.statusText}`);
+        }
+        return response.blob();
+      })
+      .then((blob) => blob.arrayBuffer());
+  }
 }

--- a/app/javascript/src/fetchers/PrintCodeFetcher.js
+++ b/app/javascript/src/fetchers/PrintCodeFetcher.js
@@ -25,10 +25,12 @@ export default class PrintCodeFetcher {
     };
     // Fetch the PDF
     return fetch(url, requestOptions)
-      .then((response) => response.blob())
-      .then((result) => result.arrayBuffer())
-      .catch((errorMessage) => {
-        console.log(errorMessage);
-      });
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Print code request failed: ${response.status} ${response.statusText}`);
+        }
+        return response.blob();
+      })
+      .then((result) => result.arrayBuffer());
   }
 }

--- a/app/pdfs/code_pdf.rb
+++ b/app/pdfs/code_pdf.rb
@@ -43,6 +43,7 @@ class CodePdf < Prawn::Document
   # @return [CodePdf] a new CodePdf object
   def initialize(elements, **options)
     @elements = elements
+    @code_logs_cache = preload_code_logs
     @code_type = determine_code_type(options)
     @code_image_size = options.fetch(:code_image_size, 0)
     @width = options.fetch(:width, 0)
@@ -94,7 +95,7 @@ class CodePdf < Prawn::Document
   def handle_text(element)
     values = [
       [element.name, name],
-      [element.code_log&.id, code_log],
+      [code_log_for(element)&.id, code_log],
     ]
 
     if type == ELEMENTS_TYPES.first
@@ -146,7 +147,7 @@ class CodePdf < Prawn::Document
   def display_bar_code(element)
     # Generate the barcode itself
     bar_code(element, @code_image_size_ratio)
-    text_box element.code_log.value_sm, bar_code_label_options(@width, @code_image_size_ratio)
+    text_box code_log_for(element).value_sm, bar_code_label_options(@width, @code_image_size_ratio)
     move_down TEXT_OFFSET.mm * ratio
   end
 
@@ -295,7 +296,7 @@ class CodePdf < Prawn::Document
   # @param text_position [String] The position of the text.
   # @return [void]
   def qr_code(element, width, code_image_size_ratio, text_position)
-    qr_code = Barby::QrCode.new(element.code_log.value, size: 1, level: :l)
+    qr_code = Barby::QrCode.new(code_log_for(element).value, size: 1, level: :l)
     outputter = outputter(qr_code)
     svg outputter.to_svg(square_code_options(width, code_image_size_ratio, text_position)),
         square_code_options(width, code_image_size_ratio, text_position)
@@ -307,7 +308,7 @@ class CodePdf < Prawn::Document
   # @param code_image_size_ratio [Float] The ratio used to scale the code image.
   # @return [void]
   def bar_code(element, code_image_size_ratio)
-    outputter = outputter(Barby::Code128C.new(element.code_log.value_sm))
+    outputter = outputter(Barby::Code128C.new(code_log_for(element).value_sm))
     svg outputter.to_svg(bar_code_options(code_image_size_ratio)), bar_code_options(code_image_size_ratio)
     move_down BAR_CODE_OFFSET * ratio
   end
@@ -319,7 +320,7 @@ class CodePdf < Prawn::Document
   # @param text_position [String] The position of the text.
   # @return [void]
   def data_matrix(element, width, code_image_size_ratio, text_position)
-    outputter = outputter(Barby::DataMatrix.new(element.code_log.value))
+    outputter = outputter(Barby::DataMatrix.new(code_log_for(element).value))
     svg outputter.to_svg(square_code_options(width, code_image_size_ratio, text_position)),
         square_code_options(width, code_image_size_ratio, text_position)
     move_down DATA_MATRIX_CODE_OFFSET * ratio * code_image_size_ratio
@@ -362,6 +363,27 @@ class CodePdf < Prawn::Document
 
   def outputter(code)
     Barby::SvgOutputter.new(code)
+  end
+
+  # Loads all CodeLog records for the current elements in a single query and
+  # returns them as a hash keyed by +source_id+, so callers can do an O(1)
+  # look-up instead of issuing one query per element (N+1 pattern).
+  # @return [Hash{Integer => CodeLog}]
+  def preload_code_logs
+    return {} if elements.blank?
+
+    source = elements.first.source_class
+    ids = elements.map(&:id)
+    CodeLog.where(source: source, source_id: ids)
+           .order(created_at: :desc)
+           .each_with_object({}) { |log, hash| hash[log.source_id] ||= log }
+  end
+
+  # Returns the cached CodeLog for +element+.
+  # @param element [Object]
+  # @return [CodeLog, nil]
+  def code_log_for(element)
+    @code_logs_cache[element.id]
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/pdfs/code_pdf.rb
+++ b/app/pdfs/code_pdf.rb
@@ -23,6 +23,15 @@ class CodePdf < Prawn::Document
   BAR_CODE = CODE_TYPES[1].freeze
   TEXT_POSITION_TYPES = %w[below right].freeze
   ELEMENTS_TYPES = %w[sample reaction].freeze
+  # Candidate TTF paths searched in order. The first existing file is used so
+  # element labels with non-Latin1 characters (e.g. Arabic, CJK) render instead
+  # of raising Encoding::UndefinedConversionError under Prawn's default AFM
+  # Helvetica.
+  UNICODE_FONT_PATHS = [
+    '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
+    '/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf',
+    '/usr/share/fonts/TTF/DejaVuSans.ttf',
+  ].freeze
 
   attr_reader :elements, # list of elements to be displayed
               :code_type, # type of code to be displayed, one of CODE_TYPES
@@ -62,7 +71,20 @@ class CodePdf < Prawn::Document
       page_size: page_size,
       margin: [0, 0, 0, 0],
     )
+    register_unicode_font
     iterate
+  end
+
+  # Registers a TTF that covers a broad Unicode range so element labels with
+  # non-Latin1 characters can be rendered. No-op if none of the candidates
+  # exist on the host; falls back to Prawn's default Helvetica (Win-1252) in
+  # that case.
+  def register_unicode_font
+    path = UNICODE_FONT_PATHS.find { |p| File.exist?(p) }
+    return unless path
+
+    font_families.update('Unicode' => { normal: path })
+    font 'Unicode'
   end
 
   def determine_code_type(options)

--- a/app/pdfs/code_pdf.rb
+++ b/app/pdfs/code_pdf.rb
@@ -147,7 +147,7 @@ class CodePdf < Prawn::Document
   def display_bar_code(element)
     # Generate the barcode itself
     bar_code(element, @code_image_size_ratio)
-    text_box code_log_for(element).value_sm, bar_code_label_options(@width, @code_image_size_ratio)
+    text_box code_log_for(element)&.value_sm, bar_code_label_options(@width, @code_image_size_ratio)
     move_down TEXT_OFFSET.mm * ratio
   end
 
@@ -296,7 +296,10 @@ class CodePdf < Prawn::Document
   # @param text_position [String] The position of the text.
   # @return [void]
   def qr_code(element, width, code_image_size_ratio, text_position)
-    qr_code = Barby::QrCode.new(code_log_for(element).value, size: 1, level: :l)
+    cl = code_log_for(element)
+    return unless cl
+
+    qr_code = Barby::QrCode.new(cl.value, size: 1, level: :l)
     outputter = outputter(qr_code)
     svg outputter.to_svg(square_code_options(width, code_image_size_ratio, text_position)),
         square_code_options(width, code_image_size_ratio, text_position)
@@ -308,7 +311,10 @@ class CodePdf < Prawn::Document
   # @param code_image_size_ratio [Float] The ratio used to scale the code image.
   # @return [void]
   def bar_code(element, code_image_size_ratio)
-    outputter = outputter(Barby::Code128C.new(code_log_for(element).value_sm))
+    cl = code_log_for(element)
+    return unless cl
+
+    outputter = outputter(Barby::Code128C.new(cl.value_sm))
     svg outputter.to_svg(bar_code_options(code_image_size_ratio)), bar_code_options(code_image_size_ratio)
     move_down BAR_CODE_OFFSET * ratio
   end
@@ -320,7 +326,10 @@ class CodePdf < Prawn::Document
   # @param text_position [String] The position of the text.
   # @return [void]
   def data_matrix(element, width, code_image_size_ratio, text_position)
-    outputter = outputter(Barby::DataMatrix.new(code_log_for(element).value))
+    cl = code_log_for(element)
+    return unless cl
+
+    outputter = outputter(Barby::DataMatrix.new(cl.value))
     svg outputter.to_svg(square_code_options(width, code_image_size_ratio, text_position)),
         square_code_options(width, code_image_size_ratio, text_position)
     move_down DATA_MATRIX_CODE_OFFSET * ratio * code_image_size_ratio

--- a/app/pdfs/code_pdf.rb
+++ b/app/pdfs/code_pdf.rb
@@ -145,9 +145,12 @@ class CodePdf < Prawn::Document
   # @param element [Object] The element to generate the bar code for.
   # @return [void]
   def display_bar_code(element)
+    cl = code_log_for(element)
+    return unless cl
+
     # Generate the barcode itself
     bar_code(element, @code_image_size_ratio)
-    text_box code_log_for(element)&.value_sm, bar_code_label_options(@width, @code_image_size_ratio)
+    text_box cl.value_sm, bar_code_label_options(@width, @code_image_size_ratio)
     move_down TEXT_OFFSET.mm * ratio
   end
 
@@ -381,9 +384,9 @@ class CodePdf < Prawn::Document
   def preload_code_logs
     return {} if elements.blank?
 
-    source = elements.first.source_class
+    source_class = elements.first.source_class
     ids = elements.map(&:id)
-    CodeLog.where(source: source, source_id: ids)
+    CodeLog.where(source: source_class, source_id: ids)
            .order(created_at: :desc)
            .each_with_object({}) { |log, hash| hash[log.source_id] ||= log }
   end

--- a/app/pdfs/code_pdf.rb
+++ b/app/pdfs/code_pdf.rb
@@ -77,17 +77,18 @@ class CodePdf < Prawn::Document
     @text_position = 'below' if @code_image_size_ratio > CODE_IMAGE_SIZE_LIMIT_RIGHT || code_type == BAR_CODE
   end
 
-  # Iterates through each element and formats it on the page.
+  # Iterates through each element and renders one page per element.
   # @return [void]
   def iterate
-    element = elements.first
-    format_text(element)
-    move_down MARGIN * ratio
-    display_code(element)
-    handle_text(element)
-    print_sample if display_sample && type == ELEMENTS_TYPES.first
-    # Draw the bounds of the current page
-    stroke_bounds
+    elements.each_with_index do |element, idx|
+      start_new_page if idx.positive?
+      move_down MARGIN * ratio
+      display_code(element)
+      handle_text(element)
+      print_sample(element) if display_sample && type == ELEMENTS_TYPES.first
+      # Draw the bounds of the current page
+      stroke_bounds
+    end
   end
 
   def handle_text(element)
@@ -173,26 +174,32 @@ class CodePdf < Prawn::Document
   end
 
   # Prints the sample image on the page if necessary.
+  # @param element [Object] The element whose SVG should be rendered.
   # @return [void]
-  def print_sample
+  def print_sample(element)
     return unless display_sample
 
     # Draw the sample if necessary
-    svg(File.read(image_data_getter.last), sample_option)
+    svg(File.read(image_data_for(element).last), sample_option)
     move_down SAMPLE_SVG_OFFSET.mm
   end
 
-  # Returns the width, height and URL of the SVG image associated with the first element.
-  # @param elements [Array] The elements to get the data from.
-  # @return [Array<String, String, [String, Pathname]>] An array containing the width, height and URL of the SVG image.
+  # Returns the width, height and URL of the SVG image for a specific element.
+  # @param element [Object] The element to get the SVG data from.
+  # @return [Array<String, String, [String, Pathname]>] +[width, height, path]+
   # @note returns a dummy image if the SVG file does not exist or if an error occurs.
-  def image_data_getter
-    element = elements.first
+  def image_data_for(element)
     full_svg_path = element.respond_to?(:full_svg_path, true) ? element.send(:full_svg_path) : nil
     return dummy_image if full_svg_path.nil? || !File.exist?(full_svg_path)
 
-    # Extract the width and height attributes from the SVG element
     extract_svg_size(full_svg_path)
+  end
+
+  # Returns the SVG image data for the first element. Used for page-size
+  # calculation, which is shared across all rendered pages.
+  # @return [Array<String, String, [String, Pathname]>] +[width, height, path]+
+  def image_data_getter
+    image_data_for(elements.first)
   end
 
   # Extracts the width and height of the SVG image from the given path.


### PR DESCRIPTION
## Summary

Fix the Reporting → **Print labels (bulk)** dropdown so it produces a PDF for the user's current selection, including the "All pages" checkbox and selections spread across multiple element tabs.

## Why

`SelectionGenerateButton.downloadPrintCodesPDF` silently no-op'd: it called `fetchPrintCodes(ids, template, json)`, but that fetcher only accepts a single URL and returns a blob URL — the guard rejected the result. `CodePdf` also only rendered `elements.first`, and "All pages" (`checkedAll: true`) had no IDs to iterate on the client.

## What changed

**Frontend** (`SelectionGenerateButton`, `PrintCodeFetcher`)
- Rebuild the request per selected ID and call `fetchMergedPrintCodes`.
- Collect `checkedIds` for every printable element type from `UIStore` so selections across tabs all print.
- For "All pages", POST per element type to the new `print_codes_by_ui_state` endpoint and merge PDFs with `pdf-lib`.
- Surface non-OK responses so 401/404 no longer fall through as an empty `ArrayBuffer`.
- Disable items when the active tab type isn't supported (vessel, cell_line, research_plan).

**Backend** (`code_log_api`, `code_pdf`)
- Add `POST /api/v1/code_logs/print_codes_by_ui_state` resolving elements via `klass.by_collection_id(cid).by_ui_state(...)`, authorised through `ElementsPolicy`.
- Fix `CodePdf` to iterate all elements (not just `elements.first`) and thread per-element image lookup through `print_sample`.
- DRY: lift shared helpers, add `PRINTABLE_ELEMENT_TYPES` constant and `element_class` helper, cache resolved elements on ivars.

## Test plan

- [x] Per-row selection on Samples / Reactions tab → multi-page PDF downloads.
- [x] Selections on multiple tabs → single merged PDF with pages for each type.
- [x] "All pages" checkbox → `print_codes_by_ui_state` is called and respects `uncheckedIds`.
