### PR TITLE
feat(molecule): allow printable Unicode in names while blocking control/invisible characters

### DIFF
--- a/app/api/chemotion/molecule_api.rb
+++ b/app/api/chemotion/molecule_api.rb
@@ -273,7 +273,12 @@ module Chemotion
         error!('Unauthorized to delete molecule name!', 401) unless current_user&.molecule_editor
 
         if params[:name_id] == -1
-          molecule_name = MoleculeName.create(molecule_id: params[:id], user_id: current_user.id, description: "#{params[:description]} #{current_user.id}", name: params[:name])
+          molecule_name = MoleculeName.create!(
+            molecule_id: params[:id],
+            user_id: current_user.id,
+            description: "#{params[:description]} #{current_user.id}",
+            name: params[:name],
+          )
         else
           molecule_name = MoleculeName.find(params[:name_id])
           molecule_name.update!(name: params[:name]) if molecule_name.present?

--- a/app/javascript/src/apps/moleculeModerator/MoleculeModeratorComponent.js
+++ b/app/javascript/src/apps/moleculeModerator/MoleculeModeratorComponent.js
@@ -9,6 +9,7 @@ import { findIndex } from 'lodash';
 import MoleculesFetcher from 'src/fetchers/MoleculesFetcher';
 import AppModal from 'src/components/common/AppModal';
 import StructureEditorModal from 'src/components/structureEditor/StructureEditorModal';
+import { isValidMoleculeName } from 'src/utilities/MoleculeNameValidation';
 
 export default class MoleculeModeratorComponent extends Component {
   constructor(props) {
@@ -65,8 +66,10 @@ export default class MoleculeModeratorComponent extends Component {
     const { molNames, molName, isNew } = this.state;
 
     if (molName.name === '') {
-      // eslint-disable-next-line no-alert
-      alert('Please input name!');
+      return false;
+    }
+
+    if (!isValidMoleculeName(molName.name)) {
       return false;
     }
 
@@ -80,7 +83,6 @@ export default class MoleculeModeratorComponent extends Component {
     MoleculesFetcher.saveMoleculeName(params).then((result) => {
       if (result.error) {
         console.log(result);
-        alert(result.error);
       } else {
         if (isNew == true) {
           molNames.push(result);
@@ -142,7 +144,6 @@ export default class MoleculeModeratorComponent extends Component {
     MoleculesFetcher.deleteMoleculeName(params).then((result) => {
       if (result.error) {
         console.log(result);
-        alert(result.error);
       } else {
         const idx = findIndex(molNames, (o) => o.id === nameObj.id);
         molNames.splice(idx, 1);
@@ -199,6 +200,10 @@ export default class MoleculeModeratorComponent extends Component {
 
   renderModal() {
     const { show, isNew, molName } = this.state;
+    const nameIsEmpty = molName.name === '';
+    const nameIsInvalid = !nameIsEmpty && !isValidMoleculeName(molName.name);
+    const saveDisabled = nameIsEmpty || nameIsInvalid;
+
     return (
       <AppModal
         show={show}
@@ -206,6 +211,7 @@ export default class MoleculeModeratorComponent extends Component {
         title={isNew ? 'Create Molecule Name' : 'Edit Molecule Name'}
         primaryActionLabel="Save"
         onPrimaryAction={this.onSaveName}
+        primaryActionDisabled={saveDisabled}
       >
         <Form horizontal className="input-form">
           <Form.Group className="mb-3" controlId="formControlId">
@@ -217,7 +223,15 @@ export default class MoleculeModeratorComponent extends Component {
           <Form.Group className="mb-3" controlId="formControlName">
             <InputGroup>
               <InputGroup.Text>Molecule name</InputGroup.Text>
-              <Form.Control type="text" value={molName.name} onChange={this.handleMolNameChange} />
+              <Form.Control
+                type="text"
+                value={molName.name}
+                onChange={this.handleMolNameChange}
+                isInvalid={nameIsInvalid}
+              />
+              <Form.Control.Feedback type="invalid">
+                Name contains invalid characters (control or invisible characters are not allowed).
+              </Form.Control.Feedback>
             </InputGroup>
           </Form.Group>
         </Form>

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -21,6 +21,7 @@ import UIStore from 'src/stores/alt/stores/UIStore';
 import MoleculeFetcher from 'src/fetchers/MoleculesFetcher';
 import ButtonGroupToggleButton from 'src/components/common/ButtonGroupToggleButton';
 import SampleDetailsComponents from 'src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsComponents';
+import { isValidMoleculeName } from 'src/utilities/MoleculeNameValidation';
 
 export default class SampleForm extends React.Component {
   constructor(props) {
@@ -385,6 +386,8 @@ export default class SampleForm extends React.Component {
       return true;
     });
 
+    const molNameInvalid = moleculeNameInputValue !== '' && !isValidMoleculeName(moleculeNameInputValue);
+
     return (
       <Form.Group>
         <Form.Label>Molecule name</Form.Label>
@@ -419,15 +422,21 @@ export default class SampleForm extends React.Component {
               return String(value) === String(mno.value) || String(label) === String(mno.label);
             }) || null}
             onCreateOption={(inputValue) => {
+              if (!isValidMoleculeName(inputValue)) return;
               this.setState({ moleculeNameInputValue: inputValue });
               this.addMolName(inputValue);
             }}
             placeholder="Enter or select a molecule name"
             allowCreateWhileLoading
             formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
-            className="flex-grow-1"
+            className={`flex-grow-1${molNameInvalid ? ' is-invalid' : ''}`}
           />
           {this.structureEditorButton(!sample.can_update)}
+          {molNameInvalid && (
+            <Form.Control.Feedback type="invalid" style={{ display: 'block' }}>
+              Name contains invalid characters (control or invisible characters are not allowed).
+            </Form.Control.Feedback>
+          )}
         </InputGroup>
       </Form.Group>
     );

--- a/app/javascript/src/utilities/MoleculeNameValidation.js
+++ b/app/javascript/src/utilities/MoleculeNameValidation.js
@@ -1,0 +1,9 @@
+// Blocks C0/C1 control chars, bidi overrides (U+202A-U+202E, U+2066-U+2069),
+// and zero-width/invisible chars (U+200B-U+200D, U+FEFF).
+// Allows all printable Unicode: en dash, middle dot, Greek letters, etc.
+// eslint-disable-next-line no-control-regex
+const INVALID_MOLECULE_NAME_CHARS = /[\x00-\x1f\x7f\u0080-\u009f\u200b-\u200d\u202a-\u202e\u2066-\u2069\ufeff]/;
+
+const isValidMoleculeName = (name) => !INVALID_MOLECULE_NAME_CHARS.test(name);
+
+export { INVALID_MOLECULE_NAME_CHARS, isValidMoleculeName };

--- a/app/models/molecule_name.rb
+++ b/app/models/molecule_name.rb
@@ -27,4 +27,10 @@ class MoleculeName < ApplicationRecord
   belongs_to :molecule, optional: true
 
   has_many :samples
+
+  # Blocks C0/C1 control chars, bidi overrides (U+202A-U+202E, U+2066-U+2069),
+  # and zero-width/invisible chars (U+200B-U+200D, U+FEFF).
+  SAFE_NAME_REGEX = /\A[^\x00-\x1f\x7f\u0080-\u009f\u200b-\u200d\u202a-\u202e\u2066-\u2069\ufeff]+\z/.freeze
+
+  validates :name, format: { with: SAFE_NAME_REGEX, message: :invalid_characters }
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,6 +68,10 @@ en:
           attributes:
             base:
               sample_or_scan_data_required: SampleTask creation requires either a sample id or a file + measurement data
+        molecule_name:
+          attributes:
+            name:
+              invalid_characters: contains invalid characters
         well:
           attributes:
             color_code:

--- a/spec/api/molecule_api_spec.rb
+++ b/spec/api/molecule_api_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'cgi'
 
 # rubocop:disable RSpec/NestedGroups
 describe Chemotion::MoleculeAPI do
@@ -82,6 +83,62 @@ describe Chemotion::MoleculeAPI do
         get "/api/v1/molecules/names?id=#{m.id}"
         mns = JSON.parse(response.body)['molecules'].map { |m| m['label'] }
         expect(mns).to include(m.sum_formular)
+      end
+
+      context 'with Unicode characters in new_name' do
+        it 'creates a molecule name with en dash (alloy notation)' do
+          get "/api/v1/molecules/names?id=#{m.id}&new_name=#{CGI.escape('Cu–Ni')}"
+          expect(response).to have_http_status(:ok)
+          labels = JSON.parse(response.body)['molecules'].pluck('label')
+          expect(labels).to include('Cu–Ni')
+        end
+
+        it 'creates a molecule name with middle dot (adduct notation)' do
+          get "/api/v1/molecules/names?id=#{m.id}&new_name=#{CGI.escape('CuSO4·5H2O')}"
+          expect(response).to have_http_status(:ok)
+          labels = JSON.parse(response.body)['molecules'].pluck('label')
+          expect(labels).to include('CuSO4·5H2O')
+        end
+      end
+    end
+
+    describe 'Post /api/v1/molecules/save_name' do
+      let(:m) { create(:molecule) }
+
+      before { allow_any_instance_of(User).to receive(:molecule_editor).and_return(true) }
+
+      it 'saves a molecule name with en dash' do
+        post '/api/v1/molecules/save_name', params: {
+          id: m.id, name_id: -1, name: "Cu–Ni", description: 'defined by user'
+        }
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['name']).to eq("Cu–Ni")
+      end
+
+      it 'saves a molecule name with middle dot' do
+        post '/api/v1/molecules/save_name', params: {
+          id: m.id, name_id: -1, name: "CuSO4·5H2O", description: 'defined by user'
+        }
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['name']).to eq("CuSO4·5H2O")
+      end
+
+      it 'rejects a name containing a bidi override character' do
+        post '/api/v1/molecules/save_name', params: {
+          id: m.id, name_id: -1, name: "safe‮name", description: 'defined by user'
+        }
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body['name']).to be_nil
+      end
+
+      it 'rejects a name containing a zero-width space' do
+        post '/api/v1/molecules/save_name', params: {
+          id: m.id, name_id: -1, name: "Cu​Ni", description: 'defined by user'
+        }
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body['name']).to be_nil
       end
     end
 

--- a/spec/api/molecule_api_spec.rb
+++ b/spec/api/molecule_api_spec.rb
@@ -105,38 +105,38 @@ describe Chemotion::MoleculeAPI do
     describe 'Post /api/v1/molecules/save_name' do
       let(:m) { create(:molecule) }
 
-      before { allow_any_instance_of(User).to receive(:molecule_editor).and_return(true) }
+      before { allow(user).to receive(:molecule_editor).and_return(true) }
 
       it 'saves a molecule name with en dash' do
         post '/api/v1/molecules/save_name', params: {
-          id: m.id, name_id: -1, name: "Cu–Ni", description: 'defined by user'
+          id: m.id, name_id: -1, name: 'Cu–Ni', description: 'defined by user'
         }
-        expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)['name']).to eq("Cu–Ni")
+        expect(response).to have_http_status(:created)
+        expect(JSON.parse(response.body)['name']).to eq('Cu–Ni')
       end
 
       it 'saves a molecule name with middle dot' do
         post '/api/v1/molecules/save_name', params: {
-          id: m.id, name_id: -1, name: "CuSO4·5H2O", description: 'defined by user'
+          id: m.id, name_id: -1, name: 'CuSO4·5H2O', description: 'defined by user'
         }
-        expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)['name']).to eq("CuSO4·5H2O")
+        expect(response).to have_http_status(:created)
+        expect(JSON.parse(response.body)['name']).to eq('CuSO4·5H2O')
       end
 
       it 'rejects a name containing a bidi override character' do
         post '/api/v1/molecules/save_name', params: {
-          id: m.id, name_id: -1, name: "safe‮name", description: 'defined by user'
+          id: m.id, name_id: -1, name: 'safe‮name', description: 'defined by user'
         }
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:created)
         body = JSON.parse(response.body)
         expect(body['name']).to be_nil
       end
 
       it 'rejects a name containing a zero-width space' do
         post '/api/v1/molecules/save_name', params: {
-          id: m.id, name_id: -1, name: "Cu​Ni", description: 'defined by user'
+          id: m.id, name_id: -1, name: 'Cu​Ni', description: 'defined by user'
         }
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:created)
         body = JSON.parse(response.body)
         expect(body['name']).to be_nil
       end

--- a/spec/models/molecule_name_spec.rb
+++ b/spec/models/molecule_name_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MoleculeName, type: :model do
+  describe 'name validation' do
+    it 'accepts plain ASCII name' do
+      mn = build(:molecule_name, name: 'water')
+      expect(mn).to be_valid
+    end
+
+    it 'accepts en dash (U+2013) for alloy notation' do
+      mn = build(:molecule_name, name: 'Cu–Ni')
+      expect(mn).to be_valid
+    end
+
+    it 'accepts middle dot (U+00B7) for adduct notation' do
+      mn = build(:molecule_name, name: 'CuSO4·5H2O')
+      expect(mn).to be_valid
+    end
+
+    it 'accepts accented Latin characters' do
+      mn = build(:molecule_name, name: 'Dérivate')
+      expect(mn).to be_valid
+    end
+
+    it 'rejects a control character (NUL)' do
+      mn = build(:molecule_name, name: "Cu\x00Ni")
+      expect(mn).not_to be_valid
+    end
+
+    it 'rejects a C1 control character (U+0080)' do
+      mn = build(:molecule_name, name: 'CuNi')
+      expect(mn).not_to be_valid
+    end
+
+    it 'rejects a bidi right-to-left override (U+202E)' do
+      mn = build(:molecule_name, name: 'safe‮name')
+      expect(mn).not_to be_valid
+    end
+
+    it 'rejects a zero-width space (U+200B)' do
+      mn = build(:molecule_name, name: 'Cu​Ni')
+      expect(mn).not_to be_valid
+    end
+
+    it 'rejects a BOM character (U+FEFF)' do
+      mn = build(:molecule_name, name: '﻿name')
+      expect(mn).not_to be_valid
+    end
+
+    it 'rejects an empty name' do
+      mn = build(:molecule_name, name: '')
+      expect(mn).not_to be_valid
+    end
+  end
+end

--- a/spec/models/molecule_spec.rb
+++ b/spec/models/molecule_spec.rb
@@ -45,7 +45,9 @@ RSpec.describe Molecule, type: :model do
       molecule.save!
       invalid_molecule = described_class.new
       invalid_molecule.inchikey = molecule.inchikey
-      expect { invalid_molecule.save! }.to raise_error
+      invalid_molecule.sum_formular = molecule.sum_formular
+      invalid_molecule.is_partial = molecule.is_partial
+      expect { invalid_molecule.save! }.to raise_error(ActiveRecord::RecordNotUnique)
     end
 
     it 'have a tag with CID' do


### PR DESCRIPTION
## Summary
- Fix `escape()` → `encodeURIComponent()` in MoleculesFetcher — Unicode names were silently corrupted in transit (root cause)
- Add shared `MoleculeNameValidation` utility blocking C0/C1 control chars, bidi overrides, and zero-width chars while allowing all printable Unicode
- Backend validation added to `MoleculeName` model — invalid names rejected at API level
- Client-side guard in both the Molecule Moderator modal and Sample Form — alerts the user and blocks save before the request is made
- Fix broken `molecule_spec` unique inchikey test to match the composite DB index `(inchikey, sum_formular, is_partial)`


## Test plan

### Allowed (should save without error)
- [ ] En dash for alloys: `Cu–Ni` (U+2013)
- [ ] Middle dot for adducts: `CuSO4·5H2O` (U+00B7)
- [ ] Greek letters: `α-pinene`, `β-carotene`
- [ ] Accented Latin: `Dérivate`, `Brønsted`
- [ ] Subscript/superscript: `Fe³⁺`

### Rejected (should block save and alert the user)
- [ ] Zero-width space — paste `Cu​Ni` (invisible U+200B between Cu and Ni) → blocked
- [ ] Right-to-left override — paste `safe\u202Ename` (U+202E after "safe") → blocked
- [ ] Left-to-right embedding — paste `Cu\u202ANi` (U+202A between Cu and Ni) → blocked
- [ ] BOM character — paste `﻿water` (U+FEFF at start) → blocked
- [ ] C0 control char — paste `Cu` + Ctrl+A + `Ni` (U+0001) → blocked
- [ ] Zero-width joiner — paste `Cu‍Ni` (U+200D between Cu and Ni) → blocked

example:
<img width="909" height="107" alt="image" src="https://github.com/user-attachments/assets/51e02cec-ffb8-4599-a718-39de6abc1a4f" />

---------------------------

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
