### PR TITLE
fix(ketcher): guard iframe document access against SecurityError

### DIFF
--- a/app/javascript/src/utilities/ketcherSurfaceChemistry/DomHandeling.js
+++ b/app/javascript/src/utilities/ketcherSurfaceChemistry/DomHandeling.js
@@ -311,7 +311,11 @@ const attachClickListeners = (iframeRef, buttonEvents) => {
 
   const iframeEl = iframeRef?.current;
   if (iframeEl) {
-    iframeEl.addEventListener('load', setup);
+    if (getIframeDocument()?.readyState === 'complete') {
+      setup();
+    } else {
+      iframeEl.addEventListener('load', setup);
+    }
   }
 
   // Cleanup function

--- a/app/javascript/src/utilities/ketcherSurfaceChemistry/DomHandeling.js
+++ b/app/javascript/src/utilities/ketcherSurfaceChemistry/DomHandeling.js
@@ -288,7 +288,11 @@ const attachClickListeners = (iframeRef, buttonEvents) => {
       );
 
       if (!LAYERING_FLAGS.skipTemplateName) {
-        await updateTemplatesInTheCanvas(iframeRef);
+        try {
+          await updateTemplatesInTheCanvas(iframeRef);
+        } catch (e) {
+          if (!(e instanceof DOMException && e.name === 'SecurityError')) throw e;
+        }
       }
     });
 
@@ -300,8 +304,8 @@ const attachClickListeners = (iframeRef, buttonEvents) => {
 
     // Fallback: Try to manually find buttons after some time, debounce the function
     debounceAttach = setTimeout(() => {
-      Object.keys(buttonEvents).forEach((title) => {
-        attachListenerForTitle(iframeDocument, title);
+      Object.keys(buttonEvents).forEach((selector) => {
+        attachListenerForTitle(iframeDocument, selector, buttonEvents);
       });
 
       PolymerListIconKetcherToolbarButton(iframeDocument);
@@ -329,10 +333,10 @@ const attachClickListeners = (iframeRef, buttonEvents) => {
     try {
       const iframeDocument = getIframeDocument();
       if (iframeDocument) {
-        Object.keys(buttonEvents).forEach((title) => {
-          const button = iframeDocument.querySelector(`[title="${title}"]`);
+        Object.keys(buttonEvents).forEach((selector) => {
+          const button = iframeDocument.querySelector(selector);
           if (button) {
-            button.removeEventListener('click', buttonEvents[title]);
+            button.removeEventListener('click', buttonEvents[selector]);
           }
         });
       }

--- a/app/javascript/src/utilities/ketcherSurfaceChemistry/DomHandeling.js
+++ b/app/javascript/src/utilities/ketcherSurfaceChemistry/DomHandeling.js
@@ -257,60 +257,84 @@ export const imageNodeForTextNodeSetter = async (data) => {
 
 // helper function to add mutation observers to DOM elements
 const attachClickListeners = (iframeRef, buttonEvents) => {
-  // Main function to attach listeners and observers
-  const iframeDocument = iframeRef?.current?.contentWindow?.document || null;
+  let observer = null;
+  let debounceAttach = null;
 
-  // Attach MutationObserver to listen for relevant DOM mutations (e.g., new elements added)
-  const observer = new MutationObserver(async (mutationsList) => {
-    await Promise.all(
-      mutationsList.map(async (mutation) => {
-        if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
-          await Promise.all(
-            Object.keys(buttonEvents).map(async (selector) => {
-              await attachListenerForTitle(iframeDocument, selector, buttonEvents);
-            })
-          );
-        }
-      })
-    );
-
-    if (!LAYERING_FLAGS.skipTemplateName) {
-      await updateTemplatesInTheCanvas(iframeRef);
+  const getIframeDocument = () => {
+    try {
+      return iframeRef?.current?.contentWindow?.document || null;
+    } catch (e) {
+      if (e instanceof DOMException && e.name === 'SecurityError') return null;
+      throw e;
     }
-  });
+  };
 
-  // Start observing the iframe's document for changes (child nodes added anywhere in the subtree)
-  observer.observe(iframeDocument, {
-    childList: true,
-    subtree: true,
-  });
+  const setup = () => {
+    const iframeDocument = getIframeDocument();
+    if (!iframeDocument) return;
 
-  // Fallback: Try to manually find buttons after some time, debounce the function
-  const debounceAttach = setTimeout(() => {
-    Object.keys(buttonEvents).forEach((title) => {
-      attachListenerForTitle(iframeDocument, title);
+    // Attach MutationObserver to listen for relevant DOM mutations (e.g., new elements added)
+    observer = new MutationObserver(async (mutationsList) => {
+      await Promise.all(
+        mutationsList.map(async (mutation) => {
+          if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+            await Promise.all(
+              Object.keys(buttonEvents).map(async (selector) => {
+                await attachListenerForTitle(iframeDocument, selector, buttonEvents);
+              })
+            );
+          }
+        })
+      );
+
+      if (!LAYERING_FLAGS.skipTemplateName) {
+        await updateTemplatesInTheCanvas(iframeRef);
+      }
     });
 
-    // Ensure iframe content is loaded before adding the button
-    if (iframeRef?.current?.contentWindow?.document?.readyState === 'complete') {
+    // Start observing the iframe's document for changes (child nodes added anywhere in the subtree)
+    observer.observe(iframeDocument, {
+      childList: true,
+      subtree: true,
+    });
+
+    // Fallback: Try to manually find buttons after some time, debounce the function
+    debounceAttach = setTimeout(() => {
+      Object.keys(buttonEvents).forEach((title) => {
+        attachListenerForTitle(iframeDocument, title);
+      });
+
       PolymerListIconKetcherToolbarButton(iframeDocument);
       SolidSurfaceTemplatesIconTextButton(iframeDocument);
-    } else if (iframeRef?.current?.onload) {
-      iframeRef.current.onload = PolymerListIconKetcherToolbarButton;
-      iframeRef.current.onload = SolidSurfaceTemplatesIconTextButton;
-    }
-  }, 1000);
+    }, 1000);
+  };
+
+  const iframeEl = iframeRef?.current;
+  if (iframeEl) {
+    iframeEl.addEventListener('load', setup);
+  }
 
   // Cleanup function
   return () => {
-    observer.disconnect();
-    clearTimeout(debounceAttach);
-    Object.keys(buttonEvents).forEach((title) => {
-      const button = iframeDocument.querySelector(`[title="${title}"]`);
-      if (button) {
-        button.removeEventListener('click', buttonEvents[title]);
+    if (iframeEl) {
+      iframeEl.removeEventListener('load', setup);
+    }
+    if (observer) observer.disconnect();
+    if (debounceAttach) clearTimeout(debounceAttach);
+
+    try {
+      const iframeDocument = getIframeDocument();
+      if (iframeDocument) {
+        Object.keys(buttonEvents).forEach((title) => {
+          const button = iframeDocument.querySelector(`[title="${title}"]`);
+          if (button) {
+            button.removeEventListener('click', buttonEvents[title]);
+          }
+        });
       }
-    });
+    } catch (e) {
+      if (!(e instanceof DOMException && e.name === 'SecurityError')) throw e;
+    }
   };
 };
 


### PR DESCRIPTION
### Problem
attachClickListeners accessed contentWindow.document at the top level of the function. Optional chaining guards against null but not DOMException(SecurityError), which the browser throws when the iframe is mid-navigation.

### Changes
Moved all contentWindow.document access inside a load event listener (setup) so the document is only read after the iframe has fully loaded
Wrapped every contentWindow.document access in a try/catch that absorbs SecurityError and re-throws anything else
Declared observer and debounceAttach in outer scope so the cleanup closure can still disconnect/clear them
Removed the redundant readyState === 'complete' check inside the timeout — unnecessary inside the load handler
Wrapped cleanup's DOM access in its own try/catch since the iframe may have navigated away by cleanup time

---------------



- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
