### PR TITLE
fix: prevent stale research plan list when navigating to shared collections

### DIFF
--- a/app/javascript/src/stores/alt/stores/UIStore.js
+++ b/app/javascript/src/stores/alt/stores/UIStore.js
@@ -360,12 +360,17 @@ class UIStore {
   }
 
   handleSelectCollection(collection, hasChanged = false) {
+    if (!collection) return;
+
     const state = this.state;
     const { filterCreatedAt, fromDate, toDate, userLabel, productOnly } = state;
 
     if (!hasChanged) {
       hasChanged = !state.currentCollection;
       hasChanged = hasChanged || state.currentCollection.id != collection.id;
+      const wasShared = !!(state.currentCollection?.collection_share_id);
+      const isShared = !!(collection.collection_share_id);
+      hasChanged = hasChanged || wasShared !== isShared;
       hasChanged = hasChanged || state.currentSearchSelection != null;
       hasChanged = hasChanged || state.currentSearchByID != null;
     }

--- a/app/javascript/src/utilities/routesUtils.js
+++ b/app/javascript/src/utilities/routesUtils.js
@@ -22,6 +22,8 @@ const collectionShow = (e) => {
   const collectionPromise = CollectionsFetcher.fetchByCollectionId(collectionId);
 
   collectionPromise.then((collection) => {
+    if (!collection) return;
+
     if (currentSearchSelection) {
       UIActions.selectCollectionWithoutUpdating(collection);
       ElementActions.fetchBasedOnSearchSelectionAndCollection({


### PR DESCRIPTION
Closes #3198, related to #2750.

## What was broken

When navigating to a shared collection, `collectionShow` could pass`undefined` to `UIActions.selectCollection` if the collection fetch returned no data (e.g. 404). This caused a silent `TypeError` in `UIStore.handleSelectCollection`, which blocked all element fetches and left the research plan list stale.

Note: the core fetch regression (research plans being skipped entirely for shared collections) was already fixed in #2783 by removing the old `!isSync` guard. This PR closes the remaining edge case.

## Steps to reproduce

1. User A shares a collection (with research plans) with User B
2. User B opens the shared collection → sees plans
3. User B navigates to their own collection
4. User B returns to the shared collection → list was stale (now fixed)

#### ** test case is inconsistent

-------

- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
