### PR TITLE
chore: port v3.1.2 fixes to main

### DIFF
--- a/app/api/chemotion/molecule_api.rb
+++ b/app/api/chemotion/molecule_api.rb
@@ -80,9 +80,8 @@ module Chemotion
               end
             end
           end
-          molecule.attributes.merge(temp_svg: File.exist?(svg_process[:svg_file_path]) && svg_process[:svg_file_name], ob_log: babel_info[:ob_log])
-
-          present molecule, with: Entities::MoleculeEntity
+          temp_svg = File.exist?(svg_process[:svg_file_path]) ? svg_process[:svg_file_name] : nil
+          Entities::MoleculeEntity.represent(molecule, temp_svg: temp_svg, ob_log: babel_info[:ob_log])
         end
       end
 

--- a/app/javascript/src/components/common/Select.js
+++ b/app/javascript/src/components/common/Select.js
@@ -82,6 +82,7 @@ function buildWrappedComponent(name, BaseComponent) {
         ref={ref}
         menuPortalTarget={document.body}
         menuPlacement="auto"
+        menuPosition="fixed"
         unstyled
         styles={stylesWithOverrides}
         components={mergedComponents}

--- a/lib/chemotion/open_babel_service.rb
+++ b/lib/chemotion/open_babel_service.rb
@@ -498,8 +498,11 @@ M  END
     mf = mofile_clear_coord_bonds(molfile)
     mol = mf || molfile
     # `obabel -imol #{file_name} -ocdxml`
-    input = Tempfile.new(["input", ".mol"]).path
-    output = output_path || Tempfile.new(["output", ".mol"]).path
+    # Keep Tempfile references alive until after File.read; GC finalizers delete the files.
+    input_tf = Tempfile.new(["input", ".mol"])
+    output_tf = output_path ? nil : Tempfile.new(["output", ".mol"])
+    input = input_tf.path
+    output = output_path || output_tf.path
     File.write(input, mol)
 
     c = OpenBabel::OBConversion.new
@@ -509,7 +512,10 @@ M  END
 
     orig_cdxml = File.read(output)
     shifted_cdxml, geometry = Cdxml::Shifter.new({orig_cdxml: orig_cdxml, shifter: shifter}).convey
-    return { content: shifted_cdxml, geometry: geometry, path: output }
+    { content: shifted_cdxml, geometry: geometry, path: output_path }
+  ensure
+    input_tf&.close!
+    output_tf&.close!
   end
 
   def self.smi_to_svg(smi)

--- a/lib/reporter/delta.rb
+++ b/lib/reporter/delta.rb
@@ -115,7 +115,7 @@ module Reporter
     end
 
     def buildDeltaOps(op)
-      return CGI.escapeHTML(op["insert"]) if (!op["attributes"]) && (!(op && op["insert"].is_a?(Hash) && op["insert"]["image"]))
+      return CGI.escapeHTML(op["insert"].to_s) if (!op["attributes"]) && (!(op && op["insert"].is_a?(Hash) && op["insert"]["image"]))
 
       styles = []
       tags = []
@@ -154,7 +154,7 @@ module Reporter
 
     def html_with_tags_style(op, tags, styles)
       style = styles.count > 0 ? " style=\"#{styles.join(";")}\"" : ""
-      html = "<span#{style}>#{CGI.escapeHTML(op["insert"])}</span>"
+      html = "<span#{style}>#{CGI.escapeHTML(op["insert"].to_s)}</span>"
 
       tags.each { |tag| html = "<#{tag}>#{html}</#{tag}>" }
       html

--- a/lib/reporter/docx/diagram.rb
+++ b/lib/reporter/docx/diagram.rb
@@ -9,19 +9,38 @@ module Reporter
       end
 
       def generate(products_only = false)
-        img = Sablon::Image.create_by_path(img_path(products_only))
+        path, out_tmp = img_path(products_only)
+        img = Sablon::Image.create_by_path(path)
         ole = Sablon::Ole.create_by_path(ole_path)
         Sablon::Chem.create(ole, img)
+      ensure
+        out_tmp&.close!
       end
 
+      # Renders the diagram to a file in the configured format by composing
+      # the SVG, writing it to a temp file, and driving Inkscape.
+      #
+      # The returned Tempfile must be kept alive by the caller until the
+      # path has been consumed — some consumers (e.g. caxlsx) defer the read
+      # until package serialization. Call +close!+ on it afterwards.
+      #
+      # @param products_only [Boolean] when true, render only product structures
+      # @return [Array(String, Tempfile)] +[path, tmp]+ — the rendered image
+      #   path and its backing Tempfile
+      # @raise [RuntimeError] when no SVG data is available
       def img_path(products_only = false)
+        rendered = false
         load_svg_paths
         set_svg(products_only)
         raise 'Fehler: Kein Bild angegeben' if svg_data.nil?
-        svg_path = Reporter::Img::Conv.data_to_svg(svg_data)
-        out_path = Reporter::Img::Conv.ext_to_path(@format)
-        Reporter::Img::Conv.by_inkscape(svg_path, out_path, @format)
-        out_path
+        svg_tmp = Reporter::Img::Conv.data_to_svg(svg_data)
+        out_tmp = Reporter::Img::Conv.ext_to_path(@format)
+        Reporter::Img::Conv.by_inkscape(svg_tmp.path, out_tmp.path, @format)
+        rendered = true
+        [out_tmp.path, out_tmp]
+      ensure
+        svg_tmp&.close!
+        out_tmp&.close! unless rendered
       end
 
       private

--- a/lib/reporter/helper.rb
+++ b/lib/reporter/helper.rb
@@ -12,6 +12,15 @@ module Reporter
       [long_key, web_key, short_key]
     end
 
+    # Renders a sample/product PNG via {Reporter::Docx::DiagramSample} and
+    # returns the resulting +[path, Tempfile]+ tuple. Caller must keep the
+    # Tempfile alive until the path has been consumed and then call
+    # +close!+ on it.
+    #
+    # @param p [Hash] serialized product/sample hash; must include
+    #   +:get_svg_path+
+    # @return [Array(String, Tempfile)] +[path, tmp]+ — the PNG path and its
+    #   backing Tempfile (see {Reporter::Docx::Diagram#img_path})
     def self.mol_img_path(p)
       ext = 'png'
       Reporter::Docx::DiagramSample.new(

--- a/lib/reporter/img/conv.rb
+++ b/lib/reporter/img/conv.rb
@@ -5,19 +5,35 @@ require 'nokogiri'
 module Reporter
   module Img
     module Conv
+      # Writes the given SVG markup to a fresh Tempfile and returns the
+      # (closed) Tempfile object. The caller owns the Tempfile and must call
+      # +close!+ on it when done to delete the underlying file.
+      #
+      # @param svg_data [String] raw SVG markup
+      # @return [Tempfile] a closed Tempfile whose path holds +svg_data+
       def self.data_to_svg(svg_data)
         svg_file = Tempfile.new(['diagram', '.svg'])
-        File.open(svg_file.path, 'w') { |file| file.write(svg_data) }
-        svg_file.path
+        svg_file.write(svg_data)
+        svg_file.close
+        svg_file
       end
 
+      # Allocates a closed Tempfile with the requested extension, suitable
+      # as an output target for Inkscape. The caller owns the Tempfile and
+      # must call +close!+ on it when done.
+      #
+      # @param target_ext [String, Symbol] extension without the leading dot
+      #   (e.g. +"png"+)
+      # @return [Tempfile] a closed Tempfile at the requested extension
       def self.ext_to_path(target_ext)
         output_file = Tempfile.new(['diagram', ".#{target_ext}"])
-        File.open(output_file.path, 'w')
-        output_file.path
+        output_file.close
+        output_file
       end
 
       def self.by_inkscape(input, output, ext, width: 1550, height: 440)
+        input = input.to_s
+        output = output.to_s
         # The composed reaction SVG has an outer <svg width="1560" height="440"> and
         # an inner <svg width="100%"> with no explicit height. Inkscape 1.x resolves
         # the inner height from the viewBox aspect ratio, which can exceed 440 px for
@@ -25,7 +41,7 @@ module Reporter
         # overflow, producing a blank image. Pinning height="100%" on the inner element
         # keeps it inside the outer frame and lets the viewBox scale all content
         # (including polymer images) uniformly to fit, so --export-area-page is safe.
-        prepared = pin_nested_svg_height(input)
+        prepared, prepared_tmp = pin_nested_svg_height(input)
 
         # Inkscape 1.x: --export-type and --export-filename (or -o)
         args_1x = [
@@ -46,15 +62,25 @@ module Reporter
           "--export-width=#{width.to_i} --export-height=#{height.to_i}",
         )
         raise 'Inkscape export failed' unless success
+      ensure
+        prepared_tmp&.close!
       end
 
-      # Adds height="100%" to any nested <svg> that carries width="100%" but no
-      # explicit height attribute. Returns the path of a patched temp file when
-      # changes are needed, or the original path when the SVG is already correct.
+      # Patches any nested +<svg>+ element that has +width="100%"+ but no
+      # explicit height by adding +height="100%"+. Keeps the inner frame
+      # inside the outer page so +--export-area-page+ does not clip
+      # overflowing content. When a patched copy is produced, the caller
+      # owns the returned Tempfile and must call +close!+ on it.
+      #
+      # @param svg_path [String] path to the SVG file to inspect
+      # @return [Array(String, Tempfile)] +[patched_path, tmp]+ when a
+      #   patched copy was written; caller must close! the Tempfile
+      # @return [Array(String, nil)] +[svg_path, nil]+ when the SVG needed
+      #   no patch (path is the original input)
       def self.pin_nested_svg_height(svg_path)
         doc = Nokogiri::XML(File.read(svg_path))
         outer = doc.at_xpath('//*[local-name()="svg"]')
-        return svg_path unless outer
+        return [svg_path, nil] unless outer
 
         changed = false
         outer.xpath('.//*[local-name()="svg"]').each do |inner|
@@ -63,12 +89,12 @@ module Reporter
           inner['height'] = '100%'
           changed = true
         end
-        return svg_path unless changed
+        return [svg_path, nil] unless changed
 
         tmp = Tempfile.new(['diagram_prepared', '.svg'])
         tmp.write(doc.to_xml)
         tmp.close
-        tmp.path
+        [tmp.path, tmp]
       end
 
       def self.valid?(path)

--- a/lib/reporter/xlsx/reaction_list.rb
+++ b/lib/reporter/xlsx/reaction_list.rb
@@ -13,6 +13,7 @@ module Reporter
       def initialize(args)
         @objs = args[:objs]
         @mol_serials = args[:mol_serials] || []
+        @img_tmps = []
       end
 
       def create(file_name)
@@ -28,8 +29,13 @@ module Reporter
 
             @sheet['A3:H#{row_counts}'].each do |c| c.style = Axlsx::STYLE_THIN_BORDER end
           end
+          # caxlsx defers reading image_src until Package#serialize. Image
+          # Tempfiles must remain referenced (and therefore unfinalized) until
+          # serialize has fully consumed them.
           p.serialize(file_name)
         end
+      ensure
+        @img_tmps.each(&:close!)
       end
 
       private
@@ -79,8 +85,9 @@ module Reporter
       end
 
       def add_img_to_row(p)
-        img_src = Reporter::Helper.mol_img_path(p)
+        img_src, img_tmp = Reporter::Helper.mol_img_path(p)
         return if img_src.nil?
+        @img_tmps << img_tmp if img_tmp
         @sheet.add_image(image_src: img_src) do |img|
           img.height = IMG_HEIGHT.to_i
           img.width = IMG_WIDTH.to_i

--- a/spec/lib/chemotion/open_babel_service_spec.rb
+++ b/spec/lib/chemotion/open_babel_service_spec.rb
@@ -3,6 +3,41 @@
 require 'rails_helper'
 
 RSpec.describe Chemotion::OpenBabelService do
+  describe '.get_cdxml_from_molfile' do
+    let(:conversion) { instance_double(OpenBabel::OBConversion, convert: true) }
+    let(:input_tf) { instance_double(Tempfile, path: '/tmp/input.mol', close!: nil) }
+    let(:output_tf) { instance_double(Tempfile, path: '/tmp/output.cdxml', close!: nil) }
+    let(:shifter) { instance_double(Cdxml::Shifter, convey: ['<shifted/>', { x_len: 1 }]) }
+
+    before do
+      allow(described_class).to receive(:mofile_clear_coord_bonds).and_return(nil)
+      allow(Tempfile).to receive(:new).with(['input', '.mol']).and_return(input_tf)
+      allow(File).to receive(:write)
+      allow(OpenBabel::OBConversion).to receive(:new).and_return(conversion)
+      allow(conversion).to receive(:set_in_and_out_formats)
+      allow(conversion).to receive(:open_in_and_out_files)
+      allow(File).to receive(:read).and_return('<cdxml/>')
+      allow(Cdxml::Shifter).to receive(:new).and_return(shifter)
+    end
+
+    it 'does not return an already-unlinked tempfile path when no output path is provided' do
+      allow(Tempfile).to receive(:new).with(['output', '.mol']).and_return(output_tf)
+
+      result = described_class.get_cdxml_from_molfile('molfile')
+
+      expect(result[:path]).to be_nil
+      expect(output_tf).to have_received(:close!)
+    end
+
+    it 'returns the caller-provided output path unchanged' do
+      output_path = '/tmp/caller-output.cdxml'
+
+      result = described_class.get_cdxml_from_molfile('molfile', {}, output_path)
+
+      expect(result[:path]).to eq(output_path)
+    end
+  end
+
   describe '.molecule_info_from_structure' do
     let(:conversion) { instance_double(OpenBabel::OBConversion) }
     let(:mol) { instance_double(OpenBabel::OBMol) }

--- a/spec/lib/reporter/docx/diagram_spec.rb
+++ b/spec/lib/reporter/docx/diagram_spec.rb
@@ -40,5 +40,24 @@ describe 'Reporter::Docx::Diagram' do
         expect(diagram.ole.name.split('.').last).to eq('bin')
       end
     end
+
+    describe '#img_path' do
+      let(:svg_tmp) { instance_double(Tempfile, path: '/tmp/in.svg', close!: nil) }
+      let(:out_tmp) { instance_double(Tempfile, path: '/tmp/out.png', close!: nil) }
+
+      before do
+        allow(instance).to receive(:load_svg_paths)
+        allow(instance).to receive(:set_svg) { instance.svg_data = '<svg />' }
+        allow(Reporter::Img::Conv).to receive(:data_to_svg).and_return(svg_tmp)
+        allow(Reporter::Img::Conv).to receive(:ext_to_path).and_return(out_tmp)
+      end
+
+      it 'closes the output tempfile when inkscape export fails' do
+        allow(Reporter::Img::Conv).to receive(:by_inkscape).and_raise('boom')
+
+        expect { instance.img_path }.to raise_error('boom')
+        expect(out_tmp).to have_received(:close!)
+      end
+    end
   end
 end

--- a/spec/lib/reporter/img/conv_spec.rb
+++ b/spec/lib/reporter/img/conv_spec.rb
@@ -9,8 +9,8 @@ describe Reporter::Img::Conv do
     let(:ext)    { 'png' }
 
     before do
-      # pin_nested_svg_height returns the original path when the SVG is absent/unchanged
-      allow(described_class).to receive(:pin_nested_svg_height).and_return(input)
+      # pin_nested_svg_height returns [path, nil] when the SVG needs no change
+      allow(described_class).to receive(:pin_nested_svg_height).and_return([input, nil])
     end
 
     context 'when Inkscape 1.x is available' do
@@ -48,9 +48,31 @@ describe Reporter::Img::Conv do
       end
 
       it 'prepares the SVG via pin_nested_svg_height before export' do
-        expect(described_class).to receive(:pin_nested_svg_height).with(input).and_return(input)
+        expect(described_class).to receive(:pin_nested_svg_height).with(input).and_return([input, nil])
         allow(described_class).to receive(:system).and_return(true)
         described_class.by_inkscape(input, output, ext)
+      end
+
+      it 'passes only Strings to the system call (regression: Pathname input must not raise TypeError)' do
+        expect(described_class).to receive(:system) do |cmd, *args|
+          expect(args).to all(be_a(String))
+          true
+        end
+
+        described_class.by_inkscape(Pathname.new(input), output, ext)
+      end
+    end
+
+    context 'when input is a Pathname' do
+      before { allow(described_class).to receive(:system).and_return(true) }
+
+      it 'does not raise TypeError' do
+        expect { described_class.by_inkscape(Pathname.new(input), output, ext) }.not_to raise_error
+      end
+
+      it 'converts the Pathname to a String before calling pin_nested_svg_height' do
+        expect(described_class).to receive(:pin_nested_svg_height).with(input).and_return([input, nil])
+        described_class.by_inkscape(Pathname.new(input), output, ext)
       end
     end
 
@@ -71,6 +93,28 @@ describe Reporter::Img::Conv do
         allow(described_class).to receive(:system).and_return(nil)
         expect { described_class.by_inkscape(input, output, ext) }
           .to raise_error(RuntimeError, 'Inkscape export failed')
+      end
+    end
+
+    context 'when pin_nested_svg_height returns a patched Tempfile' do
+      let(:patched_path) { '/tmp/patched.svg' }
+      let(:patched_tmp)  { instance_double(Tempfile) }
+
+      before do
+        allow(described_class).to receive(:pin_nested_svg_height).and_return([patched_path, patched_tmp])
+        allow(described_class).to receive(:system).and_return(true)
+        allow(patched_tmp).to receive(:close!)
+      end
+
+      it 'closes the patched Tempfile after export' do
+        expect(patched_tmp).to receive(:close!)
+        described_class.by_inkscape(input, output, ext)
+      end
+
+      it 'closes the patched Tempfile even when export raises' do
+        allow(described_class).to receive(:system).and_return(nil)
+        expect(patched_tmp).to receive(:close!)
+        expect { described_class.by_inkscape(input, output, ext) }.to raise_error('Inkscape export failed')
       end
     end
   end
@@ -97,17 +141,25 @@ describe Reporter::Img::Conv do
 
       it 'returns a new path (not the original)' do
         path = write_svg(svg)
-        result = described_class.pin_nested_svg_height(path)
-        expect(result).not_to eq(path)
+        result_path, = described_class.pin_nested_svg_height(path)
+        expect(result_path).not_to eq(path)
+      end
+
+      it 'returns a Tempfile as the second element' do
+        path = write_svg(svg)
+        _, result_tmp = described_class.pin_nested_svg_height(path)
+        expect(result_tmp).to be_a(Tempfile)
+        result_tmp.close!
       end
 
       it 'adds height="100%" to the inner svg element' do
         path = write_svg(svg)
-        result = described_class.pin_nested_svg_height(path)
-        doc = Nokogiri::XML(File.read(result))
+        result_path, result_tmp = described_class.pin_nested_svg_height(path)
+        doc = Nokogiri::XML(File.read(result_path))
         inner = doc.xpath('//*[local-name()="svg"]/*[local-name()="svg"]').first
         expect(inner['height']).to eq('100%')
         expect(inner['width']).to eq('100%')
+        result_tmp.close!
       end
     end
 
@@ -122,7 +174,9 @@ describe Reporter::Img::Conv do
 
       it 'returns the original path unchanged' do
         path = write_svg(svg)
-        expect(described_class.pin_nested_svg_height(path)).to eq(path)
+        result_path, result_tmp = described_class.pin_nested_svg_height(path)
+        expect(result_path).to eq(path)
+        expect(result_tmp).to be_nil
       end
     end
 
@@ -137,7 +191,9 @@ describe Reporter::Img::Conv do
 
       it 'returns the original path unchanged' do
         path = write_svg(svg)
-        expect(described_class.pin_nested_svg_height(path)).to eq(path)
+        result_path, result_tmp = described_class.pin_nested_svg_height(path)
+        expect(result_path).to eq(path)
+        expect(result_tmp).to be_nil
       end
     end
 
@@ -160,27 +216,32 @@ describe Reporter::Img::Conv do
 
       it 'adds height="100%" so polymer images are scaled within the frame, not clipped' do
         path = write_svg(svg)
-        result = described_class.pin_nested_svg_height(path)
-        doc = Nokogiri::XML(File.read(result))
+        result_path, result_tmp = described_class.pin_nested_svg_height(path)
+        doc = Nokogiri::XML(File.read(result_path))
         inner = doc.xpath('//*[local-name()="svg"]/*[local-name()="svg"]').first
         expect(inner['height']).to eq('100%')
+        result_tmp.close!
       end
 
       it 'preserves <image> elements in the output' do
         path = write_svg(svg)
-        result = described_class.pin_nested_svg_height(path)
-        doc = Nokogiri::XML(File.read(result))
+        result_path, result_tmp = described_class.pin_nested_svg_height(path)
+        doc = Nokogiri::XML(File.read(result_path))
         images = doc.xpath('//*[local-name()="image"]')
         expect(images).not_to be_empty
+        result_tmp.close!
       end
     end
   end
 
   describe '.data_to_svg' do
-    it 'writes SVG data to a temp file and returns its path' do
+    it 'writes SVG data to a temp file and returns a Tempfile' do
       svg = '<svg><circle/></svg>'
-      path = described_class.data_to_svg(svg)
-      expect(File.read(path)).to eq(svg)
+      svg_tmp = described_class.data_to_svg(svg)
+      expect(svg_tmp).to be_a(Tempfile)
+      expect(File.read(svg_tmp.path)).to eq(svg)
+    ensure
+      svg_tmp&.close!
     end
   end
 

--- a/spec/lib/reporter/xlsx/reaction_list_spec.rb
+++ b/spec/lib/reporter/xlsx/reaction_list_spec.rb
@@ -7,4 +7,53 @@ describe Reporter::Xlsx::ReactionList do
 
   include_context 'Report shared declarations'
   it_behaves_like 'Rinchi Xlsx/Csv formats'
+
+  # caxlsx defers reading image_src until Package#serialize, so the Tempfile
+  # backing a product image must stay referenced (and therefore unfinalized)
+  # until serialize has consumed it. Regression: an earlier version returned
+  # only the path String from Reporter::Helper.mol_img_path, letting the
+  # Tempfile become GC-eligible immediately and the file can be unlinked
+  # before caxlsx zips it into the .xlsx output.
+  describe 'image Tempfile GC lifetime' do
+    let(:fake_png_tmp) do
+      Tempfile.new(['fake', '.png']).tap do |tmp|
+        tmp.binmode
+        tmp.write("\x89PNG\r\n\x1a\n".b) # PNG magic bytes — enough for caxlsx to accept it
+        tmp.close
+      end
+    end
+    let(:fake_png_path) do
+      fake_png_tmp.path
+    end
+    let(:fake_tmp) { instance_spy(Tempfile) }
+    let(:list) { described_class.new(objs: [serialized_reaction]) }
+
+    after do
+      fake_png_tmp.close!
+    end
+
+    before do
+      allow(Reporter::Helper).to receive(:mol_img_path).and_return([fake_png_path, fake_tmp])
+    end
+
+    it 'retains the image Tempfile on the instance so caxlsx can read it during serialization' do
+      # If add_img_to_row had failed to retain the Tempfile, it would be
+      # GC-eligible the moment mol_img_path returned. Retaining it on @img_tmps
+      # guarantees it remains alive through Package#serialize, which inspects
+      # image_src lazily.
+      Tempfile.create(['rspec', file_extension]) do |tempfile|
+        list.create(tempfile.path)
+      end
+
+      expect(list.instance_variable_get(:@img_tmps)).to include(fake_tmp)
+    end
+
+    it 'closes the image Tempfile after create finishes' do
+      Tempfile.create(['rspec', file_extension]) do |tempfile|
+        list.create(tempfile.path)
+      end
+
+      expect(fake_tmp).to have_received(:close!).at_least(:once)
+    end
+  end
 end


### PR DESCRIPTION
| Commit | Title |
|--------|-------|
| `97735e773` | fix(UI): correct react-select portal dropdown positioning in modals (#3250) |
| `854e7bf4b` | fix(API): expose temp_svg from molecules SMILES endpoint (#3252) |
| `995741110` | fix(report): Tempfile GC lifetimes and Pathname handling in Inkscape pipeline (#3253) |
| `684738606` | fix(report): coerce Quill op["insert"] to String before CGI.escapeHTML (#3258) | 