### PR TITLE
fix: restore bulk attachment delete and 204 No Content response contract

### DIFF
--- a/app/api/chemotion/attachment_api.rb
+++ b/app/api/chemotion/attachment_api.rb
@@ -138,9 +138,11 @@ module Chemotion
       end
 
       desc 'Bulk Delete Attachments'
+      params do
+        requires :ids, type: Array[Integer], desc: 'IDs of attachments to delete'
+      end
       delete 'bulk_delete' do
-        ids = params[:ids]
-        attachments = Attachment.where(id: ids)
+        attachments = Attachment.where(id: params[:ids])
 
         unpermitted_attachments = attachments.reject { |attachment| writable?(attachment) }
 

--- a/app/api/chemotion/collection_elements_api.rb
+++ b/app/api/chemotion/collection_elements_api.rb
@@ -34,7 +34,8 @@ module Chemotion
           collection_id: params[:collection_id],
           ui_state: params[:ui_state].except(:currentCollection),
         )
-        { status: 204 }
+        status 204
+        body false
       end
     end
   end

--- a/app/api/chemotion/collection_share_api.rb
+++ b/app/api/chemotion/collection_share_api.rb
@@ -82,7 +82,8 @@ module Chemotion
 
         collection.update(shared: false) if CollectionShare.where(collection: collection).none?
 
-        { status: 204 }
+        status 204
+        body false
       end
     end
   end

--- a/app/javascript/src/api_clients/ChemotionApiClient.js
+++ b/app/javascript/src/api_clients/ChemotionApiClient.js
@@ -82,6 +82,11 @@ const patchJson = (apiEndpoint, options) => {
 
 const deleteRequest = (apiEndpoint, options = {}) => {
   const defaults = { method: 'DELETE' };
+
+  if (options.body != null && typeof options.body !== 'string') {
+    options.body = JSON.stringify(options.body);
+  }
+
   return apiRequest(apiEndpoint, { ...defaults, ...options });
 };
 

--- a/app/javascript/src/api_clients/ChemotionApiClient.js
+++ b/app/javascript/src/api_clients/ChemotionApiClient.js
@@ -2,11 +2,31 @@
 // TODO: research if the following import can be safely removed
 // import 'whatwg-fetch';
 
-// most low level request, which actually calls fetch
+/**
+ * Low-level request wrapper shared by every verb helper; the only place that
+ * actually calls `fetch`.
+ *
+ * Response handling is configurable through two option callbacks:
+ *
+ * - `handleResponseSuccess(response)` maps the resolved `Response` to the value
+ *   the returned promise resolves with. The default parses the JSON body, except
+ *   that a `204 No Content` resolves to `null` — a 204 has an empty body, so
+ *   `response.json()` would reject with "Unexpected end of JSON input". Override
+ *   it to operate on the raw `Response` instead; e.g. an endpoint that replies
+ *   `204` on success and carries no body should pass
+ *   `handleResponseSuccess: (response) => response.ok` to resolve a boolean
+ *   (`response.ok` over `=== 204` so it survives a later success-status change).
+ * - `handleResponseError(exception)` runs on a network/parse failure.
+ *
+ * @param {string} apiEndpoint - request URL
+ * @param {object} options - `fetch` options, plus the two handlers above
+ * @returns {Promise<*>} whatever `handleResponseSuccess` returns (JSON body by
+ *   default; `null` on 204)
+ */
 const apiRequest = (apiEndpoint, options) => {
   const globalDefaults = {
     credentials: 'same-origin',
-    handleResponseSuccess: (response) => response.json(),
+    handleResponseSuccess: (response) => (response.status === 204 ? null : response.json()),
     handleResponseError: (exception) => { console.log(exception); },
     headers: { Accept: 'application/json', 'Content-Type': 'application/json' }
   };

--- a/app/javascript/src/fetchers/AdminFetcher.js
+++ b/app/javascript/src/fetchers/AdminFetcher.js
@@ -61,9 +61,18 @@ export default class AdminFetcher {
     return ApiClient.putJson(`/api/v1/admin/users/${userId}/profile/`, { body: otherParams });
   }
 
+  /**
+   * Enables/disables OLS terms. The endpoint replies 204 No Content, so success
+   * is read from the HTTP status.
+   *
+   * @param {object} params - { owl_name, enableIds, disableIds }
+   * @returns {Promise<boolean>} true on success (see ChemotionApiClient.apiRequest)
+   */
   static olsTermDisableEnable(params) {
-    return ApiClient.postJson('/api/v1/admin/olsEnableDisable/', { body: params })
-      .then((response) => response.status === 204);
+    return ApiClient.postJson('/api/v1/admin/olsEnableDisable/', {
+      body: params,
+      handleResponseSuccess: (response) => response.ok,
+    });
   }
 
   static importOlsTerms(file) {

--- a/app/javascript/src/fetchers/AttachmentFetcher.js
+++ b/app/javascript/src/fetchers/AttachmentFetcher.js
@@ -286,8 +286,8 @@ export default class AttachmentFetcher {
       .then((json) => new Attachment(json.attachment));
   }
 
-  static bulkDeleteAttachments(attachmentIdsToDelete) {
-    return ApiClient.deleteRequest('/api/v1/attachments/bulk_delete', { body: attachmentIdsToDelete });
+  static bulkDeleteAttachments(ids) {
+    return ApiClient.deleteRequest('/api/v1/attachments/bulk_delete', { body: { ids } });
   }
 
   static deleteContainerLink(params) {

--- a/app/javascript/src/fetchers/CollectionElementsFetcher.js
+++ b/app/javascript/src/fetchers/CollectionElementsFetcher.js
@@ -5,9 +5,17 @@ export default class CollectionElementsFetcher {
     return ApiClient.postJson('/api/v1/collection_elements', { body: params });
   }
 
+  /**
+   * Removes the ui_state-selected elements from the collection. The endpoint
+   * replies 204 No Content, so success is read from the HTTP status.
+   *
+   * @param {object} params - { collection_id, ui_state }
+   * @returns {Promise<boolean>} true on success (see ChemotionApiClient.apiRequest)
+   */
   static deleteElementsFromCollection(params) {
     return ApiClient.deleteRequest(`/api/v1/collection_elements/${params.collection_id}`, {
-      body: JSON.stringify(params)
+      body: JSON.stringify(params),
+      handleResponseSuccess: (response) => response.ok,
     });
   }
 }

--- a/app/javascript/src/fetchers/CollectionSharesFetcher.js
+++ b/app/javascript/src/fetchers/CollectionSharesFetcher.js
@@ -15,7 +15,16 @@ export default class CollectionSharesFetcher {
       .then((json) => json.collection_share);
   }
 
+  /**
+   * Deletes a collection share. The endpoint replies 204 No Content, so success
+   * is read from the HTTP status.
+   *
+   * @param {number} collectionId - id of the collection share to delete
+   * @returns {Promise<boolean>} true on success (see ChemotionApiClient.apiRequest)
+   */
   static deleteCollectionShare(collectionId) {
-    return ApiClient.deleteRequest(`/api/v1/collection_shares/${collectionId}`);
+    return ApiClient.deleteRequest(`/api/v1/collection_shares/${collectionId}`, {
+      handleResponseSuccess: (response) => response.ok,
+    });
   }
 }

--- a/app/javascript/src/fetchers/CollectionSharesFetcher.js
+++ b/app/javascript/src/fetchers/CollectionSharesFetcher.js
@@ -19,11 +19,11 @@ export default class CollectionSharesFetcher {
    * Deletes a collection share. The endpoint replies 204 No Content, so success
    * is read from the HTTP status.
    *
-   * @param {number} collectionId - id of the collection share to delete
+   * @param {number} collectionShareId - id of the collection share to delete
    * @returns {Promise<boolean>} true on success (see ChemotionApiClient.apiRequest)
    */
-  static deleteCollectionShare(collectionId) {
-    return ApiClient.deleteRequest(`/api/v1/collection_shares/${collectionId}`, {
+  static deleteCollectionShare(collectionShareId) {
+    return ApiClient.deleteRequest(`/api/v1/collection_shares/${collectionShareId}`, {
       handleResponseSuccess: (response) => response.ok,
     });
   }

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -218,8 +218,8 @@ export const CollectionsStore = types
       }
     }),
     deleteCollectionShare: flow(function* deleteCollectionShare(collectionShareId, collectionId) {
-      const response = yield CollectionSharesFetcher.deleteCollectionShare(collectionShareId)
-      if (response.status === 204) {
+      const success = yield CollectionSharesFetcher.deleteCollectionShare(collectionShareId)
+      if (success) {
         self.fetchCollections()
         self.getSharedWithUsers(collectionId)
       }
@@ -236,9 +236,9 @@ export const CollectionsStore = types
       }
     }),
     removeElementsFromCollection: flow(function* removeElementsFromCollection(params) {
-      const response = yield CollectionElementsFetcher.deleteElementsFromCollection(params)
+      const success = yield CollectionElementsFetcher.deleteElementsFromCollection(params)
 
-      if (response.status === 204) {
+      if (success) {
         // refresh elements
         ElementActions.refreshElementsAfterCollectionChanges(params.ui_state.currentCollection.id)
         return true

--- a/spec/api/chemotion/admin_api_spec.rb
+++ b/spec/api/chemotion/admin_api_spec.rb
@@ -106,4 +106,18 @@ RSpec.describe Chemotion::AdminAPI do
       end
     end
   end
+
+  describe 'POST /api/v1/admin/olsEnableDisable' do
+    before do
+      # Isolate the public-file writes; we only assert the HTTP contract here.
+      allow(OlsTerm).to receive(:write_public_file)
+      post '/api/v1/admin/olsEnableDisable/', params: { owl_name: 'chebi' }
+    end
+
+    # The fetcher (AdminFetcher.olsTermDisableEnable) treats success as status 204;
+    # this pins that contract so a status change can't silently break the admin UI.
+    it 'returns 204 No Content on success' do
+      expect(response).to have_http_status(:no_content)
+    end
+  end
 end

--- a/spec/api/chemotion/attachment_api_spec.rb
+++ b/spec/api/chemotion/attachment_api_spec.rb
@@ -80,6 +80,61 @@ describe Chemotion::AttachmentAPI do
     end
   end
 
+  describe 'DELETE /api/v1/attachments/bulk_delete' do
+    let(:attachment_one) { create(:attachment) }
+    let(:attachment_two) { create(:attachment) }
+    let(:ids) { [attachment_one.id, attachment_two.id] }
+    let(:execute_request) do
+      delete '/api/v1/attachments/bulk_delete',
+             params: { ids: ids }.to_json,
+             headers: { 'CONTENT_TYPE' => 'application/json' }
+    end
+
+    before do |example|
+      if example.metadata[:enable_attachment_policy_can_delete].present?
+        allow(AttachmentPolicy).to receive(:can_delete?).and_return(true)
+      end
+
+      execute_request
+    end
+
+    context 'when "AttachmentPolicy" allows deletion', :enable_attachment_policy_can_delete do
+      it 'returns with the right http status' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'deletes exactly the requested attachments' do
+        expect(Attachment.where(id: ids)).to be_empty
+      end
+
+      it 'returns the deleted attachments' do
+        expect(parsed_json_response['deleted_attachments'].size).to eq(2)
+      end
+    end
+
+    context 'when "AttachmentPolicy" denies deletion' do
+      it 'returns with an error' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'does not delete any attachment' do
+        expect(Attachment.where(id: ids).count).to eq(2)
+      end
+    end
+
+    context 'when the ids param is missing' do
+      let(:execute_request) do
+        delete '/api/v1/attachments/bulk_delete',
+               params: {}.to_json,
+               headers: { 'CONTENT_TYPE' => 'application/json' }
+      end
+
+      it 'is rejected by the typed param instead of silently no-op deleting' do
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
+
   describe 'DELETE /api/v1/attachments/link/{attachment_id}' do
     let(:execute_request) { delete "/api/v1/attachments/link/#{attachment_id}" }
 

--- a/spec/api/chemotion/collection_elements_api_spec.rb
+++ b/spec/api/chemotion/collection_elements_api_spec.rb
@@ -153,5 +153,28 @@ describe Chemotion::CollectionElementsAPI do
       expect(response.status).to eq 403
     end
   end
+
+  context 'when removing own elements from an own collection' do
+    let(:source_collection_user) { user }
+    let(:remove_input) do
+      {
+        ui_state: {
+          currentCollection: { id: 0 },
+          sample: {
+            checkedAll: false,
+            checkedIds: [sample1.id, sample2.id, sample3.id],
+            uncheckedIds: [],
+          },
+        },
+      }
+    end
+
+    it 'responds 204 No Content with an empty body' do
+      delete "/api/v1/collection_elements/#{source_collection.id}", params: remove_input
+
+      expect(response).to have_http_status(:no_content)
+      expect(response.body).to be_blank
+    end
+  end
 end
 # rubocop:enable RSpec/IndexedLet, RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations

--- a/spec/api/chemotion/collection_share_api_spec.rb
+++ b/spec/api/chemotion/collection_share_api_spec.rb
@@ -75,6 +75,12 @@ describe Chemotion::CollectionShareAPI do
       end.to change(CollectionShare, :count).by(-1)
     end
 
+    it 'responds 204 No Content with an empty body' do
+      delete "/api/v1/collection_shares/#{collection_share.id}"
+      expect(response).to have_http_status(:no_content)
+      expect(response.body).to be_blank
+    end
+
     it 'updates the collections shared flag if that was the last share' do
       expect(collection.collection_shares.count).to eq 1
       expect do

--- a/spec/javascripts/packs/src/api_clients/ChemotionApiClient.spec.js
+++ b/spec/javascripts/packs/src/api_clients/ChemotionApiClient.spec.js
@@ -1,0 +1,47 @@
+import ApiClient from 'src/api_clients/ChemotionApiClient';
+import expect from 'expect';
+import sinon from 'sinon';
+import {
+  describe, it, beforeEach, afterEach
+} from 'mocha';
+
+describe('ChemotionApiClient.deleteRequest', () => {
+  let fetchStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch');
+    fetchStub.resolves(new Response(JSON.stringify({ ok: true })));
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+  });
+
+  it('JSON-encodes a non-string body (symmetry with postJson/putJson)', async () => {
+    await ApiClient.deleteRequest('/api/v1/attachments/bulk_delete', { body: { ids: [1, 2, 3] } });
+
+    sinon.assert.calledOnce(fetchStub);
+    const [url, options] = fetchStub.firstCall.args;
+    expect(url).toEqual('/api/v1/attachments/bulk_delete');
+    expect(options.method).toEqual('DELETE');
+    // The body must be the serialized JSON string, not a coerced "[object Object]"
+    expect(options.body).toEqual(JSON.stringify({ ids: [1, 2, 3] }));
+    expect(JSON.parse(options.body)).toEqual({ ids: [1, 2, 3] });
+  });
+
+  it('does not double-encode a body that is already a string', async () => {
+    const preSerialized = JSON.stringify({ ids: [4, 5] });
+    await ApiClient.deleteRequest('/api/v1/some/endpoint', { body: preSerialized });
+
+    const [, options] = fetchStub.firstCall.args;
+    expect(options.body).toEqual(preSerialized);
+  });
+
+  it('leaves a bodyless DELETE untouched', async () => {
+    await ApiClient.deleteRequest('/api/v1/attachments/link/1');
+
+    const [, options] = fetchStub.firstCall.args;
+    expect(options.method).toEqual('DELETE');
+    expect(options.body).toBe(undefined);
+  });
+});

--- a/spec/javascripts/packs/src/api_clients/ChemotionApiClient.spec.js
+++ b/spec/javascripts/packs/src/api_clients/ChemotionApiClient.spec.js
@@ -45,3 +45,32 @@ describe('ChemotionApiClient.deleteRequest', () => {
     expect(options.body).toBe(undefined);
   });
 });
+
+describe('ChemotionApiClient 204 No Content handling', () => {
+  let fetchStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+  });
+
+  it('resolves null (does not throw) when the response is 204 with an empty body', async () => {
+    // A real 204 has no body; response.json() would throw "Unexpected end of JSON input".
+    fetchStub.resolves(new Response(null, { status: 204 }));
+
+    const result = await ApiClient.deleteRequest('/api/v1/collection_shares/1');
+
+    expect(result).toBe(null);
+  });
+
+  it('still parses the JSON body for a normal 200 response', async () => {
+    fetchStub.resolves(new Response(JSON.stringify({ hello: 'world' }), { status: 200 }));
+
+    const result = await ApiClient.getJson('/api/v1/anything');
+
+    expect(result).toEqual({ hello: 'world' });
+  });
+});

--- a/spec/javascripts/packs/src/fetchers/AdminFetcher.spec.js
+++ b/spec/javascripts/packs/src/fetchers/AdminFetcher.spec.js
@@ -1,0 +1,56 @@
+import AdminFetcher from 'src/fetchers/AdminFetcher';
+import expect from 'expect';
+import sinon from 'sinon';
+import {
+  describe, it, beforeEach, afterEach
+} from 'mocha';
+
+describe('AdminFetcher.olsTermDisableEnable', () => {
+  let fetchStub;
+  const params = { owl_name: 'chebi', enableIds: ['1|x'], disableIds: [] };
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+  });
+
+  it('sends the params as a JSON body to the enable/disable endpoint', async () => {
+    fetchStub.resolves(new Response(null, { status: 204 }));
+
+    await AdminFetcher.olsTermDisableEnable(params);
+
+    sinon.assert.calledOnce(fetchStub);
+    const [url, options] = fetchStub.firstCall.args;
+    expect(url).toEqual('/api/v1/admin/olsEnableDisable/');
+    expect(options.method).toEqual('POST');
+    expect(JSON.parse(options.body)).toEqual(params);
+  });
+
+  it('resolves true on a 204 (success), reading the HTTP status not the parsed body', async () => {
+    // A 204 has an empty body; the fix reads response.ok, never response.json().
+    fetchStub.resolves(new Response(null, { status: 204 }));
+
+    const result = await AdminFetcher.olsTermDisableEnable(params);
+
+    expect(result).toBe(true);
+  });
+
+  it('resolves true for any 2xx success (response.ok), not strictly 204', async () => {
+    fetchStub.resolves(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    const result = await AdminFetcher.olsTermDisableEnable(params);
+
+    expect(result).toBe(true);
+  });
+
+  it('resolves false on a non-2xx response', async () => {
+    fetchStub.resolves(new Response(JSON.stringify({ error: 'boom' }), { status: 422 }));
+
+    const result = await AdminFetcher.olsTermDisableEnable(params);
+
+    expect(result).toBe(false);
+  });
+});

--- a/spec/javascripts/packs/src/fetchers/AttachmentFetcher.spec.js
+++ b/spec/javascripts/packs/src/fetchers/AttachmentFetcher.spec.js
@@ -1,0 +1,31 @@
+import AttachmentFetcher from 'src/fetchers/AttachmentFetcher';
+import expect from 'expect';
+import sinon from 'sinon';
+import {
+  describe, it, beforeEach, afterEach
+} from 'mocha';
+
+describe('AttachmentFetcher.bulkDeleteAttachments', () => {
+  let fetchStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch');
+    fetchStub.resolves(new Response(JSON.stringify({ deleted_attachments: [] })));
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+  });
+
+  it('sends a DELETE with a JSON { ids: [...] } body the server can read', async () => {
+    await AttachmentFetcher.bulkDeleteAttachments([1, 2, 3]);
+
+    sinon.assert.calledOnce(fetchStub);
+    const [url, options] = fetchStub.firstCall.args;
+    expect(url).toEqual('/api/v1/attachments/bulk_delete');
+    expect(options.method).toEqual('DELETE');
+    // Regression guard: must be {"ids":[1,2,3]}, NOT the lossy CSV "1,2,3"
+    expect(options.body).toEqual(JSON.stringify({ ids: [1, 2, 3] }));
+    expect(JSON.parse(options.body)).toEqual({ ids: [1, 2, 3] });
+  });
+});


### PR DESCRIPTION
Follow-up to #3294 (the fetcher unification refactor, now merged). That PR introduced two blocking regressions in the unified `ChemotionApiClient`; this PR fixes them at the root and restores the coverage whose removal let them slip through. Net change is small (16 files, +332/−16) — the bulk of #3294 is already on `main`.

## What was broken

**1. Bulk attachment delete silently no-opped.** `AttachmentFetcher.bulkDeleteAttachments` passed a bare array as the DELETE body. Unlike `postJson`/`putJson`/`patchJson`, `deleteRequest` did not `JSON.stringify` it, so `fetch` coerced `[1,2,3]` to the string `"1,2,3"` under a JSON content type — invalid JSON. `params[:ids]` came back `nil`, `Attachment.where(id: nil)` matched nothing, and the delete no-opped (the inbox optimistically removed the rows, so they reappeared on reload).

**2. The client could not consume `204 No Content`.** The default `handleResponseSuccess` always called `response.json()`, which throws on an empty body. To dodge this, #3294 had downgraded two endpoints from `status 204` to returning a hash `{ status: 204 }` — making the HTTP status line `200`/`201` while the body carried `{"status":204}`, contradicting the real status and silently changing a public `/api/v1` contract. The same client bug also broke `AdminFetcher.olsTermDisableEnable`, which reported failure on every successful 204 save.

## Fixes

- **`ChemotionApiClient`**: `deleteRequest` JSON-encodes a non-string body (matching the other JSON verbs; leaves already-stringified and bodyless DELETEs untouched); the default success handler resolves `null` on 204 instead of throwing.
- **`AttachmentFetcher.bulkDeleteAttachments`**: sends `{ body: { ids } }` so the wire payload is `{"ids":[...]}`.
- **`attachment_api` bulk_delete**: `requires :ids, type: Array[Integer]` — Grape now coerces/validates and rejects garbage with 400 instead of a silent no-op.
- **`collection_elements` / `collection_share` DELETE**: restore proper `status 204` + empty body; their fetchers and `CollectionsStore` read success from `response.ok` rather than a parsed body.
- **`AdminFetcher.olsTermDisableEnable`**: reports success from `response.ok`, in step with the other 204 callers.

## Tests

Adds the request-shape and 204-contract coverage the rework had stripped — JS specs for the client and fetchers, Ruby specs for the bulk-delete allow/deny/missing-ids paths and for both reverted endpoints returning 204 with an empty body.

## Out of scope

Pre-existing `{ status: 204/201 }` returns in other endpoints (`collection_api`, `collection_elements` POST, `collection_share` POST, `message_api`) predate #3294 and are left as a tracked follow-up.