### PR TITLE
feat(reaction): add µmol as unit option to reaction scheme amount fields

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/MaterialCalculations.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/MaterialCalculations.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Form } from 'react-bootstrap';
 
 import NumeralInputWithUnitsCompo from 'src/apps/mydb/elements/details/NumeralInputWithUnitsCompo';
+import { metricPrefixesMol } from 'src/utilities/MetricsUtils';
 
 export default class MaterialCalculations extends Component {
   materialVolume() {
@@ -45,7 +46,6 @@ export default class MaterialCalculations extends Component {
     ) ? material.metrics[0]
       : 'm';
 
-    const metricPrefixesMol = ['m', 'n', 'u'];
     const metricMol = (
       material.metrics
       && material.metrics.length > 2

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/MaterialCalculations.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/MaterialCalculations.js
@@ -45,7 +45,7 @@ export default class MaterialCalculations extends Component {
     ) ? material.metrics[0]
       : 'm';
 
-    const metricPrefixesMol = ['m', 'n'];
+    const metricPrefixesMol = ['m', 'n', 'u'];
     const metricMol = (
       material.metrics
       && material.metrics.length > 2

--- a/app/javascript/src/utilities/MetricsUtils.js
+++ b/app/javascript/src/utilities/MetricsUtils.js
@@ -28,7 +28,7 @@ const metricPrefixesMolConc = ['m', 'n'];
 
 /**
  * Gets the metric prefix for molecular amount (mol) from component metrics.
- * Uses index 2 of the metrics array with valid prefixes ['m', 'n'].
+ * Uses index 2 of the metrics array with valid prefixes ['m', 'n', 'u'].
  *
  * @param {Object} component - The component object containing metrics
  * @returns {string} The metric prefix for mol units (default: 'm')

--- a/app/javascript/src/utilities/MetricsUtils.js
+++ b/app/javascript/src/utilities/MetricsUtils.js
@@ -18,7 +18,7 @@ const getMetricPrefix = (metrics, index, validPrefixes, defaultPrefix = 'm') => 
  * Common metric prefixes for molecular amounts (mol)
  * @type {Array<string>}
  */
-const metricPrefixesMol = ['m', 'n'];
+const metricPrefixesMol = ['m', 'n', 'u'];
 
 /**
  * Common metric prefixes for concentrations (mol/l)

--- a/spec/javascripts/utils/MetricsUtils.spec.js
+++ b/spec/javascripts/utils/MetricsUtils.spec.js
@@ -1,0 +1,72 @@
+import { describe, it } from 'mocha';
+import assert from 'assert';
+
+import {
+  getMetricPrefix,
+  getMetricMol,
+  getMetricMolConc,
+  metricPrefixesMol,
+  metricPrefixesMolConc,
+} from '../../../app/javascript/src/utilities/MetricsUtils';
+
+describe('MetricsUtils', () => {
+  describe('metricPrefixesMol', () => {
+    it('includes milli prefix', () => {
+      assert.ok(metricPrefixesMol.includes('m'));
+    });
+
+    it('includes micro prefix (u) for µmol support', () => {
+      assert.ok(metricPrefixesMol.includes('u'));
+    });
+
+    it('includes none prefix (n) for base mol unit', () => {
+      assert.ok(metricPrefixesMol.includes('n'));
+    });
+  });
+
+  describe('getMetricPrefix', () => {
+    it('returns micro prefix when metrics[index] is u', () => {
+      const result = getMetricPrefix(['m', 'm', 'u'], 2, metricPrefixesMol, 'm');
+      assert.strictEqual(result, 'u');
+    });
+
+    it('returns milli prefix when metrics[index] is m', () => {
+      const result = getMetricPrefix(['m', 'm', 'm'], 2, metricPrefixesMol, 'u');
+      assert.strictEqual(result, 'm');
+    });
+
+    it('returns default when prefix not in validPrefixes', () => {
+      const result = getMetricPrefix(['m', 'm', 'k'], 2, metricPrefixesMol, 'm');
+      assert.strictEqual(result, 'm');
+    });
+
+    it('returns default when metrics is too short', () => {
+      const result = getMetricPrefix(['m'], 2, metricPrefixesMol, 'm');
+      assert.strictEqual(result, 'm');
+    });
+  });
+
+  describe('getMetricMol', () => {
+    it('returns micro prefix (u) for µmol from metrics index 2', () => {
+      const component = { metrics: ['m', 'm', 'u', 'm'] };
+      assert.strictEqual(getMetricMol(component), 'u');
+    });
+
+    it('returns default m when metrics are missing', () => {
+      const component = {};
+      assert.strictEqual(getMetricMol(component), 'm');
+    });
+  });
+
+  describe('getMetricMolConc', () => {
+    it('returns the prefix at metrics index 3', () => {
+      const component = { metrics: ['m', 'm', 'm', 'n'] };
+      assert.strictEqual(getMetricMolConc(component), 'n');
+    });
+
+    it('returns default m when metrics are missing', () => {
+      const component = {};
+      assert.strictEqual(getMetricMolConc(component), 'm');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds µmol as a selectable unit in the molar amount fields of the Reaction Scheme
- Fixes the inconsistency where mass (µg) and volume (µL) had micro-scale options but mol did not
- Covers all material rows: starting materials, reactants, products, and mixture components

## Changes
- `MetricsUtils.js`: add `'u'` (micro) to `metricPrefixesMol` — propagates to Material.js, ReactionMaterialComponentsGroup.js, SampleComponent.js
- `MaterialCalculations.js`: add `'u'` to its local `metricPrefixesMol` copy (SBMM adjusted amounts row)
- `MetricsUtils.spec.js`: new test file covering µmol prefix inclusion and getMetricMol/getMetricPrefix behaviour

<img width="253" height="394" alt="Screenshot 2026-06-02 134420" src="https://github.com/user-attachments/assets/8933c291-073c-4789-8463-75944c554761" />

-------------

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
