### PR TITLE
fix: harden sample-task loading, dedup All-collection inserts, and reaction comment N+1

### DIFF
--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -283,9 +283,12 @@ module Chemotion
         reaction.save!
         update_element_labels(reaction, params[:user_labels], current_user.id)
         reaction.save_segments(segments: params[:segments], current_user_id: current_user.id)
-        CollectionsReaction.create(reaction: reaction, collection: collection)
-        CollectionsReaction.create(reaction: reaction,
-                                   collection: Collection.get_all_collection_for_user(current_user.id))
+        all_collection = Collection.get_all_collection_for_user(current_user.id)
+        # Use find_or_create_by so we don't violate the unique
+        # (reaction_id, collection_id) index when the chosen collection is the
+        # user's "All" collection (both inserts would otherwise be identical).
+        CollectionsReaction.find_or_create_by(reaction: reaction, collection: collection) if collection
+        CollectionsReaction.find_or_create_by(reaction: reaction, collection: all_collection)
         CollectionsReaction.update_tag_by_element_ids(reaction.id)
 
         if reaction

--- a/app/api/chemotion/research_plan_api.rb
+++ b/app/api/chemotion/research_plan_api.rb
@@ -96,7 +96,7 @@ module Chemotion
         all_coll = Collection.get_all_collection_for_user(current_user.id)
         # Avoid violating the unique (research_plan_id, collection_id) index when
         # the chosen collection is already the user's "All" collection.
-        research_plan.collections << all_coll if all_coll && !research_plan.collections.include?(all_coll)
+        research_plan.collections << all_coll if all_coll && research_plan.collections.exclude?(all_coll)
 
         update_element_labels(research_plan, params[:user_labels], current_user.id)
         present research_plan.reload, with: Entities::ResearchPlanEntity, root: :research_plan

--- a/app/api/chemotion/research_plan_api.rb
+++ b/app/api/chemotion/research_plan_api.rb
@@ -94,7 +94,9 @@ module Chemotion
         end
 
         all_coll = Collection.get_all_collection_for_user(current_user.id)
-        research_plan.collections << all_coll
+        # Avoid violating the unique (research_plan_id, collection_id) index when
+        # the chosen collection is already the user's "All" collection.
+        research_plan.collections << all_coll if all_coll && !research_plan.collections.include?(all_coll)
 
         update_element_labels(research_plan, params[:user_labels], current_user.id)
         present research_plan.reload, with: Entities::ResearchPlanEntity, root: :research_plan

--- a/app/api/chemotion/screen_api.rb
+++ b/app/api/chemotion/screen_api.rb
@@ -195,8 +195,11 @@ module Chemotion
         recent_ols_term_update('chmo', kinds) if kinds&.length&.positive?
 
         collection = current_user.collections.where(id: params[:collection_id]).take
-        screen.collections << collection
-        screen.collections << Collection.get_all_collection_for_user(current_user.id)
+        all_collection = Collection.get_all_collection_for_user(current_user.id)
+        # Avoid violating the unique (screen_id, collection_id) index when the
+        # chosen collection is already the user's "All" collection.
+        screen.collections << collection if collection
+        screen.collections << all_collection if all_collection && !screen.collections.include?(all_collection)
 
         params[:wellplate_ids].each do |id|
           ScreensWellplate.find_or_create_by(wellplate_id: id, screen_id: screen.id)

--- a/app/api/chemotion/screen_api.rb
+++ b/app/api/chemotion/screen_api.rb
@@ -199,7 +199,7 @@ module Chemotion
         # Avoid violating the unique (screen_id, collection_id) index when the
         # chosen collection is already the user's "All" collection.
         screen.collections << collection if collection
-        screen.collections << all_collection if all_collection && !screen.collections.include?(all_collection)
+        screen.collections << all_collection if all_collection && screen.collections.exclude?(all_collection)
 
         params[:wellplate_ids].each do |id|
           ScreensWellplate.find_or_create_by(wellplate_id: id, screen_id: screen.id)

--- a/app/api/entities/reaction_entity.rb
+++ b/app/api/entities/reaction_entity.rb
@@ -108,7 +108,10 @@ module Entities
     end
 
     def comment_count
-      object.comments.count
+      # Use size so the preloaded :comments association (see
+      # Reaction.includes_for_list_display) is counted in memory, avoiding an
+      # N+1 COUNT(*) query per reaction in the list endpoint.
+      object.comments.size
     end
 
     def variations

--- a/app/javascript/src/apps/mydb/mainNavigation/topbar/NoticeButton.js
+++ b/app/javascript/src/apps/mydb/mainNavigation/topbar/NoticeButton.js
@@ -205,13 +205,15 @@ export default function NoticeButton() {
     if (remainTime < idleTimeoutRef.current) {
       const { attachmentNotificationStore } = context;
       MessagesFetcher.fetchMessages(0).then((result) => {
-        result.messages.forEach((message) => {
+        const messages = result?.messages;
+        if (!Array.isArray(messages)) { return; }
+        messages.forEach((message) => {
           if (message.subject === 'Send TPA attachment arrival notification') {
             attachmentNotificationStore.addMessage(message);
           }
         });
-        result.messages.sort((a, b) => b.id - a.id);
-        setNewNotices(result.messages);
+        messages.sort((a, b) => b.id - a.id);
+        setNewNotices(messages);
         setServerVersion(result.version);
       });
     }

--- a/app/javascript/src/fetchers/SampleTasksFetcher.js
+++ b/app/javascript/src/fetchers/SampleTasksFetcher.js
@@ -6,7 +6,9 @@ export default class SampleTaskFetcher {
   }
 
   static assignSample(sampleId, sampleTaskId) {
-    return ApiClient.putJson(`/api/v1/sample_tasks/${sampleTaskId}`, { body: sampleId });
+    return ApiClient.putJson(`/api/v1/sample_tasks/${sampleTaskId}`, {
+      body: { sample_id: sampleId }
+    });
   }
 
   static createSampleTask(sampleId, requiredScanResults) {
@@ -23,7 +25,17 @@ export default class SampleTaskFetcher {
   }
 
   static #fetchSampleTasks(status) {
-    return ApiClient.getJson(`/api/v1/sample_tasks?status=${status}`)
-      .then((json) => json.sample_tasks);
+    return ApiClient.getJson(`/api/v1/sample_tasks?status=${status}`, {
+      handleResponseSuccess: (response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to fetch sample tasks (status=${status}): ${response.status} ${response.statusText}`);
+        }
+        return response.json();
+      },
+      handleResponseError: (error) => {
+        console.error(error);
+        return { sample_tasks: [] };
+      }
+    }).then((json) => json.sample_tasks || []);
   }
 }

--- a/app/javascript/src/models/SequenceBasedMacromoleculeSample.js
+++ b/app/javascript/src/models/SequenceBasedMacromoleculeSample.js
@@ -1281,7 +1281,7 @@ export default class SequenceBasedMacromoleculeSample extends Element {
       obtained_by: '',
       supplier: '',
       formulation: '',
-      purity: '',
+      purity: 1,
       purity_detection: '',
       purification_method: '',
       inventory_sample: false,

--- a/app/javascript/src/stores/mobx/SampleTasksStore.jsx
+++ b/app/javascript/src/stores/mobx/SampleTasksStore.jsx
@@ -34,6 +34,9 @@ export const SampleTasksStore = types
     load: flow(function* loadOpenSampleTasks() {
       let result = yield SampleTasksFetcher.openSampleTasks();
       self.sample_tasks.clear();
+
+      if (!Array.isArray(result)) { return; }
+
       result.forEach(entry => self.sample_tasks.set(entry.id, SampleTask.create({ ...entry })));
     }),
     toggleSampleTaskInbox() {

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -109,7 +109,7 @@ class Reaction < ApplicationRecord
   scope :by_status, ->(query) { where('reactions.status ILIKE ?', "%#{sanitize_sql_like(query)}%") }
   scope :search_by_reaction_status, ->(query) { where(status: query) }
   scope :search_by_reaction_rinchi_string, ->(query) { where(rinchi_string: query) }
-  scope :includes_for_list_display, -> { includes(:tag) }
+  scope :includes_for_list_display, -> { includes(:tag, :comments) }
 
   has_many :collections_reactions, dependent: :destroy
   has_many :collections, through: :collections_reactions

--- a/app/usecases/device_descriptions/create.rb
+++ b/app/usecases/device_descriptions/create.rb
@@ -17,15 +17,15 @@ module Usecases
           save_segments(device_description)
           device_description.reload
           collection = Collection.accessible_for(current_user).find(params[:collection_id])
-          CollectionsDeviceDescription.create(device_description: device_description, collection: collection)
-
           all_collection_of_collection_owner = Collection.get_all_collection_for_user(current_user)
-          if collection.id != all_collection_of_collection_owner.id
-            CollectionsDeviceDescription.create(
-              device_description: device_description,
-              collection: all_collection_of_collection_owner,
-            )
-          end
+          # find_or_create_by avoids violating the unique
+          # (device_description_id, collection_id) index when the chosen
+          # collection is already the user's "All" collection.
+          CollectionsDeviceDescription.find_or_create_by(device_description: device_description, collection: collection)
+          CollectionsDeviceDescription.find_or_create_by(
+            device_description: device_description,
+            collection: all_collection_of_collection_owner,
+          )
 
           device_description
         end

--- a/app/usecases/wellplates/create.rb
+++ b/app/usecases/wellplates/create.rb
@@ -22,10 +22,13 @@ module Usecases
           wellplate.save_segments(segments: params[:segments], current_user_id: current_user.id)
           update_element_labels(wellplate, params[:user_labels], current_user.id)
 
+          # find_or_create_by avoids violating the unique
+          # (wellplate_id, collection_id) index when the chosen collection is
+          # already the relevant "All" collection (it is attached on create above).
           if collection_is_owned_by_user?
-            CollectionsWellplate.create(wellplate: wellplate, collection: all_collection_of_current_user)
+            CollectionsWellplate.find_or_create_by(wellplate: wellplate, collection: all_collection_of_current_user)
           elsif collection_is_shared_to_user?
-            CollectionsWellplate.create(wellplate: wellplate, collection: all_collection_of_sharer)
+            CollectionsWellplate.find_or_create_by(wellplate: wellplate, collection: all_collection_of_sharer)
           end
 
           WellplateUpdater


### PR DESCRIPTION
- Guard sample task load when the API returns no array; harden SampleTasksFetcher
- Preload comments and use .size for comment_count on the reactions list (N+1 fix)
- Use find_or_create_by / skip duplicate append when the target collection is already “All” (reactions, samples, wellplates, screens, research plans, device descriptions)
- Default SBMM sample purity to 1 in buildEmpty (UI parity with Sample)

Closes https://github.com/ComPlat/chemotion/issues/507