### PR TITLE
fix(sample): prevent duplicate collection assignment when creating a sample in the "All" collection

### DIFF
--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -595,14 +595,16 @@ module Chemotion
         literatures = attributes.delete(:literatures)
 
         sample = Sample.new(attributes)
+        collections = []
 
         if params[:collection_id]
           collection = Collection.accessible_for(current_user).find_by(id: params[:collection_id])
-          sample.collections << collection if collection.present?
+          collections << collection if collection.present?
         end
 
         all_coll = Collection.get_all_collection_for_user(current_user.id)
-        sample.collections << all_coll
+        collections << all_coll if all_coll.present?
+        sample.collections = collections.uniq
 
         sample.container = update_datamodel(params[:container])
         sample.update_inventory_label(params[:xref][:inventory_label], params[:collection_id])


### PR DESCRIPTION
### Problem

Creating a sample while the active collection is the user's **"All"** collection failed — the sample could not be created.

`SampleAPI`'s create endpoint assigns the new sample to two collections: the collection the request targets (`params[:collection_id]`) and the user's built-in "All" collection. When the targeted collection *is* the "All" collection, the old code appended the same collection record twice:

```ruby
sample.collections << collection if collection.present?   # the targeted collection
...
all_coll = Collection.get_all_collection_for_user(current_user.id)
sample.collections << all_coll                            # the "All" collection — same record
```

This produced a duplicate `collections_samples` join row, which the database rejects, so the whole create transaction failed. The append also ran unconditionally even when `all_coll` was absent.

### Fix

Build the collection list first, deduplicate it, and assign it once (`app/api/chemotion/sample_api.rb:595`):

```ruby
collections = []
collections << collection if collection.present?
collections << all_coll if all_coll.present?
sample.collections = collections.uniq
```

- `.uniq` collapses the duplicate when the targeted collection and the "All" collection are the same record, so no duplicate join row is created.
- The `all_coll.present?` guard avoids appending a `nil`.

### Scope

- One file: `app/api/chemotion/sample_api.rb` (+4 / −2).
- Behavior is unchanged for the normal case (creating a sample in a regular collection still links it to both that collection and "All"); only the previously-failing "All"-collection case is fixed.

### Testing

- [ ] Create a sample with the **"All"** collection active → succeeds, linked once.
- [ ] Create a sample in a regular collection → still linked to both that collection and "All".
