### PR TITLE
fix: handle non-finite volume values gracefully in ReactionDetailsScheme

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
@@ -1942,11 +1942,12 @@ export default class ReactionDetailsScheme extends React.Component {
     const prefix = 'm';
 
     if (!isDisabled) {
-      // Pass undefined explicitly when null/empty to avoid default value of 0
-      // The component will show empty instead of "n.d." when value is undefined
-      const volumeValue = (reaction.volume != null && reaction.volume !== '')
-        ? reaction.volume
-        : undefined;
+      // Coerce to a Number: the backend serializes `volume` (a BigDecimal) as a
+      // string (e.g. "0.005"), and NumeralInputWithUnitsCompo renders "n.d."
+      // whenever the value is not Number.isFinite. Pass undefined for
+      // null/empty/invalid so the field shows empty instead of a default 0.
+      const parsedVolume = parseFloat(reaction.volume);
+      const volumeValue = Number.isFinite(parsedVolume) ? parsedVolume : undefined;
 
       return (
         <Form.Group>


### PR DESCRIPTION
Refactored volume parsing logic to ensure invalid, null, or empty values are coerced to undefined, preventing erroneous default values and maintaining expected UI behavior.

Closes https://github.com/ComPlat/chemotion/issues/508 and duplicates https://github.com/ComPlat/chemotion_ELN/pull/3288