### PR TITLE
Refactor affiliations

### DIFF
--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -4,7 +4,7 @@
 require 'grape-entity'
 require 'grape-swagger'
 
-class API < Grape::API
+class API < Grape::API # rubocop:disable Metrics/ClassLength
   include LogidzeModule
 
   format :json
@@ -207,6 +207,7 @@ class API < Grape::API
   mount Chemotion::InstrumentAPI
   mount Chemotion::MessageAPI
   mount Chemotion::AdminAPI
+  mount Chemotion::AdminAffiliationAPI
   mount Chemotion::AdminUserAPI
   mount Chemotion::AdminInfoSupportAPI
   mount Chemotion::EditorAPI

--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -211,6 +211,7 @@ class API < Grape::API
   mount Chemotion::InstrumentAPI
   mount Chemotion::MessageAPI
   mount Chemotion::AdminAPI
+  mount Chemotion::AdminAffiliationAPI
   mount Chemotion::AdminUserAPI
   mount Chemotion::AdminInfoSupportAPI
   mount Chemotion::EditorAPI

--- a/app/api/chemotion/admin_affiliation_api.rb
+++ b/app/api/chemotion/admin_affiliation_api.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Chemotion
+  class AdminAffiliationAPI < Grape::API
+    resource :admin do
+      before do
+        authorized = current_user.is_a?(Admin) || current_user&.affiliation_moderator
+        error!('401 Unauthorized', 401) unless authorized
+      end
+
+      namespace :affiliation_suggestions do
+        desc 'List suggestions'
+        params do
+          optional :status, type: String, values: %w[pending approved rejected], default: 'pending',
+                            desc: 'filter by status'
+        end
+        get do
+          AffiliationSuggestion
+            .where(status: AffiliationSuggestion.statuses[params[:status]])
+            .includes(:user)
+            .order(created_at: :desc)
+            .as_json(
+              only: %i[id organization department group country ror_id status created_at],
+              include: { user: { only: %i[id name email] } },
+            )
+        end
+
+        desc 'Approve a suggestion'
+        params do
+          optional :organization, type: String, desc: 'edited organization'
+          optional :department, type: String, desc: 'edited department'
+          optional :group, type: String, desc: 'edited working group'
+          optional :country, type: String, desc: 'edited country'
+          optional :ror_id, type: String, desc: 'edited ROR id'
+        end
+        put ':id/approve' do
+          edits = declared(params, include_missing: false).except(:id)
+          Usecases::AffiliationSuggestions::Suggestion.new(current_user).approve(params[:id], edits)
+          { ok: true }
+        rescue ActiveRecord::RecordNotFound
+          error!({ error: 'Suggestion no longer exists (it may have been withdrawn).' }, 404)
+        rescue Usecases::AffiliationSuggestions::Errors::AlreadyProcessed, ActiveRecord::RecordInvalid => e
+          error!({ error: e.message }, 422)
+        end
+
+        desc 'Reject a suggestion'
+        put ':id/reject' do
+          Usecases::AffiliationSuggestions::Suggestion.new(current_user).reject(params[:id])
+          { ok: true }
+        rescue ActiveRecord::RecordNotFound
+          error!({ error: 'Suggestion no longer exists (it may have been withdrawn).' }, 404)
+        rescue Usecases::AffiliationSuggestions::Errors::AlreadyProcessed, ActiveRecord::RecordInvalid => e
+          error!({ error: e.message }, 422)
+        end
+      end
+    end
+  end
+end

--- a/app/api/chemotion/admin_user_api.rb
+++ b/app/api/chemotion/admin_user_api.rb
@@ -205,6 +205,8 @@ module Chemotion
             params do
               optional :is_templates_moderator, type: Boolean,
                                                 desc: 'enable or disable ketcherails template moderation'
+              optional :affiliation_moderator, type: Boolean,
+                                               desc: 'enable or disable affiliation suggestion moderation'
               optional :molecule_editor, type: Boolean, desc: 'enable or disable molecule moderation'
               optional :converter_admin, type: Boolean, desc: 'converter profile'
               optional :global_text_template_editor, type: Boolean, desc: 'enable editing global text templates'
@@ -221,6 +223,11 @@ module Chemotion
               case params[:is_templates_moderator]
               when true, false
                 pdata = pdata.merge('is_templates_moderator' => params[:is_templates_moderator])
+              end
+
+              case params[:affiliation_moderator]
+              when true, false
+                pdata = pdata.merge('affiliation_moderator' => params[:affiliation_moderator])
               end
 
               case params[:converter_admin]

--- a/app/api/chemotion/admin_user_api.rb
+++ b/app/api/chemotion/admin_user_api.rb
@@ -207,6 +207,8 @@ module Chemotion
             params do
               optional :is_templates_moderator, type: Boolean,
                                                 desc: 'enable or disable ketcherails template moderation'
+              optional :affiliation_moderator, type: Boolean,
+                                               desc: 'enable or disable affiliation suggestion moderation'
               optional :molecule_editor, type: Boolean, desc: 'enable or disable molecule moderation'
               optional :converter_admin, type: Boolean, desc: 'converter profile'
               optional :global_text_template_editor, type: Boolean, desc: 'enable editing global text templates'
@@ -223,6 +225,11 @@ module Chemotion
               case params[:is_templates_moderator]
               when true, false
                 pdata = pdata.merge('is_templates_moderator' => params[:is_templates_moderator])
+              end
+
+              case params[:affiliation_moderator]
+              when true, false
+                pdata = pdata.merge('affiliation_moderator' => params[:affiliation_moderator])
               end
 
               case params[:converter_admin]

--- a/app/api/chemotion/affiliation_api.rb
+++ b/app/api/chemotion/affiliation_api.rb
@@ -2,6 +2,20 @@
 
 module Chemotion
   class AffiliationAPI < Grape::API
+    helpers do
+      # Scope affiliations to an organization, preferring the stable ROR id and
+      # falling back to a case-insensitive name match for legacy/non-ROR data.
+      def scope_by_organization(scope, prms)
+        if prms[:ror_id].present?
+          scope.where(ror_id: prms[:ror_id])
+        elsif prms[:organization].present?
+          scope.where('LOWER(organization) = LOWER(?)', prms[:organization])
+        else
+          scope
+        end
+      end
+    end
+
     namespace :public do
       namespace :affiliations do
         params do
@@ -10,7 +24,16 @@ module Chemotion
 
         desc 'Return all countries available'
         get 'countries' do
-          ISO3166::Country.all_translated
+          ISO3166::Country.all_translated.compact.sort
+        end
+
+        desc 'Search organizations via ROR API'
+        params do
+          requires :q, type: String, desc: 'search term'
+          optional :country, type: String, desc: 'country name to filter by'
+        end
+        get 'ror_search' do
+          Chemotion::RorService.search(params[:q], country: params[:country])
         end
 
         desc 'Return all current organizations'
@@ -18,14 +41,26 @@ module Chemotion
           Affiliation.pluck('DISTINCT organization')
         end
 
-        desc 'Return all current departments'
+        desc 'Return departments, optionally scoped by organization or ROR id'
+        params do
+          optional :organization, type: String, desc: 'filter by organization'
+          optional :ror_id, type: String, desc: 'filter by ROR id'
+        end
         get 'departments' do
-          Affiliation.pluck('DISTINCT department')
+          scope = scope_by_organization(Affiliation.where.not(department: [nil, '']), params)
+          scope.distinct.pluck(:department).compact
         end
 
-        desc 'Return all current groups'
+        desc 'Return working groups, optionally scoped by organization/ROR id and department'
+        params do
+          optional :organization, type: String, desc: 'filter by organization'
+          optional :ror_id, type: String, desc: 'filter by ROR id'
+          optional :department, type: String, desc: 'filter by department'
+        end
         get 'groups' do
-          Affiliation.pluck('DISTINCT "group"')
+          scope = scope_by_organization(Affiliation.where.not(group: [nil, '']), params)
+          scope = scope.where('LOWER(department) = LOWER(?)', params[:department]) if params[:department].present?
+          scope.distinct.pluck(:group).compact
         end
       end
     end
@@ -38,7 +73,7 @@ module Chemotion
       desc 'get user affiliations'
       get  do
         @affiliations.order(to: :desc, from: :desc, created_at: :desc)
-                     .as_json(methods: %i[country organization department group])
+                     .as_json(methods: %i[country organization department group ror_id])
       end
 
       desc 'create user affiliation'
@@ -47,26 +82,15 @@ module Chemotion
         optional :country, type: String, desc: 'country'
         optional :department, type: String, desc: 'department'
         optional :group, type: String, desc: 'working group'
-        optional :from, type: String, desc: 'from'
-        optional :to, type: String, desc: 'to'
+        optional :ror_id, type: String, desc: 'ROR id'
+        optional :from, type: Date, desc: 'start date'
+        optional :to, type: Date, desc: 'end date'
       end
       post do
-        attributes = declared(params, include_missing: false).compact_blank
-        from = attributes.delete(:from)
-        from = from.present? ? Date.strptime(from, '%Y-%m') : nil
-        to = attributes.delete(:to)
-        to = to.present? ? Date.strptime(to, '%Y-%m') : nil
-        ua_attributes = {
-          user_id: current_user.id,
-          affiliation: Affiliation.find_or_create_by(attributes),
-          from: from,
-          to: to,
-        }.compact_blank
-
-        UserAffiliation.create(ua_attributes)
+        Usecases::Affiliations::UserAffiliations.new(current_user).create(declared(params, include_missing: false))
         status 201
-      rescue ActiveRecord::RecordInvalid => e
-        { error: e.message }
+      rescue Usecases::Affiliations::Errors::DuplicateAffiliation, ActiveRecord::RecordInvalid => e
+        error!({ error: e.message }, 422)
       end
 
       desc 'update user affiliation'
@@ -76,29 +100,68 @@ module Chemotion
         optional :country, type: String, desc: 'country'
         optional :department, type: String, desc: 'department'
         optional :group, type: String, desc: 'working group'
-        optional :from, type: String, desc: 'from'
-        optional :to, type: String, desc: 'to'
+        optional :ror_id, type: String, desc: 'ROR id'
+        optional :from, type: Date, desc: 'start date'
+        optional :to, type: Date, desc: 'end date'
       end
       put do
-        attributes = declared(params, include_missing: false).compact_blank
-        affiliation = Affiliation.find_or_create_by(attributes.except(:from, :to, :id))
-        ua_attributes = {
-          affiliation_id: affiliation.id,
-          to: attributes[:to].present? ? Date.strptime(attributes[:to], '%Y-%m') : nil,
-          from: attributes[:from].present? ? Date.strptime(attributes[:from], '%Y-%m') : nil,
-        }.compact_blank
-        @affiliations.find(params[:id]).update(ua_attributes)
-      rescue ActiveRecord::RecordInvalid => e
-        { error: e.message }
+        Usecases::Affiliations::UserAffiliations.new(current_user).update(declared(params, include_missing: false))
+      rescue ActiveRecord::RecordNotFound
+        error!({ error: 'Not found' }, 404)
+      rescue Usecases::Affiliations::Errors::DuplicateAffiliation, ActiveRecord::RecordInvalid => e
+        error!({ error: e.message }, 422)
       end
 
       desc 'delete user affiliation'
       delete ':id' do
-        u_affiliation = @affiliations.find(params[:id])
-        u_affiliation.destroy!
-        Affiliation.find_by(id: params[:id])&.destroy! if UserAffiliation.where(affiliation_id: params[:id]).empty?
+        Usecases::Affiliations::UserAffiliations.new(current_user).destroy(params)
+      rescue ActiveRecord::RecordNotFound
+        error!({ error: 'Not found' }, 404)
       rescue ActiveRecord::RecordInvalid => e
         error!({ error: e.message }, 422)
+      end
+    end
+
+    namespace :affiliation_suggestions do
+      before { @suggestions = current_user.affiliation_suggestions }
+
+      desc 'Get current user suggestions'
+      params do
+        optional :status, type: String, values: %w[pending approved rejected], desc: 'filter by status'
+      end
+      get do
+        scope = @suggestions
+        scope = scope.where(status: AffiliationSuggestion.statuses[params[:status]]) if params[:status].present?
+        scope.order(created_at: :desc)
+             .as_json(only: %i[id organization department group country from to status created_at])
+      end
+
+      desc 'Submit a new affiliation suggestion'
+      params do
+        optional :organization, type: String, desc: 'organization name'
+        optional :department, type: String, desc: 'department name'
+        optional :group, type: String, desc: 'working group name'
+        optional :country, type: String, desc: 'country'
+        optional :ror_id, type: String, desc: 'ROR id'
+        optional :from, type: Date, desc: 'start date'
+        optional :to, type: Date, desc: 'end date'
+        optional :target_user_affiliation_id, type: Integer, desc: 'UserAffiliation being edited'
+      end
+      post do
+        suggestion = Usecases::AffiliationSuggestions::Suggestion.new(current_user)
+                                                                 .create(declared(params, include_missing: false))
+        status 201
+        suggestion.as_json(only: %i[id organization department group country status])
+      rescue Usecases::AffiliationSuggestions::Errors::DuplicateSuggestion, ActiveRecord::RecordInvalid => e
+        error!({ error: e.message }, 422)
+      end
+
+      desc 'Withdraw a pending suggestion'
+      delete ':id' do
+        Usecases::AffiliationSuggestions::Suggestion.new(current_user).withdraw(params[:id])
+        status 200
+      rescue ActiveRecord::RecordNotFound
+        error!({ error: 'Not found' }, 404)
       end
     end
   end

--- a/app/api/entities/user_entity.rb
+++ b/app/api/entities/user_entity.rb
@@ -25,6 +25,7 @@ module Entities
     expose :current_sign_in_at, if: ->(obj, _opts) { obj.respond_to? :current_sign_in_at }
     expose :locked_at, if: ->(obj, _opts) { obj.respond_to? :locked_at }
     expose :is_templates_moderator, documentation: { type: 'Boolean', desc: 'ketcherails template administrator' }
+    expose :affiliation_moderator, documentation: { type: 'Boolean', desc: 'affiliation suggestion moderator' }
     expose :molecule_editor, documentation: { type: 'Boolean', desc: 'molecule administrator' }
     expose :converter_admin, documentation: { type: 'Boolean', desc: 'converter administrator' }
     expose :global_text_template_editor, documentation: { type: 'Boolean', desc: 'global text template editor' }

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -16,14 +16,16 @@ module Users
 
     def create
       build_resource(sign_up_params)
-      find_affiliation
+      capture_signup_affiliation
       default_password
       providers
 
       yield resource if block_given?
       if resource.save
+        attach_or_suggest_affiliation
         resource_saved_handler
       else
+        resource.affiliations.build(@signup_affiliation || {})
         resource_not_saved_handler
       end
     end
@@ -46,9 +48,31 @@ module Users
       resource.providers = provider
     end
 
-    def find_affiliation
-      resource.affiliations = [Affiliation.find_or_create_by(resource.affiliations.first.slice(:country, :organization,
-                                                                                               :department, :group))]
+    def capture_signup_affiliation
+      first = resource.affiliations.first
+      @signup_affiliation = first&.slice(:country, :organization, :department, :group)&.symbolize_keys
+      @signup_affiliation[:country] = known_country(@signup_affiliation[:country]) if @signup_affiliation
+      resource.affiliations = []
+    end
+
+    # Free text is allowed in the input; anything not on the ISO list is dropped.
+    def known_country(name)
+      ISO3166::Country.all_translated.compact.find { |country| country.casecmp?(name.to_s.strip) }
+    end
+
+    # A failure here must never break the account that was just created.
+    def attach_or_suggest_affiliation
+      return if @signup_affiliation.blank? || @signup_affiliation[:organization].blank?
+
+      route_affiliation
+    rescue StandardError => e
+      Rails.logger.error("Signup affiliation routing failed: #{e.class}: #{e.message}")
+    end
+
+    def route_affiliation
+      Usecases::AffiliationSuggestions::Suggestion.new(resource).create(@signup_affiliation)
+    rescue Usecases::AffiliationSuggestions::Errors::DuplicateSuggestion
+      Usecases::Affiliations::UserAffiliations.new(resource).create(@signup_affiliation)
     end
 
     def default_password

--- a/app/javascript/src/apps/admin/AdminHome.js
+++ b/app/javascript/src/apps/admin/AdminHome.js
@@ -14,6 +14,7 @@ import DevicesList from 'src/apps/admin/devices/DevicesList';
 // import TemplateManagement from 'src/apps/admin/TemplateManagement';
 import ThirdPartyApp from 'src/apps/admin/ThirdPartyApp';
 import InfoSupportLinks from 'src/apps/admin/InfoSupportLinks';
+import AffiliationSuggestions from 'src/apps/admin/AffiliationSuggestions';
 
 const ADMIN_PAGES = [
   { key: 0, label: 'Dashboard', component: AdminDashboard },
@@ -28,6 +29,7 @@ const ADMIN_PAGES = [
   { key: 14, label: 'ChemSpectra Layouts', component: ChemSpectraLayouts },
   { key: 15, label: 'Third Party Apps', component: ThirdPartyApp },
   { key: 16, label: 'Info & Support Links', component: InfoSupportLinks },
+  { key: 17, label: 'Affiliations', component: AffiliationSuggestions },
 ];
 
 export default function AdminHome() {

--- a/app/javascript/src/apps/admin/AffiliationSuggestions.js
+++ b/app/javascript/src/apps/admin/AffiliationSuggestions.js
@@ -1,0 +1,217 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Table, Button, Badge, Form, Alert
+} from 'react-bootstrap';
+import AppModal from 'src/components/common/AppModal';
+import { Select, CreatableSelect } from 'src/components/common/Select';
+import OrganizationSelect from 'src/components/affiliation/OrganizationSelect';
+import AdminFetcher from 'src/fetchers/AdminFetcher';
+import UserSettingsFetcher from 'src/fetchers/UserSettingsFetcher';
+
+const AffiliationSuggestions = () => {
+  const [suggestions, setSuggestions] = useState([]);
+  const [statusFilter, setStatusFilter] = useState('pending');
+  const [countryOptions, setCountryOptions] = useState([]);
+  const [deptOptions, setDeptOptions] = useState([]);
+  const [groupOptions, setGroupOptions] = useState([]);
+  const [editSug, setEditSug] = useState(null);
+  const [actionError, setActionError] = useState(null);
+
+  const load = (status) => {
+    AdminFetcher.fetchAffiliationSuggestions(status)
+      .then((data) => setSuggestions(data || []));
+  };
+
+  useEffect(() => { load(statusFilter); }, [statusFilter]);
+
+  useEffect(() => {
+    UserSettingsFetcher.getAutoCompleteSuggestions('countries')
+      .then((data) => setCountryOptions((data || []).map((c) => ({ value: c.value, label: c.label }))));
+  }, []);
+
+  // Department/working-group options scoped to the organization being approved.
+  // Fields are disabled without an org, so stale options are never shown.
+  useEffect(() => {
+    const org = editSug?.organization;
+    if (!org) return;
+    UserSettingsFetcher.getAutoCompleteSuggestions('departments', org, '', editSug.ror_id || '')
+      .then((data) => setDeptOptions(data || []));
+  }, [editSug?.organization, editSug?.ror_id]);
+
+  useEffect(() => {
+    const org = editSug?.organization;
+    if (!org) return;
+    UserSettingsFetcher.getAutoCompleteSuggestions('groups', org, editSug.department || '', editSug.ror_id || '')
+      .then((data) => setGroupOptions(data || []));
+  }, [editSug?.organization, editSug?.department, editSug?.ror_id]);
+
+  const handleAction = (id, action, body = {}) => {
+    AdminFetcher.updateAffiliationSuggestion(id, action, body)
+      .then((result) => {
+        setActionError(result && result.error ? result.error : null);
+        setEditSug(null);
+        load(statusFilter);
+      });
+  };
+
+  const setEditField = (patch) => setEditSug((prev) => ({ ...prev, ...patch }));
+
+  const handleOrgChange = (choice) => {
+    const organization = choice ? choice.label : '';
+    const rorId = choice && choice.value && choice.value !== choice.label ? choice.value : '';
+    setEditField({
+      organization,
+      ror_id: rorId,
+      ...(choice && choice.country ? { country: choice.country } : {}),
+    });
+  };
+
+  const statusBadge = (status) => {
+    const map = { pending: 'warning', approved: 'success', rejected: 'danger' };
+    return <Badge bg={map[status] || 'secondary'}>{status}</Badge>;
+  };
+
+  return (
+    <div className="p-3">
+      <h4>Affiliation Suggestions</h4>
+      {actionError && (
+        <Alert variant="danger" dismissible onClose={() => setActionError(null)}>
+          {actionError}
+        </Alert>
+      )}
+      <div className="mb-3 d-flex gap-2">
+        {['pending', 'approved', 'rejected'].map((s) => (
+          <Button
+            key={s}
+            size="sm"
+            variant={statusFilter === s ? 'primary' : 'outline-secondary'}
+            onClick={() => setStatusFilter(s)}
+          >
+            {s.charAt(0).toUpperCase() + s.slice(1)}
+          </Button>
+        ))}
+      </div>
+
+      <Table striped bordered hover size="sm">
+        <thead>
+          <tr>
+            <th>User</th>
+            <th>Organization</th>
+            <th>Department</th>
+            <th>Working Group</th>
+            <th>Country</th>
+            <th>Submitted</th>
+            <th>Status</th>
+            {statusFilter === 'pending' && <th>Actions</th>}
+          </tr>
+        </thead>
+        <tbody>
+          {suggestions.map((s) => (
+            <tr key={s.id}>
+              <td>
+                {s.user?.name}
+                {' '}
+                <small className="text-muted">
+                  (
+                  {s.user?.email}
+                  )
+                </small>
+              </td>
+              <td>{s.organization}</td>
+              <td>{s.department || '—'}</td>
+              <td>{s.group || '—'}</td>
+              <td>{s.country || '—'}</td>
+              <td>{new Date(s.created_at).toLocaleDateString()}</td>
+              <td>{statusBadge(s.status)}</td>
+              {statusFilter === 'pending' && (
+                <td>
+                  <Button size="sm" variant="outline-secondary" className="me-1" onClick={() => setEditSug({ ...s })}>
+                    Edit
+                  </Button>
+                  <Button size="sm" variant="success" className="me-1" onClick={() => handleAction(s.id, 'approve')}>
+                    Approve
+                  </Button>
+                  <Button size="sm" variant="danger" onClick={() => handleAction(s.id, 'reject')}>
+                    Reject
+                  </Button>
+                </td>
+              )}
+            </tr>
+          ))}
+          {suggestions.length === 0 && (
+            <tr>
+              <td colSpan={statusFilter === 'pending' ? 8 : 7} className="text-center text-muted">
+                {`No ${statusFilter} suggestions`}
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </Table>
+
+      <AppModal
+        show={!!editSug}
+        onHide={() => setEditSug(null)}
+        title="Edit & approve request"
+        primaryActionLabel="Approve"
+        onPrimaryAction={() => editSug && handleAction(editSug.id, 'approve', {
+          organization: editSug.organization || '',
+          department: editSug.department || '',
+          group: editSug.group || '',
+          country: editSug.country || '',
+          ...(editSug.ror_id ? { ror_id: editSug.ror_id } : {}),
+        })}
+      >
+        {editSug && (
+          <div className="d-flex flex-column gap-3">
+            <Form.Group>
+              <Form.Label>Country</Form.Label>
+              <Select
+                isClearable
+                placeholder="Select country"
+                options={countryOptions}
+                value={countryOptions.find((o) => o.value === editSug.country) || null}
+                onChange={(c) => setEditField({ country: c ? c.value : '' })}
+              />
+            </Form.Group>
+            <Form.Group>
+              <Form.Label>Organization</Form.Label>
+              <OrganizationSelect
+                value={editSug.organization
+                  ? { value: editSug.ror_id || editSug.organization, label: editSug.organization }
+                  : null}
+                country={editSug.country || ''}
+                onChange={handleOrgChange}
+              />
+            </Form.Group>
+            <Form.Group>
+              <Form.Label>Department</Form.Label>
+              <CreatableSelect
+                isClearable
+                isDisabled={!editSug.organization}
+                placeholder="Select or add a department"
+                options={deptOptions}
+                value={editSug.department ? { value: editSug.department, label: editSug.department } : null}
+                onChange={(o) => setEditField({ department: o ? o.value : '' })}
+                onCreateOption={(v) => setEditField({ department: v })}
+              />
+            </Form.Group>
+            <Form.Group>
+              <Form.Label>Working group</Form.Label>
+              <CreatableSelect
+                isClearable
+                isDisabled={!editSug.organization}
+                placeholder="Select or add a working group"
+                options={groupOptions}
+                value={editSug.group ? { value: editSug.group, label: editSug.group } : null}
+                onChange={(o) => setEditField({ group: o ? o.value : '' })}
+                onCreateOption={(v) => setEditField({ group: v })}
+              />
+            </Form.Group>
+          </div>
+        )}
+      </AppModal>
+    </div>
+  );
+};
+
+export default AffiliationSuggestions;

--- a/app/javascript/src/apps/admin/UserManagement.js
+++ b/app/javascript/src/apps/admin/UserManagement.js
@@ -116,6 +116,16 @@ const templateModeratorDisableTooltip = (
     Disable Ketcher template editing for this user (currently enabled)
   </Tooltip>
 );
+const affiliationModeratorEnableTooltip = (
+  <Tooltip id="affiliation_moderator_enable_tooltip">
+    Enable affiliation suggestion approval for this user (currently disabled)
+  </Tooltip>
+);
+const affiliationModeratorDisableTooltip = (
+  <Tooltip id="affiliation_moderator_disable_tooltip">
+    Disable affiliation suggestion approval for this user (currently enabled)
+  </Tooltip>
+);
 const moleculeModeratorEnableTooltip = (
   <Tooltip id="assign_button">
     Enable editing the representation of the global molecules for this user (currently disabled)
@@ -351,6 +361,11 @@ export default class UserManagement extends React.Component {
   handleTemplatesModerator(id, isTemplatesModerator) {
     const message = `Ketcher-template editing has been ${isTemplatesModerator === true ? 'en' : 'dis'}abled for user ${id}`;
     this.updateProfile({ userId: id, is_templates_moderator: !isTemplatesModerator }, message);
+  }
+
+  handleAffiliationModerator(id, isAffiliationModerator) {
+    const message = `Affiliation approval has been ${isAffiliationModerator === true ? 'dis' : 'en'}abled for user ${id}`;
+    this.updateProfile({ userId: id, affiliation_moderator: !isAffiliationModerator }, message);
   }
 
   handleMoleculesModerator(id, isMoleculesEditor) {
@@ -1476,6 +1491,19 @@ export default class UserManagement extends React.Component {
               className="me-1"
             >
               <i className="fa fa-book" aria-hidden="true" />
+            </Button>
+          </OverlayTrigger>
+          <OverlayTrigger
+            placement="bottom"
+            overlay={(g.affiliation_moderator === null || g.affiliation_moderator === false) ? affiliationModeratorEnableTooltip : affiliationModeratorDisableTooltip}
+          >
+            <Button
+              size="sm"
+              variant={(g.affiliation_moderator === null || g.affiliation_moderator === false) ? 'light' : 'success'}
+              onClick={() => this.handleAffiliationModerator(g.id, g.affiliation_moderator)}
+              className="me-1"
+            >
+              <i className="fa fa-university" aria-hidden="true" />
             </Button>
           </OverlayTrigger>
           <OverlayTrigger

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -1060,34 +1060,29 @@ export default class SampleForm extends React.Component {
    * @returns {JSX.Element|false} The rendered input or false if not applicable
    */
   totalMixtureVolume(sample) {
-    const isDisabled = sample.isMethodDisabled('amount_value')
-      || sample.gas_type === 'gas'
-      || sample.gas_type === 'feedstock'
-      || sample.contains_residues
-      || !sample.can_update;
+    const isDisabled = sample.isMethodDisabled('amount_value') || !sample.can_update;
 
     const metricPrefixes = ['m', 'u', 'n'];
     const prefix = sample.metrics?.[3] && metricPrefixes.includes(sample.metrics[3])
       ? sample.metrics[3]
       : 'm';
 
-    if (!isDisabled) {
-      return (
-        <NumeralInputWithUnitsCompo
-          value={sample.amount_l}
-          unit="l"
-          label="Total volume"
-          metricPrefix={prefix}
-          metricPrefixes={metricPrefixes}
-          precision={5}
-          title="Total volume"
-          variant="light"
-          id="numInput_total_mixture_volume_l"
-          showInfoTooltipTotalVol
-          onChange={(e) => this.handleMixtureAmountLChanged(e, sample)}
-        />
-      );
-    }
+    return (
+      <NumeralInputWithUnitsCompo
+        value={sample.amount_l}
+        unit="l"
+        label="Total volume"
+        metricPrefix={prefix}
+        metricPrefixes={metricPrefixes}
+        precision={5}
+        title="Total volume"
+        variant="light"
+        id="numInput_total_mixture_volume_l"
+        showInfoTooltipTotalVol
+        disabled={isDisabled}
+        onChange={(e) => this.handleMixtureAmountLChanged(e, sample)}
+      />
+    );
   }
 
   /**

--- a/app/javascript/src/apps/userSettings/AccountProfile.js
+++ b/app/javascript/src/apps/userSettings/AccountProfile.js
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Container, Card, Row, Col, Form, Button, Alert, Modal
+  Container, Card, Row, Col, Form, Button, Alert, Modal, Nav
 } from 'react-bootstrap';
 import UsersFetcher from 'src/fetchers/UsersFetcher';
 import InventoryLabelSettings from 'src/apps/settings/InventoryLabelSettings';
@@ -14,6 +14,7 @@ import AuthToken from 'src/apps/userSettings/AuthToken';
 import { TwoFactorSettings } from 'src/apps/userSettings/TwoFA';
 import { AccountSettings, DeleteSettings } from 'src/apps/userSettings/UserSettings';
 import Affiliations from 'src/apps/userSettings/Affiliations';
+import AffiliationSuggestions from 'src/apps/admin/AffiliationSuggestions';
 import TextTemplates from 'src/apps/userSettings/TextTemplates';
 
 const AuthenticationSettings = ({ currentUser }) => {
@@ -313,13 +314,39 @@ const ExternalSettings = () => {
   );
 }
 
-const AffiliationsSettings = () => {
+const AffiliationsSettings = ({ currentUser }) => {
+  const [tab, setTab] = useState('mine');
+  const isModerator = currentUser.profile?.data?.affiliation_moderator;
+
+  if (!isModerator) {
+    return (
+      <Container className="my-3 d-flex flex-column gap-3">
+        <Affiliations />
+      </Container>
+    );
+  }
+
   return (
     <Container className="my-3 d-flex flex-column gap-3">
-      <Affiliations />
+      <Nav variant="tabs" activeKey={tab} onSelect={(k) => setTab(k)}>
+        <Nav.Item>
+          <Nav.Link eventKey="mine">My affiliations</Nav.Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Nav.Link eventKey="requests">Requests</Nav.Link>
+        </Nav.Item>
+      </Nav>
+      {tab === 'mine' ? <Affiliations /> : <AffiliationSuggestions />}
     </Container>
   );
-}
+};
+
+AffiliationsSettings.propTypes = {
+  currentUser: PropTypes.shape({
+    profile: PropTypes.shape({ data: PropTypes.shape({ affiliation_moderator: PropTypes.bool }) }),
+  }).isRequired,
+};
+
 const AccountProfile = ({ currentUser, closeSettings }) => {
   const [currentSettings, setCurrentSettings] = useState('account');
 
@@ -334,7 +361,7 @@ const AccountProfile = ({ currentUser, closeSettings }) => {
       return <ExternalSettings />;
     }
     if (currentSettings === 'affiliations') {
-      return <AffiliationsSettings />;
+      return <AffiliationsSettings currentUser={currentUser} />;
     }
     if (currentSettings === 'text-templates') {
       return <TextTemplates />;

--- a/app/javascript/src/apps/userSettings/Affiliations.js
+++ b/app/javascript/src/apps/userSettings/Affiliations.js
@@ -1,39 +1,82 @@
-import React, { useState, useEffect } from 'react';
-import { CreatableSelect } from 'src/components/common/Select';
-import {
-  Button, Modal, OverlayTrigger, Table, Tooltip, Popover
-} from 'react-bootstrap';
+import React, { useState, useEffect, useRef } from 'react';
+import ReactDOM from 'react-dom';
 import DatePicker from 'react-datepicker';
-import moment from 'moment';
+import { Select } from 'src/components/common/Select';
+import {
+  Button, Overlay, OverlayTrigger, Table, Tooltip, Popover
+} from 'react-bootstrap';
 
 import UserSettingsFetcher from 'src/fetchers/UserSettingsFetcher';
+import NotificationActions from 'src/stores/alt/actions/NotificationActions';
+import OrganizationSelect from 'src/components/affiliation/OrganizationSelect';
+import AffiliationSelect from 'src/components/affiliation/AffiliationSelect';
 
 function Affiliations() {
   const [affiliations, setAffiliations] = useState([]);
   const [countryOptions, setCountryOptions] = useState([]);
-  const [orgOptions, setOrgOptions] = useState([]);
-  const [deptOptions, setDeptOptions] = useState([]);
-  const [groupOptions, setGroupOptions] = useState([]);
   const [inputError, setInputError] = useState({});
-  const [errorMsg, setErrorMsg] = useState('');
   const [showConfirmIndex, setShowConfirmIndex] = useState(null);
-  const [inputValues, setInputValues] = useState({});
+  const [pendingSuggestions, setPendingSuggestions] = useState([]);
+  // field: 'organization' | 'department' | 'group' | null — which suggestion popover is open
+  const [suggestionPopover, setSuggestionPopover] = useState({ field: null, value: '' });
+  const [orgHints, setOrgHints] = useState([]);
 
-  const currentEntries = affiliations.filter((entry) => entry.current);
+  // Refs for suggestion trigger buttons — passed to <Overlay target> to avoid
+  // OverlayTrigger's dequal deep-compare hitting circular DOM/fiber refs.
+  const orgTriggerRef = useRef(null);
+  const deptTriggerRef = useRef(null);
+  const groupTriggerRef = useRef(null);
+  const suggestionTriggerRefs = { organization: orgTriggerRef, department: deptTriggerRef, group: groupTriggerRef };
+
+  const savedEntries = affiliations.filter((entry) => entry.id);
+
+  // Display dates in the browser's locale (built from parts to avoid a timezone shift).
+  const displayDate = (v) => {
+    if (!v) return '';
+    const [y, m, d] = String(v).slice(0, 10).split('-');
+    return new Date(y, m - 1, d).toLocaleDateString();
+  };
+  // DatePicker needs a Date object, built from parts to avoid a timezone shift.
+  const parseDateValue = (v) => {
+    if (!v) return null;
+    const [y, m, d] = String(v).slice(0, 10).split('-');
+    return new Date(y, m - 1, d);
+  };
+  const formatDateValue = (date) => {
+    if (!date) return '';
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  };
+  const isPast = (entry) => !!entry.to && new Date(entry.to) < new Date();
+  const rorLink = (rorId) => rorId && (
+    <a
+      href={`https://ror.org/${rorId}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="ms-1"
+      aria-label="View in ROR registry"
+      title="View in ROR registry"
+    >
+      <i className="fa fa-external-link" />
+    </a>
+  );
 
   const getAllAffiliations = () => {
     UserSettingsFetcher.getAllAffiliations()
       .then((data) => {
-        setAffiliations(data.map((item) => (
-          {
-            ...item,
-            disabled: true,
-            current: item.from !== null && item.to === null
-          }
-        )));
+        setAffiliations(data.map((item) => ({
+          ...item,
+          disabled: true,
+        })));
       });
-    setErrorMsg('');
     setInputError({});
+  };
+
+  const refreshSuggestions = () => {
+    UserSettingsFetcher.getPendingSuggestions()
+      .then((data) => setPendingSuggestions(data || []));
   };
 
   useEffect(() => {
@@ -46,38 +89,121 @@ function Affiliations() {
         setInputError({});
       });
 
-    UserSettingsFetcher.getAutoCompleteSuggestions('organizations')
-      .then((data) => {
-        setOrgOptions(data.map((item) => ({ value: item.value, label: item.label })));
-      })
-      .catch((error) => {
-        console.log(error);
-      });
-
-    UserSettingsFetcher.getAutoCompleteSuggestions('departments')
-      .then((data) => {
-        setDeptOptions(data.map((item) => ({ value: item.value, label: item.label })));
-      })
-      .catch((error) => {
-        console.log(error);
-      });
-
-    UserSettingsFetcher.getAutoCompleteSuggestions('groups')
-      .then((data) => {
-        setGroupOptions(data.map((item) => ({ value: item.value, label: item.label })));
-      })
-      .catch((error) => {
-        console.log(error);
-      });
     getAllAffiliations();
+
+    UserSettingsFetcher.getPendingSuggestions()
+      .then((data) => setPendingSuggestions(data || []));
   }, []);
 
-  const handleCreateOrUpdateAffiliation = (index) => {
-    const params = affiliations[index];
-    const callFunction = params.id ? UserSettingsFetcher.updateAffiliation : UserSettingsFetcher.createAffiliation;
+  // Debounced ROR hint search when the org suggestion popover is open.
+  // Only fires for 3+ char queries; filters to results whose label contains the query
+  // to avoid false positives from ROR's substring matching on short terms.
+  useEffect(() => {
+    const query = suggestionPopover.value.trim();
+    if (suggestionPopover.field !== 'organization' || query.length < 3) {
+      setOrgHints([]);
+      return undefined;
+    }
+    const timer = setTimeout(() => {
+      // Trust ROR's ranking (it resolves acronyms like "KIT" → Karlsruhe Institute
+      // of Technology, which a literal substring filter would discard).
+      UserSettingsFetcher.searchRorOrganizations(query)
+        .then((results) => setOrgHints((results || []).slice(0, 5)));
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [suggestionPopover.value, suggestionPopover.field]);
 
-    callFunction(params)
-      .then(() => getAllAffiliations())
+  // Shallow-merge a patch into a single row by index.
+  const patchRow = (index, patch) => setAffiliations(
+    (prev) => prev.map((row, i) => (i === index ? { ...row, ...patch } : row)),
+  );
+
+  // Options are stored per row (item.deptOptions/item.groupOptions) so two rows
+  // in edit mode at once never share — or clobber — each other's dropdowns.
+  const loadRowDeptOptions = (index, organization, rorId) => {
+    if (!organization && !rorId) { patchRow(index, { deptOptions: [] }); return; }
+    UserSettingsFetcher.getAutoCompleteSuggestions('departments', organization, '', rorId)
+      .then((data) => patchRow(index, { deptOptions: data || [] }));
+  };
+
+  const loadRowGroupOptions = (index, organization, department, rorId) => {
+    if (!organization && !rorId) { patchRow(index, { groupOptions: [] }); return; }
+    UserSettingsFetcher.getAutoCompleteSuggestions('groups', organization, department, rorId)
+      .then((data) => patchRow(index, { groupOptions: data || [] }));
+  };
+
+  const clearFieldError = (index, field) => {
+    setInputError((prev) => {
+      if (!prev[index]) return prev;
+      const next = { ...prev, [index]: { ...prev[index] } };
+      delete next[index][field];
+      if (Object.keys(next[index]).length === 0) delete next[index];
+      return next;
+    });
+  };
+
+  // Organization picks carry ROR data; apply org name, ror_id and country in a
+  // single state update so a follow-up change can't clobber the others.
+  const handleOrganizationChange = (index, choice) => {
+    const organization = choice ? choice.label : '';
+    // ROR results have value=ror_id (distinct from name); registry picks have value=label.
+    const rorId = choice && choice.value && choice.value !== choice.label ? choice.value : '';
+    const country = choice && choice.country ? choice.country : null;
+
+    setAffiliations((prev) => prev.map((row, i) => (i === index
+      ? {
+        ...row,
+        organization,
+        ror_id: rorId,
+        ...(country ? { country } : {}),
+        department: '',
+        group: '',
+        deptOptions: [],
+        groupOptions: [],
+        // Picked from a dropdown = an existing org, so nothing on this row is pending.
+        pendingFields: [],
+      }
+      : row)));
+
+    if (organization) clearFieldError(index, 'organization');
+    else setInputError((prev) => ({ ...prev, [index]: { ...prev[index], organization: true } }));
+
+    loadRowDeptOptions(index, organization, rorId);
+  };
+
+  const handleCreateOrUpdateAffiliation = (index) => {
+    const row = affiliations[index];
+    const payload = {
+      id: row.id,
+      country: row.country,
+      organization: row.organization,
+      department: row.department,
+      group: row.group,
+      ror_id: row.ror_id,
+      from: row.from || '',
+      to: row.to || '',
+    };
+    const callFunction = row.id
+      ? UserSettingsFetcher.updateAffiliation
+      : UserSettingsFetcher.createAffiliation;
+
+    callFunction(payload)
+      .then((result) => {
+        if (result && result.error) {
+          NotificationActions.add({
+            title: 'Affiliation not saved',
+            message: result.error,
+            level: 'error',
+            position: 'tc',
+            dismissible: 'button',
+            autoDismiss: 5,
+          });
+          // Keep the row open with the user's input so they can fix and retry.
+          setAffiliations((prev) => prev.map((r, i) => (i === index ? { ...r, disabled: false } : r)));
+          return;
+        }
+        getAllAffiliations();
+      })
       .catch((error) => {
         console.error(error);
       });
@@ -88,7 +214,7 @@ function Affiliations() {
     if (id) {
       UserSettingsFetcher.deleteAffiliation(id)
         .then((result) => {
-          if (result.error) {
+          if (result && result.error) {
             console.error(result.error);
             return false;
           }
@@ -96,33 +222,67 @@ function Affiliations() {
           return true;
         });
     } else {
-      affiliations.splice(index, 1);
-      setAffiliations(affiliations);
-      setInputValues({});
+      setAffiliations((prev) => prev.filter((_, i) => i !== index));
     }
   };
 
   const onChangeHandler = (index, field, value) => {
-    const updatedAffiliations = [...affiliations];
-    updatedAffiliations[index][field] = value;
-    const newInputErrors = { ...inputError };
-    if (field === 'from' && (updatedAffiliations[index].from === null || updatedAffiliations[index].from === '')) {
-      newInputErrors[index] = { ...newInputErrors[index], from: true };
-      setErrorMsg('From date is Required');
-    } else if (field === 'to' && updatedAffiliations[index].from > value) {
-      newInputErrors[index] = { ...newInputErrors[index], to: true };
-      setErrorMsg('Invalid date');
-    } else if (field === 'organization' && !value) {
-      newInputErrors[index] = { ...newInputErrors[index], organization: true };
-      setErrorMsg('Organization is required');
-    } else if (newInputErrors[index]) {
-      delete newInputErrors[index][field];
-      if (Object.keys(newInputErrors[index]).length === 0) {
-        delete newInputErrors[index];
-      }
+    setAffiliations((prev) => prev.map((row, i) => {
+      if (i !== index) return row;
+      const updated = { ...row, [field]: value };
+      if (field === 'department') updated.group = '';
+      // Choosing from a dropdown means this field is an existing value, not a suggestion.
+      if (row.pendingFields) updated.pendingFields = row.pendingFields.filter((f) => f !== field);
+      return updated;
+    }));
+
+    if (field === 'department') {
+      const row = affiliations[index];
+      loadRowGroupOptions(index, row.organization, value, row.ror_id);
     }
-    setInputError(newInputErrors);
-    setAffiliations(updatedAffiliations);
+    clearFieldError(index, field);
+  };
+
+  const submitSuggestion = (params, onDone) => {
+    UserSettingsFetcher.createSuggestion(params)
+      .then((result) => {
+        if (result && result.error) {
+          NotificationActions.add({
+            title: 'Request not submitted',
+            message: result.error,
+            level: 'error',
+            position: 'tc',
+            dismissible: 'button',
+            autoDismiss: 5,
+          });
+          return;
+        }
+        // Batch both updates into one render cycle — avoids dequal stack overflow
+        // in OverlayTrigger when Promise callbacks trigger separate re-renders (React 17).
+        ReactDOM.unstable_batchedUpdates(() => {
+          onDone();
+          setAffiliations((prev) => prev.filter((a) => a.id));
+        });
+        NotificationActions.add({
+          title: 'Affiliation request submitted',
+          message: 'Your affiliation will be added once an admin approves it.',
+          level: 'info',
+          position: 'tc',
+          dismissible: 'button',
+          autoDismiss: 5,
+        });
+        UserSettingsFetcher.getPendingSuggestions().then((data) => setPendingSuggestions(data || []));
+      })
+      .catch(() => {
+        NotificationActions.add({
+          title: 'Submission failed',
+          message: 'Your request could not be submitted. Please try again.',
+          level: 'error',
+          position: 'tc',
+          dismissible: 'button',
+          autoDismiss: 5,
+        });
+      });
   };
 
   const handleSaveButtonClick = (index) => {
@@ -132,21 +292,215 @@ function Affiliations() {
     if (!updatedAffiliations[index].organization) {
       newInputErrors[index] = { ...newInputErrors[index], organization: true };
       setInputError(newInputErrors);
-      setErrorMsg('Organization is required');
-      return;
-    }
-    if (!updatedAffiliations[index].from) {
-      newInputErrors[index] = { ...newInputErrors[index], from: true };
-      setInputError(newInputErrors);
-      setErrorMsg('From date is required');
       return;
     }
 
-    if (!newInputErrors[index] || !Object.keys(newInputErrors[index]).length) {
-      updatedAffiliations[index].disabled = true;
-      setAffiliations(updatedAffiliations);
-      handleCreateOrUpdateAffiliation(index);
+    if (newInputErrors[index] && Object.keys(newInputErrors[index]).length) return;
+
+    const row = updatedAffiliations[index];
+    if (row.pendingFields && row.pendingFields.length > 0) {
+      // Any pending (newly suggested) value sends the whole row to admin review.
+      const payload = {
+        organization: row.organization,
+        country: row.country || '',
+        department: row.department || '',
+        group: row.group || '',
+        from: row.from || '',
+        to: row.to || '',
+        ...(row.ror_id ? { ror_id: row.ror_id } : {}),
+        ...(row.id ? { target_user_affiliation_id: row.id } : {}),
+      };
+      submitSuggestion(payload, () => getAllAffiliations());
+      return;
     }
+
+    updatedAffiliations[index].disabled = true;
+    setAffiliations(updatedAffiliations);
+    handleCreateOrUpdateAffiliation(index);
+  };
+
+  const closeSuggestionPopover = () => setSuggestionPopover({ field: null, value: '' });
+
+  const activeRowWithOrg = affiliations.find((a) => !a.disabled && a.organization);
+
+  const handleSuggestionSubmit = () => {
+    const { field, value } = suggestionPopover;
+    if (!value.trim()) return;
+
+    // Client-side dedup: block if a matching pending suggestion already exists (case-insensitive)
+    const norm = (v) => (v || '').trim().toLowerCase();
+    const alreadyPending = pendingSuggestions.some((s) => {
+      if (field === 'organization') return norm(s.organization) === norm(value);
+      const sameOrg = norm(s.organization) === norm(activeRowWithOrg ? activeRowWithOrg.organization : '');
+      return norm(s[field]) === norm(value) && sameOrg;
+    });
+
+    // Check against the active row's already-loaded registry options (dept/group dropdowns)
+    const rowOptions = activeRowWithOrg || {};
+    let registryOptions = [];
+    if (field === 'department') registryOptions = rowOptions.deptOptions || [];
+    else if (field === 'group') registryOptions = rowOptions.groupOptions || [];
+    const alreadyInRegistry = registryOptions.some((opt) => norm(opt.value) === norm(value));
+
+    if (alreadyPending || alreadyInRegistry) {
+      NotificationActions.add({
+        title: alreadyInRegistry ? 'Already in registry' : 'Already pending',
+        message: alreadyInRegistry
+          ? `"${value.trim()}" already exists. Select it from the dropdown instead.`
+          : `A pending suggestion for this ${field} already exists.`,
+        level: 'warning',
+        position: 'tc',
+        dismissible: 'button',
+        autoDismiss: 5,
+      });
+      closeSuggestionPopover();
+      return;
+    }
+
+    // Stage the value into a row as a pending field; submission happens on Save.
+    const trimmed = value.trim();
+    const addPending = (row) => Array.from(new Set([...(row.pendingFields || []), field]));
+
+    if (field === 'organization') {
+      // Org has no required active row: stage into the open editable row, or open a new one.
+      const openIndex = affiliations.findIndex((a) => !a.disabled);
+      setAffiliations((prev) => {
+        const idx = prev.findIndex((a) => !a.disabled);
+        if (idx === -1) {
+          return [
+            ...prev.map((r) => ({ ...r, disabled: true })),
+            {
+              country: '',
+              organization: trimmed,
+              ror_id: '',
+              department: '',
+              group: '',
+              disabled: false,
+              pendingFields: ['organization'],
+            },
+          ];
+        }
+        return prev.map((r, i) => (i === idx
+          ? {
+            ...r,
+            organization: trimmed,
+            ror_id: '',
+            pendingFields: addPending(r),
+          }
+          : r));
+      });
+      if (openIndex !== -1) clearFieldError(openIndex, 'organization');
+      closeSuggestionPopover();
+      return;
+    }
+
+    // Department/group: the trigger is disabled unless an editable row already has an org.
+    const targetIndex = affiliations.findIndex((a) => !a.disabled && a.organization);
+    if (targetIndex === -1) { closeSuggestionPopover(); return; }
+    setAffiliations((prev) => prev.map((row, i) => (i === targetIndex
+      ? { ...row, [field]: trimmed, pendingFields: addPending(row) }
+      : row)));
+    closeSuggestionPopover();
+  };
+
+  // requiresOrg=false for organization suggestions (no active row needed)
+  const renderSuggestionTrigger = (field, label) => {
+    const activeRow = affiliations.find((a) => !a.disabled);
+    // Org suggestions need an open row with a country (an org belongs to a country,
+    // and ROR matches by country); department/group need a row that already has an org.
+    const disabled = field === 'organization'
+      ? (!activeRow || !activeRow.country)
+      : !activeRowWithOrg;
+    const disabledHint = field === 'organization'
+      ? 'Add a row and select a country first'
+      : 'Select an organization first';
+    const isOpen = suggestionPopover.field === field;
+    const triggerRef = suggestionTriggerRefs[field];
+
+    const btn = disabled ? (
+      <OverlayTrigger
+        placement="top"
+        overlay={<Tooltip id={`suggest-${field}-disabled`}>{disabledHint}</Tooltip>}
+      >
+        <span className="ms-1">
+          <Button size="sm" variant="link" className="p-0" disabled style={{ pointerEvents: 'none' }}>
+            <i className="fa fa-plus" />
+          </Button>
+        </span>
+      </OverlayTrigger>
+    ) : (
+      <Button
+        ref={triggerRef}
+        size="sm"
+        variant="link"
+        className="p-0 ms-1"
+        onClick={() => (isOpen
+          ? closeSuggestionPopover()
+          : setSuggestionPopover({ field, value: '' }))}
+      >
+        <i className="fa fa-plus" />
+      </Button>
+    );
+
+    return (
+      <>
+        {btn}
+        {!disabled && (
+          <Overlay
+            target={triggerRef}
+            show={isOpen}
+            placement="bottom"
+            rootClose
+            onHide={closeSuggestionPopover}
+          >
+            <Popover
+              id={`suggestion-popover-${field}`}
+              style={{ minWidth: field === 'organization' ? '300px' : '220px' }}
+            >
+              <Popover.Body>
+                <div className="mb-3">
+                  {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                  <label className="form-label form-label-sm">{label}</label>
+                  <input
+                    className="form-control form-control-sm"
+                    value={suggestionPopover.value}
+                    onChange={(e) => setSuggestionPopover((p) => ({ ...p, value: e.target.value }))}
+                  />
+                </div>
+                {field === 'organization' && orgHints.length > 0 && (
+                  <div
+                    className="mb-3 p-2 bg-light rounded border border-secondary-subtle"
+                    style={{ fontSize: '0.8rem' }}
+                  >
+                    <div className="fw-semibold mb-1">
+                      <i className="fa fa-info-circle me-1" />
+                      Possible matches in ROR — pick one from the dropdown if it fits:
+                    </div>
+                    {orgHints.map((h) => (
+                      <div key={h.value} className="text-truncate text-secondary">
+                        {h.label}
+                        {h.country && <span className="ms-1 text-muted">{` (${h.country})`}</span>}
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <div className="d-flex justify-content-end gap-2">
+                  <Button size="sm" variant="light" onClick={closeSuggestionPopover}>Cancel</Button>
+                  <Button
+                    size="sm"
+                    variant="primary"
+                    disabled={!suggestionPopover.value.trim()}
+                    onClick={handleSuggestionSubmit}
+                  >
+                    Confirm
+                  </Button>
+                </div>
+              </Popover.Body>
+            </Popover>
+          </Overlay>
+        )}
+      </>
+    );
   };
 
   const popover = (index) => (
@@ -180,39 +534,88 @@ function Affiliations() {
 
   return (
     <div>
-      <h3>My affiliations </h3>
-      <div>
-        <h4 className="fs-5 mb-3"> Current affiliations</h4>
-        <div className="d-flex flex-wrap gap-2">
-          {currentEntries.map((entry) => (
-            <div
-              key={entry.id}
-              className="border border-gray-300 rounded-2 p-2 shadow-sm mw-40 flex-grow-1"
-              style={{ minWidth: '200px', maxWidth: '350px' }}
+      <div className="d-flex align-items-center justify-content-between mb-1">
+        <h3 className="mb-0">My affiliations</h3>
+        <Button size="sm" variant="outline-secondary" onClick={() => { getAllAffiliations(); refreshSuggestions(); }}>
+          <i className="fa fa-refresh me-1" />
+          Refresh
+        </Button>
+      </div>
+      <div className="d-flex flex-nowrap gap-2 overflow-auto pb-2">
+        {savedEntries.map((entry) => (
+          <div
+            key={entry.id}
+            className="position-relative border border-gray-300 rounded-2 p-2 shadow-sm flex-shrink-0"
+            style={{ minWidth: '250px', maxWidth: '300px' }}
+          >
+            <span
+              className={`badge position-absolute top-0 end-0 m-2 ${isPast(entry) ? 'bg-secondary' : 'bg-success'}`}
             >
+              {isPast(entry) ? 'Past' : 'Current'}
+            </span>
+            <p>
+              <strong className="me-1">Country:</strong>
+              {entry.country || '—'}
+            </p>
+            <p>
+              <strong className="me-1">Organization:</strong>
+              {entry.organization}
+              {rorLink(entry.ror_id)}
+            </p>
+            <p>
+              <strong className="me-1">Department:</strong>
+              {entry.department || '—'}
+            </p>
+            <p>
+              <strong className="me-1">Group:</strong>
+              {entry.group || '—'}
+            </p>
+            {(entry.from || entry.to) && (
               <p>
-                <strong className="me-1">Country:</strong>
-                {entry.country}
+                <strong className="me-1">Period:</strong>
+                {`${displayDate(entry.from) || '…'} – ${displayDate(entry.to) || 'present'}`}
               </p>
+            )}
+          </div>
+        ))}
+        {pendingSuggestions.map((s) => (
+          <div
+            key={`suggestion-${s.id}`}
+            className="position-relative border border-warning rounded-2 p-2 shadow-sm flex-shrink-0"
+            style={{ minWidth: '250px', maxWidth: '300px' }}
+          >
+            <span className="badge position-absolute top-0 end-0 m-2 bg-warning text-dark">In Review</span>
+            <p>
+              <strong className="me-1">Country:</strong>
+              {s.country || '—'}
+            </p>
+            <p>
+              <strong className="me-1">Organization:</strong>
+              {s.organization || '—'}
+            </p>
+            <p>
+              <strong className="me-1">Department:</strong>
+              {s.department || '—'}
+            </p>
+            <p>
+              <strong className="me-1">Group:</strong>
+              {s.group || '—'}
+            </p>
+            {(s.from || s.to) && (
               <p>
-                <strong className="me-1">Organization:</strong>
-                {entry.organization}
+                <strong className="me-1">Period:</strong>
+                {`${displayDate(s.from) || '…'} – ${displayDate(s.to) || 'present'}`}
               </p>
-              <p>
-                <strong className="me-1">Department:</strong>
-                {entry.department}
-              </p>
-              <p>
-                <strong className="me-1">Group:</strong>
-                {entry.group}
-              </p>
-              <p>
-                <strong className="me-1">From:</strong>
-                {entry.from}
-              </p>
-            </div>
-          ))}
-        </div>
+            )}
+            <Button
+              size="sm"
+              variant="outline-danger"
+              onClick={() => UserSettingsFetcher.deleteSuggestion(s.id).then(() => refreshSuggestions())}
+            >
+              Withdraw
+            </Button>
+          </div>
+        ))}
       </div>
 
       <div className="d-flex justify-content-end my-1">
@@ -220,15 +623,17 @@ function Affiliations() {
           disabled={affiliations.some((item) => !item.id)}
           variant="primary"
           onClick={() => {
-            setAffiliations((prev) => [...prev, {
-              country: '',
-              organization: '',
-              department: '',
-              group: '',
-              from: '',
-              to: '',
-              disabled: false,
-            }]);
+            // Only one row is editable at a time: lock all existing rows, open the new one.
+            setAffiliations((prev) => [
+              ...prev.map((r) => ({ ...r, disabled: true })),
+              {
+                country: '',
+                organization: '',
+                department: '',
+                group: '',
+                disabled: false,
+              },
+            ]);
           }}
         >
           Add affiliation
@@ -237,13 +642,13 @@ function Affiliations() {
       </div>
       <Table striped bordered hover style={{ tableLayout: 'fixed' }}>
         <colgroup>
-          <col style={{ width: '20%' }} />
-          <col style={{ width: '20%' }} />
           <col style={{ width: '15%' }} />
-          <col style={{ width: '15%' }} />
-          <col style={{ width: '12%' }} />
-          <col style={{ width: '12%' }} />
-          <col style={{ width: '6%' }} />
+          <col style={{ width: '24%' }} />
+          <col style={{ width: '16%' }} />
+          <col style={{ width: '16%' }} />
+          <col style={{ width: '11%' }} />
+          <col style={{ width: '11%' }} />
+          <col style={{ width: '7%' }} />
         </colgroup>
         <thead>
           <tr>
@@ -251,196 +656,115 @@ function Affiliations() {
             <th>
               Organization
               <span className="text-danger ms-1">*</span>
+              {renderSuggestionTrigger('organization', 'Organization name')}
             </th>
-            <th>Department</th>
-            <th>Working Group</th>
             <th>
-              From
-              <span className="text-danger ms-1">*</span>
+              Department
+              {renderSuggestionTrigger('department', 'Department name')}
             </th>
+            <th>
+              Working Group
+              {renderSuggestionTrigger('group', 'Working group name')}
+            </th>
+            <th>From</th>
             <th>To</th>
-            <th>Control</th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
-
           {affiliations.map((item, index) => (
-            <tr key={item.id}>
+            <tr key={item.id || `new-${index}`}>
               <td>
-                {item.disabled ? item.country
+                {item.disabled ? (item.country || '—')
                   : (
-                    <CreatableSelect
-                      disabled={item.disabled}
+                    <Select
                       isClearable
-                      isInputEditable
-                      inputValue={inputValues[`${index}_country`] || item.country || ''}
-                      placeholder="Select or enter a new option"
+                      placeholder="Select country"
                       options={countryOptions}
-                      onCreateOption={(newValue) => {
-                        const newOption = { value: newValue, label: newValue };
-                        setCountryOptions((prev) => [...prev, newOption]);
-                        onChangeHandler(index, 'country', newValue);
-                      }}
                       value={countryOptions.find((option) => option.value === item.country) || null}
-                      onChange={(choice) => {
-                        const value = choice ? choice.value : '';
-                        setInputValues((prev) => ({ ...prev, [`${index}_country`]: value }));
-                        onChangeHandler(index, 'country', value);
-                      }}
-                      onInputChange={(inputValue, { action }) => {
-                        if (action === 'input-change') {
-                          setInputValues((prev) => ({ ...prev, [`${index}_country`]: inputValue }));
-                          onChangeHandler(index, 'country', inputValue);
-                        }
-                      }}
-                      allowCreateWhileLoading
-                      formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
+                      onChange={(choice) => onChangeHandler(index, 'country', choice ? choice.value : '')}
                     />
                   )}
               </td>
               <td>
-                {item.disabled ? item.organization
+                {item.disabled ? (
+                  <>
+                    {item.organization}
+                    {rorLink(item.ror_id)}
+                  </>
+                ) : (
+                  <>
+                    <OrganizationSelect
+                      value={item.organization
+                        ? { value: item.ror_id || item.organization, label: item.organization }
+                        : null}
+                      isInvalid={!!(inputError[index] && inputError[index].organization)}
+                      country={item.country || ''}
+                      onChange={(choice) => handleOrganizationChange(index, choice)}
+                    />
+                    {(item.pendingFields || []).includes('organization') && (
+                      <small className="text-warning d-block">New — pending admin approval on Save</small>
+                    )}
+                  </>
+                )}
+              </td>
+              <td>
+                {item.disabled ? (item.department || '—')
                   : (
                     <>
-                      <CreatableSelect
-                        disabled={item.disabled}
-                        isClearable
-                        isInputEditable
-                        inputValue={inputValues[`${index}_organization`] || item.organization || ''}
-                        placeholder="Select or enter a new option"
-                        className={inputError[index] && inputError[index].organization ? 'is-invalid' : ''}
-                        options={orgOptions}
-                        value={orgOptions.find((option) => option.value === item.organization) || null}
-                        onCreateOption={(newValue) => {
-                          const newOption = { value: newValue, label: newValue };
-                          setOrgOptions((prev) => [...prev, newOption]);
-                          onChangeHandler(index, 'organization', newValue);
-                        }}
-                        onChange={(choice) => {
-                          const value = choice ? choice.value : '';
-                          setInputValues((prev) => ({ ...prev, [`${index}_organization`]: value }));
-                          onChangeHandler(index, 'organization', value);
-                        }}
-                        onInputChange={(inputValue, { action }) => {
-                          if (action === 'input-change') {
-                            setInputValues((prev) => ({ ...prev, [`${index}_organization`]: inputValue }));
-                            onChangeHandler(index, 'organization', inputValue);
-                          }
-                        }}
-                        allowCreateWhileLoading
-                        formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
+                      <AffiliationSelect
+                        placeholder="Select department"
+                        value={item.department || ''}
+                        options={item.deptOptions || []}
+                        disabled={!item.organization}
+                        onChange={(val) => onChangeHandler(index, 'department', val)}
                       />
-                      {inputError[index] && inputError[index].organization && (
-                      <div className="invalid-feedback">Organization is required</div>
+                      {(item.pendingFields || []).includes('department') && (
+                        <small className="text-warning d-block">New — pending admin approval on Save</small>
                       )}
                     </>
                   )}
               </td>
               <td>
-                {item.disabled ? item.department
-                  : (
-                    <CreatableSelect
-                      disabled={item.disabled}
-                      isClearable
-                      isInputEditable
-                      inputValue={inputValues[`${index}_department`] || item.department || ''}
-                      placeholder="Select or enter a new option"
-                      options={deptOptions}
-                      value={deptOptions.find((option) => option.value === item.department) || null}
-                      onCreateOption={(newValue) => {
-                        const newOption = { value: newValue, label: newValue };
-                        setDeptOptions((prev) => [...prev, newOption]);
-                        onChangeHandler(index, 'department', newValue);
-                      }}
-                      onChange={(choice) => {
-                        const value = choice ? choice.value : '';
-                        setInputValues((prev) => ({ ...prev, [`${index}_department`]: value }));
-                        onChangeHandler(index, 'department', value);
-                      }}
-                      onInputChange={(inputValue, { action }) => {
-                        if (action === 'input-change') {
-                          setInputValues((prev) => ({ ...prev, [`${index}_department`]: inputValue }));
-                          onChangeHandler(index, 'department', inputValue);
-                        }
-                      }}
-                      allowCreateWhileLoading
-                      formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
-                    />
-                  )}
-              </td>
-              <td>
-                {item.disabled ? item.group
-                  : (
-                    <CreatableSelect
-                      placeholder="Select or enter a new option"
-                      disabled={item.disabled}
-                      isClearable
-                      isInputEditable
-                      inputValue={inputValues[`${index}_group`] || item.group || ''}
-                      value={groupOptions.find((option) => option.value === item.group) || null}
-                      options={groupOptions}
-                      onCreateOption={(newValue) => {
-                        const newOption = { value: newValue, label: newValue };
-                        setGroupOptions((prev) => [...prev, newOption]);
-                        onChangeHandler(index, 'group', newValue);
-                      }}
-                      onChange={(choice) => {
-                        const value = choice ? choice.value : '';
-                        setInputValues((prev) => ({ ...prev, [`${index}_group`]: value }));
-                        onChangeHandler(index, 'group', value);
-                      }}
-                      onInputChange={(inputValue, { action }) => {
-                        if (action === 'input-change') {
-                          setInputValues((prev) => ({ ...prev, [`${index}_group`]: inputValue }));
-                          onChangeHandler(index, 'group', inputValue);
-                        }
-                      }}
-                      allowCreateWhileLoading
-                      formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
-                    />
-                  )}
-              </td>
-              <td>
-                {item.disabled ? item.from
+                {item.disabled ? (item.group || '—')
                   : (
                     <>
-                      <DatePicker
-                          // eslint-disable-next-line no-nested-ternary
-                        placeholderText={inputError[index] ? inputError[index].from ? errorMsg : '' : 'Required'}
-                        isClearable
-                        clearButtonTitle="Clear"
-                          // eslint-disable-next-line max-len
-                        className={`py-1 rounded border ${inputError[index] && inputError[index].from ? 'border-danger' : 'border-gray'}`}
-                        showPopperArrow={false}
-                        disabled={item.disabled}
-                        showMonthYearPicker
-                        dateFormat="yyyy-MM"
-                        selected={item.from}
-                        onChange={(date) => {
-                          onChangeHandler(index, 'from', date ? moment(date).format('YYYY-MM') : null);
-                        }}
+                      <AffiliationSelect
+                        placeholder="Select working group"
+                        value={item.group || ''}
+                        options={item.groupOptions || []}
+                        disabled={!item.organization}
+                        onChange={(val) => onChangeHandler(index, 'group', val)}
                       />
-                      {inputError[index] && inputError[index].from && (
-                      <div className="invalid-feedback">From is required</div>
+                      {(item.pendingFields || []).includes('group') && (
+                        <small className="text-warning d-block">New — pending admin approval on Save</small>
                       )}
                     </>
                   )}
               </td>
               <td>
-                {item.disabled ? item.to
+                {item.disabled ? (displayDate(item.from) || '—')
                   : (
                     <DatePicker
-                      placeholderText={inputError[index] && inputError[index].to ? errorMsg : ''}
+                      selected={parseDateValue(item.from)}
+                      onChange={(date) => onChangeHandler(index, 'from', formatDateValue(date))}
                       isClearable
-                      clearButtonTitle="Clear"
-                        // eslint-disable-next-line max-len
-                      className={`py-1 rounded border ${inputError[index] && inputError[index].to ? 'border-danger' : 'border-gray'}`}
-                      showPopperArrow={false}
-                      disabled={item.disabled}
-                      showMonthYearPicker
-                      dateFormat="yyyy-MM"
-                      selected={inputError[index] && inputError[index].to ? null : item.to}
-                      onChange={(date) => onChangeHandler(index, 'to', date ? moment(date).format('YYYY-MM') : date)}
+                      placeholderText="MM/DD/YYYY"
+                      dateFormat="MM/dd/yyyy"
+                      wrapperClassName="w-100"
+                    />
+                  )}
+              </td>
+              <td>
+                {item.disabled ? (displayDate(item.to) || '—')
+                  : (
+                    <DatePicker
+                      selected={parseDateValue(item.to)}
+                      onChange={(date) => onChangeHandler(index, 'to', formatDateValue(date))}
+                      isClearable
+                      placeholderText="MM/DD/YYYY"
+                      dateFormat="MM/dd/yyyy"
+                      wrapperClassName="w-100"
                     />
                   )}
               </td>
@@ -454,16 +778,19 @@ function Affiliations() {
                           <Tooltip id="affiliation_edit_tooltip">
                             Edit affiliation
                           </Tooltip>
-                          )}
+                        )}
                       >
                         <Button
                           size="sm"
                           variant="primary"
                           className="ms-auto"
                           onClick={() => {
-                            const updatedAffiliations = [...affiliations];
-                            updatedAffiliations[index].disabled = false;
-                            setAffiliations(updatedAffiliations);
+                            // Single-row editing: open this row, lock every other one.
+                            setAffiliations((prev) => prev.map((r, i) => ({ ...r, disabled: i !== index })));
+                            // Editing doesn't fire the org onChange, so load the
+                            // org-scoped department/group options for this row.
+                            loadRowDeptOptions(index, item.organization, item.ror_id);
+                            loadRowGroupOptions(index, item.organization, item.department, item.ror_id);
                           }}
                         >
                           <i className="fa fa-edit" title="Edit affiliation" />
@@ -477,7 +804,7 @@ function Affiliations() {
                           <Tooltip id="affiliation_save_tooltip">
                             Save changes
                           </Tooltip>
-                          )}
+                        )}
                       >
                         <Button
                           size="sm"
@@ -511,6 +838,7 @@ function Affiliations() {
           ))}
         </tbody>
       </Table>
+
     </div>
   );
 }

--- a/app/javascript/src/apps/userSettings/Affiliations.js
+++ b/app/javascript/src/apps/userSettings/Affiliations.js
@@ -1,39 +1,82 @@
-import React, { useState, useEffect } from 'react';
-import { CreatableSelect } from 'src/components/common/Select';
-import {
-  Button, Modal, OverlayTrigger, Table, Tooltip, Popover
-} from 'react-bootstrap';
+import React, { useState, useEffect, useRef } from 'react';
+import ReactDOM from 'react-dom';
 import DatePicker from 'react-datepicker';
-import moment from 'moment';
+import { Select } from 'src/components/common/Select';
+import {
+  Button, Overlay, OverlayTrigger, Table, Tooltip, Popover
+} from 'react-bootstrap';
 
 import UserSettingsFetcher from 'src/fetchers/UserSettingsFetcher';
+import { rootStore } from 'src/stores/mobx/RootStore';
+import OrganizationSelect from 'src/components/affiliation/OrganizationSelect';
+import AffiliationSelect from 'src/components/affiliation/AffiliationSelect';
 
 function Affiliations() {
   const [affiliations, setAffiliations] = useState([]);
   const [countryOptions, setCountryOptions] = useState([]);
-  const [orgOptions, setOrgOptions] = useState([]);
-  const [deptOptions, setDeptOptions] = useState([]);
-  const [groupOptions, setGroupOptions] = useState([]);
   const [inputError, setInputError] = useState({});
-  const [errorMsg, setErrorMsg] = useState('');
   const [showConfirmIndex, setShowConfirmIndex] = useState(null);
-  const [inputValues, setInputValues] = useState({});
+  const [pendingSuggestions, setPendingSuggestions] = useState([]);
+  // field: 'organization' | 'department' | 'group' | null — which suggestion popover is open
+  const [suggestionPopover, setSuggestionPopover] = useState({ field: null, value: '' });
+  const [orgHints, setOrgHints] = useState([]);
 
-  const currentEntries = affiliations.filter((entry) => entry.current);
+  // Refs for suggestion trigger buttons — passed to <Overlay target> to avoid
+  // OverlayTrigger's dequal deep-compare hitting circular DOM/fiber refs.
+  const orgTriggerRef = useRef(null);
+  const deptTriggerRef = useRef(null);
+  const groupTriggerRef = useRef(null);
+  const suggestionTriggerRefs = { organization: orgTriggerRef, department: deptTriggerRef, group: groupTriggerRef };
+
+  const savedEntries = affiliations.filter((entry) => entry.id);
+
+  // Display dates in the browser's locale (built from parts to avoid a timezone shift).
+  const displayDate = (v) => {
+    if (!v) return '';
+    const [y, m, d] = String(v).slice(0, 10).split('-');
+    return new Date(y, m - 1, d).toLocaleDateString();
+  };
+  // DatePicker needs a Date object, built from parts to avoid a timezone shift.
+  const parseDateValue = (v) => {
+    if (!v) return null;
+    const [y, m, d] = String(v).slice(0, 10).split('-');
+    return new Date(y, m - 1, d);
+  };
+  const formatDateValue = (date) => {
+    if (!date) return '';
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  };
+  const isPast = (entry) => !!entry.to && new Date(entry.to) < new Date();
+  const rorLink = (rorId) => rorId && (
+    <a
+      href={`https://ror.org/${rorId}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="ms-1"
+      aria-label="View in ROR registry"
+      title="View in ROR registry"
+    >
+      <i className="fa fa-external-link" />
+    </a>
+  );
 
   const getAllAffiliations = () => {
     UserSettingsFetcher.getAllAffiliations()
       .then((data) => {
-        setAffiliations(data.map((item) => (
-          {
-            ...item,
-            disabled: true,
-            current: item.from !== null && item.to === null
-          }
-        )));
+        setAffiliations(data.map((item) => ({
+          ...item,
+          disabled: true,
+        })));
       });
-    setErrorMsg('');
     setInputError({});
+  };
+
+  const refreshSuggestions = () => {
+    UserSettingsFetcher.getPendingSuggestions()
+      .then((data) => setPendingSuggestions(data || []));
   };
 
   useEffect(() => {
@@ -46,38 +89,121 @@ function Affiliations() {
         setInputError({});
       });
 
-    UserSettingsFetcher.getAutoCompleteSuggestions('organizations')
-      .then((data) => {
-        setOrgOptions(data.map((item) => ({ value: item.value, label: item.label })));
-      })
-      .catch((error) => {
-        console.log(error);
-      });
-
-    UserSettingsFetcher.getAutoCompleteSuggestions('departments')
-      .then((data) => {
-        setDeptOptions(data.map((item) => ({ value: item.value, label: item.label })));
-      })
-      .catch((error) => {
-        console.log(error);
-      });
-
-    UserSettingsFetcher.getAutoCompleteSuggestions('groups')
-      .then((data) => {
-        setGroupOptions(data.map((item) => ({ value: item.value, label: item.label })));
-      })
-      .catch((error) => {
-        console.log(error);
-      });
     getAllAffiliations();
+
+    UserSettingsFetcher.getPendingSuggestions()
+      .then((data) => setPendingSuggestions(data || []));
   }, []);
 
-  const handleCreateOrUpdateAffiliation = (index) => {
-    const params = affiliations[index];
-    const callFunction = params.id ? UserSettingsFetcher.updateAffiliation : UserSettingsFetcher.createAffiliation;
+  // Debounced ROR hint search when the org suggestion popover is open.
+  // Only fires for 3+ char queries; filters to results whose label contains the query
+  // to avoid false positives from ROR's substring matching on short terms.
+  useEffect(() => {
+    const query = suggestionPopover.value.trim();
+    if (suggestionPopover.field !== 'organization' || query.length < 3) {
+      setOrgHints([]);
+      return undefined;
+    }
+    const timer = setTimeout(() => {
+      // Trust ROR's ranking (it resolves acronyms like "KIT" → Karlsruhe Institute
+      // of Technology, which a literal substring filter would discard).
+      UserSettingsFetcher.searchRorOrganizations(query)
+        .then((results) => setOrgHints((results || []).slice(0, 5)));
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [suggestionPopover.value, suggestionPopover.field]);
 
-    callFunction(params)
-      .then(() => getAllAffiliations())
+  // Shallow-merge a patch into a single row by index.
+  const patchRow = (index, patch) => setAffiliations(
+    (prev) => prev.map((row, i) => (i === index ? { ...row, ...patch } : row)),
+  );
+
+  // Options are stored per row (item.deptOptions/item.groupOptions) so two rows
+  // in edit mode at once never share — or clobber — each other's dropdowns.
+  const loadRowDeptOptions = (index, organization, rorId) => {
+    if (!organization && !rorId) { patchRow(index, { deptOptions: [] }); return; }
+    UserSettingsFetcher.getAutoCompleteSuggestions('departments', organization, '', rorId)
+      .then((data) => patchRow(index, { deptOptions: data || [] }));
+  };
+
+  const loadRowGroupOptions = (index, organization, department, rorId) => {
+    if (!organization && !rorId) { patchRow(index, { groupOptions: [] }); return; }
+    UserSettingsFetcher.getAutoCompleteSuggestions('groups', organization, department, rorId)
+      .then((data) => patchRow(index, { groupOptions: data || [] }));
+  };
+
+  const clearFieldError = (index, field) => {
+    setInputError((prev) => {
+      if (!prev[index]) return prev;
+      const next = { ...prev, [index]: { ...prev[index] } };
+      delete next[index][field];
+      if (Object.keys(next[index]).length === 0) delete next[index];
+      return next;
+    });
+  };
+
+  // Organization picks carry ROR data; apply org name, ror_id and country in a
+  // single state update so a follow-up change can't clobber the others.
+  const handleOrganizationChange = (index, choice) => {
+    const organization = choice ? choice.label : '';
+    // ROR results have value=ror_id (distinct from name); registry picks have value=label.
+    const rorId = choice && choice.value && choice.value !== choice.label ? choice.value : '';
+    const country = choice && choice.country ? choice.country : null;
+
+    setAffiliations((prev) => prev.map((row, i) => (i === index
+      ? {
+        ...row,
+        organization,
+        ror_id: rorId,
+        ...(country ? { country } : {}),
+        department: '',
+        group: '',
+        deptOptions: [],
+        groupOptions: [],
+        // Picked from a dropdown = an existing org, so nothing on this row is pending.
+        pendingFields: [],
+      }
+      : row)));
+
+    if (organization) clearFieldError(index, 'organization');
+    else setInputError((prev) => ({ ...prev, [index]: { ...prev[index], organization: true } }));
+
+    loadRowDeptOptions(index, organization, rorId);
+  };
+
+  const handleCreateOrUpdateAffiliation = (index) => {
+    const row = affiliations[index];
+    const payload = {
+      id: row.id,
+      country: row.country,
+      organization: row.organization,
+      department: row.department,
+      group: row.group,
+      ror_id: row.ror_id,
+      from: row.from || '',
+      to: row.to || '',
+    };
+    const callFunction = row.id
+      ? UserSettingsFetcher.updateAffiliation
+      : UserSettingsFetcher.createAffiliation;
+
+    callFunction(payload)
+      .then((result) => {
+        if (result && result.error) {
+          rootStore.notificationsStore.add({
+            title: 'Affiliation not saved',
+            message: result.error,
+            level: 'error',
+            position: 'tc',
+            dismissible: 'button',
+            autoDismiss: 5,
+          });
+          // Keep the row open with the user's input so they can fix and retry.
+          setAffiliations((prev) => prev.map((r, i) => (i === index ? { ...r, disabled: false } : r)));
+          return;
+        }
+        getAllAffiliations();
+      })
       .catch((error) => {
         console.error(error);
       });
@@ -88,7 +214,7 @@ function Affiliations() {
     if (id) {
       UserSettingsFetcher.deleteAffiliation(id)
         .then((result) => {
-          if (result.error) {
+          if (result && result.error) {
             console.error(result.error);
             return false;
           }
@@ -96,33 +222,67 @@ function Affiliations() {
           return true;
         });
     } else {
-      affiliations.splice(index, 1);
-      setAffiliations(affiliations);
-      setInputValues({});
+      setAffiliations((prev) => prev.filter((_, i) => i !== index));
     }
   };
 
   const onChangeHandler = (index, field, value) => {
-    const updatedAffiliations = [...affiliations];
-    updatedAffiliations[index][field] = value;
-    const newInputErrors = { ...inputError };
-    if (field === 'from' && (updatedAffiliations[index].from === null || updatedAffiliations[index].from === '')) {
-      newInputErrors[index] = { ...newInputErrors[index], from: true };
-      setErrorMsg('From date is Required');
-    } else if (field === 'to' && updatedAffiliations[index].from > value) {
-      newInputErrors[index] = { ...newInputErrors[index], to: true };
-      setErrorMsg('Invalid date');
-    } else if (field === 'organization' && !value) {
-      newInputErrors[index] = { ...newInputErrors[index], organization: true };
-      setErrorMsg('Organization is required');
-    } else if (newInputErrors[index]) {
-      delete newInputErrors[index][field];
-      if (Object.keys(newInputErrors[index]).length === 0) {
-        delete newInputErrors[index];
-      }
+    setAffiliations((prev) => prev.map((row, i) => {
+      if (i !== index) return row;
+      const updated = { ...row, [field]: value };
+      if (field === 'department') updated.group = '';
+      // Choosing from a dropdown means this field is an existing value, not a suggestion.
+      if (row.pendingFields) updated.pendingFields = row.pendingFields.filter((f) => f !== field);
+      return updated;
+    }));
+
+    if (field === 'department') {
+      const row = affiliations[index];
+      loadRowGroupOptions(index, row.organization, value, row.ror_id);
     }
-    setInputError(newInputErrors);
-    setAffiliations(updatedAffiliations);
+    clearFieldError(index, field);
+  };
+
+  const submitSuggestion = (params, onDone) => {
+    UserSettingsFetcher.createSuggestion(params)
+      .then((result) => {
+        if (result && result.error) {
+          rootStore.notificationsStore.add({
+            title: 'Request not submitted',
+            message: result.error,
+            level: 'error',
+            position: 'tc',
+            dismissible: 'button',
+            autoDismiss: 5,
+          });
+          return;
+        }
+        // Batch both updates into one render cycle — avoids dequal stack overflow
+        // in OverlayTrigger when Promise callbacks trigger separate re-renders (React 17).
+        ReactDOM.unstable_batchedUpdates(() => {
+          onDone();
+          setAffiliations((prev) => prev.filter((a) => a.id));
+        });
+        rootStore.notificationsStore.add({
+          title: 'Affiliation request submitted',
+          message: 'Your affiliation will be added once an admin approves it.',
+          level: 'info',
+          position: 'tc',
+          dismissible: 'button',
+          autoDismiss: 5,
+        });
+        UserSettingsFetcher.getPendingSuggestions().then((data) => setPendingSuggestions(data || []));
+      })
+      .catch(() => {
+        rootStore.notificationsStore.add({
+          title: 'Submission failed',
+          message: 'Your request could not be submitted. Please try again.',
+          level: 'error',
+          position: 'tc',
+          dismissible: 'button',
+          autoDismiss: 5,
+        });
+      });
   };
 
   const handleSaveButtonClick = (index) => {
@@ -132,21 +292,215 @@ function Affiliations() {
     if (!updatedAffiliations[index].organization) {
       newInputErrors[index] = { ...newInputErrors[index], organization: true };
       setInputError(newInputErrors);
-      setErrorMsg('Organization is required');
-      return;
-    }
-    if (!updatedAffiliations[index].from) {
-      newInputErrors[index] = { ...newInputErrors[index], from: true };
-      setInputError(newInputErrors);
-      setErrorMsg('From date is required');
       return;
     }
 
-    if (!newInputErrors[index] || !Object.keys(newInputErrors[index]).length) {
-      updatedAffiliations[index].disabled = true;
-      setAffiliations(updatedAffiliations);
-      handleCreateOrUpdateAffiliation(index);
+    if (newInputErrors[index] && Object.keys(newInputErrors[index]).length) return;
+
+    const row = updatedAffiliations[index];
+    if (row.pendingFields && row.pendingFields.length > 0) {
+      // Any pending (newly suggested) value sends the whole row to admin review.
+      const payload = {
+        organization: row.organization,
+        country: row.country || '',
+        department: row.department || '',
+        group: row.group || '',
+        from: row.from || '',
+        to: row.to || '',
+        ...(row.ror_id ? { ror_id: row.ror_id } : {}),
+        ...(row.id ? { target_user_affiliation_id: row.id } : {}),
+      };
+      submitSuggestion(payload, () => getAllAffiliations());
+      return;
     }
+
+    updatedAffiliations[index].disabled = true;
+    setAffiliations(updatedAffiliations);
+    handleCreateOrUpdateAffiliation(index);
+  };
+
+  const closeSuggestionPopover = () => setSuggestionPopover({ field: null, value: '' });
+
+  const activeRowWithOrg = affiliations.find((a) => !a.disabled && a.organization);
+
+  const handleSuggestionSubmit = () => {
+    const { field, value } = suggestionPopover;
+    if (!value.trim()) return;
+
+    // Client-side dedup: block if a matching pending suggestion already exists (case-insensitive)
+    const norm = (v) => (v || '').trim().toLowerCase();
+    const alreadyPending = pendingSuggestions.some((s) => {
+      if (field === 'organization') return norm(s.organization) === norm(value);
+      const sameOrg = norm(s.organization) === norm(activeRowWithOrg ? activeRowWithOrg.organization : '');
+      return norm(s[field]) === norm(value) && sameOrg;
+    });
+
+    // Check against the active row's already-loaded registry options (dept/group dropdowns)
+    const rowOptions = activeRowWithOrg || {};
+    let registryOptions = [];
+    if (field === 'department') registryOptions = rowOptions.deptOptions || [];
+    else if (field === 'group') registryOptions = rowOptions.groupOptions || [];
+    const alreadyInRegistry = registryOptions.some((opt) => norm(opt.value) === norm(value));
+
+    if (alreadyPending || alreadyInRegistry) {
+      rootStore.notificationsStore.add({
+        title: alreadyInRegistry ? 'Already in registry' : 'Already pending',
+        message: alreadyInRegistry
+          ? `"${value.trim()}" already exists. Select it from the dropdown instead.`
+          : `A pending suggestion for this ${field} already exists.`,
+        level: 'warning',
+        position: 'tc',
+        dismissible: 'button',
+        autoDismiss: 5,
+      });
+      closeSuggestionPopover();
+      return;
+    }
+
+    // Stage the value into a row as a pending field; submission happens on Save.
+    const trimmed = value.trim();
+    const addPending = (row) => Array.from(new Set([...(row.pendingFields || []), field]));
+
+    if (field === 'organization') {
+      // Org has no required active row: stage into the open editable row, or open a new one.
+      const openIndex = affiliations.findIndex((a) => !a.disabled);
+      setAffiliations((prev) => {
+        const idx = prev.findIndex((a) => !a.disabled);
+        if (idx === -1) {
+          return [
+            ...prev.map((r) => ({ ...r, disabled: true })),
+            {
+              country: '',
+              organization: trimmed,
+              ror_id: '',
+              department: '',
+              group: '',
+              disabled: false,
+              pendingFields: ['organization'],
+            },
+          ];
+        }
+        return prev.map((r, i) => (i === idx
+          ? {
+            ...r,
+            organization: trimmed,
+            ror_id: '',
+            pendingFields: addPending(r),
+          }
+          : r));
+      });
+      if (openIndex !== -1) clearFieldError(openIndex, 'organization');
+      closeSuggestionPopover();
+      return;
+    }
+
+    // Department/group: the trigger is disabled unless an editable row already has an org.
+    const targetIndex = affiliations.findIndex((a) => !a.disabled && a.organization);
+    if (targetIndex === -1) { closeSuggestionPopover(); return; }
+    setAffiliations((prev) => prev.map((row, i) => (i === targetIndex
+      ? { ...row, [field]: trimmed, pendingFields: addPending(row) }
+      : row)));
+    closeSuggestionPopover();
+  };
+
+  // requiresOrg=false for organization suggestions (no active row needed)
+  const renderSuggestionTrigger = (field, label) => {
+    const activeRow = affiliations.find((a) => !a.disabled);
+    // Org suggestions need an open row with a country (an org belongs to a country,
+    // and ROR matches by country); department/group need a row that already has an org.
+    const disabled = field === 'organization'
+      ? (!activeRow || !activeRow.country)
+      : !activeRowWithOrg;
+    const disabledHint = field === 'organization'
+      ? 'Add a row and select a country first'
+      : 'Select an organization first';
+    const isOpen = suggestionPopover.field === field;
+    const triggerRef = suggestionTriggerRefs[field];
+
+    const btn = disabled ? (
+      <OverlayTrigger
+        placement="top"
+        overlay={<Tooltip id={`suggest-${field}-disabled`}>{disabledHint}</Tooltip>}
+      >
+        <span className="ms-1">
+          <Button size="sm" variant="link" className="p-0" disabled style={{ pointerEvents: 'none' }}>
+            <i className="fa fa-plus" />
+          </Button>
+        </span>
+      </OverlayTrigger>
+    ) : (
+      <Button
+        ref={triggerRef}
+        size="sm"
+        variant="link"
+        className="p-0 ms-1"
+        onClick={() => (isOpen
+          ? closeSuggestionPopover()
+          : setSuggestionPopover({ field, value: '' }))}
+      >
+        <i className="fa fa-plus" />
+      </Button>
+    );
+
+    return (
+      <>
+        {btn}
+        {!disabled && (
+          <Overlay
+            target={triggerRef}
+            show={isOpen}
+            placement="bottom"
+            rootClose
+            onHide={closeSuggestionPopover}
+          >
+            <Popover
+              id={`suggestion-popover-${field}`}
+              style={{ minWidth: field === 'organization' ? '300px' : '220px' }}
+            >
+              <Popover.Body>
+                <div className="mb-3">
+                  {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                  <label className="form-label form-label-sm">{label}</label>
+                  <input
+                    className="form-control form-control-sm"
+                    value={suggestionPopover.value}
+                    onChange={(e) => setSuggestionPopover((p) => ({ ...p, value: e.target.value }))}
+                  />
+                </div>
+                {field === 'organization' && orgHints.length > 0 && (
+                  <div
+                    className="mb-3 p-2 bg-light rounded border border-secondary-subtle"
+                    style={{ fontSize: '0.8rem' }}
+                  >
+                    <div className="fw-semibold mb-1">
+                      <i className="fa fa-info-circle me-1" />
+                      Possible matches in ROR — pick one from the dropdown if it fits:
+                    </div>
+                    {orgHints.map((h) => (
+                      <div key={h.value} className="text-truncate text-secondary">
+                        {h.label}
+                        {h.country && <span className="ms-1 text-muted">{` (${h.country})`}</span>}
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <div className="d-flex justify-content-end gap-2">
+                  <Button size="sm" variant="light" onClick={closeSuggestionPopover}>Cancel</Button>
+                  <Button
+                    size="sm"
+                    variant="primary"
+                    disabled={!suggestionPopover.value.trim()}
+                    onClick={handleSuggestionSubmit}
+                  >
+                    Confirm
+                  </Button>
+                </div>
+              </Popover.Body>
+            </Popover>
+          </Overlay>
+        )}
+      </>
+    );
   };
 
   const popover = (index) => (
@@ -180,39 +534,88 @@ function Affiliations() {
 
   return (
     <div>
-      <h3>My affiliations </h3>
-      <div>
-        <h4 className="fs-5 mb-3"> Current affiliations</h4>
-        <div className="d-flex flex-wrap gap-2">
-          {currentEntries.map((entry) => (
-            <div
-              key={entry.id}
-              className="border border-gray-300 rounded-2 p-2 shadow-sm mw-40 flex-grow-1"
-              style={{ minWidth: '200px', maxWidth: '350px' }}
+      <div className="d-flex align-items-center justify-content-between mb-1">
+        <h3 className="mb-0">My affiliations</h3>
+        <Button size="sm" variant="outline-secondary" onClick={() => { getAllAffiliations(); refreshSuggestions(); }}>
+          <i className="fa fa-refresh me-1" />
+          Refresh
+        </Button>
+      </div>
+      <div className="d-flex flex-nowrap gap-2 overflow-auto pb-2">
+        {savedEntries.map((entry) => (
+          <div
+            key={entry.id}
+            className="position-relative border border-gray-300 rounded-2 p-2 shadow-sm flex-shrink-0"
+            style={{ minWidth: '250px', maxWidth: '300px' }}
+          >
+            <span
+              className={`badge position-absolute top-0 end-0 m-2 ${isPast(entry) ? 'bg-secondary' : 'bg-success'}`}
             >
+              {isPast(entry) ? 'Past' : 'Current'}
+            </span>
+            <p>
+              <strong className="me-1">Country:</strong>
+              {entry.country || '—'}
+            </p>
+            <p>
+              <strong className="me-1">Organization:</strong>
+              {entry.organization}
+              {rorLink(entry.ror_id)}
+            </p>
+            <p>
+              <strong className="me-1">Department:</strong>
+              {entry.department || '—'}
+            </p>
+            <p>
+              <strong className="me-1">Group:</strong>
+              {entry.group || '—'}
+            </p>
+            {(entry.from || entry.to) && (
               <p>
-                <strong className="me-1">Country:</strong>
-                {entry.country}
+                <strong className="me-1">Period:</strong>
+                {`${displayDate(entry.from) || '…'} – ${displayDate(entry.to) || 'present'}`}
               </p>
+            )}
+          </div>
+        ))}
+        {pendingSuggestions.map((s) => (
+          <div
+            key={`suggestion-${s.id}`}
+            className="position-relative border border-warning rounded-2 p-2 shadow-sm flex-shrink-0"
+            style={{ minWidth: '250px', maxWidth: '300px' }}
+          >
+            <span className="badge position-absolute top-0 end-0 m-2 bg-warning text-dark">In Review</span>
+            <p>
+              <strong className="me-1">Country:</strong>
+              {s.country || '—'}
+            </p>
+            <p>
+              <strong className="me-1">Organization:</strong>
+              {s.organization || '—'}
+            </p>
+            <p>
+              <strong className="me-1">Department:</strong>
+              {s.department || '—'}
+            </p>
+            <p>
+              <strong className="me-1">Group:</strong>
+              {s.group || '—'}
+            </p>
+            {(s.from || s.to) && (
               <p>
-                <strong className="me-1">Organization:</strong>
-                {entry.organization}
+                <strong className="me-1">Period:</strong>
+                {`${displayDate(s.from) || '…'} – ${displayDate(s.to) || 'present'}`}
               </p>
-              <p>
-                <strong className="me-1">Department:</strong>
-                {entry.department}
-              </p>
-              <p>
-                <strong className="me-1">Group:</strong>
-                {entry.group}
-              </p>
-              <p>
-                <strong className="me-1">From:</strong>
-                {entry.from}
-              </p>
-            </div>
-          ))}
-        </div>
+            )}
+            <Button
+              size="sm"
+              variant="outline-danger"
+              onClick={() => UserSettingsFetcher.deleteSuggestion(s.id).then(() => refreshSuggestions())}
+            >
+              Withdraw
+            </Button>
+          </div>
+        ))}
       </div>
 
       <div className="d-flex justify-content-end my-1">
@@ -220,15 +623,17 @@ function Affiliations() {
           disabled={affiliations.some((item) => !item.id)}
           variant="primary"
           onClick={() => {
-            setAffiliations((prev) => [...prev, {
-              country: '',
-              organization: '',
-              department: '',
-              group: '',
-              from: '',
-              to: '',
-              disabled: false,
-            }]);
+            // Only one row is editable at a time: lock all existing rows, open the new one.
+            setAffiliations((prev) => [
+              ...prev.map((r) => ({ ...r, disabled: true })),
+              {
+                country: '',
+                organization: '',
+                department: '',
+                group: '',
+                disabled: false,
+              },
+            ]);
           }}
         >
           Add affiliation
@@ -237,13 +642,13 @@ function Affiliations() {
       </div>
       <Table striped bordered hover style={{ tableLayout: 'fixed' }}>
         <colgroup>
-          <col style={{ width: '20%' }} />
-          <col style={{ width: '20%' }} />
           <col style={{ width: '15%' }} />
-          <col style={{ width: '15%' }} />
-          <col style={{ width: '12%' }} />
-          <col style={{ width: '12%' }} />
-          <col style={{ width: '6%' }} />
+          <col style={{ width: '24%' }} />
+          <col style={{ width: '16%' }} />
+          <col style={{ width: '16%' }} />
+          <col style={{ width: '11%' }} />
+          <col style={{ width: '11%' }} />
+          <col style={{ width: '7%' }} />
         </colgroup>
         <thead>
           <tr>
@@ -251,196 +656,115 @@ function Affiliations() {
             <th>
               Organization
               <span className="text-danger ms-1">*</span>
+              {renderSuggestionTrigger('organization', 'Organization name')}
             </th>
-            <th>Department</th>
-            <th>Working Group</th>
             <th>
-              From
-              <span className="text-danger ms-1">*</span>
+              Department
+              {renderSuggestionTrigger('department', 'Department name')}
             </th>
+            <th>
+              Working Group
+              {renderSuggestionTrigger('group', 'Working group name')}
+            </th>
+            <th>From</th>
             <th>To</th>
-            <th>Control</th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
-
           {affiliations.map((item, index) => (
-            <tr key={item.id}>
+            <tr key={item.id || `new-${index}`}>
               <td>
-                {item.disabled ? item.country
+                {item.disabled ? (item.country || '—')
                   : (
-                    <CreatableSelect
-                      disabled={item.disabled}
+                    <Select
                       isClearable
-                      isInputEditable
-                      inputValue={inputValues[`${index}_country`] || item.country || ''}
-                      placeholder="Select or enter a new option"
+                      placeholder="Select country"
                       options={countryOptions}
-                      onCreateOption={(newValue) => {
-                        const newOption = { value: newValue, label: newValue };
-                        setCountryOptions((prev) => [...prev, newOption]);
-                        onChangeHandler(index, 'country', newValue);
-                      }}
                       value={countryOptions.find((option) => option.value === item.country) || null}
-                      onChange={(choice) => {
-                        const value = choice ? choice.value : '';
-                        setInputValues((prev) => ({ ...prev, [`${index}_country`]: value }));
-                        onChangeHandler(index, 'country', value);
-                      }}
-                      onInputChange={(inputValue, { action }) => {
-                        if (action === 'input-change') {
-                          setInputValues((prev) => ({ ...prev, [`${index}_country`]: inputValue }));
-                          onChangeHandler(index, 'country', inputValue);
-                        }
-                      }}
-                      allowCreateWhileLoading
-                      formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
+                      onChange={(choice) => onChangeHandler(index, 'country', choice ? choice.value : '')}
                     />
                   )}
               </td>
               <td>
-                {item.disabled ? item.organization
+                {item.disabled ? (
+                  <>
+                    {item.organization}
+                    {rorLink(item.ror_id)}
+                  </>
+                ) : (
+                  <>
+                    <OrganizationSelect
+                      value={item.organization
+                        ? { value: item.ror_id || item.organization, label: item.organization }
+                        : null}
+                      isInvalid={!!(inputError[index] && inputError[index].organization)}
+                      country={item.country || ''}
+                      onChange={(choice) => handleOrganizationChange(index, choice)}
+                    />
+                    {(item.pendingFields || []).includes('organization') && (
+                      <small className="text-warning d-block">New — pending admin approval on Save</small>
+                    )}
+                  </>
+                )}
+              </td>
+              <td>
+                {item.disabled ? (item.department || '—')
                   : (
                     <>
-                      <CreatableSelect
-                        disabled={item.disabled}
-                        isClearable
-                        isInputEditable
-                        inputValue={inputValues[`${index}_organization`] || item.organization || ''}
-                        placeholder="Select or enter a new option"
-                        className={inputError[index] && inputError[index].organization ? 'is-invalid' : ''}
-                        options={orgOptions}
-                        value={orgOptions.find((option) => option.value === item.organization) || null}
-                        onCreateOption={(newValue) => {
-                          const newOption = { value: newValue, label: newValue };
-                          setOrgOptions((prev) => [...prev, newOption]);
-                          onChangeHandler(index, 'organization', newValue);
-                        }}
-                        onChange={(choice) => {
-                          const value = choice ? choice.value : '';
-                          setInputValues((prev) => ({ ...prev, [`${index}_organization`]: value }));
-                          onChangeHandler(index, 'organization', value);
-                        }}
-                        onInputChange={(inputValue, { action }) => {
-                          if (action === 'input-change') {
-                            setInputValues((prev) => ({ ...prev, [`${index}_organization`]: inputValue }));
-                            onChangeHandler(index, 'organization', inputValue);
-                          }
-                        }}
-                        allowCreateWhileLoading
-                        formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
+                      <AffiliationSelect
+                        placeholder="Select department"
+                        value={item.department || ''}
+                        options={item.deptOptions || []}
+                        disabled={!item.organization}
+                        onChange={(val) => onChangeHandler(index, 'department', val)}
                       />
-                      {inputError[index] && inputError[index].organization && (
-                      <div className="invalid-feedback">Organization is required</div>
+                      {(item.pendingFields || []).includes('department') && (
+                        <small className="text-warning d-block">New — pending admin approval on Save</small>
                       )}
                     </>
                   )}
               </td>
               <td>
-                {item.disabled ? item.department
-                  : (
-                    <CreatableSelect
-                      disabled={item.disabled}
-                      isClearable
-                      isInputEditable
-                      inputValue={inputValues[`${index}_department`] || item.department || ''}
-                      placeholder="Select or enter a new option"
-                      options={deptOptions}
-                      value={deptOptions.find((option) => option.value === item.department) || null}
-                      onCreateOption={(newValue) => {
-                        const newOption = { value: newValue, label: newValue };
-                        setDeptOptions((prev) => [...prev, newOption]);
-                        onChangeHandler(index, 'department', newValue);
-                      }}
-                      onChange={(choice) => {
-                        const value = choice ? choice.value : '';
-                        setInputValues((prev) => ({ ...prev, [`${index}_department`]: value }));
-                        onChangeHandler(index, 'department', value);
-                      }}
-                      onInputChange={(inputValue, { action }) => {
-                        if (action === 'input-change') {
-                          setInputValues((prev) => ({ ...prev, [`${index}_department`]: inputValue }));
-                          onChangeHandler(index, 'department', inputValue);
-                        }
-                      }}
-                      allowCreateWhileLoading
-                      formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
-                    />
-                  )}
-              </td>
-              <td>
-                {item.disabled ? item.group
-                  : (
-                    <CreatableSelect
-                      placeholder="Select or enter a new option"
-                      disabled={item.disabled}
-                      isClearable
-                      isInputEditable
-                      inputValue={inputValues[`${index}_group`] || item.group || ''}
-                      value={groupOptions.find((option) => option.value === item.group) || null}
-                      options={groupOptions}
-                      onCreateOption={(newValue) => {
-                        const newOption = { value: newValue, label: newValue };
-                        setGroupOptions((prev) => [...prev, newOption]);
-                        onChangeHandler(index, 'group', newValue);
-                      }}
-                      onChange={(choice) => {
-                        const value = choice ? choice.value : '';
-                        setInputValues((prev) => ({ ...prev, [`${index}_group`]: value }));
-                        onChangeHandler(index, 'group', value);
-                      }}
-                      onInputChange={(inputValue, { action }) => {
-                        if (action === 'input-change') {
-                          setInputValues((prev) => ({ ...prev, [`${index}_group`]: inputValue }));
-                          onChangeHandler(index, 'group', inputValue);
-                        }
-                      }}
-                      allowCreateWhileLoading
-                      formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
-                    />
-                  )}
-              </td>
-              <td>
-                {item.disabled ? item.from
+                {item.disabled ? (item.group || '—')
                   : (
                     <>
-                      <DatePicker
-                          // eslint-disable-next-line no-nested-ternary
-                        placeholderText={inputError[index] ? inputError[index].from ? errorMsg : '' : 'Required'}
-                        isClearable
-                        clearButtonTitle="Clear"
-                          // eslint-disable-next-line max-len
-                        className={`py-1 rounded border ${inputError[index] && inputError[index].from ? 'border-danger' : 'border-gray'}`}
-                        showPopperArrow={false}
-                        disabled={item.disabled}
-                        showMonthYearPicker
-                        dateFormat="yyyy-MM"
-                        selected={item.from}
-                        onChange={(date) => {
-                          onChangeHandler(index, 'from', date ? moment(date).format('YYYY-MM') : null);
-                        }}
+                      <AffiliationSelect
+                        placeholder="Select working group"
+                        value={item.group || ''}
+                        options={item.groupOptions || []}
+                        disabled={!item.organization}
+                        onChange={(val) => onChangeHandler(index, 'group', val)}
                       />
-                      {inputError[index] && inputError[index].from && (
-                      <div className="invalid-feedback">From is required</div>
+                      {(item.pendingFields || []).includes('group') && (
+                        <small className="text-warning d-block">New — pending admin approval on Save</small>
                       )}
                     </>
                   )}
               </td>
               <td>
-                {item.disabled ? item.to
+                {item.disabled ? (displayDate(item.from) || '—')
                   : (
                     <DatePicker
-                      placeholderText={inputError[index] && inputError[index].to ? errorMsg : ''}
+                      selected={parseDateValue(item.from)}
+                      onChange={(date) => onChangeHandler(index, 'from', formatDateValue(date))}
                       isClearable
-                      clearButtonTitle="Clear"
-                        // eslint-disable-next-line max-len
-                      className={`py-1 rounded border ${inputError[index] && inputError[index].to ? 'border-danger' : 'border-gray'}`}
-                      showPopperArrow={false}
-                      disabled={item.disabled}
-                      showMonthYearPicker
-                      dateFormat="yyyy-MM"
-                      selected={inputError[index] && inputError[index].to ? null : item.to}
-                      onChange={(date) => onChangeHandler(index, 'to', date ? moment(date).format('YYYY-MM') : date)}
+                      placeholderText="MM/DD/YYYY"
+                      dateFormat="MM/dd/yyyy"
+                      wrapperClassName="w-100"
+                    />
+                  )}
+              </td>
+              <td>
+                {item.disabled ? (displayDate(item.to) || '—')
+                  : (
+                    <DatePicker
+                      selected={parseDateValue(item.to)}
+                      onChange={(date) => onChangeHandler(index, 'to', formatDateValue(date))}
+                      isClearable
+                      placeholderText="MM/DD/YYYY"
+                      dateFormat="MM/dd/yyyy"
+                      wrapperClassName="w-100"
                     />
                   )}
               </td>
@@ -454,16 +778,19 @@ function Affiliations() {
                           <Tooltip id="affiliation_edit_tooltip">
                             Edit affiliation
                           </Tooltip>
-                          )}
+                        )}
                       >
                         <Button
                           size="sm"
                           variant="primary"
                           className="ms-auto"
                           onClick={() => {
-                            const updatedAffiliations = [...affiliations];
-                            updatedAffiliations[index].disabled = false;
-                            setAffiliations(updatedAffiliations);
+                            // Single-row editing: open this row, lock every other one.
+                            setAffiliations((prev) => prev.map((r, i) => ({ ...r, disabled: i !== index })));
+                            // Editing doesn't fire the org onChange, so load the
+                            // org-scoped department/group options for this row.
+                            loadRowDeptOptions(index, item.organization, item.ror_id);
+                            loadRowGroupOptions(index, item.organization, item.department, item.ror_id);
                           }}
                         >
                           <i className="fa fa-edit" title="Edit affiliation" />
@@ -477,7 +804,7 @@ function Affiliations() {
                           <Tooltip id="affiliation_save_tooltip">
                             Save changes
                           </Tooltip>
-                          )}
+                        )}
                       >
                         <Button
                           size="sm"
@@ -511,6 +838,7 @@ function Affiliations() {
           ))}
         </tbody>
       </Table>
+
     </div>
   );
 }

--- a/app/javascript/src/components/affiliation/AffiliationSelect.js
+++ b/app/javascript/src/components/affiliation/AffiliationSelect.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Select } from 'src/components/common/Select';
+
+// Shared dropdown for the department and working-group columns.
+// Options are passed in by the parent (org-scoped); no inline creation —
+// new values go through the suggestion popover instead.
+function AffiliationSelect({
+  value, options, onChange, disabled, placeholder,
+}) {
+  return (
+    <Select
+      isClearable
+      isDisabled={disabled}
+      placeholder={placeholder}
+      options={options}
+      value={value ? { value, label: value } : null}
+      onChange={(choice) => onChange(choice ? choice.value : '')}
+      styles={{ menu: (base) => ({ ...base, width: '100%', minWidth: 'unset' }) }}
+    />
+  );
+}
+
+AffiliationSelect.propTypes = {
+  value: PropTypes.string,
+  options: PropTypes.arrayOf(PropTypes.shape({ value: PropTypes.string, label: PropTypes.string })),
+  onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+  placeholder: PropTypes.string,
+};
+
+AffiliationSelect.defaultProps = {
+  value: '',
+  options: [],
+  disabled: false,
+  placeholder: 'Select...',
+};
+
+export default AffiliationSelect;

--- a/app/javascript/src/components/affiliation/OrganizationSelect.js
+++ b/app/javascript/src/components/affiliation/OrganizationSelect.js
@@ -1,0 +1,68 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { AsyncSelect } from 'src/components/common/Select';
+import UserSettingsFetcher from 'src/fetchers/UserSettingsFetcher';
+
+function OrganizationSelect({
+  value, onChange, isInvalid, country,
+}) {
+  const [localOrgs, setLocalOrgs] = useState([]);
+
+  useEffect(() => {
+    UserSettingsFetcher.getLocalOrganizations().then((orgs) => setLocalOrgs(orgs));
+  }, []);
+
+  const loadOptions = (inputValue) => {
+    if (!inputValue || inputValue.length < 2) return Promise.resolve([]);
+
+    return UserSettingsFetcher.searchRorOrganizations(inputValue, country).then((results) => {
+      const rorResults = results.filter((r) => r.label);
+      const rorNames = new Set(rorResults.map((r) => r.label.toLowerCase()));
+
+      const localMatches = localOrgs
+        .filter((org) => org.toLowerCase().includes(inputValue.toLowerCase()) && !rorNames.has(org.toLowerCase()))
+        .map((org) => ({ value: org, label: org }));
+
+      const groups = [];
+      if (rorResults.length > 0) groups.push({ label: 'ROR', options: rorResults });
+      if (localMatches.length > 0) groups.push({ label: 'From registry', options: localMatches });
+      return groups.length > 0 ? groups : [];
+    });
+  };
+
+  return (
+    <>
+      <AsyncSelect
+        isClearable
+        placeholder="Search organization..."
+        loadOptions={loadOptions}
+        value={value}
+        onChange={onChange}
+        className={isInvalid ? 'is-invalid' : ''}
+        noOptionsMessage={({ inputValue }) => (
+          inputValue.length < 2 ? 'Type at least 2 characters' : 'No organizations found'
+        )}
+        styles={{
+          menu: (base) => ({ ...base, width: '100%', minWidth: 'unset' }),
+          groupHeading: (base) => ({ ...base, fontWeight: 700, color: 'inherit' }),
+        }}
+      />
+      {isInvalid && <div className="invalid-feedback">Organization is required</div>}
+    </>
+  );
+}
+
+OrganizationSelect.propTypes = {
+  value: PropTypes.shape({ value: PropTypes.string, label: PropTypes.string }),
+  onChange: PropTypes.func.isRequired,
+  isInvalid: PropTypes.bool,
+  country: PropTypes.string,
+};
+
+OrganizationSelect.defaultProps = {
+  value: null,
+  isInvalid: false,
+  country: '',
+};
+
+export default OrganizationSelect;

--- a/app/javascript/src/fetchers/AdminFetcher.js
+++ b/app/javascript/src/fetchers/AdminFetcher.js
@@ -113,4 +113,12 @@ export default class AdminFetcher {
   static restartJob(id) {
     return ApiClient.putJson('/api/v1/admin/jobs/restart/', { body: { id } });
   }
+
+  static fetchAffiliationSuggestions(status) {
+    return ApiClient.getJson(`/api/v1/admin/affiliation_suggestions?status=${status}`);
+  }
+
+  static updateAffiliationSuggestion(id, action, body = {}) {
+    return ApiClient.putJson(`/api/v1/admin/affiliation_suggestions/${id}/${action}`, { body });
+  }
 }

--- a/app/javascript/src/fetchers/UserSettingsFetcher.js
+++ b/app/javascript/src/fetchers/UserSettingsFetcher.js
@@ -1,11 +1,44 @@
 import ApiClient from 'src/api_clients/ChemotionApiClient';
 
 export default class UserSettingsFetcher {
-  static getAutoCompleteSuggestions(type) {
-    return ApiClient.getJson(`/api/v1/public/affiliations/${type}`)
-      .then((json) => json
+  static searchRorOrganizations(query, country = '') {
+    const countryParam = country ? `&country=${encodeURIComponent(country)}` : '';
+    return ApiClient.getJson(`/api/v1/public/affiliations/ror_search?q=${encodeURIComponent(query)}${countryParam}`)
+      .then((data) => (data || []).map((item) => ({
+        value: item.ror_id,
+        label: item.name,
+        country: item.country,
+      })));
+  }
+
+  static getLocalOrganizations() {
+    return ApiClient.getJson('/api/v1/public/affiliations/organizations')
+      .then((data) => (data || []).filter(Boolean));
+  }
+
+  static getAutoCompleteSuggestions(type, organization = '', department = '', rorId = '') {
+    const params = new URLSearchParams();
+    if (organization) params.append('organization', organization);
+    if (department) params.append('department', department);
+    if (rorId) params.append('ror_id', rorId);
+    const query = params.toString() ? `?${params.toString()}` : '';
+
+    return ApiClient.getJson(`/api/v1/public/affiliations/${type}${query}`)
+      .then((data) => (data || [])
         .filter((item) => item && item.trim() !== '')
         .map((item) => ({ value: item, label: item })));
+  }
+
+  static getPendingSuggestions() {
+    return ApiClient.getJson('/api/v1/affiliation_suggestions?status=pending');
+  }
+
+  static createSuggestion(params) {
+    return ApiClient.postJson('/api/v1/affiliation_suggestions', { body: params });
+  }
+
+  static deleteSuggestion(id) {
+    return ApiClient.deleteRequest(`/api/v1/affiliation_suggestions/${id}`);
   }
 
   static getAllAffiliations() {

--- a/app/mailers/affiliation_mailer.rb
+++ b/app/mailers/affiliation_mailer.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# rubocop:disable Rails/I18nLocaleTexts
+class AffiliationMailer < ApplicationMailer
+  def suggestion_submitted(suggestion)
+    @suggestion = suggestion
+    @user = suggestion.user
+    recipients = (Admin.pluck(:email) + moderator_emails).compact.uniq
+    return if recipients.empty?
+
+    mail(to: recipients,
+         subject: "New affiliation suggestion from #{@user.name}",
+         template_name: 'suggestion') do |format|
+      format.html
+      format.text
+    end
+  end
+
+  def suggestion_approved(suggestion)
+    @suggestion = suggestion
+    @user = suggestion.user
+    mail(to: @user.email,
+         subject: '[ELN] Your affiliation suggestion has been approved',
+         template_name: 'suggestion') do |format|
+      format.html
+      format.text
+    end
+  end
+
+  def suggestion_rejected(suggestion)
+    @suggestion = suggestion
+    @user = suggestion.user
+    mail(to: @user.email,
+         subject: '[ELN] Your affiliation suggestion was not approved',
+         template_name: 'suggestion') do |format|
+      format.html
+      format.text
+    end
+  end
+
+  private
+
+  def moderator_emails
+    User.joins(:profile).where("profiles.data ->> 'affiliation_moderator' = 'true'").pluck(:email)
+  end
+end
+# rubocop:enable Rails/I18nLocaleTexts

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -16,6 +16,7 @@
 #  to           :date
 #  domain       :string
 #  cat          :string
+#  ror_id       :string
 #
 
 class Affiliation < ApplicationRecord
@@ -23,6 +24,40 @@ class Affiliation < ApplicationRecord
 
   has_many :user_affiliations, dependent: :destroy
   has_many :users, through: :user_affiliations
+
+  # Case/accent-insensitive key for matching near-duplicate free-text values.
+  # Falls back to the downcased original for non-Latin scripts, which the
+  # a-z0-9 filter would otherwise collapse to an empty (all-equal) key.
+  def self.normalize_key(value)
+    return '' if value.blank?
+
+    key = value.to_s
+               .unicode_normalize(:nfkd)
+               .gsub(/\p{Mn}/, '')
+               .downcase
+               .gsub(/[^a-z0-9]+/, ' ')
+               .strip
+    key.presence || value.to_s.downcase.strip
+  end
+
+  # Returns the first-seen stored value matching value's normalized key, else value.
+  def self.canonical(field, value)
+    return value if value.blank?
+
+    key = normalize_key(value)
+    match = nil
+    where.not(field => [nil, '']).in_batches(of: 1_000) do |batch|
+      match = batch.distinct.pluck(field).find { |v| normalize_key(v) == key }
+      break if match
+    end
+    match || value
+  end
+
+  # Locks and destroys the row if no UserAffiliation references it anymore.
+  def self.destroy_if_orphaned!(id)
+    affiliation = lock.find_by(id: id)
+    affiliation&.destroy! if affiliation && UserAffiliation.where(affiliation_id: id).empty?
+  end
 
   def output_array_full
     [group, department, organization, country]

--- a/app/models/affiliation_suggestion.rb
+++ b/app/models/affiliation_suggestion.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: affiliation_suggestions
+#
+#  id                         :bigint           not null, primary key
+#  country                    :string
+#  department                 :string
+#  from                       :date
+#  group                      :string
+#  organization               :string
+#  status                     :integer          default("pending"), not null
+#  to                         :date
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  affiliation_id             :integer
+#  ror_id                     :string
+#  target_user_affiliation_id :integer
+#  user_id                    :integer          not null
+#
+# Indexes
+#
+#  index_affiliation_suggestions_on_status   (status)
+#  index_affiliation_suggestions_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class AffiliationSuggestion < ApplicationRecord
+  enum status: { pending: 0, approved: 1, rejected: 2 }
+
+  belongs_to :user
+  belongs_to :affiliation, optional: true
+
+  validates :organization, :department, :group, :country, allow_blank: true, length: { maximum: 255 }
+  validate do
+    next if [organization, department, group].any?(&:present?)
+
+    errors.add(:base, 'must include an organization, department, or group')
+  end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -74,6 +74,7 @@ class Profile < ApplicationRecord
 
   def data_default_bool
     data['is_templates_moderator'] = false
+    data['affiliation_moderator'] = false
     data['molecule_editor'] = false
     data['converter_admin'] = false
     data['inbox_auto'] = false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -101,6 +101,7 @@ class User < ApplicationRecord
 
   has_many :user_affiliations, dependent: :destroy
   has_many :affiliations, through: :user_affiliations
+  has_many :affiliation_suggestions, dependent: :destroy
 
   has_many :computed_props
 
@@ -336,6 +337,10 @@ class User < ApplicationRecord
 
   def is_templates_moderator
     profile&.data&.fetch('is_templates_moderator', false)
+  end
+
+  def affiliation_moderator
+    profile&.data&.fetch('affiliation_moderator', false)
   end
 
   def molecule_editor

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -101,6 +101,7 @@ class User < ApplicationRecord
 
   has_many :user_affiliations, dependent: :destroy
   has_many :affiliations, through: :user_affiliations
+  has_many :affiliation_suggestions, dependent: :destroy
 
   has_many :computed_props
 
@@ -352,6 +353,10 @@ class User < ApplicationRecord
 
   def is_templates_moderator
     profile&.data&.fetch('is_templates_moderator', false)
+  end
+
+  def affiliation_moderator
+    profile&.data&.fetch('affiliation_moderator', false)
   end
 
   def molecule_editor

--- a/app/models/user_affiliation.rb
+++ b/app/models/user_affiliation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: user_affiliations
@@ -18,6 +20,15 @@ class UserAffiliation < ApplicationRecord
   belongs_to :user
   belongs_to :affiliation
 
+  delegate :country, :organization, :department, :group, :ror_id, to: :affiliation, prefix: false, allow_nil: true
 
-  delegate :country, :organization, :department, :group, to: :affiliation, prefix: false, allow_nil: true
+  validate :end_date_after_start_date
+
+  private
+
+  def end_date_after_start_date
+    return if from.blank? || to.blank? || to >= from
+
+    errors.add(:to, 'must be after the start date')
+  end
 end

--- a/app/usecases/affiliation_suggestions/errors.rb
+++ b/app/usecases/affiliation_suggestions/errors.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Usecases
+  module AffiliationSuggestions
+    module Errors
+      # Raised when a user submits a suggestion that duplicates a pending one or
+      # an entry already present in the affiliation registry.
+      class DuplicateSuggestion < StandardError; end
+
+      # Raised when approving or rejecting a suggestion that is no longer pending.
+      class AlreadyProcessed < StandardError; end
+    end
+  end
+end

--- a/app/usecases/affiliation_suggestions/suggestion.rb
+++ b/app/usecases/affiliation_suggestions/suggestion.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+module Usecases
+  module AffiliationSuggestions
+    # User submission plus admin approval/rejection of affiliation suggestions.
+    # Admin actions are reachable only through the admin API namespace.
+    class Suggestion
+      NAME_COLUMNS = %i[organization department group].freeze
+
+      def initialize(current_user)
+        @current_user = current_user
+      end
+
+      def create(params)
+        params = params.compact_blank
+        ensure_no_pending_duplicate!(params)
+        ensure_not_in_registry!(params)
+
+        suggestion = AffiliationSuggestion.create!(params.merge(user_id: @current_user.id))
+        AffiliationMailer.suggestion_submitted(suggestion)&.deliver_later
+        suggestion
+      end
+
+      def approve(id, edits = {})
+        suggestion = with_pending(id) do |s|
+          s.assign_attributes(
+            edits.slice(:organization, :department, :group, :country, :ror_id).transform_values(&:presence),
+          )
+          # A name-only suggestion (department/working group) is approved without an affiliation.
+          if s.organization.present?
+            affiliation = registry_row_for(s)
+            apply_affiliation(s, affiliation)
+            s.update!(status: :approved, affiliation_id: affiliation.id)
+          else
+            s.update!(status: :approved)
+          end
+        end
+        AffiliationMailer.suggestion_approved(suggestion).deliver_later
+        suggestion
+      end
+
+      def reject(id)
+        suggestion = with_pending(id) { |s| s.update!(status: :rejected) }
+        AffiliationMailer.suggestion_rejected(suggestion).deliver_later
+        suggestion
+      end
+
+      def withdraw(id)
+        @current_user.affiliation_suggestions.pending.find(id).destroy!
+      end
+
+      private
+
+      # Lock the row so two admins (or a double-click) can't both process it.
+      def with_pending(id)
+        suggestion = AffiliationSuggestion.find(id)
+        suggestion.with_lock do
+          unless suggestion.pending?
+            raise Usecases::AffiliationSuggestions::Errors::AlreadyProcessed, 'Already processed'
+          end
+
+          yield suggestion
+        end
+        suggestion
+      end
+
+      # Same ROR org can live in the registry under another display name; match by
+      # ror_id first so approval reuses that row instead of minting a duplicate.
+      def registry_row_for(suggestion)
+        organization = Affiliation.canonical(:organization, suggestion.organization)
+        department = Affiliation.canonical(:department, suggestion.department)
+        group = Affiliation.canonical(:group, suggestion.group)
+        if suggestion.ror_id.present?
+          existing = Affiliation.find_by(ror_id: suggestion.ror_id, department: department, group: group)
+          return existing if existing
+        end
+        Affiliation.find_or_create_by!(
+          organization: organization,
+          department: department,
+          group: group,
+          country: suggestion.country,
+          ror_id: suggestion.ror_id,
+        )
+      end
+
+      # Repoint the edited UserAffiliation when the suggestion targets one the
+      # submitter actually owns, otherwise add a new UserAffiliation. Scoping to
+      # the submitter blocks a forged target_user_affiliation_id from repointing
+      # someone else's affiliation on approval.
+      def apply_affiliation(suggestion, affiliation)
+        dates = { from: suggestion.from, to: suggestion.to }.compact
+        target = suggestion.user.user_affiliations.find_by(id: suggestion.target_user_affiliation_id)
+        if target
+          repoint(target, affiliation, dates)
+        else
+          link = UserAffiliation.find_or_create_by!(user_id: suggestion.user_id, affiliation_id: affiliation.id)
+          link.update!(dates) if dates.any?
+        end
+      end
+
+      # When the user already holds the target affiliation through another row,
+      # drop the edited row instead of repointing it — one affiliation, one record.
+      def repoint(user_affiliation, affiliation, dates = {})
+        duplicate = UserAffiliation.where(user_id: user_affiliation.user_id, affiliation_id: affiliation.id)
+                                   .where.not(id: user_affiliation.id).exists?
+        old_affiliation_id = user_affiliation.affiliation_id
+        ActiveRecord::Base.transaction do
+          duplicate ? user_affiliation.destroy! : user_affiliation.update!(affiliation_id: affiliation.id, **dates)
+          Affiliation.destroy_if_orphaned!(old_affiliation_id) if old_affiliation_id != affiliation.id
+        end
+      end
+
+      # Case/accent-insensitive comparison via Affiliation.normalize_key, done in
+      # Ruby over small sets (a user's pending suggestions, the curated registry).
+      def same_value?(stored, submitted)
+        Affiliation.normalize_key(stored) == Affiliation.normalize_key(submitted)
+      end
+
+      def ensure_no_pending_duplicate!(params)
+        duplicate = @current_user.affiliation_suggestions.pending.any? do |s|
+          NAME_COLUMNS.all? { |col| same_value?(s[col], params[col]) }
+        end
+        return unless duplicate
+
+        raise Usecases::AffiliationSuggestions::Errors::DuplicateSuggestion,
+              'You already have a pending suggestion with these details.'
+      end
+
+      # The organization also counts as matching when the ROR ids are identical,
+      # so a known org under another display name is not treated as new.
+      def organization_match?(params, org, ror)
+        params[:organization].blank? || same_value?(org, params[:organization]) ||
+          (params[:ror_id].present? && ror == params[:ror_id])
+      end
+
+      def registry_match?(params, org, dept, group, ror)
+        organization_match?(params, org, ror) &&
+          (params[:department].blank? || same_value?(dept, params[:department])) &&
+          (params[:group].blank? || same_value?(group, params[:group]))
+      end
+
+      def ensure_not_in_registry!(params)
+        exists = Affiliation.in_batches(of: 1_000).any? do |batch|
+          batch.pluck(:organization, :department, :group, :ror_id)
+               .any? { |org, dept, group, ror| registry_match?(params, org, dept, group, ror) }
+        end
+        return unless exists
+
+        raise Usecases::AffiliationSuggestions::Errors::DuplicateSuggestion,
+              'This already exists in the affiliation registry.'
+      end
+    end
+  end
+end

--- a/app/usecases/affiliations/errors.rb
+++ b/app/usecases/affiliations/errors.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Usecases
+  module Affiliations
+    module Errors
+      class DuplicateAffiliation < StandardError; end
+    end
+  end
+end

--- a/app/usecases/affiliations/user_affiliations.rb
+++ b/app/usecases/affiliations/user_affiliations.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Usecases
+  module Affiliations
+    # CRUD for the current user's affiliations. Reuses an existing Affiliation
+    # row when the normalized attributes already exist, and cleans up an
+    # Affiliation once no user references it.
+    class UserAffiliations
+      def initialize(current_user)
+        @current_user = current_user
+      end
+
+      def create(params)
+        affiliation = Affiliation.find_or_create_by!(affiliation_attributes(params))
+        ensure_not_duplicate!(affiliation.id)
+        scope.create!(affiliation_id: affiliation.id, **params.slice(:from, :to))
+      end
+
+      def update(params)
+        affiliation = Affiliation.find_or_create_by!(affiliation_attributes(params))
+        user_affiliation = scope.find(params[:id])
+        ensure_not_duplicate!(affiliation.id, except: user_affiliation.id)
+        user_affiliation.update!(affiliation_id: affiliation.id, **params.slice(:from, :to))
+      end
+
+      def destroy(params)
+        user_affiliation = scope.find(params[:id])
+        affiliation_id = user_affiliation.affiliation_id
+        ActiveRecord::Base.transaction do
+          user_affiliation.destroy!
+          Affiliation.destroy_if_orphaned!(affiliation_id)
+        end
+      end
+
+      private
+
+      def scope
+        @current_user.user_affiliations
+      end
+
+      def ensure_not_duplicate!(affiliation_id, except: nil)
+        relation = scope.where(affiliation_id: affiliation_id)
+        relation = relation.where.not(id: except) if except
+        return unless relation.exists?
+
+        raise Usecases::Affiliations::Errors::DuplicateAffiliation, 'You already have this affiliation.'
+      end
+
+      # Full identity with explicit nils: a blank department must match rows
+      # where department IS NULL, not any row of the same organization.
+      def affiliation_attributes(params)
+        attributes = %i[organization department group country ror_id].index_with { |key| params[key].presence }
+        %i[organization department group].each do |key|
+          attributes[key] = Affiliation.canonical(key, attributes[key].strip) if attributes[key]
+        end
+        attributes
+      end
+    end
+  end
+end

--- a/app/views/affiliation_mailer/suggestion.html.haml
+++ b/app/views/affiliation_mailer/suggestion.html.haml
@@ -1,0 +1,22 @@
+- if action_name == 'suggestion_submitted'
+  %p
+    User
+    %strong= @user.name
+    (#{@user.email}) submitted a new affiliation suggestion. Log in to the admin panel to approve or reject it.
+- elsif action_name == 'suggestion_approved'
+  %p Your affiliation suggestion has been approved and is now visible in your affiliations.
+- else
+  %p Your affiliation suggestion was not approved. Contact your ELN administrator if you have questions.
+%table
+  %tr
+    %th Organization
+    %td= @suggestion.organization.presence || '—'
+  %tr
+    %th Department
+    %td= @suggestion.department.presence || '—'
+  %tr
+    %th Working Group
+    %td= @suggestion.group.presence || '—'
+  %tr
+    %th Country
+    %td= @suggestion.country.presence || '—'

--- a/app/views/affiliation_mailer/suggestion.text.haml
+++ b/app/views/affiliation_mailer/suggestion.text.haml
@@ -1,0 +1,11 @@
+- if action_name == 'suggestion_submitted'
+  = "User #{@user.name} (#{@user.email}) submitted a new affiliation suggestion. Log in to the admin panel to approve or reject it."
+- elsif action_name == 'suggestion_approved'
+  = 'Your affiliation suggestion has been approved and is now visible in your affiliations.'
+- else
+  = 'Your affiliation suggestion was not approved. Contact your ELN administrator if you have questions.'
+
+= "Organization:  #{@suggestion.organization.presence || '—'}"
+= "Department:    #{@suggestion.department.presence || '—'}"
+= "Working Group: #{@suggestion.group.presence || '—'}"
+= "Country:       #{@suggestion.country.presence || '—'}"

--- a/app/views/devise/shared/_affiliations.html.haml
+++ b/app/views/devise/shared/_affiliations.html.haml
@@ -4,7 +4,7 @@
 .form-group.mb-3
   = f.label "Country", class: 'form-label'
   = f.text_field :country, autofocus: true, class: 'form-control',
-      id: 'country-select'
+      id: 'country-select', placeholder: 'Start typing and pick a country'
 .form-group.mb-3
   = f.label "Organization", class: "required form-label"
   = f.text_field :organization, autofocus: true, class: 'form-control',

--- a/db/migrate/20260610000000_create_affiliation_suggestions.rb
+++ b/db/migrate/20260610000000_create_affiliation_suggestions.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class CreateAffiliationSuggestions < ActiveRecord::Migration[6.1]
+  def up
+    create_table :affiliation_suggestions do |t|
+      t.integer :user_id, null: false
+      t.string :organization
+      t.string :department
+      t.string :group
+      t.string :country
+      t.integer :status, default: 0, null: false
+      t.integer :affiliation_id
+      t.string :ror_id
+      t.integer :target_user_affiliation_id
+      t.date :from
+      t.date :to
+
+      t.timestamps
+    end
+
+    add_index :affiliation_suggestions, :user_id
+    add_index :affiliation_suggestions, :status
+    add_foreign_key :affiliation_suggestions, :users
+  end
+
+  def down
+    drop_table :affiliation_suggestions
+  end
+end

--- a/db/migrate/20260622000000_add_ror_id_to_affiliations.rb
+++ b/db/migrate/20260622000000_add_ror_id_to_affiliations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRorIdToAffiliations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :affiliations, :ror_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_06_12_000000) do
+ActiveRecord::Schema.define(version: 2026_06_22_000000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -19,6 +19,24 @@ ActiveRecord::Schema.define(version: 2026_06_12_000000) do
   enable_extension "plpgsql"
   enable_extension "rdkit"
   enable_extension "uuid-ossp"
+
+  create_table "affiliation_suggestions", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "organization"
+    t.string "department"
+    t.string "group"
+    t.string "country"
+    t.integer "status", default: 0, null: false
+    t.integer "affiliation_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "ror_id"
+    t.integer "target_user_affiliation_id"
+    t.date "from"
+    t.date "to"
+    t.index ["status"], name: "index_affiliation_suggestions_on_status"
+    t.index ["user_id"], name: "index_affiliation_suggestions_on_user_id"
+  end
 
   create_table "affiliations", id: :serial, force: :cascade do |t|
     t.string "company"
@@ -32,6 +50,7 @@ ActiveRecord::Schema.define(version: 2026_06_12_000000) do
     t.date "to"
     t.string "domain"
     t.string "cat"
+    t.string "ror_id"
   end
 
   create_table "analyses_experiments", id: :serial, force: :cascade do |t|
@@ -1810,6 +1829,7 @@ ActiveRecord::Schema.define(version: 2026_06_12_000000) do
     t.index ["wellplate_id"], name: "index_wells_on_wellplate_id"
   end
 
+  add_foreign_key "affiliation_suggestions", "users"
   add_foreign_key "api_tokens", "users"
   add_foreign_key "chemicals", "sequence_based_macromolecule_samples"
   add_foreign_key "collection_shares", "collections"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,6 +20,24 @@ ActiveRecord::Schema.define(version: 2026_07_09_140001) do
   enable_extension "rdkit"
   enable_extension "uuid-ossp"
 
+  create_table "affiliation_suggestions", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "organization"
+    t.string "department"
+    t.string "group"
+    t.string "country"
+    t.integer "status", default: 0, null: false
+    t.integer "affiliation_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "ror_id"
+    t.integer "target_user_affiliation_id"
+    t.date "from"
+    t.date "to"
+    t.index ["status"], name: "index_affiliation_suggestions_on_status"
+    t.index ["user_id"], name: "index_affiliation_suggestions_on_user_id"
+  end
+
   create_table "affiliations", id: :serial, force: :cascade do |t|
     t.string "company"
     t.string "country"
@@ -32,6 +50,7 @@ ActiveRecord::Schema.define(version: 2026_07_09_140001) do
     t.date "to"
     t.string "domain"
     t.string "cat"
+    t.string "ror_id"
   end
 
   create_table "analyses_experiments", id: :serial, force: :cascade do |t|
@@ -1868,6 +1887,7 @@ ActiveRecord::Schema.define(version: 2026_07_09_140001) do
     t.index ["wellplate_id"], name: "index_wells_on_wellplate_id"
   end
 
+  add_foreign_key "affiliation_suggestions", "users"
   add_foreign_key "api_tokens", "users"
   add_foreign_key "chemicals", "sequence_based_macromolecule_samples"
   add_foreign_key "collection_shares", "collections"

--- a/lib/chemotion/ror_service.rb
+++ b/lib/chemotion/ror_service.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Chemotion
+  class RorService
+    include HTTParty
+
+    ROR_API_BASE = 'https://api.ror.org/v2/organizations'
+    REQUEST_TIMEOUT = 10
+
+    class << self
+      def search(query, country: nil)
+        return [] if query.to_s.strip.length < 2
+
+        response = HTTParty.get(build_url(query, country), request_options)
+        return [] unless response.success?
+
+        (JSON.parse(response.body)['items'] || []).filter_map { |item| parse_item(item) if item['id'] }
+      rescue StandardError => e
+        Rails.logger.error "ROR API error: #{e.message}"
+        []
+      end
+
+      private
+
+      def build_url(query, country)
+        filter = country_filter(country)
+        "#{ROR_API_BASE}?query=#{URI.encode_www_form_component(query.strip)}&page=1#{filter}"
+      end
+
+      def country_filter(country)
+        code = ISO3166::Country.find_country_by_any_name(country.to_s)&.alpha2
+        code ? "&filter=country.country_code:#{code}" : ''
+      end
+
+      def parse_item(item)
+        {
+          ror_id: item['id'].split('/').last,
+          name: extract_display_name(item),
+          country: item.dig('locations', 0, 'geonames_details', 'country_name'),
+        }
+      end
+
+      def extract_display_name(item)
+        item['names']&.find { |n| n['types']&.include?('ror_display') }&.dig('value')
+      end
+
+      def request_options
+        {
+          timeout: REQUEST_TIMEOUT,
+          headers: { 'Accept' => 'application/json' },
+        }
+      end
+    end
+  end
+end

--- a/spec/api/chemotion/admin_affiliation_api_spec.rb
+++ b/spec/api/chemotion/admin_affiliation_api_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Chemotion::AdminAffiliationAPI do
+  let!(:admin) { create(:admin) }
+  let!(:user) { create(:person) }
+  let!(:suggestion) { create(:affiliation_suggestion, user: user, organization: 'KIT', department: 'IOC') }
+  let(:warden_instance) { instance_double(WardenAuthentication) }
+
+  describe 'GET /api/v1/admin/affiliation_suggestions' do
+    before { allow(WardenAuthentication).to receive(:new).and_return(warden_instance) }
+
+    context 'when admin' do
+      before { allow(warden_instance).to receive(:current_user).and_return(admin) }
+
+      it 'lists pending suggestions' do
+        get '/api/v1/admin/affiliation_suggestions'
+        expect(response).to have_http_status(:ok)
+        expect(parsed_json_response.length).to eq(1)
+      end
+
+      it 'includes the ror_id so the edit modal round-trips it on approve' do
+        get '/api/v1/admin/affiliation_suggestions'
+        expect(parsed_json_response.first).to have_key('ror_id')
+      end
+    end
+
+    context 'when the user is an affiliation moderator' do
+      let(:moderator) { create(:person) }
+
+      before do
+        moderator.profile.update!(data: moderator.profile.data.merge('affiliation_moderator' => true))
+        allow(warden_instance).to receive(:current_user).and_return(moderator)
+      end
+
+      it 'lists pending suggestions' do
+        get '/api/v1/admin/affiliation_suggestions'
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when the user is not an admin' do
+      before { allow(warden_instance).to receive(:current_user).and_return(user) }
+
+      it 'returns 401' do
+        get '/api/v1/admin/affiliation_suggestions'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'PUT /api/v1/admin/affiliation_suggestions/:id/approve' do
+    let(:mail_double) { instance_double(ActionMailer::MessageDelivery, deliver_later: nil) }
+    let(:mailer_double) { class_double(AffiliationMailer, suggestion_approved: mail_double) }
+
+    before do
+      allow(WardenAuthentication).to receive(:new).and_return(warden_instance)
+      allow(warden_instance).to receive(:current_user).and_return(admin)
+      stub_const('AffiliationMailer', mailer_double)
+    end
+
+    it 'creates a UserAffiliation and marks suggestion approved', :aggregate_failures do
+      expect do
+        put "/api/v1/admin/affiliation_suggestions/#{suggestion.id}/approve"
+      end.to change(UserAffiliation, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(suggestion.reload).to be_approved
+      expect(suggestion.reload.affiliation_id).not_to be_nil
+    end
+
+    it 'applies edited fields before approving', :aggregate_failures do
+      put "/api/v1/admin/affiliation_suggestions/#{suggestion.id}/approve", params: { department: 'ITC' }
+      expect(response).to have_http_status(:ok)
+      expect(suggestion.reload.department).to eq('ITC')
+      expect(Affiliation.find(suggestion.affiliation_id).department).to eq('ITC')
+    end
+
+    it 'approves a name-only suggestion without creating an affiliation', :aggregate_failures do
+      name_only = create(:affiliation_suggestion, user: user, organization: nil, department: 'New Dept')
+
+      expect do
+        put "/api/v1/admin/affiliation_suggestions/#{name_only.id}/approve"
+      end.not_to change(UserAffiliation, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(name_only.reload).to be_approved
+      expect(name_only.affiliation_id).to be_nil
+    end
+
+    it 'reuses the registry row matched by ROR id instead of duplicating the organization', :aggregate_failures do
+      existing = Affiliation.create!(organization: 'Karlsruhe Institute of Technology', ror_id: '04t3en479')
+      sugg = create(:affiliation_suggestion, user: user, organization: 'KIT', department: nil, ror_id: '04t3en479')
+
+      expect do
+        put "/api/v1/admin/affiliation_suggestions/#{sugg.id}/approve"
+      end.not_to change(Affiliation, :count)
+
+      expect(sugg.reload.affiliation_id).to eq(existing.id)
+    end
+
+    it 'canonicalizes a case-variant organization on approval', :aggregate_failures do
+      Affiliation.create!(organization: 'Zewail City', country: 'Germany')
+      sugg = create(:affiliation_suggestion, user: user, organization: 'zewail city', department: nil)
+
+      expect do
+        put "/api/v1/admin/affiliation_suggestions/#{sugg.id}/approve"
+      end.not_to change(Affiliation, :count)
+
+      expect(Affiliation.find(sugg.reload.affiliation_id).organization).to eq('Zewail City')
+    end
+
+    it 'carries the suggestion from/to dates onto the created user affiliation', :aggregate_failures do
+      dated = create(:affiliation_suggestion,
+                     user: user, organization: 'KIT', department: 'IPC',
+                     from: '2020-01-01', to: '2022-12-31')
+
+      put "/api/v1/admin/affiliation_suggestions/#{dated.id}/approve"
+
+      ua = user.user_affiliations.find_by(affiliation_id: dated.reload.affiliation_id)
+      expect(ua.from).to eq(Date.new(2020, 1, 1))
+      expect(ua.to).to eq(Date.new(2022, 12, 31))
+    end
+
+    it 'copies the ROR id onto the created affiliation' do
+      with_ror = create(
+        :affiliation_suggestion, user: user, organization: 'KIT', department: 'IFG', ror_id: '04t3en479'
+      )
+      put "/api/v1/admin/affiliation_suggestions/#{with_ror.id}/approve"
+      expect(Affiliation.find(with_ror.reload.affiliation_id).ror_id).to eq('04t3en479')
+    end
+
+    it 'repoints the edited user affiliation instead of creating a new one' do
+      original = Affiliation.create!(organization: 'KIT', department: 'IBCS', country: 'Germany')
+      ua = UserAffiliation.create!(user: user, affiliation: original)
+      sugg = create(:affiliation_suggestion,
+                    user: user, organization: 'KIT', department: 'IBCS', group: 'Levkin',
+                    country: 'Germany', target_user_affiliation_id: ua.id)
+
+      put "/api/v1/admin/affiliation_suggestions/#{sugg.id}/approve"
+
+      expect(ua.reload.affiliation.group).to eq('Levkin')
+      expect(UserAffiliation.where(user: user).count).to eq(1)
+    end
+
+    it 'drops the edited row when the user already holds the target affiliation', :aggregate_failures do
+      target = Affiliation.create!(organization: 'KIT', department: 'IOC', country: 'Germany')
+      edited = Affiliation.create!(organization: 'KIT', department: 'IBCS', country: 'Germany')
+      UserAffiliation.create!(user: user, affiliation: target)
+      editing = UserAffiliation.create!(user: user, affiliation: edited)
+      sugg = create(:affiliation_suggestion,
+                    user: user, organization: 'KIT', department: 'IOC',
+                    country: 'Germany', target_user_affiliation_id: editing.id)
+
+      put "/api/v1/admin/affiliation_suggestions/#{sugg.id}/approve"
+
+      expect(user.user_affiliations.count).to eq(1)
+      expect(user.affiliations.map(&:department)).to eq(['IOC'])
+    end
+  end
+
+  describe 'PUT /api/v1/admin/affiliation_suggestions/:id/reject' do
+    let(:mail_double) { instance_double(ActionMailer::MessageDelivery, deliver_later: nil) }
+    let(:mailer_double) { class_double(AffiliationMailer, suggestion_rejected: mail_double) }
+
+    before do
+      allow(WardenAuthentication).to receive(:new).and_return(warden_instance)
+      allow(warden_instance).to receive(:current_user).and_return(admin)
+      stub_const('AffiliationMailer', mailer_double)
+    end
+
+    it 'marks suggestion rejected' do
+      put "/api/v1/admin/affiliation_suggestions/#{suggestion.id}/reject"
+      expect(response).to have_http_status(:ok)
+      expect(suggestion.reload).to be_rejected
+    end
+  end
+end

--- a/spec/api/chemotion/affiliation_api_spec.rb
+++ b/spec/api/chemotion/affiliation_api_spec.rb
@@ -1,0 +1,300 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Chemotion::AffiliationAPI do
+  describe 'GET /api/v1/public/affiliations/departments' do
+    before do
+      Affiliation.create!(organization: 'KIT', department: 'IOC', country: 'Germany')
+      Affiliation.create!(organization: 'KIT', department: 'ITC', country: 'Germany')
+      Affiliation.create!(organization: 'MIT', department: 'Chemistry', country: 'US')
+    end
+
+    it 'returns all departments when no org filter' do
+      get '/api/v1/public/affiliations/departments'
+      expect(response).to have_http_status(:ok)
+      expect(parsed_json_response).to include('IOC', 'ITC', 'Chemistry')
+    end
+
+    it 'returns only departments for the given organization' do
+      get '/api/v1/public/affiliations/departments', params: { organization: 'KIT' }
+      expect(parsed_json_response).to include('IOC', 'ITC')
+      expect(parsed_json_response).not_to include('Chemistry')
+    end
+
+    it 'matches the organization case-insensitively' do
+      get '/api/v1/public/affiliations/departments', params: { organization: 'kit' }
+      expect(parsed_json_response).to include('IOC', 'ITC')
+    end
+
+    it 'scopes by ROR id when given' do
+      Affiliation.create!(organization: 'KIT', department: 'IFG', country: 'Germany', ror_id: '04t3en479')
+      get '/api/v1/public/affiliations/departments', params: { ror_id: '04t3en479' }
+      expect(parsed_json_response).to eq(['IFG'])
+    end
+  end
+
+  describe 'GET /api/v1/public/affiliations/ror_search' do
+    let(:ror_payload) do
+      {
+        items: [
+          {
+            id: 'https://ror.org/04t3en479',
+            names: [
+              { value: 'KIT', types: ['acronym'] },
+              { value: 'Karlsruhe Institute of Technology', types: %w[ror_display label] },
+            ],
+            locations: [{ geonames_details: { country_name: 'Germany' } }],
+          },
+        ],
+      }.to_json
+    end
+
+    it 'maps ROR v2 items to ror_id, display name and country', :aggregate_failures do
+      ror_response = instance_double(HTTParty::Response, success?: true, body: ror_payload)
+      allow(HTTParty).to receive(:get).and_return(ror_response)
+
+      get '/api/v1/public/affiliations/ror_search', params: { q: 'Karlsruhe' }
+
+      expect(response).to have_http_status(:ok)
+      result = parsed_json_response.first
+      expect(result['ror_id']).to eq('04t3en479')
+      expect(result['name']).to eq('Karlsruhe Institute of Technology')
+      expect(result['country']).to eq('Germany')
+    end
+
+    it 'returns an empty list when the ROR API fails' do
+      allow(HTTParty).to receive(:get).and_raise(Net::OpenTimeout)
+
+      get '/api/v1/public/affiliations/ror_search', params: { q: 'Karlsruhe' }
+
+      expect(parsed_json_response).to eq([])
+    end
+  end
+
+  describe 'GET /api/v1/public/affiliations/groups' do
+    before do
+      Affiliation.create!(organization: 'KIT', department: 'IOC', group: 'Brause', country: 'Germany')
+      Affiliation.create!(organization: 'KIT', department: 'ITC', group: 'Other', country: 'Germany')
+    end
+
+    it 'returns all groups when no params given' do
+      get '/api/v1/public/affiliations/groups'
+      expect(response).to have_http_status(:ok)
+      expect(parsed_json_response).to include('Brause', 'Other')
+    end
+
+    it 'returns groups scoped by org and department' do
+      get '/api/v1/public/affiliations/groups', params: { organization: 'KIT', department: 'IOC' }
+      expect(parsed_json_response).to include('Brause')
+      expect(parsed_json_response).not_to include('Other')
+    end
+  end
+
+  describe 'POST /api/v1/affiliation_suggestions' do
+    let(:user) { create(:person) }
+    let(:warden_instance) { instance_double(WardenAuthentication) }
+    let(:mail_double) { instance_double(ActionMailer::MessageDelivery, deliver_later: nil) }
+    let(:mailer_double) { class_double(AffiliationMailer, suggestion_submitted: mail_double) }
+
+    before do
+      allow(WardenAuthentication).to receive(:new).and_return(warden_instance)
+      allow(warden_instance).to receive(:current_user).and_return(user)
+      stub_const('AffiliationMailer', mailer_double)
+    end
+
+    it 'creates a pending suggestion' do
+      post '/api/v1/affiliation_suggestions', params: {
+        organization: 'KIT', department: 'New Dept', country: 'Germany'
+      }
+      expect(response).to have_http_status(:created)
+      expect(AffiliationSuggestion.last).to be_pending
+      expect(AffiliationSuggestion.last.organization).to eq('KIT')
+    end
+
+    it 'creates a pending suggestion with only department (no organization)' do
+      post '/api/v1/affiliation_suggestions', params: { department: 'New Dept' }
+      expect(response).to have_http_status(:created)
+      expect(AffiliationSuggestion.last.department).to eq('New Dept')
+    end
+
+    it 'creates a pending suggestion with a working group ("group" is a reserved SQL word)' do
+      post '/api/v1/affiliation_suggestions', params: { organization: 'KIT', group: 'Levkin' }
+      expect(response).to have_http_status(:created)
+      expect(AffiliationSuggestion.last.group).to eq('Levkin')
+    end
+
+    it 'rejects an accent variant of an existing registry entry' do
+      Affiliation.create!(organization: 'ETH Zürich')
+      post '/api/v1/affiliation_suggestions', params: { organization: 'ETH Zurich' }
+      expect(response).to have_http_status(422)
+    end
+
+    it 'stores the ROR id on the suggestion' do
+      post '/api/v1/affiliation_suggestions', params: { organization: 'KIT', group: 'Levkin', ror_id: '04t3en479' }
+      expect(response).to have_http_status(:created)
+      expect(AffiliationSuggestion.last.ror_id).to eq('04t3en479')
+    end
+
+    it 'stores the target user affiliation id when editing' do
+      ua = UserAffiliation.create!(user: user, affiliation: Affiliation.create!(organization: 'KIT'))
+      post '/api/v1/affiliation_suggestions', params: {
+        organization: 'KIT', group: 'Levkin', target_user_affiliation_id: ua.id
+      }
+      expect(response).to have_http_status(:created)
+      expect(AffiliationSuggestion.last.target_user_affiliation_id).to eq(ua.id)
+    end
+  end
+
+  describe 'DELETE /api/v1/affiliation_suggestions/:id' do
+    let(:user) { create(:person) }
+    let(:warden_instance) { instance_double(WardenAuthentication) }
+
+    before do
+      allow(WardenAuthentication).to receive(:new).and_return(warden_instance)
+      allow(warden_instance).to receive(:current_user).and_return(user)
+    end
+
+    it 'withdraws the user own pending suggestion' do
+      sugg = create(:affiliation_suggestion, user: user, organization: 'KIT', status: :pending)
+      expect { delete "/api/v1/affiliation_suggestions/#{sugg.id}" }
+        .to change(AffiliationSuggestion, :count).by(-1)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'DELETE /api/v1/affiliations/:id' do
+    let(:user) { create(:person) }
+    let(:warden_instance) { instance_double(WardenAuthentication) }
+    let(:affiliation) { Affiliation.create!(organization: 'KIT', department: 'IOC') }
+
+    before do
+      allow(WardenAuthentication).to receive(:new).and_return(warden_instance)
+      allow(warden_instance).to receive(:current_user).and_return(user)
+    end
+
+    it 'removes the orphaned affiliation once no user references it', :aggregate_failures do
+      user_affiliation = UserAffiliation.create!(user: user, affiliation: affiliation)
+
+      expect do
+        delete "/api/v1/affiliations/#{user_affiliation.id}"
+      end.to change(Affiliation, :count).by(-1)
+
+      expect(response).to have_http_status(:ok)
+      expect(Affiliation.find_by(id: affiliation.id)).to be_nil
+    end
+
+    it 'keeps the affiliation while another user still references it' do
+      other_user = create(:person)
+      user_affiliation = UserAffiliation.create!(user: user, affiliation: affiliation)
+      UserAffiliation.create!(user: other_user, affiliation: affiliation)
+
+      expect do
+        delete "/api/v1/affiliations/#{user_affiliation.id}"
+      end.not_to change(Affiliation, :count)
+    end
+  end
+
+  describe 'create/update with blank department or group' do
+    let(:user) { create(:person) }
+    let(:warden_instance) { instance_double(WardenAuthentication) }
+
+    before do
+      allow(WardenAuthentication).to receive(:new).and_return(warden_instance)
+      allow(warden_instance).to receive(:current_user).and_return(user)
+    end
+
+    it 'accepts a create when department and group are sent blank', :aggregate_failures do
+      post '/api/v1/affiliations', params: { organization: 'KIT', country: 'Germany', department: '', group: '' }
+      expect(response).to have_http_status(:created)
+      expect(user.reload.affiliations.last.organization).to eq('KIT')
+    end
+
+    it 'accepts blank from/to date strings' do
+      post '/api/v1/affiliations', params: { organization: 'KIT', from: '', to: '' }
+      expect(response).to have_http_status(:created)
+    end
+
+    it 'reuses the existing organization row for a case variant', :aggregate_failures do
+      Affiliation.create!(organization: 'KIT')
+      expect do
+        post '/api/v1/affiliations', params: { organization: 'kit' }
+      end.not_to change(Affiliation, :count)
+      expect(user.reload.affiliations.last.organization).to eq('KIT')
+    end
+
+    it 'accepts an update with a blank department', :aggregate_failures do
+      ua = UserAffiliation.create!(user: user, affiliation: Affiliation.create!(organization: 'KIT', department: 'IOC'))
+      put '/api/v1/affiliations', params: { id: ua.id, organization: 'KIT', department: '' }
+      expect(response).to have_http_status(:ok)
+      expect(ua.reload.affiliation.department).to be_nil
+    end
+
+    it 'rejects a duplicate affiliation and notifies the user', :aggregate_failures do
+      details = { organization: 'KIT', department: 'IOC', country: 'Germany' }
+      post '/api/v1/affiliations', params: details
+      expect do
+        post '/api/v1/affiliations', params: details
+      end.not_to change(user.user_affiliations, :count)
+      expect(response).to have_http_status(422)
+      expect(parsed_json_response['error']).to eq('You already have this affiliation.')
+    end
+  end
+
+  describe 'from/to dates on a user affiliation' do
+    let(:user) { create(:person) }
+    let(:warden_instance) { instance_double(WardenAuthentication) }
+
+    before do
+      allow(WardenAuthentication).to receive(:new).and_return(warden_instance)
+      allow(warden_instance).to receive(:current_user).and_return(user)
+    end
+
+    it 'stores from and to on the link, not on the shared affiliation', :aggregate_failures do
+      post '/api/v1/affiliations', params: { organization: 'KIT', from: '2020-01-01', to: '2022-12-31' }
+      ua = user.user_affiliations.last
+      expect(ua.from).to eq(Date.new(2020, 1, 1))
+      expect(ua.to).to eq(Date.new(2022, 12, 31))
+      expect(ua.affiliation.from).to be_nil
+    end
+
+    it 'rejects editing one affiliation into another the user already has', :aggregate_failures do
+      Affiliation.create!(organization: 'KIT')
+      post '/api/v1/affiliations', params: { organization: 'KIT' }
+      post '/api/v1/affiliations', params: { organization: 'MIT' }
+      mit = user.user_affiliations.find_by(affiliation: Affiliation.find_by(organization: 'MIT'))
+      put '/api/v1/affiliations', params: { id: mit.id, organization: 'KIT' }
+      expect(response).to have_http_status(422)
+      expect(parsed_json_response['error']).to eq('You already have this affiliation.')
+    end
+
+    it 'updates the dates without splitting the affiliation row', :aggregate_failures do
+      post '/api/v1/affiliations', params: { organization: 'KIT', from: '2020-01-01' }
+      ua = user.user_affiliations.last
+      expect do
+        put '/api/v1/affiliations', params: { id: ua.id, organization: 'KIT', to: '2024-06-30' }
+      end.not_to change(Affiliation, :count)
+      expect(ua.reload.to).to eq(Date.new(2024, 6, 30))
+    end
+  end
+
+  describe 'GET /api/v1/affiliation_suggestions' do
+    let(:user) { create(:person) }
+    let(:warden_instance) { instance_double(WardenAuthentication) }
+
+    before do
+      allow(WardenAuthentication).to receive(:new).and_return(warden_instance)
+      allow(warden_instance).to receive(:current_user).and_return(user)
+      create(:affiliation_suggestion, user: user, organization: 'KIT', status: :pending)
+      create(:affiliation_suggestion, user: user, organization: 'MIT', status: :approved)
+    end
+
+    it 'returns pending suggestions for current user' do
+      get '/api/v1/affiliation_suggestions', params: { status: 'pending' }
+      expect(response).to have_http_status(:ok)
+      result = parsed_json_response
+      expect(result.length).to eq(1)
+      expect(result.first['organization']).to eq('KIT')
+    end
+  end
+end

--- a/spec/factories/affiliation_suggestions.rb
+++ b/spec/factories/affiliation_suggestions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :affiliation_suggestion do
+    organization { 'KIT' }
+    department { 'IOC' }
+    group { nil }
+    country { 'Germany' }
+    status { :pending }
+    association :user, factory: :person
+  end
+end

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: affiliations
+#
+#  id           :integer          not null, primary key
+#  company      :string
+#  country      :string
+#  organization :string
+#  department   :string
+#  group        :string
+#  created_at   :datetime
+#  updated_at   :datetime
+#  from         :date
+#  to           :date
+#  domain       :string
+#  cat          :string
+#  ror_id       :string
+#
+
+require 'rails_helper'
+
+RSpec.describe Affiliation do
+  describe '.normalize_key' do
+    it 'returns empty string for blank input' do
+      expect(described_class.normalize_key(nil)).to eq('')
+      expect(described_class.normalize_key('')).to eq('')
+      expect(described_class.normalize_key('   ')).to eq('')
+    end
+
+    it 'lowercases and collapses punctuation/whitespace' do
+      expect(described_class.normalize_key('Organic   Chemistry!!')).to eq('organic chemistry')
+    end
+
+    it 'strips accents' do
+      expect(described_class.normalize_key('Jäne')).to eq('jane')
+    end
+
+    it 'maps accent+case variants to the same key as the plain form' do
+      expect(described_class.normalize_key('Jäne DOË'))
+        .to eq(described_class.normalize_key('jane doe'))
+    end
+
+    it 'does not merge genuinely different values' do
+      expect(described_class.normalize_key('Organic Chemistry'))
+        .not_to eq(described_class.normalize_key('Inorganic Chemistry'))
+    end
+
+    # Documented limitation: NFKD does not transliterate ü -> ue
+    it 'treats umlaut and -ue spellings as distinct' do
+      expect(described_class.normalize_key('Müller'))
+        .not_to eq(described_class.normalize_key('Mueller'))
+    end
+  end
+
+  describe '.canonical' do
+    let(:base_attrs) { { organization: 'KIT', department: 'Organic Chemistry', group: 'Jäne Doë' } }
+
+    before { described_class.create!(base_attrs) }
+
+    it 'returns the input unchanged when blank' do
+      expect(described_class.canonical(:department, '')).to eq('')
+      expect(described_class.canonical(:department, nil)).to be_nil
+    end
+
+    it 'returns the existing stored value for a near-duplicate department' do
+      expect(described_class.canonical(:department, 'organic   chemistry'))
+        .to eq('Organic Chemistry')
+    end
+
+    it 'matches the reserved-word group column too' do
+      expect(described_class.canonical(:group, 'jane doe')).to eq('Jäne Doë')
+    end
+
+    it 'returns the input when no stored value matches' do
+      expect(described_class.canonical(:department, 'Photochemistry'))
+        .to eq('Photochemistry')
+    end
+
+    it 'ignores rows with blank values in the field' do
+      described_class.create!(organization: 'KIT', department: nil, group: nil)
+      expect(described_class.canonical(:department, 'something new'))
+        .to eq('something new')
+    end
+  end
+end

--- a/spec/models/affiliation_suggestion_spec.rb
+++ b/spec/models/affiliation_suggestion_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: affiliation_suggestions
+#
+#  id                         :bigint           not null, primary key
+#  country                    :string
+#  department                 :string
+#  from                       :date
+#  group                      :string
+#  organization               :string
+#  status                     :integer          default("pending"), not null
+#  to                         :date
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  affiliation_id             :integer
+#  ror_id                     :string
+#  target_user_affiliation_id :integer
+#  user_id                    :integer          not null
+#
+# Indexes
+#
+#  index_affiliation_suggestions_on_status   (status)
+#  index_affiliation_suggestions_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe AffiliationSuggestion, type: :model do
+  let(:user) { create(:person) }
+
+  describe 'validations' do
+    it 'is valid without organization (department-only suggestion)' do
+      suggestion = build(:affiliation_suggestion, user: user, organization: nil, department: 'IOC')
+      expect(suggestion).to be_valid
+    end
+
+    it 'is valid with organization and user' do
+      suggestion = build(:affiliation_suggestion, user: user, organization: 'KIT')
+      expect(suggestion).to be_valid
+    end
+  end
+
+  describe 'status enum' do
+    it 'defaults to pending' do
+      suggestion = create(:affiliation_suggestion, user: user, organization: 'KIT')
+      expect(suggestion).to be_pending
+    end
+
+    it 'can be approved' do
+      suggestion = create(:affiliation_suggestion, user: user, organization: 'KIT')
+      suggestion.approved!
+      expect(suggestion).to be_approved
+    end
+
+    it 'can be rejected' do
+      suggestion = create(:affiliation_suggestion, user: user, organization: 'KIT')
+      suggestion.rejected!
+      expect(suggestion).to be_rejected
+    end
+  end
+end

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'User registration affiliation routing', type: :request do
+  let(:base_params) do
+    {
+      first_name: 'New', last_name: 'Bie',
+      password: 'testtest123', password_confirmation: 'testtest123'
+    }
+  end
+
+  it 'files a pending suggestion when the organization is not in the registry', :aggregate_failures do
+    expect do
+      post user_registration_path, params: { user: base_params.merge(
+        email: 'newbie@example.com', name_abbreviation: 'nb1',
+        affiliations_attributes: { '0' => { organization: 'Totally New Institute', country: 'Germany' } }
+      ) }
+    end.to change(AffiliationSuggestion, :count).by(1)
+
+    user = User.find_by(email: 'newbie@example.com')
+    expect(user.affiliations).to be_empty
+    expect(AffiliationSuggestion.last.organization).to eq('Totally New Institute')
+  end
+
+  it 'drops a country that is not on the ISO list', :aggregate_failures do
+    post user_registration_path, params: { user: base_params.merge(
+      email: 'madeup@example.com', name_abbreviation: 'mu1',
+      affiliations_attributes: { '0' => { organization: 'Some New Lab', country: 'Middle Earth' } }
+    ) }
+
+    expect(AffiliationSuggestion.last.organization).to eq('Some New Lab')
+    expect(AffiliationSuggestion.last.country).to be_nil
+  end
+
+  it 'attaches an existing registry organization without a suggestion', :aggregate_failures do
+    Affiliation.create!(organization: 'KIT', country: 'Germany')
+
+    expect do
+      post user_registration_path, params: { user: base_params.merge(
+        email: 'kit@example.com', name_abbreviation: 'kt1',
+        affiliations_attributes: { '0' => { organization: 'KIT', country: 'Germany' } }
+      ) }
+    end.not_to change(AffiliationSuggestion, :count)
+
+    expect(User.find_by(email: 'kit@example.com').affiliations.map(&:organization)).to include('KIT')
+  end
+end


### PR DESCRIPTION
## What this does

Reworks "My Affiliations" and adds an admin/moderator review step for new affiliation values.

The old form took free-text for organization/department/group, so the registry slowly filled with typos and near-duplicates. Organizations now come from ROR, and anything genuinely new has to be approved before it enters the shared registry. Signup goes through the same path.

## Behaviour

You build a row first. The "+" on a column stages a new value into the row rather than submitting it. On Save, a row containing any new value becomes a single pending suggestion; a row made only of existing values just saves. Editing an existing affiliation works the same way: your current one stays put until a reviewer approves the change. Affiliations also support optional From/To dates.

Reviewers receive a list to approve or reject and can fix a suggestion (e.g., correct a typo or link to the right ROR org) before approving it. Approve adds the value to the registry (reusing a matching row if there is one) and either attaches it to the user or repoints the affiliation being edited. Reject leaves the user's existing affiliation untouched. Approve/reject is concurrency-safe — the row is locked so two reviewers (or a double-click) can't both process the same suggestion. Users can withdraw their own pending suggestions. The user is emailed when a suggestion is submitted, approved, or rejected.

An admin can delegate this review work: granting a user the `Affiliation Moderator` privilege (User Management) gives them a **Requests** tab in their own Settings → Affiliations, with the same approve/reject/edit tools as the admin panel — without giving them admin access.

## Implementation notes

- ROR backs org field; we store `ror_ids by it.
- API logic lives in use cases now, so the Grape endpoints are thin. Frontend talks through ChemotionApiClient.
- Matching ignores case and accents, so "Organic Chemistry" and "organic chemistry" don't both land in the registry.
- Signup routes through the same suggesettings page: a known organization isattached immediately, a new one files a pending suggestion.

## Schema
- New `affiliation_suggestions` table (, `ror_id`,`target_user_affiliation_id`).
- New `ror_id` on `affiliations`.
- New `affiliation_moderator` flag on u

## Test Instance
https://az-affiliations.deploy.chemdev.scc.kit.edu/


----------
- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [x] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
