### PR TITLE
fix(reaction UI): allow decimals in coefficients

### DIFF
--- a/app/assets/stylesheets/components/ReactionMaterial.scss
+++ b/app/assets/stylesheets/components/ReactionMaterial.scss
@@ -67,7 +67,7 @@ $rm-columns: (
   "mass": map-get($rm-sizes, "numeral-with-units"),
   "molarity": map-get($rm-sizes, "numeral-with-units"),
   "loading": map-get($rm-sizes, "numeral-with-units"),
-  "coefficient": map-get($rm-sizes, "square"),
+  "coefficient": map-get($rm-sizes, "small-numeral"),
   "amount": calc(#{3 * map-get($rm-sizes, "numeral-with-units")} + #{gap(2)}),
   // volume, mass, molarity + gap
   "molar-mass": map-get($rm-sizes, "numeral-with-units"),

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
@@ -1680,12 +1680,12 @@ export default class ReactionDetailsScheme extends React.Component {
   updatedSamplesForCoefficientChange(samples, updatedSample) {
     return samples.map((sample) => {
       if (sample.id === updatedSample.id) {
-        // set sampple.coefficient to default value, if user set coeff. value to zero
-        if (updatedSample.coefficient % 1 !== 0 || updatedSample.coefficient === 0) {
+        // reset coefficient to default value if user sets it to zero or negative
+        if (!updatedSample.coefficient || updatedSample.coefficient <= 0) {
           updatedSample.coefficient = 1;
           sample.coefficient = updatedSample.coefficient;
           NotificationActions.add({
-            message: 'The sample coefficient should be a positive integer',
+            message: 'The sample coefficient should be a positive number',
             level: 'error'
           });
         } else {

--- a/spec/features/reaction_coefficiency_spec.rb
+++ b/spec/features/reaction_coefficiency_spec.rb
@@ -79,6 +79,19 @@ describe 'Coeffiency Reactions' do
       messages = find_all('.notification-message', text: 'Experimental mass value is larger than possible')
       expect(messages.length).to be >= 1
     end
+
+    it 'accepts non-integer coefficients and computes correct yield', :js do
+      find('.tree-view', text: 'chemotion-repository.net').click
+      first('i.icon-reaction').click
+      first('span.isvg.loaded.reaction').click
+      inputs = find_all("input[name='coefficient']")
+      # H2 (ref, coeff=1.5) + O2 -> H2O (coeff=1.5): yield = (0.002*1.5)/(0.002*1.5) = 100%
+      inputs[0].set(1.5)
+      inputs[2].set(1.5)
+      find_by_id('submit-reaction-btn').click
+      expect(find("input[name='yield']").value).to eq('100%')
+      expect(page).not_to have_selector('.notification-message', text: 'positive integer')
+    end
   end
 
   describe 'Coeffiency Second Reaction' do


### PR DESCRIPTION

Reaction coefficients were silently reset to 1 whenever a decimal value was entered. The database already stores coefficients as floats.

-----

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
