### PR TITLE
feat(mixtures): support multiple components sharing the same molecule

### DIFF
--- a/app/api/chemotion/component_api.rb
+++ b/app/api/chemotion/component_api.rb
@@ -62,12 +62,7 @@ module Chemotion
         authorize_sample_update!(sample)
 
         ActiveRecord::Base.transaction do
-          # Delete first so the keep-list only needs to consider rows that already
-          # exist in the DB (identified by their integer ids). Newly added
-          # components (string ids like 'new_1') are inserted by Create afterwards
-          # and are therefore unaffected by the deletion step.
-          Usecases::Components::DeleteRemovedComponents.new(sample.id, params[:components]).execute!
-          Usecases::Components::Create.new(sample, params[:components]).execute!
+          Usecases::Components::Reconcile.new(sample, params[:components]).execute!
         end
         present Component.where(sample_id: sample.id), with: Entities::ComponentEntity
       end

--- a/app/api/chemotion/component_api.rb
+++ b/app/api/chemotion/component_api.rb
@@ -62,8 +62,12 @@ module Chemotion
         authorize_sample_update!(sample)
 
         ActiveRecord::Base.transaction do
-          Usecases::Components::Create.new(sample, params[:components]).execute!
+          # Delete first so the keep-list only needs to consider rows that already
+          # exist in the DB (identified by their integer ids). Newly added
+          # components (string ids like 'new_1') are inserted by Create afterwards
+          # and are therefore unaffected by the deletion step.
           Usecases::Components::DeleteRemovedComponents.new(sample.id, params[:components]).execute!
+          Usecases::Components::Create.new(sample, params[:components]).execute!
         end
         present Component.where(sample_id: sample.id), with: Entities::ComponentEntity
       end

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsComponents.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsComponents.js
@@ -647,7 +647,9 @@ export default class SampleDetailsComponents extends React.Component {
    * @returns {JSX.Element} The modal component
    */
   renderModal() {
-    const { showModal } = this.state;
+    const { showModal, droppedMaterial } = this.state;
+    const { srcMat, tagMat } = droppedMaterial || {};
+    const sameMolecule = Sample.haveSameMolecule(srcMat, tagMat);
 
     return (
       <AppModal
@@ -661,6 +663,19 @@ export default class SampleDetailsComponents extends React.Component {
         )}
       >
         <p>Do you want to merge or move this component?</p>
+        {sameMolecule ? (
+          <p className="text-warning">
+            <strong>Warning:</strong> These components share the same molecule.
+            Merging will remove the source component and reset the target&apos;s
+            amounts (mol, mass, volume, molarity, concentration) to zero.
+          </p>
+        ) : (
+          <p className="text-warning">
+            <strong>Warning:</strong> Merging will replace both components with a
+            new combined component. All amounts (mol, mass, volume, molarity,
+            concentration) will be reset to zero.
+          </p>
+        )}
       </AppModal>
     );
   }

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsComponentsDnd.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsComponentsDnd.js
@@ -17,6 +17,11 @@ const target = {
    * @param {Object} monitor - The drag-and-drop monitor
    */
   drop(tagProps, monitor) {
+    // React-DnD invokes drop() from innermost target outwards. If an inner row-level
+    // drop target (SampleComponent) already handled this drop, skip here to prevent
+    // duplicate component additions.
+    if (monitor.didDrop()) return;
+
     const { dropSample, dropMaterial } = tagProps;
     const srcItem = monitor.getItem();
     const srcType = monitor.getItemType();

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsComponentsDnd.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsComponentsDnd.js
@@ -20,6 +20,11 @@ const target = {
     // React-DnD invokes drop() from innermost target outwards. If an inner row-level
     // drop target (SampleComponent) already handled this drop, skip here to prevent
     // duplicate component additions.
+    //
+    // DO NOT REMOVE this guard. Sample.addMixtureComponentSync() no longer performs
+    // any duplicate detection (it always pushes the component), so this didDrop() check
+    // is the ONLY thing preventing a single drop from adding the same component twice —
+    // once via the inner row target and once via this outer container target.
     if (monitor.didDrop()) return;
 
     const { dropSample, dropMaterial } = tagProps;

--- a/app/javascript/src/models/Component.js
+++ b/app/javascript/src/models/Component.js
@@ -340,6 +340,18 @@ export default class Component extends Sample {
   }
 
   /**
+   * Resets all amount and concentration fields to zero.
+   * Used when a same-molecule merge collapses a duplicate component into this one.
+   */
+  resetAmounts() {
+    this.amount_mol = 0;
+    this.amount_g = 0;
+    this.amount_l = 0;
+    this.molarity_value = 0;
+    this.concn = 0;
+  }
+
+  /**
    * Checks if the current component has a locked concentration.
    *
    * Retrieves the `lockedComponents` list from the `ComponentStore` state

--- a/app/javascript/src/models/Component.js
+++ b/app/javascript/src/models/Component.js
@@ -782,4 +782,18 @@ export default class Component extends Sample {
 
     return comp;
   }
+
+  /**
+   * Deserialize the components returned by the save/update API so newly inserted
+   * rows pick up their real DB ids. Falls back to the local components when the
+   * response is unexpectedly empty.
+   * @param {Array} savedComponents - API response from saveOrUpdateComponents
+   * @param {Array} fallback - local components to use when the response is empty
+   * @returns {Array<Component>}
+   */
+  static refreshFromApi(savedComponents, fallback) {
+    return Array.isArray(savedComponents) && savedComponents.length > 0
+      ? savedComponents.map(Component.deserializeData)
+      : fallback;
+  }
 }

--- a/app/javascript/src/models/Sample.js
+++ b/app/javascript/src/models/Sample.js
@@ -2314,6 +2314,21 @@ export default class Sample extends Element {
   }
 
   /**
+   * Removes the source component and resets the target's amounts and concentration
+   * to zero, then recalculates mixture totals. Used when both components share the
+   * same molecule so no new molecule fetch is required.
+   * @param {Object} srcMat - The duplicate component to remove.
+   * @param {Object} tagMat - The component to keep, whose amounts will be cleared.
+   */
+  mergeSameMoleculeComponents(srcMat, tagMat) {
+    this.deleteMixtureComponent(srcMat);
+    tagMat.resetAmounts();
+    // Re-run after reset so mass and equivalents reflect the zeroed amounts.
+    this.calculateTotalMixtureMass();
+    this.updateMixtureComponentEquivalent();
+  }
+
+  /**
    * Handles total volume changes for mixture samples.
    *
    * This method is called when the total volume of a mixture is updated.
@@ -2456,7 +2471,32 @@ export default class Sample extends Element {
   }
 
   /**
-   * Merges two components into a new one by combining their SMILES and updating the mixture.
+   * Combines two different-molecule components into one by joining their SMILES,
+   * fetching the resulting molecule, and replacing both with the merged component.
+   * @async
+   * @param {Object} srcMat - The source component.
+   * @param {Object} tagMat - The target component.
+   * @param {string} tagGroup - Material group for the new merged component.
+   */
+  async mergeDifferentMoleculeComponents(srcMat, tagMat, tagGroup) {
+    const newSmiles = `${srcMat.molecule_cano_smiles}.${tagMat.molecule_cano_smiles}`;
+
+    try {
+      const newMolecule = await MoleculesFetcher.fetchBySmi(newSmiles, null, this.molfile, 'ketcher');
+      const newComponent = Sample.buildNew(newMolecule, this.collection_id);
+      newComponent.material_group = tagGroup;
+
+      this.deleteMixtureComponent(tagMat);
+      this.deleteMixtureComponent(srcMat);
+      await this.addMixtureComponent(newComponent);
+    } catch (error) {
+      console.error('Error merging components:', error);
+    }
+  }
+
+  /**
+   * Merges two components into one. Routes to the appropriate strategy based on
+   * whether the components share the same molecule.
    * @async
    * @param {Object} srcMat - The source material/component to merge.
    * @param {string} srcGroup - The source group name.
@@ -2471,18 +2511,14 @@ export default class Sample extends Element {
       console.error('Source or target material not found in components.');
       return;
     }
-    const newSmiles = `${srcMat.molecule_cano_smiles}.${tagMat.molecule_cano_smiles}`;
 
-    try {
-      const newMolecule = await MoleculesFetcher.fetchBySmi(newSmiles, null, this.molfile, 'ketcher');
-      const newComponent = Sample.buildNew(newMolecule, this.collection_id);
-      newComponent.material_group = tagGroup;
+    const srcMoleculeId = srcMat.molecule?.id;
+    const tagMoleculeId = tagMat.molecule?.id;
 
-      this.deleteMixtureComponent(tagMat);
-      this.deleteMixtureComponent(srcMat);
-      await this.addMixtureComponent(newComponent);
-    } catch (error) {
-      console.error('Error merging components:', error);
+    if (srcMoleculeId && tagMoleculeId && srcMoleculeId === tagMoleculeId) {
+      this.mergeSameMoleculeComponents(srcMat, tagMat);
+    } else {
+      await this.mergeDifferentMoleculeComponents(srcMat, tagMat, tagGroup);
     }
   }
 

--- a/app/javascript/src/models/Sample.js
+++ b/app/javascript/src/models/Sample.js
@@ -2532,8 +2532,14 @@ export default class Sample extends Element {
   }
 
   /**
-   * Fetches individual molecules for each SMILES in parallel, wraps them as
-   * Component instances, and adds them synchronously to the mixture.
+   * Fetches individual molecules for the given SMILES fragments and reconciles
+   * them with the existing components:
+   * - fragments already covered by an existing component are skipped, so
+   *   unchanged structures keep their component entry (no duplicates),
+   * - components whose structure no longer occurs in the edited structure
+   *   (i.e. it was modified in the structure editor) are updated in place
+   *   with the new molecule, preserving amounts, name, and position,
+   * - any remaining fragments are added as new Component instances.
    *
    * Does NOT call updateMixtureMolecule() — the caller is responsible for
    * triggering the combined-molecule fetch (and any intermediate setState)
@@ -2541,11 +2547,23 @@ export default class Sample extends Element {
    *
    * @param {Array<string>} mixtureSmiles - Array of SMILES strings to split.
    * @param {string} editor - The editor to use for fetching molecules.
-   * @returns {Promise<void>} Resolves once components have been added.
+   * @returns {Promise<void>} Resolves once components have been added/updated.
    */
   async splitSmilesToMolecule(mixtureSmiles, editor) {
+    const components = this.components || [];
+
+    // Fragments already covered by the current components (a merged ionic
+    // component carries a dot-joined cano_smiles like "[Na+].[Cl-]").
+    const existingFragments = new Set(
+      components.flatMap((c) => (c.molecule_cano_smiles || '').split('.')).filter(Boolean)
+    );
+
+    // Only fragments that no current component covers need to be resolved.
+    const unknownSmiles = mixtureSmiles.filter((smiles) => smiles && !existingFragments.has(smiles));
+    if (unknownSmiles.length === 0) return;
+
     const results = await Promise.all(
-      mixtureSmiles.map((smiles) => MoleculesFetcher.fetchBySmi(smiles, null, null, editor))
+      unknownSmiles.map((smiles) => MoleculesFetcher.fetchBySmi(smiles, null, null, editor))
     );
 
     // Filter out failed fetches (undefined/null) and track which SMILES failed
@@ -2555,7 +2573,7 @@ export default class Sample extends Element {
       if (molecule && molecule.id) {
         molecules.push(molecule);
       } else {
-        failedSmiles.push(mixtureSmiles[index]);
+        failedSmiles.push(unknownSmiles[index]);
       }
     });
 
@@ -2575,14 +2593,41 @@ export default class Sample extends Element {
       return;
     }
 
+    // Components whose structure no longer occurs in the edited structure were
+    // modified in the structure editor — update them in place instead of
+    // adding the edited structure as an additional component.
+    const editedFragments = new Set(mixtureSmiles);
+    const staleComponents = components.filter(
+      (component) => !(component.molecule_cano_smiles || '')
+        .split('.')
+        .every((fragment) => editedFragments.has(fragment))
+    );
+
     const { default: Component } = await import('src/models/Component');
 
-    const newComponents = molecules.map((molecule) => {
-      const newSample = Sample.buildNew(molecule, this.collection_id);
-      return new Component(newSample);
+    const newComponents = [];
+    molecules.forEach((molecule, index) => {
+      const staleComponent = staleComponents[index];
+      if (staleComponent) {
+        staleComponent.molecule = molecule;
+        staleComponent.molecule_id = molecule.id;
+        staleComponent.molfile = molecule.molfile;
+        // The molecular weight changed — re-derive the molar amount from the
+        // user-entered mass/volume so the row stays consistent.
+        staleComponent.calculateAmount(staleComponent.purity || 1.0);
+      } else {
+        const newSample = Sample.buildNew(molecule, this.collection_id);
+        newComponents.push(new Component(newSample));
+      }
     });
 
-    this.addMixtureComponentsSync(newComponents);
+    if (newComponents.length > 0) {
+      this.addMixtureComponentsSync(newComponents);
+    } else {
+      // Only in-place updates happened — refresh the mixture totals/ratios.
+      this.calculateTotalMixtureMass();
+      this.updateMixtureComponentEquivalent();
+    }
     this.syncComponentOrderToSmiles(mixtureSmiles);
   }
 

--- a/app/javascript/src/models/Sample.js
+++ b/app/javascript/src/models/Sample.js
@@ -2189,16 +2189,10 @@ export default class Sample extends Element {
    * to update the molecule/SVG via a network request.
    * @param {Object} newComponent - The new component to add.
    * @param {boolean} skipRecalculations - If true, skips expensive recalculations (for batch operations)
-   * @returns {boolean} True if the component was added, false if it was a duplicate.
+   * @returns {boolean} Always true — every component is added unconditionally.
    */
   addMixtureComponentSync(newComponent, skipRecalculations = false) {
     const tmpComponents = [...(this.components || [])];
-    // Check if this component is already present (including merged components, e.g. ionic compounds)
-    const isNew = !tmpComponents.some(
-      (component) => component.molecule.iupac_name === newComponent.molecule.iupac_name
-        || component.molecule.inchikey === newComponent.molecule.inchikey
-        || component.molecule_cano_smiles.split('.').includes(newComponent.molecule_cano_smiles)
-    );
 
     if (!newComponent.material_group) {
       newComponent.material_group = 'liquid';
@@ -2208,18 +2202,16 @@ export default class Sample extends Element {
       newComponent.purity = 1;
     }
 
-    if (isNew) {
-      tmpComponents.push(newComponent);
-      this.components = tmpComponents;
+    tmpComponents.push(newComponent);
+    this.components = tmpComponents;
 
-      if (!skipRecalculations) {
-        this.setComponentPositions();
-        this.calculateTotalMixtureMass();
-        this.updateMixtureComponentEquivalent();
-      }
+    if (!skipRecalculations) {
+      this.setComponentPositions();
+      this.calculateTotalMixtureMass();
+      this.updateMixtureComponentEquivalent();
     }
 
-    return isNew;
+    return true;
   }
 
   /**
@@ -2228,10 +2220,19 @@ export default class Sample extends Element {
    * @async
    */
   async updateMixtureMolecule() {
-    const combinedSmiles = (this.components || [])
+    // Capture the per-component SMILES list before the async fetch so the
+    // stale check below can detect any additions/removals that happen while waiting.
+    const componentSmilesSnapshot = (this.components || [])
       .map((c) => c.molecule_cano_smiles)
-      .filter(Boolean)
-      .join('.');
+      .filter(Boolean);
+
+    // Flatten each component's SMILES into individual fragments (a merged ionic compound
+    // or a "benzene dimer" carries a dot-joined cano_smiles like "c1ccccc1.c1ccccc1"),
+    // then deduplicate across all fragments so that multiple components sharing the same
+    // molecule — whether stored as separate rows or as a merged multi-fragment molecule —
+    // each contribute only one structure to the combined SVG.
+    const allFragments = componentSmilesSnapshot.flatMap((s) => s.split('.'));
+    const combinedSmiles = [...new Set(allFragments)].join('.');
 
     if (!combinedSmiles) return;
 
@@ -2246,13 +2247,14 @@ export default class Sample extends Element {
       return;
     }
 
-    // Re-validate after async fetch: discard if the component set changed while in flight.
+    // Stale check: compare the pre-fetch snapshot against the current component list.
+    // Any addition or removal during the async fetch discards this result.
     const currentSmiles = (this.components || [])
       .map((c) => c.molecule_cano_smiles)
       .filter(Boolean)
       .join('.');
 
-    if (!currentSmiles || !Sample.sameSmilesSet(combinedSmiles, currentSmiles)) {
+    if (!currentSmiles || componentSmilesSnapshot.join('.') !== currentSmiles) {
       return;
     }
 
@@ -2268,18 +2270,11 @@ export default class Sample extends Element {
   addMixtureComponentsSync(newComponents) {
     if (!newComponents || newComponents.length === 0) return;
 
-    let hasNewComponents = false;
-    newComponents.forEach((c) => {
-      const isNew = this.addMixtureComponentSync(c, true); // Skip recalculations during batch
-      if (isNew) hasNewComponents = true;
-    });
+    newComponents.forEach((c) => this.addMixtureComponentSync(c, true));
 
-    // Only perform expensive recalculations once if we actually added new components
-    if (hasNewComponents) {
-      this.setComponentPositions();
-      this.calculateTotalMixtureMass();
-      this.updateMixtureComponentEquivalent();
-    }
+    this.setComponentPositions();
+    this.calculateTotalMixtureMass();
+    this.updateMixtureComponentEquivalent();
   }
 
   /**

--- a/app/javascript/src/models/Sample.js
+++ b/app/javascript/src/models/Sample.js
@@ -1991,9 +1991,11 @@ export default class Sample extends Element {
       gas_type: this.gas_type || false,
       gas_phase_data: this.gas_phase_data,
       conversion_rate: this.conversion_rate,
-      components: this.components && this.components.length > 0
-        ? this.components.map((s) => s.serializeComponent())
-        : [],
+      // null = components never loaded on the client (list/search responses
+      // omit them) → server keeps/copies persisted ones. [] = user removed
+      // them all → server deletes. Raw API objects (no serializeComponent)
+      // are already in serialized shape and pass through as-is.
+      components: this.components?.map((comp) => comp.serializeComponent?.() ?? comp) ?? null,
       weight_percentage_reference: this.weight_percentage_reference || false,
       weight_percentage: this.weight_percentage
     };
@@ -2520,6 +2522,8 @@ export default class Sample extends Element {
   }
 
   async mergeComponents(srcMat, srcGroup, tagMat, tagGroup) {
+    if (srcMat === tagMat) return;
+
     const srcIndex = this.components.findIndex((mat) => mat === srcMat);
     const tagIndex = this.components.findIndex((mat) => mat === tagMat);
 
@@ -2563,13 +2567,49 @@ export default class Sample extends Element {
    * @returns {Promise<void>} Resolves once components have been added/updated.
    */
   async splitSmilesToMolecule(mixtureSmiles, editor) {
+    const { staleComponents, unknownSmiles } = this.partitionEditedSmiles(mixtureSmiles);
+
+    // Nothing new to fetch — still delete stale components so the list stays
+    // consistent with the edited structure.
+    if (unknownSmiles.length === 0) {
+      this.removeStaleComponents(staleComponents, mixtureSmiles);
+      return;
+    }
+
+    const resolved = await Sample.fetchMoleculesForSmiles(unknownSmiles, editor);
+
+    // Mapping an edited fragment back to its component is only unambiguous for
+    // a single edit — fragment order and component order are not guaranteed to
+    // align, so positional pairing of several edits could attach a molecule
+    // (and the user's amounts) to the wrong row.
+    if (staleComponents.length === 1 && unknownSmiles.length === 1 && resolved.length === 1) {
+      Sample.applyResolvedMolecule(staleComponents[0], resolved[0]);
+      this.calculateTotalMixtureMass();
+      this.updateMixtureComponentEquivalent();
+    } else {
+      await this.addResolvedFragmentsAsComponents(staleComponents, unknownSmiles, resolved);
+    }
+
+    this.syncComponentOrderToSmiles(mixtureSmiles);
+  }
+
+  /**
+   * Splits the edited structure into stale components (at least one fragment
+   * edited away) and fragments that still need resolving. Stale components
+   * don't count as covering any fragment: a stale "A.B" (A→A2) must not block
+   * "B" from being fetched.
+   *
+   * Matching is deliberately set-based, NOT count-based: the editor canvas is
+   * deduplicated (updateMixtureMolecule renders each distinct structure once),
+   * so fragment multiplicity in the editor carries no meaning. Duplicate
+   * same-molecule components are created via drag & drop, and counting
+   * occurrences here would wrongly delete one of them on every editor save.
+   *
+   * @returns {{staleComponents: Array<Object>, unknownSmiles: Array<string>}}
+   */
+  partitionEditedSmiles(mixtureSmiles) {
     const components = this.components || [];
 
-    // Identify stale components first — those where at least one fragment was
-    // edited away. They must not be counted as covering any fragment: a merged
-    // component "A.B" that becomes stale because A→A2 must not block "B" from
-    // being fetched, otherwise "B" is silently dropped after the stale
-    // component is updated in-place to A2.
     const editedFragments = new Set(mixtureSmiles);
     const staleComponents = components.filter(
       (component) => !(component.molecule_cano_smiles || '')
@@ -2578,7 +2618,6 @@ export default class Sample extends Element {
     );
     const staleSet = new Set(staleComponents);
 
-    // Only fragments covered by non-stale components are already resolved.
     const existingFragments = new Set(
       components
         .filter((c) => !staleSet.has(c))
@@ -2586,38 +2625,33 @@ export default class Sample extends Element {
         .filter(Boolean)
     );
 
-    // Only fragments that no current non-stale component covers need to be resolved.
     const unknownSmiles = mixtureSmiles.filter((smiles) => smiles && !existingFragments.has(smiles));
 
-    // Even when there are no new fragments to fetch, stale components (those
-    // whose fragments were removed in the editor) must be deleted so the
-    // component list stays consistent with the edited structure.
-    if (unknownSmiles.length === 0) {
-      staleComponents.forEach((c) => this.deleteMixtureComponent(c));
-      if (staleComponents.length > 0) {
-        this.calculateTotalMixtureMass();
-        this.updateMixtureComponentEquivalent();
-        this.syncComponentOrderToSmiles(mixtureSmiles);
-      }
-      return;
-    }
+    return { staleComponents, unknownSmiles };
+  }
 
+  /**
+   * Deletes the given stale components and refreshes totals/ratios/ordering.
+   */
+  removeStaleComponents(staleComponents, mixtureSmiles) {
+    if (staleComponents.length === 0) return;
+
+    staleComponents.forEach((c) => this.deleteMixtureComponent(c));
+    this.calculateTotalMixtureMass();
+    this.updateMixtureComponentEquivalent();
+    this.syncComponentOrderToSmiles(mixtureSmiles);
+  }
+
+  /**
+   * Fetches a molecule per SMILES fragment, warns the user about failures,
+   * and returns only the successfully resolved molecules (in fragment order).
+   */
+  static async fetchMoleculesForSmiles(smilesList, editor) {
     const results = await Promise.all(
-      unknownSmiles.map((smiles) => MoleculesFetcher.fetchBySmi(smiles, null, null, editor))
+      smilesList.map((smiles) => MoleculesFetcher.fetchBySmi(smiles, null, null, editor))
     );
 
-    // Filter out failed fetches (undefined/null) and track which SMILES failed
-    const failedSmiles = [];
-    const molecules = [];
-    results.forEach((molecule, index) => {
-      if (molecule && molecule.id) {
-        molecules.push(molecule);
-      } else {
-        failedSmiles.push(unknownSmiles[index]);
-      }
-    });
-
-    // Notify user if some molecules failed to resolve
+    const failedSmiles = smilesList.filter((smiles, index) => !(results[index] && results[index].id));
     if (failedSmiles.length > 0) {
       NotificationActions.add({
         title: 'Molecule Resolution Failed',
@@ -2628,44 +2662,44 @@ export default class Sample extends Element {
       });
     }
 
-    // If no valid molecules, exit early
-    if (molecules.length === 0) {
-      return;
-    }
+    return results.filter((molecule) => molecule && molecule.id);
+  }
 
-    // Components whose structure no longer occurs in the edited structure were
-    // modified in the structure editor — update them in place instead of
-    // adding the edited structure as an additional component.
+  /**
+   * Points an existing component at a newly resolved molecule, preserving its
+   * amount, name, and position.
+   */
+  static applyResolvedMolecule(component, molecule) {
+    component.molecule = molecule;
+    component.molecule_id = molecule.id;
+    component.molfile = molecule.molfile;
+    // MW changed — re-derive the molar amount from the entered mass/volume.
+    component.calculateAmount(component.purity || 1.0);
+  }
+
+  /**
+   * Ambiguous reconcile case (multiple edits, or new fragments mixed with
+   * edits): add every resolved fragment as a new component rather than guess
+   * which stale row it came from. Stale rows are deleted only when every
+   * fragment resolved; on partial failure they are kept (the user was warned).
+   */
+  async addResolvedFragmentsAsComponents(staleComponents, unknownSmiles, resolved) {
     const { default: Component } = await import('src/models/Component');
 
-    const newComponents = [];
-    molecules.forEach((molecule, index) => {
-      const staleComponent = staleComponents[index];
-      if (staleComponent) {
-        staleComponent.molecule = molecule;
-        staleComponent.molecule_id = molecule.id;
-        staleComponent.molfile = molecule.molfile;
-        // The molecular weight changed — re-derive the molar amount from the
-        // user-entered mass/volume so the row stays consistent.
-        staleComponent.calculateAmount(staleComponent.purity || 1.0);
-      } else {
-        const newSample = Sample.buildNew(molecule, this.collection_id);
-        newComponents.push(new Component(newSample));
-      }
-    });
-
-    // Stale components not reused for an in-place update (more fragments
-    // removed than added) must be deleted explicitly.
-    staleComponents.slice(molecules.length).forEach((c) => this.deleteMixtureComponent(c));
+    const newComponents = resolved.map(
+      (molecule) => new Component(Sample.buildNew(molecule, this.collection_id))
+    );
+    if (resolved.length === unknownSmiles.length) {
+      staleComponents.forEach((c) => this.deleteMixtureComponent(c));
+    }
 
     if (newComponents.length > 0) {
       this.addMixtureComponentsSync(newComponents);
     } else {
-      // Only in-place updates happened — refresh the mixture totals/ratios.
+      // Every fetch failed — still refresh totals/ratios.
       this.calculateTotalMixtureMass();
       this.updateMixtureComponentEquivalent();
     }
-    this.syncComponentOrderToSmiles(mixtureSmiles);
   }
 
   /**

--- a/app/javascript/src/models/Sample.js
+++ b/app/javascript/src/models/Sample.js
@@ -2248,13 +2248,18 @@ export default class Sample extends Element {
     }
 
     // Stale check: compare the pre-fetch snapshot against the current component list.
-    // Any addition or removal during the async fetch discards this result.
-    const currentSmiles = (this.components || [])
+    // Sort before joining so a reorder while the fetch was in flight does not
+    // discard a valid result. Use '\0' as separator — SMILES never contain null
+    // bytes, so component boundaries stay unambiguous even when a single
+    // component's cano_smiles is itself dot-separated (e.g. multi-fragment molecules).
+    const snapshotKey = [...componentSmilesSnapshot].sort().join('\0');
+    const currentKey = (this.components || [])
       .map((c) => c.molecule_cano_smiles)
       .filter(Boolean)
-      .join('.');
+      .sort()
+      .join('\0');
 
-    if (!currentSmiles || componentSmilesSnapshot.join('.') !== currentSmiles) {
+    if (!currentKey || snapshotKey !== currentKey) {
       return;
     }
 
@@ -2483,14 +2488,19 @@ export default class Sample extends Element {
 
     try {
       const newMolecule = await MoleculesFetcher.fetchBySmi(newSmiles, null, this.molfile, 'ketcher');
-      const newComponent = Sample.buildNew(newMolecule, this.collection_id);
-      newComponent.material_group = tagGroup;
+      if (!newMolecule) throw new Error('Failed to fetch merged molecule');
 
+      const newSample = Sample.buildNew(newMolecule, this.collection_id);
+      newSample.material_group = tagGroup;
+
+      const { default: Component } = await import('src/models/Component');
+
+      await this.addMixtureComponent(new Component(newSample));
       this.deleteMixtureComponent(tagMat);
       this.deleteMixtureComponent(srcMat);
-      await this.addMixtureComponent(newComponent);
     } catch (error) {
       console.error('Error merging components:', error);
+      NotificationActions.add({ message: 'Failed to merge components. Please try again.', level: 'error' });
     }
   }
 
@@ -2503,6 +2513,12 @@ export default class Sample extends Element {
    * @param {Object} tagMat - The target material/component to merge with.
    * @param {string} tagGroup - The target group name.
    */
+  static haveSameMolecule(matA, matB) {
+    const idA = matA?.molecule?.id || matA?.molecule_id;
+    const idB = matB?.molecule?.id || matB?.molecule_id;
+    return !!(idA && idB && idA === idB);
+  }
+
   async mergeComponents(srcMat, srcGroup, tagMat, tagGroup) {
     const srcIndex = this.components.findIndex((mat) => mat === srcMat);
     const tagIndex = this.components.findIndex((mat) => mat === tagMat);
@@ -2512,10 +2528,7 @@ export default class Sample extends Element {
       return;
     }
 
-    const srcMoleculeId = srcMat.molecule?.id;
-    const tagMoleculeId = tagMat.molecule?.id;
-
-    if (srcMoleculeId && tagMoleculeId && srcMoleculeId === tagMoleculeId) {
+    if (Sample.haveSameMolecule(srcMat, tagMat)) {
       this.mergeSameMoleculeComponents(srcMat, tagMat);
     } else {
       await this.mergeDifferentMoleculeComponents(srcMat, tagMat, tagGroup);
@@ -2552,15 +2565,42 @@ export default class Sample extends Element {
   async splitSmilesToMolecule(mixtureSmiles, editor) {
     const components = this.components || [];
 
-    // Fragments already covered by the current components (a merged ionic
-    // component carries a dot-joined cano_smiles like "[Na+].[Cl-]").
+    // Identify stale components first — those where at least one fragment was
+    // edited away. They must not be counted as covering any fragment: a merged
+    // component "A.B" that becomes stale because A→A2 must not block "B" from
+    // being fetched, otherwise "B" is silently dropped after the stale
+    // component is updated in-place to A2.
+    const editedFragments = new Set(mixtureSmiles);
+    const staleComponents = components.filter(
+      (component) => !(component.molecule_cano_smiles || '')
+        .split('.')
+        .every((fragment) => editedFragments.has(fragment))
+    );
+    const staleSet = new Set(staleComponents);
+
+    // Only fragments covered by non-stale components are already resolved.
     const existingFragments = new Set(
-      components.flatMap((c) => (c.molecule_cano_smiles || '').split('.')).filter(Boolean)
+      components
+        .filter((c) => !staleSet.has(c))
+        .flatMap((c) => (c.molecule_cano_smiles || '').split('.'))
+        .filter(Boolean)
     );
 
-    // Only fragments that no current component covers need to be resolved.
+    // Only fragments that no current non-stale component covers need to be resolved.
     const unknownSmiles = mixtureSmiles.filter((smiles) => smiles && !existingFragments.has(smiles));
-    if (unknownSmiles.length === 0) return;
+
+    // Even when there are no new fragments to fetch, stale components (those
+    // whose fragments were removed in the editor) must be deleted so the
+    // component list stays consistent with the edited structure.
+    if (unknownSmiles.length === 0) {
+      staleComponents.forEach((c) => this.deleteMixtureComponent(c));
+      if (staleComponents.length > 0) {
+        this.calculateTotalMixtureMass();
+        this.updateMixtureComponentEquivalent();
+        this.syncComponentOrderToSmiles(mixtureSmiles);
+      }
+      return;
+    }
 
     const results = await Promise.all(
       unknownSmiles.map((smiles) => MoleculesFetcher.fetchBySmi(smiles, null, null, editor))
@@ -2596,13 +2636,6 @@ export default class Sample extends Element {
     // Components whose structure no longer occurs in the edited structure were
     // modified in the structure editor — update them in place instead of
     // adding the edited structure as an additional component.
-    const editedFragments = new Set(mixtureSmiles);
-    const staleComponents = components.filter(
-      (component) => !(component.molecule_cano_smiles || '')
-        .split('.')
-        .every((fragment) => editedFragments.has(fragment))
-    );
-
     const { default: Component } = await import('src/models/Component');
 
     const newComponents = [];
@@ -2620,6 +2653,10 @@ export default class Sample extends Element {
         newComponents.push(new Component(newSample));
       }
     });
+
+    // Stale components not reused for an in-place update (more fragments
+    // removed than added) must be deleted explicitly.
+    staleComponents.slice(molecules.length).forEach((c) => this.deleteMixtureComponent(c));
 
     if (newComponents.length > 0) {
       this.addMixtureComponentsSync(newComponents);

--- a/app/javascript/src/stores/alt/actions/ElementActions.js
+++ b/app/javascript/src/stores/alt/actions/ElementActions.js
@@ -484,9 +484,7 @@ class ElementActions {
 
         // Initialize components on newSample before updating material in reaction
         if (sample.isMixture() && sample.components) {
-          const refreshed = Array.isArray(savedComponents) && savedComponents.length > 0
-            ? savedComponents.map(Component.deserializeData)
-            : sample.components;
+          const refreshed = Component.refreshFromApi(savedComponents, sample.components);
           newSample.initialComponents(refreshed);
         }
 

--- a/app/javascript/src/stores/alt/actions/ElementActions.js
+++ b/app/javascript/src/stores/alt/actions/ElementActions.js
@@ -29,6 +29,7 @@ import SequenceBasedMacromoleculeSamplesFetcher from 'src/fetchers/SequenceBased
 
 import GenericEl from 'src/models/GenericEl';
 import Sample from 'src/models/Sample';
+import Component from 'src/models/Component';
 import Reaction from 'src/models/Reaction';
 import Wellplate from 'src/models/Wellplate';
 import CellLine from 'src/models/cellLine/CellLine';
@@ -471,9 +472,11 @@ class ElementActions {
   updateSampleForReaction(sample, reaction, closeView = true) {
     return async (dispatch) => {
       try {
-        // Save components first if it's a mixture
+        // Save components first if it's a mixture and capture the API response so
+        // newly inserted rows pick up their real DB ids on subsequent saves.
+        let savedComponents = null;
         if (sample.isMixture() && sample.components) {
-          await ComponentsFetcher.saveOrUpdateComponents(sample, sample.components);
+          savedComponents = await ComponentsFetcher.saveOrUpdateComponents(sample, sample.components);
         }
 
         // Update sample
@@ -481,7 +484,10 @@ class ElementActions {
 
         // Initialize components on newSample before updating material in reaction
         if (sample.isMixture() && sample.components) {
-          newSample.initialComponents(sample.components);
+          const refreshed = Array.isArray(savedComponents) && savedComponents.length > 0
+            ? savedComponents.map(Component.deserializeData)
+            : sample.components;
+          newSample.initialComponents(refreshed);
         }
 
         // Update the material in the reaction and dispatch

--- a/app/javascript/src/stores/alt/stores/ElementStore.js
+++ b/app/javascript/src/stores/alt/stores/ElementStore.js
@@ -728,6 +728,9 @@ class ElementStore {
               return new Component(sampleData);
             });
             await result.initialComponents(sampleComponents);
+            if (this.state.currentElement === result) {
+              this.setState({ currentElement: result });
+            }
           })
           .catch((errorMessage) => {
             console.log(errorMessage);
@@ -743,10 +746,11 @@ class ElementStore {
         .then(async (savedComponents) => {
           // Use the API response so newly inserted rows pick up their real DB ids.
           // Falls back to the local components if the response is unexpectedly empty.
-          const refreshed = Array.isArray(savedComponents) && savedComponents.length > 0
-            ? savedComponents.map(Component.deserializeData)
-            : components;
+          const refreshed = Component.refreshFromApi(savedComponents, components);
           await element.initialComponents(refreshed);
+          if (this.state.currentElement === element) {
+            this.setState({ currentElement: element });
+          }
         })
         .catch((errorMessage) => {
           console.log(errorMessage);
@@ -767,9 +771,7 @@ class ElementStore {
     if (newSample.isMixture()) {
       ComponentsFetcher.saveOrUpdateComponents(newSample, components)
         .then(async (savedComponents) => {
-          const refreshed = Array.isArray(savedComponents) && savedComponents.length > 0
-            ? savedComponents.map(Component.deserializeData)
-            : components;
+          const refreshed = Component.refreshFromApi(savedComponents, components);
           await newSample.initialComponents(refreshed);
         })
         .catch((errorMessage) => {
@@ -814,12 +816,18 @@ class ElementStore {
 
   handleUpdateLinkedElement({ element, closeView, components }) {
     if (element instanceof Sample && element.isMixture()) {
+      // Seed element with current Component instances so names display immediately
+      // without waiting for saveOrUpdateComponents to resolve.
+      if (Array.isArray(components) && components.length > 0) {
+        element.components = components;
+      }
       ComponentsFetcher.saveOrUpdateComponents(element, components)
         .then((savedComponents) => {
-          const refreshed = Array.isArray(savedComponents) && savedComponents.length > 0
-            ? savedComponents.map(Component.deserializeData)
-            : components;
+          const refreshed = Component.refreshFromApi(savedComponents, components);
           element.initialComponents(refreshed);
+          if (this.state.currentElement === element) {
+            this.setState({ currentElement: element });
+          }
         })
         .catch((errorMessage) => {
           console.log(errorMessage);

--- a/app/javascript/src/stores/alt/stores/ElementStore.js
+++ b/app/javascript/src/stores/alt/stores/ElementStore.js
@@ -740,8 +740,13 @@ class ElementStore {
   handleCreateSample({ element, closeView, components }) {
     if (element.isMixture()) {
       ComponentsFetcher.saveOrUpdateComponents(element, components)
-        .then(async () => {
-          await element.initialComponents(components);
+        .then(async (savedComponents) => {
+          // Use the API response so newly inserted rows pick up their real DB ids.
+          // Falls back to the local components if the response is unexpectedly empty.
+          const refreshed = Array.isArray(savedComponents) && savedComponents.length > 0
+            ? savedComponents.map(Component.deserializeData)
+            : components;
+          await element.initialComponents(refreshed);
         })
         .catch((errorMessage) => {
           console.log(errorMessage);
@@ -761,8 +766,11 @@ class ElementStore {
     UserActions.fetchCurrentUser();
     if (newSample.isMixture()) {
       ComponentsFetcher.saveOrUpdateComponents(newSample, components)
-        .then(async () => {
-          await newSample.initialComponents(components);
+        .then(async (savedComponents) => {
+          const refreshed = Array.isArray(savedComponents) && savedComponents.length > 0
+            ? savedComponents.map(Component.deserializeData)
+            : components;
+          await newSample.initialComponents(refreshed);
         })
         .catch((errorMessage) => {
           console.log(errorMessage);
@@ -807,8 +815,11 @@ class ElementStore {
   handleUpdateLinkedElement({ element, closeView, components }) {
     if (element instanceof Sample && element.isMixture()) {
       ComponentsFetcher.saveOrUpdateComponents(element, components)
-        .then(() => {
-          element.initialComponents(components);
+        .then((savedComponents) => {
+          const refreshed = Array.isArray(savedComponents) && savedComponents.length > 0
+            ? savedComponents.map(Component.deserializeData)
+            : components;
+          element.initialComponents(refreshed);
         })
         .catch((errorMessage) => {
           console.log(errorMessage);

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -417,7 +417,7 @@ class Sample < ApplicationRecord
   # rubocop:disable Metrics/PerceivedComplexity
   # rubocop:disable Style/MethodDefParentheses
   # rubocop:disable Style/OptionalBooleanParameter
-  def create_subsample user, collection_ids, copy_ea = false, type = nil
+  def create_subsample user, collection_ids, copy_ea = false, type = nil, copy_components: true
     subsample = dup
     subsample.xref['inventory_label'] = nil
     subsample.skip_inventory_label_update = true
@@ -452,7 +452,10 @@ class Sample < ApplicationRecord
     subsample.container = Container.create_root_container
     subsample.save!
 
-    create_components_for_mixture_subsample(subsample)
+    # Callers that reconcile the subsample's components from a client payload
+    # (e.g. the reaction editor) pass copy_components: false so we don't insert
+    # parent-copied rows that the payload would then duplicate.
+    create_components_for_mixture_subsample(subsample) if copy_components
     create_chemical_entry_for_subsample(id, subsample.id, type) unless type.nil?
 
     subsample

--- a/app/usecases/components/create.rb
+++ b/app/usecases/components/create.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 # Use case for creating or updating components for a given sample.
-# Iterates through the provided components, finds or initializes each by sample and molecule_id,
-# assigns attributes, and saves with validation.
+# Iterates through the provided components, finds or initializes each by component id,
+# assigns attributes, and saves with validation. Lookup is keyed on the component id
+# (not molecule_id) so a mixture can hold multiple components that share the same molecule.
 module Usecases
   module Components
     class Create
@@ -20,12 +21,16 @@ module Usecases
         add_molecule_data_to_components
 
         @components.each do |component_params|
-          molecule_id = component_params.dig(:component_properties, :molecule_id).to_i
+          # Look up by component id rather than molecule_id so multiple components
+          # sharing the same molecule are persisted as separate rows.
+          # Integer ids reference existing components; non-integer ids (e.g. 'new_1',
+          # 'comp_xxx') indicate newly added components and trigger a fresh insert.
+          component_id = Integer(component_params[:id], exception: false)
 
-          component = Component
-                      .where("sample_id = ? AND CAST(component_properties ->> 'molecule_id' AS INTEGER) = ?",
-                             @sample_id, molecule_id)
-                      .first_or_initialize(sample_id: @sample_id)
+          component = Component.find_by(
+            sample_id: @sample_id,
+            id: component_id,
+          ) || Component.new(sample_id: @sample_id)
 
           component.assign_attributes(
             name: component_params[:name],

--- a/app/usecases/components/create.rb
+++ b/app/usecases/components/create.rb
@@ -7,14 +7,25 @@
 module Usecases
   module Components
     class Create
-      def initialize(sample, components)
-        @sample = sample
-        @sample_id = sample.id
-        @components = components.map do |cp|
+      # Single source of truth for the components-payload shape shared by
+      # DeleteRemovedComponents and Create: an array of indifferent-access hashes,
+      # each with an indifferent-access :component_properties. Idempotent and
+      # nil-safe, so it is cheap to call defensively at every entry point.
+      def self.normalize(components)
+        (components || []).map do |cp|
           c = cp.with_indifferent_access
           c[:component_properties] = c[:component_properties].with_indifferent_access if c[:component_properties]
           c
         end
+      end
+
+      # `components` is expected to be already normalized by the caller via
+      # Usecases::Components::Create.normalize (Reconcile normalizes once and passes
+      # the same array here and to DeleteRemovedComponents).
+      def initialize(sample, components)
+        @sample = sample
+        @sample_id = sample.id
+        @components = components
       end
 
       def execute!

--- a/app/usecases/components/create.rb
+++ b/app/usecases/components/create.rb
@@ -10,7 +10,11 @@ module Usecases
       def initialize(sample, components)
         @sample = sample
         @sample_id = sample.id
-        @components = components
+        @components = components.map do |cp|
+          c = cp.with_indifferent_access
+          c[:component_properties] = c[:component_properties].with_indifferent_access if c[:component_properties]
+          c
+        end
       end
 
       def execute!
@@ -27,10 +31,12 @@ module Usecases
           # 'comp_xxx') indicate newly added components and trigger a fresh insert.
           component_id = Integer(component_params[:id], exception: false)
 
-          component = Component.find_by(
-            sample_id: @sample_id,
-            id: component_id,
-          ) || Component.new(sample_id: @sample_id)
+          component = if component_id
+                        Component.find_by(sample_id: @sample_id, id: component_id) ||
+                          Component.new(sample_id: @sample_id)
+                      else
+                        Component.new(sample_id: @sample_id)
+                      end
 
           component.assign_attributes(
             name: component_params[:name],

--- a/app/usecases/components/delete_removed_components.rb
+++ b/app/usecases/components/delete_removed_components.rb
@@ -7,7 +7,7 @@ module Usecases
     class DeleteRemovedComponents
       def initialize(sample_id, components_params)
         @sample_id = sample_id
-        @components_params = components_params
+        @components_params = components_params.map(&:with_indifferent_access)
       end
 
       def execute!
@@ -16,7 +16,7 @@ module Usecases
         # ignored here; they are inserted by Usecases::Components::Create.
         ids_to_keep = @components_params.filter_map do |cp|
           Integer(cp[:id], exception: false)
-        end.compact
+        end
 
         scope = Component.where(sample_id: @sample_id)
         scope = scope.where.not(id: ids_to_keep) if ids_to_keep.any?

--- a/app/usecases/components/delete_removed_components.rb
+++ b/app/usecases/components/delete_removed_components.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Use case for deleting components that are no longer present in the update payload for a sample.
-# Finds all components for the sample whose molecule_id is not in the provided list and deletes them.
+# Finds all existing components for the sample whose id is not in the provided list and deletes them.
 module Usecases
   module Components
     class DeleteRemovedComponents
@@ -11,15 +11,16 @@ module Usecases
       end
 
       def execute!
-        # Collect molecule_ids to keep from the incoming params
-        molecule_ids_to_keep = @components_params.filter_map do |cp|
-          cp.dig(:component_properties, :molecule_id)&.to_i
-        end
+        # Collect existing component ids to keep. Non-integer ids (e.g. client-side
+        # placeholders like 'new_1') correspond to brand-new components and are
+        # ignored here; they are inserted by Usecases::Components::Create.
+        ids_to_keep = @components_params.filter_map do |cp|
+          Integer(cp[:id], exception: false)
+        end.compact
 
-        # Delete all components for the sample whose molecule_id is not in the keep list
-        Component.where(sample_id: @sample_id)
-                 .where.not("CAST(component_properties ->> 'molecule_id' AS INTEGER) IN (?)", molecule_ids_to_keep)
-                 .destroy_all
+        scope = Component.where(sample_id: @sample_id)
+        scope = scope.where.not(id: ids_to_keep) if ids_to_keep.any?
+        scope.destroy_all
       end
     end
   end

--- a/app/usecases/components/delete_removed_components.rb
+++ b/app/usecases/components/delete_removed_components.rb
@@ -1,26 +1,43 @@
 # frozen_string_literal: true
 
 # Use case for deleting components that are no longer present in the update payload for a sample.
-# Finds all existing components for the sample whose id is not in the provided list and deletes them.
+# Deletes this sample's components whose id is not referenced by the payload. An empty or
+# all-placeholder payload is authoritative (the client sends [] to clear a mixture), so it
+# deletes all existing components. The one exception: if the payload references integer ids
+# but none belong to this sample (foreign/parent ids on a freshly split sub-sample), it is not
+# describing this sample's rows, so deletion is skipped to avoid wiping real components.
 module Usecases
   module Components
     class DeleteRemovedComponents
+      # Normalizes defensively (idempotent — Reconcile already passes a normalized
+      # array): without indifferent access, a string-keyed payload would make every
+      # cp[:id] lookup miss, so referenced_ids would be empty and the payload would
+      # wrongly count as an authoritative "delete everything" instruction.
       def initialize(sample_id, components_params)
         @sample_id = sample_id
-        @components_params = components_params.map(&:with_indifferent_access)
+        @components_params = Usecases::Components::Create.normalize(components_params)
       end
 
       def execute!
-        # Collect existing component ids to keep. Non-integer ids (e.g. client-side
-        # placeholders like 'new_1') correspond to brand-new components and are
-        # ignored here; they are inserted by Usecases::Components::Create.
-        ids_to_keep = @components_params.filter_map do |cp|
-          Integer(cp[:id], exception: false)
-        end
+        own_ids = Component.where(sample_id: @sample_id).pluck(:id)
 
-        scope = Component.where(sample_id: @sample_id)
-        scope = scope.where.not(id: ids_to_keep) if ids_to_keep.any?
-        scope.destroy_all
+        # (1) Restrict the keep-list to ids that ACTUALLY belong to this sample.
+        # Placeholder ids ('new_1') and integer ids that reference another sample's
+        # components are ignored — the rows they represent are inserted by Create.
+        referenced_ids = @components_params.filter_map { |cp| Integer(cp[:id], exception: false) }
+        referenced_own_ids = own_ids & referenced_ids
+
+        # (2) Skip deletion ONLY when the payload carries integer ids but none of
+        # them belong to this sample (e.g. a freshly split sub-sample whose
+        # serialized components still carry the parent's ids) — that payload isn't
+        # describing this sample's rows, so deleting by it would wrongly wipe them.
+        # Otherwise the payload is authoritative: an empty or all-placeholder list
+        # legitimately means "these are all the components now" (the client sends
+        # [] to clear a mixture), so components it no longer references are deleted.
+        return if referenced_ids.any? && referenced_own_ids.empty?
+
+        # Delete this sample's components that the payload no longer references.
+        Component.where(sample_id: @sample_id, id: own_ids - referenced_own_ids).destroy_all
       end
     end
   end

--- a/app/usecases/components/reconcile.rb
+++ b/app/usecases/components/reconcile.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Use case for reconciling a sample's persisted components with a client payload.
+# Normalizes the payload once, then deletes rows the payload no longer references
+# and creates/updates the rest. This is the single entry point shared by the
+# standalone component API and the reaction material-update flow so the
+# delete-before-create ordering lives in exactly one place.
+module Usecases
+  module Components
+    class Reconcile
+      def initialize(sample, components)
+        @sample = sample
+        @components = Create.normalize(components)
+      end
+
+      def execute!
+        # Delete first so the keep-list only needs to consider rows that already
+        # exist in the DB (identified by their integer ids). Newly added
+        # components (string ids like 'new_1') are inserted by Create afterwards
+        # and are therefore unaffected by the deletion step.
+        DeleteRemovedComponents.new(@sample.id, @components).execute!
+        Create.new(@sample, @components).execute!
+      end
+    end
+  end
+end

--- a/app/usecases/reactions/update_materials.rb
+++ b/app/usecases/reactions/update_materials.rb
@@ -110,37 +110,14 @@ module Usecases
               samples.each_with_index do |sample, idx|
                 sample.position = idx if sample.position.nil?
                 sample.reference = false if material_group == 'solvent' && sample.reference == true
-                # Track whether the chosen branch has already persisted this sample's
-                # mixture components so we don't insert them a second time below.
-                components_already_persisted = false
-                if sample.is_new
-                  if sample.parent_id && material_group != 'product'
-                    modified_sample = create_sub_sample(
-                      sample,
-                      fixed_label,
-                      weight_percentage_ref_record_target_amount,
-                    )
-                    # create_sub_sample copies the parent's components onto the new
-                    # subsample (Sample#create_components_for_mixture_subsample), so
-                    # they are already persisted at this point.
-                    components_already_persisted = true
-                  else
-                    modified_sample = create_new_sample(sample, fixed_label, weight_percentage_ref_record_target_amount)
-                  end
-                else
-                  modified_sample = update_existing_sample(
-                    sample,
-                    fixed_label,
-                    weight_percentage_ref_record_target_amount,
-                  )
-                  # update_existing_sample already reconciles components internally.
-                  components_already_persisted = true
-                end
+                modified_sample = persist_sample(
+                  sample,
+                  material_group,
+                  fixed_label,
+                  weight_percentage_ref_record_target_amount,
+                )
 
-                if !components_already_persisted &&
-                   sample.components.present? && sample.sample_type == Sample::SAMPLE_TYPE_MIXTURE
-                  Usecases::Components::Create.new(modified_sample, sample.components).execute!
-                end
+                reconcile_mixture_components(modified_sample, sample)
 
                 if sample.segments
                   modified_sample.save_segments(segments: sample.segments,
@@ -162,10 +139,51 @@ module Usecases
 
       private
 
+      # Reconcile a mixture sample's persisted components with the client payload,
+      # deleting the ones the user removed and creating/updating the rest via the
+      # shared use case — the same flow the standalone component API uses. Without
+      # this, update_existing_sample only ever created components (removed ones
+      # survived) and a dragged-in sub-sample's client edits were shadowed by the
+      # parent copy.
+      #
+      # Skip only when components is nil (the payload omitted the key — e.g. a
+      # sub-sample keeping its parent copy). An explicit empty array is a real
+      # instruction ("the mixture now has no components") and is reconciled, which
+      # deletes any persisted components.
+      def reconcile_mixture_components(modified_sample, sample)
+        return unless sample.sample_type == Sample::SAMPLE_TYPE_MIXTURE
+        return if sample.components.nil?
+
+        Usecases::Components::Reconcile.new(modified_sample, sample.components).execute!
+      end
+
+      # Create or update a single sample, dispatching to the create-subsample,
+      # create-new, or update-existing path.
+      def persist_sample(sample, material_group, fixed_label, target_amount)
+        return update_existing_sample(sample, fixed_label, target_amount) unless sample.is_new
+
+        if sample.parent_id && material_group != 'product'
+          create_sub_sample(sample, fixed_label, target_amount)
+        else
+          create_new_sample(sample, fixed_label, target_amount)
+        end
+      end
+
       def create_sub_sample(sample, fixed_label, target_amount = nil)
         parent_sample = Sample.find(sample.parent_id)
 
-        subsample = parent_sample.create_subsample(@current_user, @reaction.collections, true, 'reaction')
+        # When the payload provides components (including an explicit empty array),
+        # reconcile_mixture_components is the single source of truth for them, so
+        # skip copying the parent's copies here (they would be duplicated, or should
+        # be cleared). Only copy the parent's components when the payload omits the
+        # key entirely (components is nil), matching reconcile's nil skip.
+        subsample = parent_sample.create_subsample(
+          @current_user,
+          @reaction.collections,
+          true,
+          'reaction',
+          copy_components: sample.components.nil?,
+        )
         subsample.short_label = fixed_label if fixed_label
 
         if @reaction.weight_percentage && sample.weight_percentage.present? &&
@@ -274,10 +292,6 @@ module Usecases
         existing_sample.short_label = fixed_label if fixed_label
         existing_sample.name = sample.name if sample.name
         existing_sample.dry_solvent = sample.dry_solvent
-        # Handle components for mixture samples using the proper use case
-        if sample.sample_type == Sample::SAMPLE_TYPE_MIXTURE && sample.components.present?
-          Usecases::Components::Create.new(existing_sample, sample.components).execute!
-        end
         existing_sample.solvent = sample.solvent
 
         if r = existing_sample.residues[0]

--- a/app/usecases/reactions/update_materials.rb
+++ b/app/usecases/reactions/update_materials.rb
@@ -110,6 +110,9 @@ module Usecases
               samples.each_with_index do |sample, idx|
                 sample.position = idx if sample.position.nil?
                 sample.reference = false if material_group == 'solvent' && sample.reference == true
+                # Track whether the chosen branch has already persisted this sample's
+                # mixture components so we don't insert them a second time below.
+                components_already_persisted = false
                 if sample.is_new
                   if sample.parent_id && material_group != 'product'
                     modified_sample = create_sub_sample(
@@ -117,6 +120,10 @@ module Usecases
                       fixed_label,
                       weight_percentage_ref_record_target_amount,
                     )
+                    # create_sub_sample copies the parent's components onto the new
+                    # subsample (Sample#create_components_for_mixture_subsample), so
+                    # they are already persisted at this point.
+                    components_already_persisted = true
                   else
                     modified_sample = create_new_sample(sample, fixed_label, weight_percentage_ref_record_target_amount)
                   end
@@ -126,9 +133,12 @@ module Usecases
                     fixed_label,
                     weight_percentage_ref_record_target_amount,
                   )
+                  # update_existing_sample already reconciles components internally.
+                  components_already_persisted = true
                 end
 
-                if sample.components.present? && sample.sample_type == Sample::SAMPLE_TYPE_MIXTURE
+                if !components_already_persisted &&
+                   sample.components.present? && sample.sample_type == Sample::SAMPLE_TYPE_MIXTURE
                   Usecases::Components::Create.new(modified_sample, sample.components).execute!
                 end
 

--- a/spec/javascripts/packs/src/models/Component.spec.js
+++ b/spec/javascripts/packs/src/models/Component.spec.js
@@ -1141,4 +1141,34 @@ describe('Component', () => {
       expect(component.molarity_value).toBe(null);
     });
   });
+
+  describe('resetAmounts', () => {
+    it('sets amount_mol, amount_g, amount_l, molarity_value, and concn to 0', () => {
+      component.amount_mol = 0.05;
+      component.amount_g = 9.0;
+      component.amount_l = 0.005;
+      component.molarity_value = 0.5;
+      component.concn = 0.5;
+
+      component.resetAmounts();
+
+      expect(component.amount_mol).toBe(0);
+      expect(component.amount_g).toBe(0);
+      expect(component.amount_l).toBe(0);
+      expect(component.molarity_value).toBe(0);
+      expect(component.concn).toBe(0);
+    });
+
+    it('does not affect purity, equivalent, or other fields', () => {
+      component.purity = 0.98;
+      component.equivalent = 2.0;
+      component.density = 1.2;
+
+      component.resetAmounts();
+
+      expect(component.purity).toBe(0.98);
+      expect(component.equivalent).toBe(2.0);
+      expect(component.density).toBe(1.2);
+    });
+  });
 });

--- a/spec/javascripts/packs/src/models/Sample.spec.js
+++ b/spec/javascripts/packs/src/models/Sample.spec.js
@@ -2210,6 +2210,14 @@ describe('Sample', async () => {
       return comp;
     }
 
+    beforeEach(() => {
+      sinon.restore();
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
     it('collapses two same-molecule components into one', async () => {
       const comp1 = makeComp(1, 42);
       const comp2 = makeComp(2, 42);
@@ -2263,21 +2271,16 @@ describe('Sample', async () => {
       expect(calcEquivSpy.callCount).toBe(2);
     });
 
-it('does not fetch a new molecule when molecules are the same', async () => {
-  const fetchStub = sinon.stub(MoleculesFetcher, 'fetchBySmi');
+    it('does not fetch a new molecule when molecules are the same', async () => {
+      const fetchStub = sinon.stub(MoleculesFetcher, 'fetchBySmi');
+      const comp1 = makeComp(1, 42);
+      const comp2 = makeComp(2, 42);
+      const sample = makeSample([comp1, comp2]);
 
-  try {
-    const comp1 = makeComp(1, 42);
-    const comp2 = makeComp(2, 42);
-    const sample = makeSample([comp1, comp2]);
+      await sample.mergeComponents(comp1, 'liquid', comp2, 'liquid');
 
-    await sample.mergeComponents(comp1, 'liquid', comp2, 'liquid');
-
-    expect(fetchStub.called).toBe(false);
-  } finally {
-    fetchStub.restore();
-  }
-});
+      expect(fetchStub.called).toBe(false);
+    });
   });
 
   describe('Sample.splitSmilesToMolecule() — structure editor reconciliation', () => {
@@ -2351,6 +2354,139 @@ it('does not fetch a new molecule when molecules are the same', async () => {
 
       expect(sample.components.length).toBe(3);
       expect(sample.components[2].molecule.id).toBe(77);
+    });
+
+    it('does not mis-attribute molecules when several fragments are edited at once', async () => {
+      // Both components edited, and the editor emits the new fragments in the
+      // reverse of the component order. Positional pairing would swap the
+      // molecules onto the wrong rows; the guardrail instead adds the edited
+      // fragments as fresh components without corrupting either original row.
+      const molX2 = { id: 201, cano_smiles: 'X2', molfile: 'x2' };
+      const molY2 = { id: 202, cano_smiles: 'Y2', molfile: 'y2' };
+      const fetchStub = sinon.stub(MoleculesFetcher, 'fetchBySmi');
+      fetchStub.withArgs('Y2').resolves(molY2);
+      fetchStub.withArgs('X2').resolves(molX2);
+      const compX = makeComponent(1, 42, 'X');
+      const compY = makeComponent(2, 43, 'Y');
+      const sample = makeMixture([compX, compY]);
+
+      await sample.splitSmilesToMolecule(['Y2', 'X2'], 'ketcher');
+
+      const moleculeIds = sample.components.map((c) => c.molecule.id);
+      expect(sample.components.length).toBe(2);
+      expect(moleculeIds).toContain(201);
+      expect(moleculeIds).toContain(202);
+      // The original rows were dropped, not silently re-pointed to a wrong molecule.
+      expect(sample.components).not.toContain(compX);
+      expect(sample.components).not.toContain(compY);
+    });
+
+    it('keeps both same-molecule components when the deduplicated editor structure is saved', async () => {
+      // Two components sharing one molecule render as a SINGLE structure in
+      // the editor (updateMixtureMolecule dedupes fragments), so a save emits
+      // one fragment. Set-based matching must treat both components as
+      // covered — count-based matching would delete one of them on every save.
+      const fetchStub = sinon.stub(MoleculesFetcher, 'fetchBySmi');
+      const compA = makeComponent(1, 43, 'c1ccccc1');
+      const compB = makeComponent(2, 43, 'c1ccccc1');
+      const sample = makeMixture([compA, compB]);
+
+      await sample.splitSmilesToMolecule(['c1ccccc1'], 'ketcher');
+
+      expect(fetchStub.called).toBe(false);
+      expect(sample.components.length).toBe(2);
+    });
+
+    it('ignores a duplicate ring drawn in the editor (canvas is deduplicated by design)', async () => {
+      // Drawing a second copy of an existing structure does not create a
+      // second component — duplicates are added via drag & drop, and the
+      // canvas would collapse back to one structure anyway.
+      const fetchStub = sinon.stub(MoleculesFetcher, 'fetchBySmi');
+      const compA = makeComponent(1, 43, 'c1ccccc1');
+      const sample = makeMixture([compA]);
+
+      await sample.splitSmilesToMolecule(['c1ccccc1', 'c1ccccc1'], 'ketcher');
+
+      expect(fetchStub.called).toBe(false);
+      expect(sample.components.length).toBe(1);
+      expect(sample.components[0]).toBe(compA);
+    });
+
+    it('does not corrupt existing components when a middle fetch fails during a multi-edit', async () => {
+      // C1=A, C2=B, C3=C all edited to X, Y, Z; the fetch for Y fails. In the
+      // ambiguous multi-edit path the resolved fragments are added as new
+      // components and — because not every fragment resolved — the originals are
+      // left untouched rather than corrupted or partially deleted.
+      const molX = { id: 201, cano_smiles: 'X', molfile: 'x' };
+      const molZ = { id: 203, cano_smiles: 'Z', molfile: 'z' };
+      const fetchStub = sinon.stub(MoleculesFetcher, 'fetchBySmi');
+      fetchStub.withArgs('X').resolves(molX);
+      fetchStub.withArgs('Y').resolves(null); // resolution failure
+      fetchStub.withArgs('Z').resolves(molZ);
+      const compA = makeComponent(1, 41, 'A');
+      const compB = makeComponent(2, 42, 'B');
+      const compC = makeComponent(3, 43, 'C');
+      const sample = makeMixture([compA, compB, compC]);
+
+      await sample.splitSmilesToMolecule(['X', 'Y', 'Z'], 'ketcher');
+
+      // No existing component was mutated to the wrong molecule.
+      expect(compA.molecule.id).toBe(41);
+      expect(compB.molecule.id).toBe(42);
+      expect(compC.molecule.id).toBe(43);
+      // The resolved fragments were added as new components.
+      const moleculeIds = sample.components.map((c) => c.molecule.id);
+      expect(moleculeIds).toContain(201);
+      expect(moleculeIds).toContain(203);
+    });
+  });
+
+  describe('Sample.serializeMaterial() — components tri-state', () => {
+    function makeMixture() {
+      const s = new Sample();
+      s.sample_type = 'Mixture';
+      return s;
+    }
+
+    it('serializes never-loaded components as null (server keeps/copies persisted ones)', () => {
+      const sample = makeMixture();
+
+      expect(sample.serializeMaterial().components).toBe(null);
+    });
+
+    it('serializes an explicitly emptied component list as [] (delete-all instruction)', () => {
+      const sample = makeMixture();
+      sample.components = [];
+
+      expect(sample.serializeMaterial().components).toEqual([]);
+    });
+
+    it('serializes hydrated components via serializeComponent', () => {
+      const sample = makeMixture();
+      const comp = new Component({});
+      comp.id = 1;
+      comp.molecule = { id: 42, cano_smiles: 'CCO' };
+      sample.components = [comp];
+
+      const serialized = sample.serializeMaterial().components;
+      expect(serialized.length).toBe(1);
+      expect(serialized[0].id).toBe(1);
+      expect(serialized[0].component_properties.molecule_id).toBe(42);
+    });
+
+    it('passes raw API component objects through unchanged instead of crashing', () => {
+      const sample = makeMixture();
+      const raw = {
+        id: 7,
+        name: 'Comp A',
+        position: 0,
+        component_properties: { molecule_id: 42, amount_mol: 0.1 },
+      };
+      sample.components = [raw];
+
+      const serialized = sample.serializeMaterial().components;
+      expect(serialized.length).toBe(1);
+      expect(serialized[0]).toEqual(raw);
     });
   });
 });

--- a/spec/javascripts/packs/src/models/Sample.spec.js
+++ b/spec/javascripts/packs/src/models/Sample.spec.js
@@ -2197,16 +2197,17 @@ describe('Sample', async () => {
     }
 
     function makeComp(id, moleculeId, amounts = {}) {
-      return {
-        id,
-        molecule: { id: moleculeId },
-        amount_mol: amounts.mol ?? 0.01,
-        amount_g: amounts.g ?? 1.8,
-        amount_l: amounts.l ?? 0.001,
-        material_group: 'liquid',
-        position: 0,
-        reference: false,
-      };
+      const comp = new Component({});
+      comp.id = id;
+      comp.molecule = { id: moleculeId };
+      comp.amount_mol = amounts.mol ?? 0.01;
+      comp.amount_g = amounts.g ?? 1.8;
+      comp.amount_l = amounts.l ?? 0.001;
+      comp.material_group = 'liquid';
+      comp.position = 0;
+      comp.reference = false;
+      comp.purity = 1;
+      return comp;
     }
 
     it('collapses two same-molecule components into one', async () => {
@@ -2262,18 +2263,21 @@ describe('Sample', async () => {
       expect(calcEquivSpy.callCount).toBe(2);
     });
 
-    it('does not fetch a new molecule when molecules are the same', async () => {
-      const fetchStub = sinon.stub(MoleculesFetcher, 'fetchBySmi');
+it('does not fetch a new molecule when molecules are the same', async () => {
+  const fetchStub = sinon.stub(MoleculesFetcher, 'fetchBySmi');
 
-      const comp1 = makeComp(1, 42);
-      const comp2 = makeComp(2, 42);
-      const sample = makeSample([comp1, comp2]);
+  try {
+    const comp1 = makeComp(1, 42);
+    const comp2 = makeComp(2, 42);
+    const sample = makeSample([comp1, comp2]);
 
-      await sample.mergeComponents(comp1, 'liquid', comp2, 'liquid');
+    await sample.mergeComponents(comp1, 'liquid', comp2, 'liquid');
 
-      expect(fetchStub.called).toBe(false);
-      fetchStub.restore();
-    });
+    expect(fetchStub.called).toBe(false);
+  } finally {
+    fetchStub.restore();
+  }
+});
   });
 
   describe('Sample.splitSmilesToMolecule() — structure editor reconciliation', () => {

--- a/spec/javascripts/packs/src/models/Sample.spec.js
+++ b/spec/javascripts/packs/src/models/Sample.spec.js
@@ -2275,4 +2275,78 @@ describe('Sample', async () => {
       fetchStub.restore();
     });
   });
+
+  describe('Sample.splitSmilesToMolecule() — structure editor reconciliation', () => {
+    function makeComponent(id, moleculeId, canoSmiles) {
+      const comp = new Component({});
+      comp.id = id;
+      comp.molecule = { id: moleculeId, cano_smiles: canoSmiles };
+      comp.material_group = 'liquid';
+      comp.purity = 1;
+      return comp;
+    }
+
+    function makeMixture(comps) {
+      const s = new Sample();
+      s.sample_type = 'Mixture';
+      s.components = comps;
+      return s;
+    }
+
+    // Restore in beforeEach too: an earlier failing test can leak a
+    // fetchBySmi stub, which would make stubbing here throw.
+    beforeEach(() => {
+      sinon.restore();
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('does not re-add components whose structure is unchanged', async () => {
+      const fetchStub = sinon.stub(MoleculesFetcher, 'fetchBySmi');
+      const compA = makeComponent(1, 42, 'CCO');
+      const compB = makeComponent(2, 43, 'c1ccccc1');
+      const sample = makeMixture([compA, compB]);
+
+      await sample.splitSmilesToMolecule(['CCO', 'c1ccccc1'], 'ketcher');
+
+      expect(fetchStub.called).toBe(false);
+      expect(sample.components.length).toBe(2);
+    });
+
+    it('updates the existing component in place when its structure was edited', async () => {
+      const editedMolecule = { id: 99, cano_smiles: 'CCC', molfile: 'edited molfile' };
+      const fetchStub = sinon.stub(MoleculesFetcher, 'fetchBySmi').resolves(editedMolecule);
+      const compA = makeComponent(1, 42, 'CCO');
+      const compB = makeComponent(2, 43, 'c1ccccc1');
+      const sample = makeMixture([compA, compB]);
+
+      // 'CCO' was edited to 'CCC' in the structure editor
+      await sample.splitSmilesToMolecule(['CCC', 'c1ccccc1'], 'ketcher');
+
+      expect(fetchStub.calledOnce).toBe(true);
+      expect(fetchStub.firstCall.args[0]).toBe('CCC');
+      // No additional component; the stale one was updated in place
+      expect(sample.components.length).toBe(2);
+      expect(sample.components[0]).toBe(compA);
+      expect(compA.molecule.id).toBe(99);
+      expect(compA.molecule_cano_smiles).toBe('CCC');
+      expect(compA.molfile).toBe('edited molfile');
+    });
+
+    it('adds a new component when a new structure was drawn', async () => {
+      const newMolecule = { id: 77, cano_smiles: 'CCC', molfile: 'new molfile' };
+      sinon.stub(MoleculesFetcher, 'fetchBySmi').resolves(newMolecule);
+      const compA = makeComponent(1, 42, 'CCO');
+      const compB = makeComponent(2, 43, 'c1ccccc1');
+      const sample = makeMixture([compA, compB]);
+
+      // a third structure was added in the structure editor
+      await sample.splitSmilesToMolecule(['CCO', 'c1ccccc1', 'CCC'], 'ketcher');
+
+      expect(sample.components.length).toBe(3);
+      expect(sample.components[2].molecule.id).toBe(77);
+    });
+  });
 });

--- a/spec/javascripts/packs/src/models/Sample.spec.js
+++ b/spec/javascripts/packs/src/models/Sample.spec.js
@@ -6,6 +6,7 @@ import SampleFactory from 'factories/SampleFactory';
 import Sample from 'src/models/Sample.js';
 import Reaction from 'src/models/Reaction';
 import Component from 'src/models/Component';
+import MoleculesFetcher from 'src/fetchers/MoleculesFetcher';
 
 describe('Sample', async () => {
   const referenceSample = await SampleFactory.build('SampleFactory.water_100g');
@@ -2184,6 +2185,94 @@ describe('Sample', async () => {
       expect(sample.preserveConcentration).toBe(false);
       expect(sample.amount_value).toBe(originalValue);
       expect(sample.amount_unit).toBe(originalUnit);
+    });
+  });
+
+  describe('Sample.mergeComponents() — same molecule', () => {
+    function makeSample(comps) {
+      const s = new Sample();
+      s.sample_type = 'Mixture';
+      s.components = comps;
+      return s;
+    }
+
+    function makeComp(id, moleculeId, amounts = {}) {
+      return {
+        id,
+        molecule: { id: moleculeId },
+        amount_mol: amounts.mol ?? 0.01,
+        amount_g: amounts.g ?? 1.8,
+        amount_l: amounts.l ?? 0.001,
+        material_group: 'liquid',
+        position: 0,
+        reference: false,
+      };
+    }
+
+    it('collapses two same-molecule components into one', async () => {
+      const comp1 = makeComp(1, 42);
+      const comp2 = makeComp(2, 42);
+      const sample = makeSample([comp1, comp2]);
+
+      await sample.mergeComponents(comp1, 'liquid', comp2, 'liquid');
+
+      expect(sample.components.length).toBe(1);
+    });
+
+    it('retains the target component (not the source)', async () => {
+      const comp1 = makeComp(1, 42);
+      const comp2 = makeComp(2, 42);
+      const sample = makeSample([comp1, comp2]);
+
+      await sample.mergeComponents(comp1, 'liquid', comp2, 'liquid');
+
+      expect(sample.components[0]).toBe(comp2);
+    });
+
+    it('resets target amounts and concentration to 0', async () => {
+      const comp1 = makeComp(1, 42, { mol: 0.01, g: 1.8, l: 0.001 });
+      const comp2 = makeComp(2, 42, { mol: 0.05, g: 9.0, l: 0.005 });
+      comp2.molarity_value = 0.5;
+      comp2.concn = 0.5;
+      const sample = makeSample([comp1, comp2]);
+
+      await sample.mergeComponents(comp1, 'liquid', comp2, 'liquid');
+
+      expect(sample.components[0].amount_mol).toBe(0);
+      expect(sample.components[0].amount_g).toBe(0);
+      expect(sample.components[0].amount_l).toBe(0);
+      expect(sample.components[0].molarity_value).toBe(0);
+      expect(sample.components[0].concn).toBe(0);
+    });
+
+    it('recalculates mass and equivalents after resetting amounts', async () => {
+      const calcMassSpy = sinon.spy();
+      const calcEquivSpy = sinon.spy();
+
+      const comp1 = makeComp(1, 42, { mol: 0.01, g: 1.8, l: 0.001 });
+      const comp2 = makeComp(2, 42, { mol: 0.05, g: 9.0, l: 0.005 });
+      const sample = makeSample([comp1, comp2]);
+      sample.calculateTotalMixtureMass = calcMassSpy;
+      sample.updateMixtureComponentEquivalent = calcEquivSpy;
+
+      await sample.mergeComponents(comp1, 'liquid', comp2, 'liquid');
+
+      // Called once by deleteMixtureComponent and once after resetAmounts
+      expect(calcMassSpy.callCount).toBe(2);
+      expect(calcEquivSpy.callCount).toBe(2);
+    });
+
+    it('does not fetch a new molecule when molecules are the same', async () => {
+      const fetchStub = sinon.stub(MoleculesFetcher, 'fetchBySmi');
+
+      const comp1 = makeComp(1, 42);
+      const comp2 = makeComp(2, 42);
+      const sample = makeSample([comp1, comp2]);
+
+      await sample.mergeComponents(comp1, 'liquid', comp2, 'liquid');
+
+      expect(fetchStub.called).toBe(false);
+      fetchStub.restore();
     });
   });
 });

--- a/spec/usecases/components/create_spec.rb
+++ b/spec/usecases/components/create_spec.rb
@@ -193,6 +193,50 @@ RSpec.describe Usecases::Components::Create do
       end
     end
 
+    context 'when adding multiple components that share the same molecule' do
+      let(:sample_type) { Sample::SAMPLE_TYPE_MIXTURE }
+      let(:total_mixture_mass) { 100.0 }
+      let(:components_params) do
+        [
+          {
+            id: 'new_1',
+            name: 'Toluene A',
+            position: 1,
+            component_properties: {
+              molecule_id: molecule_1.id,
+              amount_mol: 0.1,
+              amount_g: 50.0,
+            },
+          },
+          {
+            id: 'new_2',
+            name: 'Toluene B',
+            position: 2,
+            component_properties: {
+              molecule_id: molecule_1.id,
+              amount_mol: 0.2,
+              amount_g: 30.0,
+            },
+          },
+        ]
+      end
+
+      before do
+        sample_details_double = instance_double(Hash)
+        allow(sample_details_double).to receive(:dig).with('total_mixture_mass_g').and_return(total_mixture_mass)
+        allow(sample).to receive(:sample_details).and_return(sample_details_double)
+      end
+
+      it 'persists each component as its own row' do
+        expect { use_case.execute! }
+          .to change(Component, :count).by(2)
+
+        components = Component.where(sample_id: sample.id).order(:position)
+        expect(components.map(&:name)).to eq(['Toluene A', 'Toluene B'])
+        expect(components.map { |c| c.component_properties['molecule_id'] }).to eq([molecule_1.id, molecule_1.id])
+      end
+    end
+
     context 'when updating existing components' do
       let(:sample_type) { Sample::SAMPLE_TYPE_MIXTURE }
       let(:total_mixture_mass) { 200.0 }

--- a/spec/usecases/components/create_spec.rb
+++ b/spec/usecases/components/create_spec.rb
@@ -322,7 +322,7 @@ RSpec.describe Usecases::Components::Create do
         allow(sample).to receive(:sample_details).and_return(sample_details_double)
       end
 
-      it 'modifies component_properties hash in place' do
+      it 'calculates relative_molecular_weight on the normalized components' do
         components_params = [
           {
             id: 'new_1',
@@ -335,13 +335,11 @@ RSpec.describe Usecases::Components::Create do
           },
         ]
 
-        # The calculation should modify the hash in place
-        expect(components_params.first[:component_properties][:relative_molecular_weight]).to be_nil
-
         use_case = described_class.new(sample, components_params)
         use_case.send(:calculate_relative_molecular_weights)
 
-        expect(components_params.first[:component_properties][:relative_molecular_weight]).to eq(500.0)
+        internal = use_case.instance_variable_get(:@components)
+        expect(internal.first[:component_properties][:relative_molecular_weight]).to eq(500.0)
       end
     end
   end

--- a/spec/usecases/components/delete_removed_components_spec.rb
+++ b/spec/usecases/components/delete_removed_components_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Usecases::Components::DeleteRemovedComponents do
     context 'when all ids are placeholder strings' do
       let(:components_params) { [{ id: 'new_1' }, { id: 'new_2' }] }
 
-      it 'deletes all existing components for the sample' do
+      it 'deletes all existing components (the all-new payload is authoritative)' do
         use_case.execute!
         expect(Component.where(sample_id: sample.id).count).to eq(0)
       end
@@ -58,9 +58,19 @@ RSpec.describe Usecases::Components::DeleteRemovedComponents do
     context 'when components_params is empty' do
       let(:components_params) { [] }
 
-      it 'deletes all existing components for the sample' do
+      it 'deletes all existing components (an empty payload clears the mixture)' do
         use_case.execute!
         expect(Component.where(sample_id: sample.id).count).to eq(0)
+      end
+    end
+
+    context 'when the payload is string-keyed (not yet normalized)' do
+      let(:components_params) { [{ 'id' => component_a.id }] }
+
+      it 'still resolves the keep-list instead of wiping all components' do
+        use_case.execute!
+        remaining_ids = Component.where(sample_id: sample.id).pluck(:id)
+        expect(remaining_ids).to contain_exactly(component_a.id)
       end
     end
 
@@ -82,6 +92,22 @@ RSpec.describe Usecases::Components::DeleteRemovedComponents do
       described_class.new(sample.id, []).execute!
 
       expect(Component.find_by(id: other_component.id)).to be_present
+    end
+
+    context 'when the payload references only ids belonging to another sample' do
+      # A freshly split sub-sample's serialized components still carry the PARENT's
+      # component ids. Those integer ids are not this sample's rows, so the payload
+      # is not authoritative for deletion — it must not wipe this sample's real
+      # components (which Create would then re-insert as churned copies).
+      let(:other_sample) { create(:sample) }
+      let!(:foreign_component) { create(:component, sample: other_sample, position: 1) }
+      let(:components_params) { [{ id: foreign_component.id }] }
+
+      it 'does not delete this sample\'s components' do
+        use_case.execute!
+        remaining_ids = Component.where(sample_id: sample.id).pluck(:id)
+        expect(remaining_ids).to contain_exactly(component_a.id, component_b.id, component_c.id)
+      end
     end
   end
 end

--- a/spec/usecases/components/delete_removed_components_spec.rb
+++ b/spec/usecases/components/delete_removed_components_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Usecases::Components::DeleteRemovedComponents do
+  let(:sample) { create(:sample) }
+  let(:use_case) { described_class.new(sample.id, components_params) }
+
+  describe '#execute!' do
+    let!(:component_a) { create(:component, sample: sample, position: 1) }
+    let!(:component_b) { create(:component, sample: sample, position: 2) }
+    let!(:component_c) { create(:component, sample: sample, position: 3) }
+
+    context 'when ids_to_keep are integer ids' do
+      let(:components_params) { [{ id: component_a.id }, { id: component_b.id }] }
+
+      it 'deletes only the components not in the keep list' do
+        use_case.execute!
+        remaining_ids = Component.where(sample_id: sample.id).pluck(:id)
+        expect(remaining_ids).to contain_exactly(component_a.id, component_b.id)
+        expect(remaining_ids).not_to include(component_c.id)
+      end
+    end
+
+    context 'when ids_to_keep are numeric string ids' do
+      let(:components_params) { [{ id: component_a.id.to_s }, { id: component_b.id.to_s }] }
+
+      it 'treats numeric strings as existing ids and preserves those components' do
+        use_case.execute!
+        remaining_ids = Component.where(sample_id: sample.id).pluck(:id)
+        expect(remaining_ids).to contain_exactly(component_a.id, component_b.id)
+        expect(remaining_ids).not_to include(component_c.id)
+      end
+    end
+
+    context 'when ids_to_keep mix integer ids and placeholder string ids' do
+      let(:components_params) do
+        [{ id: component_a.id }, { id: 'new_1' }, { id: 'comp_xyz' }]
+      end
+
+      it 'keeps the component with a real integer id and ignores placeholder ids' do
+        use_case.execute!
+        remaining_ids = Component.where(sample_id: sample.id).pluck(:id)
+        expect(remaining_ids).to contain_exactly(component_a.id)
+        expect(remaining_ids).not_to include(component_b.id, component_c.id)
+      end
+    end
+
+    context 'when all ids are placeholder strings' do
+      let(:components_params) { [{ id: 'new_1' }, { id: 'new_2' }] }
+
+      it 'deletes all existing components for the sample' do
+        use_case.execute!
+        expect(Component.where(sample_id: sample.id).count).to eq(0)
+      end
+    end
+
+    context 'when components_params is empty' do
+      let(:components_params) { [] }
+
+      it 'deletes all existing components for the sample' do
+        use_case.execute!
+        expect(Component.where(sample_id: sample.id).count).to eq(0)
+      end
+    end
+
+    context 'when all existing component ids are in the keep list' do
+      let(:components_params) do
+        [{ id: component_a.id }, { id: component_b.id }, { id: component_c.id }]
+      end
+
+      it 'does not delete any components' do
+        use_case.execute!
+        expect(Component.where(sample_id: sample.id).count).to eq(3)
+      end
+    end
+
+    it 'does not affect components belonging to other samples' do
+      other_sample = create(:sample)
+      other_component = create(:component, sample: other_sample, position: 1)
+
+      described_class.new(sample.id, []).execute!
+
+      expect(Component.find_by(id: other_component.id)).to be_present
+    end
+  end
+end

--- a/spec/usecases/components/reconcile_spec.rb
+++ b/spec/usecases/components/reconcile_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Usecases::Components::Reconcile do
+  let(:molecule_a) { create(:molecule) }
+  let(:molecule_b) { create(:molecule) }
+  let(:sample) { create(:sample, sample_type: Sample::SAMPLE_TYPE_MIXTURE) }
+  let!(:component_a) do
+    create(:component, sample: sample, name: 'Comp A', position: 0,
+                       component_properties: { 'molecule_id' => molecule_a.id, 'amount_mol' => 0.1 })
+  end
+  let!(:component_b) do
+    create(:component, sample: sample, name: 'Comp B', position: 1,
+                       component_properties: { 'molecule_id' => molecule_b.id, 'amount_mol' => 0.2 })
+  end
+
+  describe '#execute!' do
+    # Payload keeps Comp A (renamed), drops Comp B, and adds a brand-new row.
+    let(:components_params) do
+      [
+        { id: component_a.id, name: 'Comp A (edited)', position: 0,
+          component_properties: { molecule_id: molecule_a.id, amount_mol: 0.1 } },
+        { id: 'new_1', name: 'Comp C', position: 1,
+          component_properties: { molecule_id: molecule_b.id, amount_mol: 0.3 } },
+      ]
+    end
+
+    it 'deletes removed components, updates kept ones, and inserts new ones in a single call' do
+      described_class.new(sample, components_params).execute!
+
+      components = Component.where(sample_id: sample.id).order(:position)
+      expect(components.pluck(:name)).to eq(['Comp A (edited)', 'Comp C'])
+      expect(Component.exists?(component_b.id)).to be(false)
+    end
+
+    it 'normalizes string-keyed payloads so the keep-list is honored' do
+      string_keyed = [{ 'id' => component_a.id, 'name' => 'Comp A',
+                        'component_properties' => { 'molecule_id' => molecule_a.id } }]
+
+      described_class.new(sample, string_keyed).execute!
+
+      expect(Component.where(sample_id: sample.id).pluck(:name)).to contain_exactly('Comp A')
+    end
+  end
+end

--- a/spec/usecases/reactions/update_materials_spec.rb
+++ b/spec/usecases/reactions/update_materials_spec.rb
@@ -195,29 +195,31 @@ describe Usecases::Reactions::UpdateMaterials do
       let(:samples) do
         {
           'reactants' => [
-            'target_amount_unit' => 'mg',
-            'target_amount_value' => 86.09596,
-            'equivalent' => 1,
-            'reference' => false,
-            'is_new' => true,
-            'molfile' => molfile,
-            'container' => root_container,
-            'parent_id' => mixture_parent.id,
-            'sample_type' => Sample::SAMPLE_TYPE_MIXTURE,
-            'components' => [
-              {
-                'id' => parent_component_a.id,
-                'name' => 'Comp A',
-                'position' => 0,
-                'component_properties' => { 'molecule_id' => molecule_a.id, 'amount_mol' => 0.1 },
-              },
-              {
-                'id' => parent_component_b.id,
-                'name' => 'Comp B',
-                'position' => 1,
-                'component_properties' => { 'molecule_id' => molecule_b.id, 'amount_mol' => 0.2 },
-              },
-            ],
+            {
+              'target_amount_unit' => 'mg',
+              'target_amount_value' => 86.09596,
+              'equivalent' => 1,
+              'reference' => false,
+              'is_new' => true,
+              'molfile' => molfile,
+              'container' => root_container,
+              'parent_id' => mixture_parent.id,
+              'sample_type' => Sample::SAMPLE_TYPE_MIXTURE,
+              'components' => [
+                {
+                  'id' => parent_component_a.id,
+                  'name' => 'Comp A',
+                  'position' => 0,
+                  'component_properties' => { 'molecule_id' => molecule_a.id, 'amount_mol' => 0.1 },
+                },
+                {
+                  'id' => parent_component_b.id,
+                  'name' => 'Comp B',
+                  'position' => 1,
+                  'component_properties' => { 'molecule_id' => molecule_b.id, 'amount_mol' => 0.2 },
+                },
+              ],
+            },
           ],
         }
       end
@@ -227,6 +229,157 @@ describe Usecases::Reactions::UpdateMaterials do
 
         expect(subsample).to be_present
         expect(Component.where(sample_id: subsample.id).count).to eq(2)
+      end
+    end
+
+    context 'when a new mixture sub-sample carries client-edited components' do
+      let(:molecule_a) { create(:molecule) }
+      let(:molecule_b) { create(:molecule) }
+      let(:mixture_parent) do
+        create(:sample, name: 'MixtureParent',
+                        sample_type: Sample::SAMPLE_TYPE_MIXTURE,
+                        container: create(:container))
+      end
+      let!(:parent_component_a) do
+        create(:component, sample: mixture_parent, name: 'Comp A', position: 0,
+                           component_properties: { 'molecule_id' => molecule_a.id, 'amount_mol' => 0.1 })
+      end
+      let!(:parent_component_b) do
+        create(:component, sample: mixture_parent, name: 'Comp B', position: 1,
+                           component_properties: { 'molecule_id' => molecule_b.id, 'amount_mol' => 0.2 })
+      end
+      # The user renamed Comp A and changed its amount before the first save; the
+      # payload carries the edited values while still referencing the parent's ids.
+      let(:samples) do
+        {
+          'reactants' => [
+            {
+              'target_amount_unit' => 'mg',
+              'target_amount_value' => 86.09596,
+              'equivalent' => 1,
+              'reference' => false,
+              'is_new' => true,
+              'molfile' => molfile,
+              'container' => root_container,
+              'parent_id' => mixture_parent.id,
+              'sample_type' => Sample::SAMPLE_TYPE_MIXTURE,
+              'components' => [
+                {
+                  'id' => parent_component_a.id,
+                  'name' => 'Comp A (edited)',
+                  'position' => 0,
+                  'component_properties' => { 'molecule_id' => molecule_a.id, 'amount_mol' => 0.5 },
+                },
+                {
+                  'id' => parent_component_b.id,
+                  'name' => 'Comp B',
+                  'position' => 1,
+                  'component_properties' => { 'molecule_id' => molecule_b.id, 'amount_mol' => 0.2 },
+                },
+              ],
+            },
+          ],
+        }
+      end
+
+      it 'persists the client-edited component values, not the parent copies' do
+        subsample = Sample.find_by(short_label: 'reactant')
+        components = Component.where(sample_id: subsample.id).order(:position)
+
+        expect(components.count).to eq(2)
+        expect(components.first.name).to eq('Comp A (edited)')
+        expect(components.first.component_properties['amount_mol']).to eq(0.5)
+      end
+    end
+
+    context 'when an existing mixture sample has a component removed' do
+      let(:molecule_a) { create(:molecule) }
+      let(:molecule_b) { create(:molecule) }
+      # Build the sample with both components here (not via let!) so they exist
+      # before the shared `before` hook runs execute! — the removed one (Comp B) is
+      # not referenced in the payload, so a let! would create it after execute! and
+      # mask the deletion.
+      let(:mixture_sample) do
+        s = create(:sample, name: 'Mixture',
+                            sample_type: Sample::SAMPLE_TYPE_MIXTURE,
+                            container: create(:container))
+        create(:component, sample: s, name: 'Comp A', position: 0,
+                           component_properties: { 'molecule_id' => molecule_a.id, 'amount_mol' => 0.1 })
+        create(:component, sample: s, name: 'Comp B', position: 1,
+                           component_properties: { 'molecule_id' => molecule_b.id, 'amount_mol' => 0.2 })
+        s
+      end
+      let(:component_a) { mixture_sample.components.find_by(name: 'Comp A') }
+      # The client removed Comp B in the reaction editor: only Comp A remains.
+      let(:samples) do
+        {
+          'starting_materials' => [
+            {
+              'id' => mixture_sample.id,
+              'name' => 'Mixture',
+              'target_amount_unit' => 'mg',
+              'target_amount_value' => 75.09596,
+              'equivalent' => 1,
+              'reference' => false,
+              'is_new' => false,
+              'molfile' => molfile,
+              'container' => root_container,
+              'sample_type' => Sample::SAMPLE_TYPE_MIXTURE,
+              'components' => [
+                {
+                  'id' => component_a.id,
+                  'name' => 'Comp A',
+                  'position' => 0,
+                  'component_properties' => { 'molecule_id' => molecule_a.id, 'amount_mol' => 0.1 },
+                },
+              ],
+            },
+          ],
+        }
+      end
+
+      it 'deletes the removed component' do
+        expect(Component.where(sample_id: mixture_sample.id).pluck(:name)).to contain_exactly('Comp A')
+      end
+    end
+
+    context 'when an existing mixture sample has all components cleared' do
+      let(:molecule_a) { create(:molecule) }
+      let(:molecule_b) { create(:molecule) }
+      let(:mixture_sample) do
+        s = create(:sample, name: 'Mixture',
+                            sample_type: Sample::SAMPLE_TYPE_MIXTURE,
+                            container: create(:container))
+        create(:component, sample: s, name: 'Comp A', position: 0,
+                           component_properties: { 'molecule_id' => molecule_a.id, 'amount_mol' => 0.1 })
+        create(:component, sample: s, name: 'Comp B', position: 1,
+                           component_properties: { 'molecule_id' => molecule_b.id, 'amount_mol' => 0.2 })
+        s
+      end
+      # The client cleared every component; it sends an explicit empty array, which
+      # must reconcile to zero persisted components (nil would instead be skipped).
+      let(:samples) do
+        {
+          'starting_materials' => [
+            {
+              'id' => mixture_sample.id,
+              'name' => 'Mixture',
+              'target_amount_unit' => 'mg',
+              'target_amount_value' => 75.09596,
+              'equivalent' => 1,
+              'reference' => false,
+              'is_new' => false,
+              'molfile' => molfile,
+              'container' => root_container,
+              'sample_type' => Sample::SAMPLE_TYPE_MIXTURE,
+              'components' => [],
+            },
+          ],
+        }
+      end
+
+      it 'deletes all persisted components' do
+        expect(Component.where(sample_id: mixture_sample.id).count).to eq(0)
       end
     end
 

--- a/spec/usecases/reactions/update_materials_spec.rb
+++ b/spec/usecases/reactions/update_materials_spec.rb
@@ -173,6 +173,63 @@ describe Usecases::Reactions::UpdateMaterials do
       end
     end
 
+    context 'when sample is a new mixture sub-sample' do
+      let(:molecule_a) { create(:molecule) }
+      let(:molecule_b) { create(:molecule) }
+      let(:mixture_parent) do
+        create(:sample, name: 'MixtureParent',
+                        sample_type: Sample::SAMPLE_TYPE_MIXTURE,
+                        container: create(:container))
+      end
+      let!(:parent_component_a) do
+        create(:component, sample: mixture_parent, name: 'Comp A', position: 0,
+                           component_properties: { 'molecule_id' => molecule_a.id, 'amount_mol' => 0.1 })
+      end
+      let!(:parent_component_b) do
+        create(:component, sample: mixture_parent, name: 'Comp B', position: 1,
+                           component_properties: { 'molecule_id' => molecule_b.id, 'amount_mol' => 0.2 })
+      end
+      # Mirrors the front-end payload for a freshly dragged-in mixture: a new
+      # split sub-sample whose serialized components still carry the parent's
+      # component ids.
+      let(:samples) do
+        {
+          'reactants' => [
+            'target_amount_unit' => 'mg',
+            'target_amount_value' => 86.09596,
+            'equivalent' => 1,
+            'reference' => false,
+            'is_new' => true,
+            'molfile' => molfile,
+            'container' => root_container,
+            'parent_id' => mixture_parent.id,
+            'sample_type' => Sample::SAMPLE_TYPE_MIXTURE,
+            'components' => [
+              {
+                'id' => parent_component_a.id,
+                'name' => 'Comp A',
+                'position' => 0,
+                'component_properties' => { 'molecule_id' => molecule_a.id, 'amount_mol' => 0.1 },
+              },
+              {
+                'id' => parent_component_b.id,
+                'name' => 'Comp B',
+                'position' => 1,
+                'component_properties' => { 'molecule_id' => molecule_b.id, 'amount_mol' => 0.2 },
+              },
+            ],
+          ],
+        }
+      end
+
+      it 'copies the parent components onto the sub-sample without duplicating them' do
+        subsample = Sample.find_by(short_label: 'reactant')
+
+        expect(subsample).to be_present
+        expect(Component.where(sample_id: subsample.id).count).to eq(2)
+      end
+    end
+
     context 'when vessel volume is valid' do
       it 'returns the calculated mole gas product' do
         result = class_instance.send(:update_mole_gas_product, product_sample, 80)


### PR DESCRIPTION
- Updated the component creation process to handle multiple components sharing the same molecule, ensuring each is persisted as a separate row. [Demo](https://drive.google.com/file/d/1LsF3AJzyu6J7_GW6cLu7YBbDqh9DtDiL/view?usp=sharing)
- Enhanced the deletion logic to remove components based on their IDs rather than molecule IDs, allowing for better management of newly added components.
- Improved the handling of component updates in the sample's state, ensuring that the API response is utilized to refresh component data accurately.
- Added checks to prevent duplicate component additions during drag-and-drop operations in the UI.
- Fixed an issue where editing an existing component in the structure editor incorrectly created a new component instead of updating the existing one. [Demo](https://drive.google.com/file/d/1WjzjfI0XSo6tx-FTkyoKW-OnVm6QLRKu/view)

This refactor aims to enhance the integrity and performance of component management within samples, particularly for mixtures.

Closes https://github.com/ComPlat/chemotion/issues/515
