### PR TITLE
feat(UI): add numeric inputs for moisture and particle size, and dropdown for physical state in SampleForm

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -937,6 +937,7 @@ export default class SampleDetails extends React.Component {
       rfsovents,
       supplier,
       private_notes,
+      color,
       moisture,
       particle_size,
       physical_state,

--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -937,6 +937,9 @@ export default class SampleDetails extends React.Component {
       rfsovents,
       supplier,
       private_notes,
+      moisture,
+      particle_size,
+      physical_state,
       ...customKeys
     } = cloneDeep(xref || {});
     const check = ['form', 'solubility', 'refractive_index', 'flash_point', 'inventory_label'];

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -786,6 +786,79 @@ export default class SampleForm extends React.Component {
     );
   }
 
+  numericInputWithAddon(sample, field, label, addonText, min = null, max = null) {
+    const key = field.split('xref_')[1];
+    const updateValue = (sample.xref && sample.xref[key] != null) ? sample.xref[key] : '';
+
+    const handleChange = (e) => {
+      const { value } = e.target;
+      if (value === '') {
+        this.handleFieldChanged(field, null);
+        return;
+      }
+      const parsed = parseFloat(value);
+      // ignore intermediate/invalid states (e.g. "-") so we never store NaN in xref
+      if (Number.isNaN(parsed)) return;
+
+      let next = parsed;
+      if (min != null && next < min) next = min;
+      if (max != null && next > max) next = max;
+      if (next !== parsed) {
+        NotificationActions.add({
+          message: max != null
+            ? `${label} must be between ${min} and ${max}`
+            : `${label} must be at least ${min}`,
+          level: 'error',
+        });
+      }
+      this.handleFieldChanged(field, next);
+    };
+
+    return (
+      <Form.Group>
+        <Form.Label>{label}</Form.Label>
+        <InputGroup>
+          <Form.Control
+            type="number"
+            step="any"
+            min={min != null ? min : undefined}
+            max={max != null ? max : undefined}
+            value={updateValue}
+            onChange={handleChange}
+            disabled={!sample.can_update}
+            readOnly={!sample.can_update}
+          />
+          <InputGroup.Text>{addonText}</InputGroup.Text>
+        </InputGroup>
+      </Form.Group>
+    );
+  }
+
+  physicalStateInput(sample) {
+    const physicalStateOptions = [
+      { label: 'solid', value: 'solid' },
+      { label: 'liquid', value: 'liquid' },
+      { label: 'gas', value: 'gas' },
+    ];
+
+    const currentValue = sample.xref?.physical_state;
+    const selectedOption = physicalStateOptions.find((o) => o.value === currentValue) || null;
+
+    return (
+      <Form.Group>
+        <Form.Label>Physical state</Form.Label>
+        <Select
+          name="physicalState"
+          isClearable
+          isDisabled={!sample.can_update}
+          options={physicalStateOptions}
+          value={selectedOption}
+          onChange={(option) => this.handleFieldChanged('xref_physical_state', option ? option.value : null)}
+        />
+      </Form.Group>
+    );
+  }
+
   inputWithUnit(sample, field, label) {
     const value = sample.xref && sample.xref[field.split('xref_')[1]] ? sample.xref[field.split('xref_')[1]].value : '';
     const unit = sample.xref && sample.xref[field.split('xref_')[1]] ? sample.xref[field.split('xref_')[1]].unit : '°C';
@@ -1275,6 +1348,11 @@ export default class SampleForm extends React.Component {
                 <Col>{this.textInput(sample, 'xref_form', 'Form')}</Col>
                 <Col>{this.textInput(sample, 'xref_color', 'Color')}</Col>
                 <Col>{this.textInput(sample, 'xref_solubility', 'Soluble in')}</Col>
+              </Row>
+              <Row className="mb-4">
+                <Col>{this.numericInputWithAddon(sample, 'xref_moisture', 'Moisture', '%', 0, 100)}</Col>
+                <Col>{this.numericInputWithAddon(sample, 'xref_particle_size', 'Particle size', 'µm', 0)}</Col>
+                <Col>{this.physicalStateInput(sample)}</Col>
               </Row>
               <Row className="align-items-start mb-4">
                 <Col>

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -786,33 +786,42 @@ export default class SampleForm extends React.Component {
     );
   }
 
+  // store the value as typed; bounds are enforced on blur to avoid rewriting in-progress input
+  handleNumericChange(field, value) {
+    if (value === '') {
+      this.handleFieldChanged(field, null);
+      return;
+    }
+    const parsed = parseFloat(value);
+    // ignore intermediate/invalid states (e.g. "-") so we never store NaN in xref
+    if (Number.isNaN(parsed)) return;
+    this.handleFieldChanged(field, parsed);
+  }
+
+  // clamp to [min, max] on blur so the user can finish typing before correction
+  handleNumericBlur(field, label, value, min, max) {
+    if (value === '') return;
+
+    const parsed = parseFloat(value);
+    if (Number.isNaN(parsed)) return;
+
+    let next = parsed;
+    if (min != null && next < min) next = min;
+    if (max != null && next > max) next = max;
+    if (next === parsed) return;
+
+    NotificationActions.add({
+      message: max != null
+        ? `${label} must be between ${min} and ${max}`
+        : `${label} must be at least ${min}`,
+      level: 'error',
+    });
+    this.handleFieldChanged(field, next);
+  }
+
   numericInputWithAddon(sample, field, label, addonText, min = null, max = null) {
     const key = field.split('xref_')[1];
     const updateValue = (sample.xref && sample.xref[key] != null) ? sample.xref[key] : '';
-
-    const handleChange = (e) => {
-      const { value } = e.target;
-      if (value === '') {
-        this.handleFieldChanged(field, null);
-        return;
-      }
-      const parsed = parseFloat(value);
-      // ignore intermediate/invalid states (e.g. "-") so we never store NaN in xref
-      if (Number.isNaN(parsed)) return;
-
-      let next = parsed;
-      if (min != null && next < min) next = min;
-      if (max != null && next > max) next = max;
-      if (next !== parsed) {
-        NotificationActions.add({
-          message: max != null
-            ? `${label} must be between ${min} and ${max}`
-            : `${label} must be at least ${min}`,
-          level: 'error',
-        });
-      }
-      this.handleFieldChanged(field, next);
-    };
 
     return (
       <Form.Group>
@@ -824,7 +833,8 @@ export default class SampleForm extends React.Component {
             min={min != null ? min : undefined}
             max={max != null ? max : undefined}
             value={updateValue}
-            onChange={handleChange}
+            onChange={(e) => this.handleNumericChange(field, e.target.value)}
+            onBlur={(e) => this.handleNumericBlur(field, label, e.target.value, min, max)}
             disabled={!sample.can_update}
             readOnly={!sample.can_update}
           />
@@ -836,9 +846,9 @@ export default class SampleForm extends React.Component {
 
   physicalStateInput(sample) {
     const physicalStateOptions = [
-      { label: 'solid', value: 'solid' },
-      { label: 'liquid', value: 'liquid' },
-      { label: 'gas', value: 'gas' },
+      { label: 'Solid', value: 'solid' },
+      { label: 'Liquid', value: 'liquid' },
+      { label: 'Gas', value: 'gas' },
     ];
 
     const currentValue = sample.xref?.physical_state;

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -792,9 +792,15 @@ export default class SampleForm extends React.Component {
       this.handleFieldChanged(field, null);
       return;
     }
-    const parsed = parseFloat(value);
-    // ignore intermediate/invalid states (e.g. "-") so we never store NaN in xref
-    if (Number.isNaN(parsed)) return;
+    // Preserve intermediate decimals (e.g. "12.") so the user can continue typing
+    // without React rewriting the value to "12". Normalized to a number on blur.
+    if (value.endsWith('.') && value !== '.') {
+      this.handleFieldChanged(field, value);
+      return;
+    }
+    const parsed = Number(value);
+    // ignore intermediate/invalid states (e.g. "-") so we never store NaN/Infinity in xref
+    if (!Number.isFinite(parsed)) return;
     this.handleFieldChanged(field, parsed);
   }
 
@@ -802,21 +808,28 @@ export default class SampleForm extends React.Component {
   handleNumericBlur(field, label, value, min, max) {
     if (value === '') return;
 
-    const parsed = parseFloat(value);
-    if (Number.isNaN(parsed)) return;
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) return;
 
     let next = parsed;
     if (min != null && next < min) next = min;
     if (max != null && next > max) next = max;
-    if (next === parsed) return;
 
-    NotificationActions.add({
-      message: max != null
-        ? `${label} must be between ${min} and ${max}`
-        : `${label} must be at least ${min}`,
-      level: 'error',
-    });
-    this.handleFieldChanged(field, next);
+    if (next !== parsed) {
+      NotificationActions.add({
+        message: max != null
+          ? `${label} must be between ${min} and ${max}`
+          : `${label} must be at least ${min}`,
+        level: 'error',
+      });
+    }
+
+    // Normalize to a number on blur: stores the clamped value, and also converts
+    // any in-progress string left by handleNumericChange (e.g. "12." -> 12).
+    // Skip when the typed text is already the canonical number to avoid redundant writes.
+    if (next !== parsed || String(next) !== value) {
+      this.handleFieldChanged(field, next);
+    }
   }
 
   numericInputWithAddon(sample, field, label, addonText, min = null, max = null) {

--- a/app/services/versioning/serializers/sample_serializer.rb
+++ b/app/services/versioning/serializers/sample_serializer.rb
@@ -146,6 +146,24 @@ module Versioning
               revert: %i[xref.refractive_index],
               formatter: jsonb_formatter('refractive_index'),
             },
+            {
+              name: 'xref.moisture',
+              label: 'Moisture',
+              revert: %i[xref.moisture],
+              formatter: jsonb_formatter('moisture'),
+            },
+            {
+              name: 'xref.particle_size',
+              label: 'Particle size',
+              revert: %i[xref.particle_size],
+              formatter: jsonb_formatter('particle_size'),
+            },
+            {
+              name: 'xref.physical_state',
+              label: 'Physical state',
+              revert: %i[xref.physical_state],
+              formatter: jsonb_formatter('physical_state'),
+            },
           ],
           solvent: {
             label: 'Solvent',

--- a/app/services/versioning/serializers/sample_serializer.rb
+++ b/app/services/versioning/serializers/sample_serializer.rb
@@ -103,68 +103,7 @@ module Versioning
             formatter: metrics_formatter,
             revertible_value_formatter: default_formatter,
           },
-          xref: [
-            {
-              name: 'xref.cas',
-              label: 'CAS',
-              revert: %i[xref.cas],
-              formatter: jsonb_formatter('cas'),
-            },
-            {
-              name: 'xref.inventory_label',
-              label: 'Inventory label',
-              revert: %i[xref.inventory_label],
-              formatter: jsonb_formatter('inventory_label'),
-            },
-            {
-              name: 'xref.flash_point',
-              label: 'Flash Point',
-              revert: %i[xref.flash_point],
-              formatter: jsonb_formatter('flash_point', 'value'),
-            },
-            {
-              name: 'xref.form',
-              label: 'Form',
-              revert: %i[xref.form],
-              formatter: jsonb_formatter('form'),
-            },
-            {
-              name: 'xref.color',
-              label: 'Color',
-              revert: %i[xref.color],
-              formatter: jsonb_formatter('color'),
-            },
-            {
-              name: 'xref.solubility',
-              label: 'Solubility',
-              revert: %i[xref.solubility],
-              formatter: jsonb_formatter('solubility'),
-            },
-            {
-              name: 'xref.refractive_index',
-              label: 'Refractive Index',
-              revert: %i[xref.refractive_index],
-              formatter: jsonb_formatter('refractive_index'),
-            },
-            {
-              name: 'xref.moisture',
-              label: 'Moisture',
-              revert: %i[xref.moisture],
-              formatter: jsonb_formatter('moisture'),
-            },
-            {
-              name: 'xref.particle_size',
-              label: 'Particle size',
-              revert: %i[xref.particle_size],
-              formatter: jsonb_formatter('particle_size'),
-            },
-            {
-              name: 'xref.physical_state',
-              label: 'Physical state',
-              revert: %i[xref.physical_state],
-              formatter: jsonb_formatter('physical_state'),
-            },
-          ],
+          xref: xref_field_definitions,
           solvent: {
             label: 'Solvent',
             kind: :solvent,
@@ -187,6 +126,33 @@ module Versioning
       end
 
       private
+
+      # Each xref entry follows the same shape: it reads/writes a single key under
+      # the sample's jsonb `xref` column. flash_point is the only one that targets a
+      # nested path ('value'), so the formatter path is passed through verbatim.
+      def xref_field_definitions
+        [
+          xref_field('cas', 'CAS'),
+          xref_field('inventory_label', 'Inventory label'),
+          xref_field('flash_point', 'Flash Point', 'value'),
+          xref_field('form', 'Form'),
+          xref_field('color', 'Color'),
+          xref_field('solubility', 'Solubility'),
+          xref_field('refractive_index', 'Refractive Index'),
+          xref_field('moisture', 'Moisture'),
+          xref_field('particle_size', 'Particle size'),
+          xref_field('physical_state', 'Physical state'),
+        ]
+      end
+
+      def xref_field(key, label, *path)
+        {
+          name: "xref.#{key}",
+          label: label,
+          revert: [:"xref.#{key}"],
+          formatter: jsonb_formatter(key, *path),
+        }
+      end
 
       def molecule_names_lookup
         @molecule_names_lookup ||= begin

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.spec.js
@@ -1,0 +1,124 @@
+import expect from 'expect';
+import sinon from 'sinon';
+import { configure, shallow } from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import {
+  describe, it, beforeEach, afterEach
+} from 'mocha';
+import SampleForm from 'src/apps/mydb/elements/details/samples/propertiesTab/SampleForm';
+import NotificationActions from 'src/stores/alt/actions/NotificationActions';
+import SampleFactory from 'factories/SampleFactory';
+
+configure({ adapter: new Adapter() });
+
+const buildInstance = (sample) => {
+  const instance = new SampleForm({
+    sample,
+    handleSampleChanged: () => {},
+    showStructureEditor: () => {},
+    customizableField: () => {},
+    decoupleMolecule: () => {},
+  });
+  // isolate from the heavy real implementation so we only assert the input wiring
+  instance.handleFieldChanged = sinon.spy();
+  return instance;
+};
+
+const findControl = (wrapper) => wrapper.find('FormControl');
+
+describe('SampleForm new property inputs', () => {
+  let sample;
+  let instance;
+
+  beforeEach(async () => {
+    sinon.stub(NotificationActions, 'add');
+    sample = await SampleFactory.build('empty');
+    sample.can_update = true;
+    sample.xref = {};
+    instance = buildInstance(sample);
+  });
+
+  afterEach(() => {
+    NotificationActions.add.restore();
+  });
+
+  describe('numericInputWithAddon', () => {
+    it('stores the parsed value as typed without clamping (clamp is on blur)', () => {
+      const wrapper = shallow(instance.numericInputWithAddon(sample, 'xref_moisture', 'Moisture', '%', 0, 100));
+      findControl(wrapper).simulate('change', { target: { value: '150' } });
+      expect(instance.handleFieldChanged.calledWith('xref_moisture', 150)).toEqual(true);
+      expect(NotificationActions.add.called).toEqual(false);
+    });
+
+    it('stores decimal values and exposes step="any"', () => {
+      const wrapper = shallow(instance.numericInputWithAddon(sample, 'xref_moisture', 'Moisture', '%', 0, 100));
+      expect(findControl(wrapper).props().step).toEqual('any');
+      findControl(wrapper).simulate('change', { target: { value: '12.5' } });
+      expect(instance.handleFieldChanged.calledWith('xref_moisture', 12.5)).toEqual(true);
+    });
+
+    it('stores null for an empty input', () => {
+      const wrapper = shallow(instance.numericInputWithAddon(sample, 'xref_moisture', 'Moisture', '%', 0, 100));
+      findControl(wrapper).simulate('change', { target: { value: '' } });
+      expect(instance.handleFieldChanged.calledWith('xref_moisture', null)).toEqual(true);
+    });
+
+    it('never stores NaN for intermediate/invalid input', () => {
+      const wrapper = shallow(instance.numericInputWithAddon(sample, 'xref_moisture', 'Moisture', '%', 0, 100));
+      findControl(wrapper).simulate('change', { target: { value: '-' } });
+      expect(instance.handleFieldChanged.called).toEqual(false);
+    });
+
+    it('clamps to the max bound on blur and notifies', () => {
+      const wrapper = shallow(instance.numericInputWithAddon(sample, 'xref_moisture', 'Moisture', '%', 0, 100));
+      findControl(wrapper).simulate('blur', { target: { value: '150' } });
+      expect(instance.handleFieldChanged.calledWith('xref_moisture', 100)).toEqual(true);
+      expect(NotificationActions.add.calledOnce).toEqual(true);
+    });
+
+    it('clamps to the min bound on blur and notifies', () => {
+      const wrapper = shallow(instance.numericInputWithAddon(sample, 'xref_particle_size', 'Particle size', 'µm', 0));
+      findControl(wrapper).simulate('blur', { target: { value: '-5' } });
+      expect(instance.handleFieldChanged.calledWith('xref_particle_size', 0)).toEqual(true);
+      expect(NotificationActions.add.calledOnce).toEqual(true);
+    });
+
+    it('does not clamp or notify for an in-range value on blur', () => {
+      const wrapper = shallow(instance.numericInputWithAddon(sample, 'xref_moisture', 'Moisture', '%', 0, 100));
+      findControl(wrapper).simulate('blur', { target: { value: '42' } });
+      expect(instance.handleFieldChanged.called).toEqual(false);
+      expect(NotificationActions.add.called).toEqual(false);
+    });
+  });
+
+  describe('physicalStateInput', () => {
+    const findSelect = (wrapper) => wrapper.findWhere((n) => n.prop('name') === 'physicalState');
+
+    it('renders capitalized labels with lowercase values', () => {
+      const wrapper = shallow(instance.physicalStateInput(sample));
+      expect(findSelect(wrapper).props().options).toEqual([
+        { label: 'Solid', value: 'solid' },
+        { label: 'Liquid', value: 'liquid' },
+        { label: 'Gas', value: 'gas' },
+      ]);
+    });
+
+    it('reflects the current xref value as the selected option', () => {
+      sample.xref = { physical_state: 'liquid' };
+      const wrapper = shallow(instance.physicalStateInput(sample));
+      expect(findSelect(wrapper).props().value).toEqual({ label: 'Liquid', value: 'liquid' });
+    });
+
+    it('stores the lowercase value on selection', () => {
+      const wrapper = shallow(instance.physicalStateInput(sample));
+      findSelect(wrapper).props().onChange({ label: 'Solid', value: 'solid' });
+      expect(instance.handleFieldChanged.calledWith('xref_physical_state', 'solid')).toEqual(true);
+    });
+
+    it('stores null when cleared', () => {
+      const wrapper = shallow(instance.physicalStateInput(sample));
+      findSelect(wrapper).props().onChange(null);
+      expect(instance.handleFieldChanged.calledWith('xref_physical_state', null)).toEqual(true);
+    });
+  });
+});


### PR DESCRIPTION
- Introduced `numericInputWithAddon` method for handling numeric inputs with an addon text.
- Added `physicalStateInput` method to allow selection of physical states (solid, liquid, gas).
- Integrated new input fields for moisture, particle size, and physical state into the SampleForm layout.

Closes https://github.com/ComPlat/chemotion_ELN/issues/3242
