### PR TITLE
fix(js): replace removed default Immutable export with named imports

### DIFF
--- a/app/javascript/src/apps/mydb/collections/LiteratureModal.js
+++ b/app/javascript/src/apps/mydb/collections/LiteratureModal.js
@@ -9,7 +9,7 @@ import {
   OverlayTrigger,
   Tooltip
 } from 'react-bootstrap';
-import Immutable from 'immutable';
+import { Map } from 'immutable';
 import { uniqBy } from 'lodash';
 import AppModal from 'src/components/common/AppModal';
 import {
@@ -132,7 +132,7 @@ export default class LiteratureModal extends Component {
     this.state = {
       sampleRefs: [],
       reactionRefs: [],
-      selectedRefs: new Immutable.Map(),
+      selectedRefs: new Map(),
       literature: Literature.buildEmpty(),
       sorting: 'element',
       sortedIds: [],

--- a/app/javascript/src/apps/mydb/collections/LiteratureModal.js
+++ b/app/javascript/src/apps/mydb/collections/LiteratureModal.js
@@ -132,7 +132,7 @@ export default class LiteratureModal extends Component {
     this.state = {
       sampleRefs: [],
       reactionRefs: [],
-      selectedRefs: new Map(),
+      selectedRefs: Map(),
       literature: Literature.buildEmpty(),
       sorting: 'element',
       sortedIds: [],

--- a/app/javascript/src/apps/mydb/elements/details/ElementDetailSortTab.js
+++ b/app/javascript/src/apps/mydb/elements/details/ElementDetailSortTab.js
@@ -9,7 +9,7 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import { Popover } from 'react-bootstrap';
-import Immutable from 'immutable';
+import { List } from 'immutable';
 import { isEmpty, set } from 'lodash';
 import UserStore from 'src/stores/alt/stores/UserStore';
 import UserActions from 'src/stores/alt/actions/UserActions';
@@ -29,8 +29,8 @@ export default function ElementDetailSortTab({
   openedFromCollectionId,
 }) {
   const { collections } = useContext(StoreContext);
-  const [visible, setVisible] = useState(Immutable.List());
-  const [hidden, setHidden] = useState(Immutable.List());
+  const [visible, setVisible] = useState(List());
+  const [hidden, setHidden] = useState(List());
   const addInventoryTabRef = useRef(addInventoryTab);
   const availableTabsRef = useRef(availableTabs);
   const onTabPositionChangedRef = useRef(onTabPositionChanged);

--- a/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/DeviceDescriptionDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/deviceDescriptions/DeviceDescriptionDetails.js
@@ -11,7 +11,7 @@ import { commentActivation } from 'src/utilities/CommentHelper';
 import MatrixCheck from 'src/components/common/MatrixCheck';
 import ElementDetailCard from 'src/apps/mydb/elements/details/ElementDetailCard';
 import ElementDetailSortTab from 'src/apps/mydb/elements/details/ElementDetailSortTab';
-import Immutable from 'immutable';
+import { List } from 'immutable';
 import { formatTimeStampsOfElement } from 'src/utilities/timezoneHelper';
 
 import AttachmentFetcher from 'src/fetchers/AttachmentFetcher';
@@ -40,7 +40,7 @@ function DeviceDescriptionDetails({ openedFromCollectionId }) {
   const { currentCollection } = UIStore.getState();
   const { currentUser } = UserStore.getState();
 
-  const [visibleTabs, setVisibleTabs] = useState(Immutable.List());
+  const [visibleTabs, setVisibleTabs] = useState(List());
   const tabContents = [];
 
   useEffect(() => {

--- a/app/javascript/src/apps/mydb/elements/details/literature/DetailsTabLiteratures.js
+++ b/app/javascript/src/apps/mydb/elements/details/literature/DetailsTabLiteratures.js
@@ -58,7 +58,7 @@ export default class DetailsTabLiteratures extends Component {
 
     this.state = {
       literature: this.createEmptyLiterature(this.props.element.type),
-      literatures: new Map(),
+      literatures: Map(),
       sortedIds: [],
     };
     this.handleInputChange = this.handleInputChange.bind(this);

--- a/app/javascript/src/apps/mydb/elements/details/literature/DetailsTabLiteratures.js
+++ b/app/javascript/src/apps/mydb/elements/details/literature/DetailsTabLiteratures.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Row, Col } from 'react-bootstrap';
 import uuid from 'uuid';
-import Immutable from 'immutable';
+import { Map } from 'immutable';
 import {
   Citation, doiValid, sanitizeDoi, groupByCitation, AddButton, LiteratureInput, LiteralType
 } from 'src/apps/mydb/elements/details/literature/LiteratureCommon';
@@ -58,7 +58,7 @@ export default class DetailsTabLiteratures extends Component {
 
     this.state = {
       literature: this.createEmptyLiterature(this.props.element.type),
-      literatures: new Immutable.Map(),
+      literatures: new Map(),
       sortedIds: [],
     };
     this.handleInputChange = this.handleInputChange.bind(this);

--- a/app/javascript/src/apps/mydb/elements/details/literature/LiteratureDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/literature/LiteratureDetails.js
@@ -137,7 +137,7 @@ export default class LiteratureDetails extends Component {
       literature: Literature.buildEmpty(),
       sorting: 'element',
       sortedIds: [],
-      selectedRefs: new Map()
+      selectedRefs: Map()
     };
     this.handleUIStoreChange = this.handleUIStoreChange.bind(this);
     this.loadSelectedReferences = this.loadSelectedReferences.bind(this);

--- a/app/javascript/src/apps/mydb/elements/details/literature/LiteratureDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/literature/LiteratureDetails.js
@@ -6,7 +6,7 @@ import {
   Row,
   Col
 } from 'react-bootstrap';
-import Immutable from 'immutable';
+import { Map } from 'immutable';
 import { uniqBy } from 'lodash';
 import {
   Citation,
@@ -137,7 +137,7 @@ export default class LiteratureDetails extends Component {
       literature: Literature.buildEmpty(),
       sorting: 'element',
       sortedIds: [],
-      selectedRefs: new Immutable.Map()
+      selectedRefs: new Map()
     };
     this.handleUIStoreChange = this.handleUIStoreChange.bind(this);
     this.loadSelectedReferences = this.loadSelectedReferences.bind(this);

--- a/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -38,7 +38,7 @@ import ExportSamplesButton from 'src/apps/mydb/elements/details/ExportSamplesBut
 import { permitOn } from 'src/components/common/uis';
 import { addSegmentTabs } from 'src/components/generic/SegmentDetails';
 import AppModal from 'src/components/common/AppModal';
-import Immutable from 'immutable';
+import { List } from 'immutable';
 import ElementDetailSortTab from 'src/apps/mydb/elements/details/ElementDetailSortTab';
 import ScifinderSearch from 'src/components/scifinder/ScifinderSearch';
 import MatrixCheck from 'src/components/common/MatrixCheck';
@@ -79,7 +79,7 @@ export default class ReactionDetails extends Component {
       reaction,
       activeTab: UIStore.getState().reaction.activeTab,
       activeAnalysisTab: UIStore.getState().reaction.activeAnalysisTab,
-      visible: Immutable.List(),
+      visible: List(),
       sfn: UIStore.getState().hasSfn,
       currentUser: (UserStore.getState() && UserStore.getState().currentUser) || {},
       reactionSvgVersion: 0, // Bumped when graphic is updated so shouldComponentUpdate sees a state change (we mutate reaction in place)

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
@@ -6,7 +6,7 @@ import {
   Tooltip, OverlayTrigger, ButtonToolbar, Tabs, Tab, Dropdown, ButtonGroup
 } from 'react-bootstrap';
 import { unionBy, findIndex } from 'lodash';
-import Immutable from 'immutable';
+import { List } from 'immutable';
 import { StoreContext } from 'src/stores/mobx/RootStore';
 import UIActions from 'src/stores/alt/actions/UIActions';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
@@ -51,7 +51,7 @@ export default class ResearchPlanDetails extends Component {
     const { researchPlan } = props;
     this.state = {
       researchPlan,
-      visible: Immutable.List(),
+      visible: List(),
       currentUser: (UserStore.getState() && UserStore.getState().currentUser) || {},
     };
     this.handleSwitchMode = this.handleSwitchMode.bind(this);

--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -14,7 +14,7 @@ import AppModal from 'src/components/common/AppModal';
 import { CreatableSelect } from 'src/components/common/Select';
 import { cloneDeep, findIndex, set } from 'lodash';
 import uuid from 'uuid';
-import Immutable from 'immutable';
+import { List } from 'immutable';
 
 import ElementActions from 'src/stores/alt/actions/ElementActions';
 import DetailActions from 'src/stores/alt/actions/DetailActions';
@@ -154,7 +154,7 @@ export default class SampleDetails extends React.Component {
       quickCreator: false,
       showInchikey: false,
       pageMessage: null,
-      visible: Immutable.List(),
+      visible: List(),
       startExport: false,
       sfn: UIStore.getState().hasSfn,
       saveInventoryAction: false,

--- a/app/javascript/src/apps/mydb/elements/details/screens/ScreenDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/ScreenDetails.js
@@ -5,7 +5,7 @@ import {
   Tabs, Tab
 } from 'react-bootstrap';
 import { unionBy, findIndex } from 'lodash';
-import Immutable from 'immutable';
+import { List } from 'immutable';
 
 import DetailActions from 'src/stores/alt/actions/DetailActions';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
@@ -41,7 +41,7 @@ export default class ScreenDetails extends Component {
     this.state = {
       screen,
       activeTab: UIStore.getState().screen.activeTab,
-      visible: Immutable.List(),
+      visible: List(),
       expandedResearchPlanId: null,
       currentUser: (UserStore.getState() && UserStore.getState().currentUser) || {},
     };

--- a/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/SequenceBasedMacromoleculeSampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/SequenceBasedMacromoleculeSampleDetails.js
@@ -22,7 +22,7 @@ import AttachmentForm
 import ConflictModal
   from 'src/apps/mydb/elements/details/sequenceBasedMacromoleculeSamples/ConflictModal';
 import { collectionHasPermission } from 'src/utilities/collectionUtilities';
-import Immutable from 'immutable';
+import { List } from 'immutable';
 import { set } from 'lodash';
 import { formatTimeStampsOfElement } from 'src/utilities/timezoneHelper';
 
@@ -48,7 +48,7 @@ function SequenceBasedMacromoleculeSampleDetails({ openedFromCollectionId }) {
   const { currentCollection } = UIStore.getState();
   const { currentUser } = UserStore.getState();
 
-  const [visibleTabs, setVisibleTabs] = useState(Immutable.List());
+  const [visibleTabs, setVisibleTabs] = useState(List());
   const submitLabel = sbmmSample.isNew ? 'Create' : 'Save';
   const tabContents = [];
   const alertRef = useRef();

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
@@ -5,7 +5,7 @@ import {
   Card, ListGroup, ListGroupItem, Tabs, Tab
 } from 'react-bootstrap';
 import { findIndex } from 'lodash';
-import Immutable from 'immutable';
+import { List } from 'immutable';
 import { StoreContext } from 'src/stores/mobx/RootStore';
 import LoadingActions from 'src/stores/alt/actions/LoadingActions';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
@@ -52,7 +52,7 @@ export default class WellplateDetails extends Component {
       wellplate,
       activeTab: UIStore.getState().wellplate.activeTab,
       showWellplate: true,
-      visible: Immutable.List(),
+      visible: List(),
       currentUser: (UserStore.getState() && UserStore.getState().currentUser) || {},
     };
     this.handleWellplateChanged = this.handleWellplateChanged.bind(this);

--- a/app/javascript/src/apps/mydb/elements/list/ElementAllCheckbox.js
+++ b/app/javascript/src/apps/mydb/elements/list/ElementAllCheckbox.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import Immutable from 'immutable';
+import { List } from 'immutable';
 
 import UIStore from 'src/stores/alt/stores/UIStore';
 import UIActions from 'src/stores/alt/actions/UIActions';
@@ -15,7 +15,7 @@ export default function ElementAllCheckbox({ type }) {
   useEffect(() => {
     const onUpdate = (uiStore) => {
       const typeState = uiStore[type] ?? {};
-      const { checkedAll = false, checkedIds = Immutable.List() } = typeState;
+      const { checkedAll = false, checkedIds = List() } = typeState;
       if (checkedAll) {
         setUiState('checked');
       } else if (checkedIds.size > 0) {

--- a/app/javascript/src/apps/mydb/elements/list/ElementsList.js
+++ b/app/javascript/src/apps/mydb/elements/list/ElementsList.js
@@ -1,4 +1,4 @@
-import Immutable from 'immutable';
+import { List, Set } from 'immutable';
 import React from 'react';
 import {
   Tabs, Tab, Tooltip, OverlayTrigger, Button
@@ -31,8 +31,8 @@ function getVisibleAndHiddenFromLayout(layout) {
   });
 
   return {
-    visible: Immutable.List(visible).sortBy((t) => layout[t]),
-    hidden: Immutable.List(hidden).sortBy((t) => -1 * layout[t]),
+    visible: List(visible).sortBy((t) => layout[t]),
+    hidden: List(hidden).sortBy((t) => -1 * layout[t]),
   };
 }
 
@@ -43,8 +43,8 @@ export default class ElementsList extends React.Component {
     super(props);
     this.state = {
       totalElements: {},
-      visible: Immutable.List(),
-      hidden: Immutable.List(),
+      visible: List(),
+      hidden: List(),
       genericEls: [],
       currentTab: 0,
       totalCheckedElements: {},
@@ -85,8 +85,8 @@ export default class ElementsList extends React.Component {
   }
 
   onChangeUser(state) {
-    let visible = Immutable.List();
-    let hidden = Immutable.List();
+    let visible = List();
+    let hidden = List();
     let { currentType, currentTab } = state;
 
     if (state?.profile?.data?.layout) {
@@ -125,8 +125,8 @@ export default class ElementsList extends React.Component {
     elNames.forEach((type) => {
       const elementUI = state[type] || {
         checkedAll: false,
-        checkedIds: Immutable.List(),
-        uncheckedIds: Immutable.List(),
+        checkedIds: List(),
+        uncheckedIds: List(),
       };
       const element = ElementStore.getState().elements[`${type}s`];
       const nextCount = elementUI.checkedAll
@@ -176,7 +176,7 @@ export default class ElementsList extends React.Component {
 
     const hasSearchApplied = !!UIStore.getState().currentSearchByID;
 
-    const constEls = Immutable.Set(allElnElements);
+    const constEls = Set(allElnElements);
     const tabItems = visible.map((value, i) => {
       let iconClass = `icon-${value}`;
       let ttl = (

--- a/app/javascript/src/components/generic/GenericElDetails.js
+++ b/app/javascript/src/components/generic/GenericElDetails.js
@@ -9,7 +9,7 @@ import {
   Tab,
 } from 'react-bootstrap';
 import { cloneDeep, findIndex, merge } from 'lodash';
-import Immutable from 'immutable';
+import { List } from 'immutable';
 import { StoreContext } from 'src/stores/mobx/RootStore';
 import {
   GenUIProvider, GenInterface, GenToolbar, browseElement
@@ -53,7 +53,7 @@ export default class GenericElDetails extends Component {
       genericEl: props.genericEl,
       activeTab: 0,
       // List of all visible segment tabs.
-      visible: Immutable.List(),
+      visible: List(),
       expandAll: undefined,
     };
     this.onChangeUI = this.onChangeUI.bind(this);

--- a/app/javascript/src/fetchers/LiteraturesFetcher.js
+++ b/app/javascript/src/fetchers/LiteraturesFetcher.js
@@ -1,11 +1,11 @@
 import 'whatwg-fetch';
-import Immutable from 'immutable';
+import { List, Map } from 'immutable';
 import Literature from 'src/models/Literature';
 
 export default class LiteraturesFetcher {
   static fetchElementReferences(element) {
     if (!element || element.isNew) {
-      return Promise.resolve(Immutable.List());
+      return Promise.resolve(List());
     }
     const { type, id } = element;
     return fetch(`/api/v1/literatures?element_type=${type}&element_id=${id}`, {
@@ -13,7 +13,7 @@ export default class LiteraturesFetcher {
     }).then((response) => response.json())
       .then((json) => json.literatures)
       .then((literatures) => literatures.map((literature) => new Literature(literature)))
-      .then((lits) => lits.reduce((acc, l) => acc.set(l.literal_id, l), new Immutable.Map()))
+      .then((lits) => lits.reduce((acc, l) => acc.set(l.literal_id, l), new Map()))
       .catch((errorMessage) => { console.log(errorMessage); });
   }
 
@@ -21,7 +21,7 @@ export default class LiteraturesFetcher {
     const { element, literature } = params;
     const { type, id } = element;
     if (!element || element.isNew) {
-      return Promise.resolve(Immutable.List());
+      return Promise.resolve(List());
     }
     return fetch('/api/v1/literatures', {
       credentials: 'same-origin',
@@ -34,7 +34,7 @@ export default class LiteraturesFetcher {
     }).then((response) => response.json())
       .then((json) => { if (json.error) { throw json; } return json.literatures; })
       .then((literatures) => literatures.map((lits) => new Literature(lits)))
-      .then((lits) => lits.reduce((acc, l) => acc.set(l.literal_id, l), new Immutable.Map()))
+      .then((lits) => lits.reduce((acc, l) => acc.set(l.literal_id, l), new Map()))
       .catch((errorMessage) => { console.log(errorMessage); throw errorMessage; });
   }
 
@@ -75,7 +75,7 @@ export default class LiteraturesFetcher {
     }).then((response) => response.json())
       .then((json) => { if (json.error) { throw json; } return json.literatures; })
       .then((literatures) => literatures.map((lits) => new Literature(lits)))
-      .then((lits) => lits.reduce((acc, l) => acc.set(l.literal_id, l), new Immutable.Map()))
+      .then((lits) => lits.reduce((acc, l) => acc.set(l.literal_id, l), new Map()))
       .catch((errorMessage) => { console.log(errorMessage); throw errorMessage; });
   }
 
@@ -98,10 +98,10 @@ export default class LiteraturesFetcher {
           researchPlanRefs,
         } = json;
         return {
-          collectionRefs: Immutable.List(collectionRefs.map((lit) => new Literature(lit))),
-          sampleRefs: Immutable.List(sampleRefs.map((lit) => new Literature(lit))),
-          reactionRefs: Immutable.List(reactionRefs.map((lit) => new Literature(lit))),
-          researchPlanRefs: Immutable.List(researchPlanRefs.map((lit) => new Literature(lit))),
+          collectionRefs: List(collectionRefs.map((lit) => new Literature(lit))),
+          sampleRefs: List(sampleRefs.map((lit) => new Literature(lit))),
+          reactionRefs: List(reactionRefs.map((lit) => new Literature(lit))),
+          researchPlanRefs: List(researchPlanRefs.map((lit) => new Literature(lit))),
         };
       })
       .catch((errorMessage) => { console.log(errorMessage); });
@@ -118,7 +118,7 @@ export default class LiteraturesFetcher {
       body: JSON.stringify(params)
     }).then((response) => response.json())
       .then((json) => json.selectedRefs.map((lit) => new Literature(lit)))
-      .then((lits) => lits.reduce((acc, l) => acc.set(l.literal_id, l), new Immutable.Map()))
+      .then((lits) => lits.reduce((acc, l) => acc.set(l.literal_id, l), new Map()))
       .catch((errorMessage) => { console.log(errorMessage); });
   }
 }

--- a/app/javascript/src/fetchers/LiteraturesFetcher.js
+++ b/app/javascript/src/fetchers/LiteraturesFetcher.js
@@ -13,7 +13,7 @@ export default class LiteraturesFetcher {
     }).then((response) => response.json())
       .then((json) => json.literatures)
       .then((literatures) => literatures.map((literature) => new Literature(literature)))
-      .then((lits) => lits.reduce((acc, l) => acc.set(l.literal_id, l), new Map()))
+      .then((lits) => lits.reduce((acc, l) => acc.set(l.literal_id, l), Map()))
       .catch((errorMessage) => { console.log(errorMessage); });
   }
 
@@ -34,7 +34,7 @@ export default class LiteraturesFetcher {
     }).then((response) => response.json())
       .then((json) => { if (json.error) { throw json; } return json.literatures; })
       .then((literatures) => literatures.map((lits) => new Literature(lits)))
-      .then((lits) => lits.reduce((acc, l) => acc.set(l.literal_id, l), new Map()))
+      .then((lits) => lits.reduce((acc, l) => acc.set(l.literal_id, l), Map()))
       .catch((errorMessage) => { console.log(errorMessage); throw errorMessage; });
   }
 
@@ -75,7 +75,7 @@ export default class LiteraturesFetcher {
     }).then((response) => response.json())
       .then((json) => { if (json.error) { throw json; } return json.literatures; })
       .then((literatures) => literatures.map((lits) => new Literature(lits)))
-      .then((lits) => lits.reduce((acc, l) => acc.set(l.literal_id, l), new Map()))
+      .then((lits) => lits.reduce((acc, l) => acc.set(l.literal_id, l), Map()))
       .catch((errorMessage) => { console.log(errorMessage); throw errorMessage; });
   }
 
@@ -118,7 +118,7 @@ export default class LiteraturesFetcher {
       body: JSON.stringify(params)
     }).then((response) => response.json())
       .then((json) => json.selectedRefs.map((lit) => new Literature(lit)))
-      .then((lits) => lits.reduce((acc, l) => acc.set(l.literal_id, l), new Map()))
+      .then((lits) => lits.reduce((acc, l) => acc.set(l.literal_id, l), Map()))
       .catch((errorMessage) => { console.log(errorMessage); });
   }
 }

--- a/app/javascript/src/fetchers/ReactionsFetcher.js
+++ b/app/javascript/src/fetchers/ReactionsFetcher.js
@@ -1,5 +1,5 @@
 import 'whatwg-fetch';
-import Immutable from 'immutable';
+import { Map } from 'immutable';
 
 import BaseFetcher from 'src/fetchers/BaseFetcher';
 import Reaction from 'src/models/Reaction';
@@ -35,7 +35,7 @@ export default class ReactionsFetcher {
             }
             if (json.literatures && json.literatures.length > 0) {
               const tliteratures = json.literatures.map((literature) => new Literature(literature));
-              const lits = tliteratures.reduce((acc, l) => acc.set(l.literal_id, l), new Immutable.Map());
+              const lits = tliteratures.reduce((acc, l) => acc.set(l.literal_id, l), new Map());
               reaction.literatures = lits;
             }
             if (json.research_plans && json.research_plans.length > 0) {

--- a/app/javascript/src/fetchers/ReactionsFetcher.js
+++ b/app/javascript/src/fetchers/ReactionsFetcher.js
@@ -35,7 +35,7 @@ export default class ReactionsFetcher {
             }
             if (json.literatures && json.literatures.length > 0) {
               const tliteratures = json.literatures.map((literature) => new Literature(literature));
-              const lits = tliteratures.reduce((acc, l) => acc.set(l.literal_id, l), new Map());
+              const lits = tliteratures.reduce((acc, l) => acc.set(l.literal_id, l), Map());
               reaction.literatures = lits;
             }
             if (json.research_plans && json.research_plans.length > 0) {

--- a/app/javascript/src/fetchers/ResearchPlansFetcher.js
+++ b/app/javascript/src/fetchers/ResearchPlansFetcher.js
@@ -1,5 +1,5 @@
 import 'whatwg-fetch';
-import Immutable from 'immutable';
+import { Map } from 'immutable';
 
 import ResearchPlan from 'src/models/ResearchPlan';
 import AttachmentFetcher from 'src/fetchers/AttachmentFetcher';
@@ -19,7 +19,7 @@ export default class ResearchPlansFetcher {
         rResearchPlan.attachments = json.attachments;
         if (json.literatures && json.literatures.length > 0) {
           const tliteratures = json.literatures.map((literature) => new Literature(literature));
-          const lits = tliteratures.reduce((acc, l) => acc.set(l.literal_id, l), new Immutable.Map());
+          const lits = tliteratures.reduce((acc, l) => acc.set(l.literal_id, l), new Map());
           rResearchPlan.literatures = lits;
           rResearchPlan.updateChecksum();
         }

--- a/app/javascript/src/fetchers/ResearchPlansFetcher.js
+++ b/app/javascript/src/fetchers/ResearchPlansFetcher.js
@@ -19,7 +19,7 @@ export default class ResearchPlansFetcher {
         rResearchPlan.attachments = json.attachments;
         if (json.literatures && json.literatures.length > 0) {
           const tliteratures = json.literatures.map((literature) => new Literature(literature));
-          const lits = tliteratures.reduce((acc, l) => acc.set(l.literal_id, l), new Map());
+          const lits = tliteratures.reduce((acc, l) => acc.set(l.literal_id, l), Map());
           rResearchPlan.literatures = lits;
           rResearchPlan.updateChecksum();
         }

--- a/app/javascript/src/fetchers/SamplesFetcher.js
+++ b/app/javascript/src/fetchers/SamplesFetcher.js
@@ -1,5 +1,5 @@
 import 'whatwg-fetch';
-import Immutable from 'immutable';
+import { Map } from 'immutable';
 
 import Sample from 'src/models/Sample';
 import NotificationActions from 'src/stores/alt/actions/NotificationActions';
@@ -34,7 +34,7 @@ export default class SamplesFetcher {
         // build literature map by literal_id
         const literatures = (json.literatures || []).reduce(
           (acc, l) => acc.set(l.literal_id, new Literature(l)),
-          new Immutable.Map()
+          new Map()
         );
 
         // attach literatures per sample BEFORE enrichment
@@ -64,7 +64,7 @@ export default class SamplesFetcher {
         const rSample = new Sample(json.sample);
         if (json.literatures && json.literatures.length > 0) {
           const tliteratures = json.literatures.map((literature) => new Literature(literature));
-          const lits = tliteratures.reduce((acc, l) => acc.set(l.literal_id, l), new Immutable.Map());
+          const lits = tliteratures.reduce((acc, l) => acc.set(l.literal_id, l), new Map());
           rSample.literatures = lits;
           rSample.updateChecksum();
         }

--- a/app/javascript/src/fetchers/SamplesFetcher.js
+++ b/app/javascript/src/fetchers/SamplesFetcher.js
@@ -34,7 +34,7 @@ export default class SamplesFetcher {
         // build literature map by literal_id
         const literatures = (json.literatures || []).reduce(
           (acc, l) => acc.set(l.literal_id, new Literature(l)),
-          new Map()
+          Map()
         );
 
         // attach literatures per sample BEFORE enrichment
@@ -64,7 +64,7 @@ export default class SamplesFetcher {
         const rSample = new Sample(json.sample);
         if (json.literatures && json.literatures.length > 0) {
           const tliteratures = json.literatures.map((literature) => new Literature(literature));
-          const lits = tliteratures.reduce((acc, l) => acc.set(l.literal_id, l), new Map());
+          const lits = tliteratures.reduce((acc, l) => acc.set(l.literal_id, l), Map());
           rSample.literatures = lits;
           rSample.updateChecksum();
         }

--- a/app/javascript/src/models/LiteratureMap.js
+++ b/app/javascript/src/models/LiteratureMap.js
@@ -1,7 +1,7 @@
 import uuid from 'uuid';
 import sha256 from 'sha256';
 import _ from 'lodash';
-import Immutable from 'immutable';
+import { List } from 'immutable';
 
 export default class LiteratureMap {
 
@@ -17,11 +17,11 @@ export default class LiteratureMap {
 
   static buildEmpty() {
     return new LiteratureMap({
-      collectionRefs: Immutable.List(),
-      sampleRefs: Immutable.List(),
-      reactionRefs: Immutable.List(),
-      researchPlanRefs: Immutable.List(),
-      selectedRefs: Immutable.List(),
+      collectionRefs: List(),
+      sampleRefs: List(),
+      reactionRefs: List(),
+      researchPlanRefs: List(),
+      selectedRefs: List(),
       collection_id: null,
     });
   }

--- a/app/javascript/src/utilities/CollectionTabsHelper.js
+++ b/app/javascript/src/utilities/CollectionTabsHelper.js
@@ -1,5 +1,5 @@
 import { getElementSegments } from './ElementUtils';
-import Immutable from 'immutable';
+import { List } from 'immutable';
 
 export const TAB_DISPLAY_NAMES = {
   qc_curation: 'QC & curation',
@@ -45,8 +45,8 @@ const getVisibilityList = (layout, availableTabs, addInventoryTab) => {
   }
   hidden = hidden.filter(n => n);
   return {
-    visible: Immutable.List(visible.filter(n => n !== undefined)),
-    hidden: Immutable.List(hidden.filter(n => (n !== undefined && n !== first)))
+    visible: List(visible.filter(n => n !== undefined)),
+    hidden: List(hidden.filter(n => (n !== undefined && n !== first)))
   };
 };
 


### PR DESCRIPTION
## Summary

- Immutable v5.0.0 (introduced by #2994) dropped the default export, so `import Immutable from 'immutable'` no longer resolves. Without this fix the bundle compiles via webpack's CJS interop fallback but `Immutable.Map`/`List`/`Set` references are runtime-undefined on every screen that uses them.
- Converted the 20 affected files to named imports (`{ List }`, `{ Map }`, `{ Set }`, `{ List, Map }`, or `{ List, Set }` depending on usage) and rewrote `Immutable.X` callsites accordingly.
- No behavior change; same collection types, just imported the v5-supported way.

## Test plan

- [x] `yarn webpack` (via the dev `webpacker` service) compiles successfully — no module-resolution errors.
- [x] Rails dev server boots and serves the home page.
- [x] Login with a test account works.
- [x] Click through each affected detail tab to confirm runtime behavior: Sample, Reaction, Wellplate, Screen, ResearchPlan, SBM Sample, DeviceDescription, Literature (sample + reaction + research plan tabs), Collection LiteratureModal, ElementsList, GenericElDetails.

refs: #2994