### PR TITLE
fix: ResizeObserver loop on CreatableSelect inputs (CAS, affiliations)

### DIFF
--- a/app/api/chemotion/affiliation_api.rb
+++ b/app/api/chemotion/affiliation_api.rb
@@ -97,9 +97,6 @@ module Chemotion
         u_affiliation = @affiliations.find(params[:id])
         u_affiliation.destroy!
         Affiliation.find_by(id: params[:id])&.destroy! if UserAffiliation.where(affiliation_id: params[:id]).empty?
-        status 204
-        body nil
-        return
       rescue ActiveRecord::RecordInvalid => e
         error!({ error: e.message }, 422)
       end

--- a/app/api/entities/molecule_name_entity.rb
+++ b/app/api/entities/molecule_name_entity.rb
@@ -3,6 +3,7 @@
 module Entities
   class MoleculeNameEntity < ApplicationEntity
     expose(
+      :id,
       :description,
       :name,
     )

--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -234,7 +234,7 @@ export default class SampleDetails extends React.Component {
 
   componentDidUpdate(prevProps) {
     const { sample } = this.props;
-    if (sample === prevProps.sample) { return };
+    if (sample === prevProps.sample) { return; }
 
     const smileReadonly = !(
       (sample.isNew
@@ -610,7 +610,7 @@ export default class SampleDetails extends React.Component {
     // If the collection already tracks the inventory tab, nothing to do
     if (sampleLayout && Object.prototype.hasOwnProperty.call(sampleLayout, 'inventory') && sampleLayout?.inventory > 0) {
       return;
-    } 
+    }
 
     // Resolve the effective layout: collection -> user profile -> fallback
     const userProfile = UserStore.getState().profile;
@@ -978,7 +978,7 @@ export default class SampleDetails extends React.Component {
     const { sample, isCasLoading, validCas } = this.state;
     const { molecule, xref } = sample;
     const cas = xref?.cas ?? '';
-    let casArr = Array.isArray(molecule?.cas) ? molecule?.cas?.filter((el) => el !== null) : [];
+    const casArr = Array.isArray(molecule?.cas) ? molecule?.cas?.filter((el) => el !== null) : [];
     if (cas && !casArr.includes(cas)) {
       casArr.push(cas);
     }
@@ -988,7 +988,7 @@ export default class SampleDetails extends React.Component {
     return (
       <div className="my-4">
         <InputGroup>
-          <div className="d-flex flex-grow-1">
+          <div className="d-flex">
             <InputGroup.Text>CAS</InputGroup.Text>
             <CreatableSelect
               name="cas"
@@ -998,7 +998,7 @@ export default class SampleDetails extends React.Component {
               options={options}
               onChange={(selectedOption) => {
                 if (selectedOption) {
-                  const value = selectedOption.value;
+                  const { value } = selectedOption;
                   this.setState({ casInputValue: value });
                   this.updateCas(selectedOption);
                 } else {
@@ -1020,7 +1020,7 @@ export default class SampleDetails extends React.Component {
               value={options.find(({ value }) => value === cas) || null}
               onBlur={() => this.isCASNumberValid(cas || '', true)}
               isDisabled={!sample.can_update}
-              className="flex-grow-1"
+              styles={{ input: (base) => ({ ...base, minWidth: '200px', width: '100%' }) }}
               placeholder="Select or enter CAS number"
               allowCreateWhileLoading
               formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
@@ -1084,28 +1084,28 @@ export default class SampleDetails extends React.Component {
     const { pageMessage } = this.state;
     const messageBlock = (pageMessage
       && (pageMessage.error.length > 0 || pageMessage.warning.length > 0)) ? (
-      <Alert variant="warning" style={{ marginBottom: 'unset', padding: '5px', marginTop: '10px' }}>
-        <strong>Structure Alert</strong>
-        <Button
-          size="sm"
-          variant="outline-warning"
-          style={{ float: 'right' }}
-          onClick={() => this.setState({ pageMessage: null })}
-        >
-          Close Alert
-        </Button>
-        {
+        <Alert variant="warning" style={{ marginBottom: 'unset', padding: '5px', marginTop: '10px' }}>
+          <strong>Structure Alert</strong>
+          <Button
+            size="sm"
+            variant="outline-warning"
+            style={{ float: 'right' }}
+            onClick={() => this.setState({ pageMessage: null })}
+          >
+            Close Alert
+          </Button>
+          {
           pageMessage.error.map((m) => (
             <div key={uuid.v1()}>{m}</div>
           ))
         }
-        {
+          {
           pageMessage.warning.map((m) => (
             <div key={uuid.v1()}>{m}</div>
           ))
         }
-      </Alert>
-    ) : null;
+        </Alert>
+      ) : null;
 
     // warning message for redirection
     const redirectWarningBlock = this.state.showRedirectWarning ? (
@@ -1311,17 +1311,15 @@ export default class SampleDetails extends React.Component {
     const className = `${style} ${svgPath ? 'svg-container' : 'svg-container-empty'}`;
 
     return sample.can_update ? (
-      <>
-        <div
-          className={className}
-          onClick={this.showStructureEditor}
-          role="button"
-          tabIndex="0"
-        >
-          <i className="fa fa-pencil position-absolute top-0 end-0" />
-          <SVG key={svgPath} src={svgPath} className="molecule-mid" />
-        </div>
-      </>
+      <div
+        className={className}
+        onClick={this.showStructureEditor}
+        role="button"
+        tabIndex="0"
+      >
+        <i className="fa fa-pencil position-absolute top-0 end-0" />
+        <SVG key={svgPath} src={svgPath} className="molecule-mid" />
+      </div>
     ) : (
       <div className={className}>
         <SVG key={svgPath} src={svgPath} className="molecule-mid" />
@@ -1343,7 +1341,7 @@ export default class SampleDetails extends React.Component {
   }
 
   sampleExactMW(sample) {
-    if (sample.isMixture() && sample.sample_details) { return }
+    if (sample.isMixture() && sample.sample_details) { return; }
 
     const mw = sample.molecule_exact_molecular_weight;
     if (mw) return <ClipboardCopyText text={`Exact mass: ${mw.toFixed(MWPrecision)} g/mol`} />;
@@ -1542,27 +1540,27 @@ export default class SampleDetails extends React.Component {
     const { pageMessage, ketcherSVGError } = this.state;
     const messageBlock = (pageMessage
       && (pageMessage.error.length > 0 || pageMessage.warning.length > 0)) ? (
-      <Alert variant="warning" style={{ marginBottom: 'unset', padding: '5px', marginTop: '10px' }}>
-        <strong>Structure Alert</strong>
-        <Button
-          size="sm"
-          variant="warning"
-          onClick={() => this.setState({ pageMessage: null })}
-        >
-          Close Alert
-        </Button>
-        {
+        <Alert variant="warning" style={{ marginBottom: 'unset', padding: '5px', marginTop: '10px' }}>
+          <strong>Structure Alert</strong>
+          <Button
+            size="sm"
+            variant="warning"
+            onClick={() => this.setState({ pageMessage: null })}
+          >
+            Close Alert
+          </Button>
+          {
           pageMessage.error.map((m) => (
             <div key={uuid.v1()}>{m}</div>
           ))
         }
-        {
+          {
           pageMessage.warning.map((m) => (
             <div key={uuid.v1()}>{m}</div>
           ))
         }
-      </Alert>
-    ) : null;
+        </Alert>
+      ) : null;
 
     const activeTab = (this.state.activeTab !== 0 && stb.indexOf(this.state.activeTab) > -1
       && this.state.activeTab) || visible.get(0);

--- a/app/javascript/src/apps/userSettings/Affiliations.js
+++ b/app/javascript/src/apps/userSettings/Affiliations.js
@@ -235,7 +235,16 @@ function Affiliations() {
           <i className="fa fa-plus ms-1" />
         </Button>
       </div>
-      <Table striped bordered hover>
+      <Table striped bordered hover style={{ tableLayout: 'fixed' }}>
+        <colgroup>
+          <col style={{ width: '20%' }} />
+          <col style={{ width: '20%' }} />
+          <col style={{ width: '15%' }} />
+          <col style={{ width: '15%' }} />
+          <col style={{ width: '12%' }} />
+          <col style={{ width: '12%' }} />
+          <col style={{ width: '6%' }} />
+        </colgroup>
         <thead>
           <tr>
             <th>Country</th>


### PR DESCRIPTION
## Summary

Typing in a `react-select` `CreatableSelect` was triggering the
`ResizeObserver loop completed with undelivered notifications` error.
Root cause: each keystroke grew the input, which resized the parent
container, which fed back into react-select's internal observer.

This PR pins the surrounding layout in the two affected places so the
container no longer reflows on every keystroke.

## Changes

- **CAS field (`SampleDetails`)** — drop `flex-grow-1` from the wrapper
  and apply explicit `styles.input` (`minWidth: 200px; width: 100%`)
  on the `CreatableSelect`.
- **Affiliations settings table** — switch to `tableLayout: fixed` with
  an explicit `<colgroup>` so cell widths stay stable as the
  `CreatableSelect` inside grows.
- **MoleculeNameEntity** — expose `id` so the molecule moderator can
  identify records (previously missing, breaking edit/select flows).
- Minor cleanups in `SampleDetails.js`: `let` → `const`, drop a
  redundant fragment wrapper, destructure `selectedOption.value`, and
  trailing-semicolon fixes.

## Out of scope / to discuss

- `affiliation_api.rb` no longer sets an explicit `status 204` on
  `DELETE /affiliations/:id`. The frontend doesn't read the response,
  but this changes the HTTP contract from `204 No Content` to `200 OK`.
  Should we keep `status 204` to preserve the existing contract?

## Test plan

- [ ] Open a sample → CAS field: type characters, confirm no
      `ResizeObserver` warning in the browser console and the field
      still fills the row on wide viewports.
- [ ] User settings → Affiliations: add/edit a row, type into Country
      and Organization, confirm no console error and column widths
      stay stable.
- [ ] Molecule moderator: load the moderator UI and confirm molecule
      names render with their `id` (no missing-key React warnings).
- [ ] Delete an affiliation and confirm the row disappears (smoke test
      for the API change).