### PR TITLE
feat(auth): add LDAP login as an OmniAuth provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,10 @@ gem 'omniauth-oauth2', '~> 1.7', '>= 1.7.2'
 gem 'omniauth_openid_connect'
 gem 'omniauth-orcid', git: 'https://github.com/datacite/omniauth-orcid'
 gem 'omniauth-shibboleth'
+# LDAP login as an OmniAuth provider; pulls in net-ldap. 2.3.1+ widened its
+# omniauth dependency to ">= 1.2, < 3" so it resolves against our omniauth 1.9
+# (2.0.0-2.3.0 pinned omniauth ~> 1.8.1, which excludes 1.9).
+gem 'omniauth-ldap', '~> 2.3', '>= 2.3.1'
 
 gem 'chemical_elements'
 gem 'openbabel', '2.4.90.3', git: 'https://github.com/ptrxyz/openbabel-gem.git', branch: 'ptrxyz-ctime-fix'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -429,6 +429,7 @@ GEM
     net-imap (0.4.24)
       date
       net-protocol
+    net-ldap (0.19.0)
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
@@ -460,6 +461,11 @@ GEM
     omniauth-github (1.4.0)
       omniauth (~> 1.5)
       omniauth-oauth2 (>= 1.4.0, < 2.0)
+    omniauth-ldap (2.3.4)
+      net-ldap (~> 0.16, < 1)
+      omniauth (>= 1.2, < 3)
+      pyu-ruby-sasl (>= 0.0.3.3, < 0.1)
+      rubyntlm (~> 0.6.2, < 1)
     omniauth-oauth2 (1.7.3)
       oauth2 (>= 1.4, < 3)
       omniauth (>= 1.9, < 3)
@@ -522,6 +528,7 @@ GEM
     public_suffix (7.0.5)
     puma (5.6.9)
       nio4r (~> 2.0)
+    pyu-ruby-sasl (0.0.3.3)
     raabro (1.4.0)
     racc (1.8.1)
     rack (2.2.23)
@@ -667,6 +674,7 @@ GEM
       byebug (>= 11.1.0)
       pastel (>= 0.7.4)
       pry (>= 0.13.0)
+    rubyntlm (0.6.5)
     rubyzip (2.4.1)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -903,6 +911,7 @@ DEPENDENCIES
   nokogiri
   omniauth (~> 1.9.1)
   omniauth-github (~> 1.4.0)
+  omniauth-ldap (~> 2.3, >= 2.3.1)
   omniauth-oauth2 (~> 1.7, >= 1.7.2)
   omniauth-orcid!
   omniauth-shibboleth

--- a/app/controllers/users/omniauth_controller.rb
+++ b/app/controllers/users/omniauth_controller.rb
@@ -20,6 +20,23 @@ module Users
       auth_handler
     end
 
+    # LDAP differs from the redirect-based providers: new users are auto-provisioned
+    # and signed in directly instead of being routed to the registration form.
+    def ldap
+      if user_signed_in?
+        current_user.link_omniauth(auth.provider, auth.uid)
+        redirect_to root_path
+      else
+        @user = User.find_or_create_from_omniauth!(auth_params)
+        if @user&.persisted?
+          sign_in_and_redirect @user, event: :authentication
+        else
+          session_handler
+          redirect_to new_user_registration_url
+        end
+      end
+    end
+
     protected
 
     def auth
@@ -73,8 +90,8 @@ module Users
       provider
     end
 
-    def auth_signup
-      params = {
+    def auth_params
+      {
         email: email,
         uid: auth.uid,
         provider: auth.provider,
@@ -82,7 +99,10 @@ module Users
         last_name: last_name,
         groups: groups,
       }
-      @user = User.from_omniauth(params)
+    end
+
+    def auth_signup
+      @user = User.from_omniauth(auth_params)
       if @user.persisted?
         sign_in_and_redirect @user, event: :authentication
       else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -254,6 +254,43 @@ class User < ApplicationRecord
     errors.add(:name_abbreviation, "has to be #{min_val} to #{max_val} characters long")
   end
 
+  # @return [Array(Integer, Integer)] +[min, max]+ allowed name_abbreviation length for this type
+  def name_abbreviation_length_bounds
+    config = case type
+             when 'Group' then name_abbr_config[:length_group]
+             when 'Device' then name_abbr_config[:length_device]
+             else name_abbr_config[:length_default]
+             end
+    default_max = %w[Group Device].include?(type) ? 5 : 3
+    [config&.first || 2, config&.last || default_max]
+  end
+
+  # Candidate abbreviations derived from the user's initials, shortest/simplest first.
+  #
+  # @return [Array<String>] downcased, format-compatible candidates within the length bounds
+  def name_abbreviation_candidates
+    alphabet = ('a'..'z').to_a + ('0'..'9').to_a
+    min_len, max_len = name_abbreviation_length_bounds
+    initials = "#{first_name&.first}#{last_name&.first}".downcase.gsub(/[^a-z0-9]/, '')
+    initials = "u#{initials}" if initials.empty? || initials.start_with?(/[0-9]/)
+
+    list = []
+    (min_len..max_len).each do |len|
+      # plain prefix of the initials at this length
+      list << initials[0, len] if initials.length >= len
+      # grow a shorter prefix with one alphanumeric to fill this length
+      prefix = initials[0, len - 1]
+      alphabet.each { |char| list << (prefix + char) } if prefix.present?
+    end
+    list.uniq.select { |abbr| abbr.length.between?(min_len, max_len) && abbr.start_with?(/[a-z]/) }
+  end
+
+  # @return [Boolean] whether the currently assigned name_abbreviation passes all its validations
+  def name_abbreviation_acceptable?
+    valid?
+    errors[:name_abbreviation].blank?
+  end
+
   def mail_checker
     MailChecker.valid?(email) || errors.add(
       :email, 'from throwable email providers not accepted'
@@ -434,9 +471,69 @@ class User < ApplicationRecord
   end
 
   def link_omniauth(provider, uid)
-    providers = {} if providers.nil?
-    providers[provider] = uid
+    self.providers = (providers || {}).merge(provider => uid)
     save!
+  end
+
+  # Finds a user by email or auto-provisions one from OmniAuth data, persisting it.
+  #
+  # Unlike {from_omniauth} (which leaves new users unsaved so the controller can route
+  # them to the registration form), this creates and saves the user, generating a unique
+  # +name_abbreviation+. Used by the LDAP login flow and the JWT token endpoint.
+  #
+  # @param params [Hash] +:email+, +:uid+, +:provider+, +:first_name+, +:last_name+, +:groups+
+  # @return [User] persisted on success; an unsaved record when no unique
+  #   +name_abbreviation+ could be generated (caller checks +persisted?+)
+  def self.find_or_create_from_omniauth!(params)
+    user = by_email(params[:email]).first if params[:email].present?
+
+    if user.present?
+      user.providers = (user.providers || {}).merge(params[:provider] => params[:uid])
+    else
+      user = User.new(
+        email: params[:email]&.downcase,
+        first_name: params[:first_name],
+        last_name: params[:last_name],
+        password: Devise.friendly_token[0, 20],
+        providers: { params[:provider] => params[:uid] }.compact,
+      )
+      return user if user.generate_unique_name_abbreviation.blank?
+    end
+
+    user.save!
+    user.assign_omniauth_groups(params[:groups])
+    user
+  end
+
+  # Assigns the user to existing {Group}s parsed from OmniAuth entitlement strings.
+  #
+  # @param groups [Array<String>, nil] entries shaped +"group:<last_name>:<first_name>"+
+  # @return [void]
+  def assign_omniauth_groups(groups)
+    (groups || []).each do |entry|
+      name = entry.split(':')
+      next unless name.size == 3
+
+      group = Group.find_by(first_name: name[2], last_name: name[1])
+      self.groups << group if group.present? && groups.exclude?(group)
+    end
+  end
+
+  # Generates and assigns a unique, validation-passing +name_abbreviation+ from initials.
+  #
+  # Tries the plain initials first, then initials grown with alphanumerics, vetting each
+  # candidate against the real model validations (format, length, reserved list, uniqueness).
+  #
+  # @return [String, nil] the assigned abbreviation, or nil if the constrained space is
+  #   exhausted (+name_abbreviation+ is left blank so the caller can fall back)
+  def generate_unique_name_abbreviation
+    name_abbreviation_candidates.each do |candidate|
+      self.name_abbreviation = candidate
+      return candidate if name_abbreviation_acceptable?
+    end
+
+    self.name_abbreviation = nil
+    nil
   end
 
   def password_required?

--- a/app/services/ldap_authentication_service.rb
+++ b/app/services/ldap_authentication_service.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# Authenticates a username/password pair against the LDAP directory configured in the
+# +userProvider+ Matrice row (the same config the omniauth-ldap provider reads in
+# +config/initializers/devise.rb+).
+#
+# The OmniAuth Rack middleware only covers the browser login flow, so this service provides
+# a direct {Net::LDAP} bind for non-browser paths such as the JWT token endpoint
+# ({Usecases::Authentication::BuildToken}).
+class LdapAuthenticationService
+  # @return [Hash, nil] the +ldap+ sub-hash of the userProvider config, or nil if unavailable
+  def self.config
+    Matrice.find_by(name: 'userProvider')&.configs&.dig('ldap')
+  rescue ActiveRecord::StatementInvalid, PG::ConnectionBad, PG::UndefinedTable
+    nil
+  end
+
+  # @return [Boolean] whether LDAP login is enabled
+  def self.enabled?
+    config&.dig('enable') == true
+  end
+
+  # @param username [String] the LDAP uid value
+  # @param password [String] the user's password
+  # @return [Hash, nil] normalized attributes
+  #   (+:provider+, +:uid+, +:email+, +:first_name+, +:last_name+, +:groups+) on a
+  #   successful bind, otherwise nil
+  def self.authenticate(username, password)
+    new(config).authenticate(username, password)
+  end
+
+  # @param config [Hash, nil] the +ldap+ config sub-hash
+  def initialize(config)
+    @config = config || {}
+  end
+
+  # @param username [String] the LDAP uid value
+  # @param password [String] the user's password
+  # @return [Hash, nil] normalized attributes on success, otherwise nil
+  def authenticate(username, password)
+    return if username.blank? || password.blank?
+    return unless @config['enable'] == true && @config['host'].present?
+
+    entries = connection.bind_as(base: @config['base'], filter: search_filter(username), password: password)
+    return if entries.blank?
+
+    normalize(entries.first)
+  rescue Net::LDAP::Error => e
+    Rails.logger.error("LDAP authentication failed: #{e.message}")
+    nil
+  end
+
+  private
+
+  def connection
+    Net::LDAP.new(
+      host: @config['host'],
+      port: @config['port'] || 389,
+      base: @config['base'],
+      encryption: encryption,
+      auth: bind_auth,
+    )
+  end
+
+  # Service-account bind used for the search step; anonymous when no bind_dn is configured.
+  def bind_auth
+    return { method: :anonymous } if @config['bind_dn'].blank?
+
+    { method: :simple, username: @config['bind_dn'], password: @config['password'] }
+  end
+
+  def encryption
+    case (@config['method'] || 'plain').to_s
+    when 'ssl' then { method: :simple_tls }
+    when 'tls' then { method: :start_tls }
+    end
+  end
+
+  def search_filter(username)
+    uid_filter = Net::LDAP::Filter.eq(@config['uid'] || 'uid', username)
+    return uid_filter if @config['filter'].blank?
+
+    Net::LDAP::Filter.join(uid_filter, Net::LDAP::Filter.construct(@config['filter']))
+  end
+
+  def normalize(entry)
+    {
+      provider: 'ldap',
+      uid: attribute(entry, @config['uid'] || 'uid'),
+      email: attribute(entry, @config['email'] || 'mail'),
+      first_name: attribute(entry, @config['first_name'] || 'givenname'),
+      last_name: attribute(entry, @config['last_name'] || 'sn'),
+      groups: [],
+    }
+  end
+
+  def attribute(entry, name)
+    Array(entry[name.to_s.downcase.to_sym]).first
+  end
+end

--- a/app/usecases/authentication/build_token.rb
+++ b/app/usecases/authentication/build_token.rb
@@ -3,12 +3,40 @@
 module Usecases
   module Authentication
     class BuildToken
+      # Issues a 2-week JWT for valid credentials.
+      #
+      # Tries local DB authentication first; if that fails and LDAP is enabled, falls back to
+      # an LDAP bind, auto-provisioning the user on first successful login.
+      #
+      # @param params [Hash] +:username+ (name_abbreviation, email, or LDAP uid) and +:password+
+      # @return [String, nil] the encoded JWT, or nil when authentication fails
       def self.execute!(params)
         user = User.where(name_abbreviation: params[:username]).or(User.where(email: params[:username])).take
 
-        return if user.blank?
-        return unless user.valid_password?(params[:password])
+        return token_for(user) if user&.valid_password?(params[:password])
 
+        ldap_user = authenticate_via_ldap(params[:username], params[:password])
+        return if ldap_user.blank?
+
+        token_for(ldap_user)
+      end
+
+      # @param username [String] the LDAP uid value
+      # @param password [String] the user's password
+      # @return [User, nil] the persisted user on a successful LDAP login, otherwise nil
+      def self.authenticate_via_ldap(username, password)
+        return unless LdapAuthenticationService.enabled?
+
+        attrs = LdapAuthenticationService.authenticate(username, password)
+        return if attrs.blank?
+
+        user = User.find_or_create_from_omniauth!(attrs)
+        user if user&.persisted?
+      end
+
+      # @param user [User]
+      # @return [String] the encoded JWT
+      def self.token_for(user)
         payload = {
           first_name: user.first_name,
           user_id: user.id,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -285,6 +285,24 @@ Devise.setup do |config| # rubocop:disable Metrics/BlockLength
         label: auth_config.dig('shibboleth', 'label') || 'Shibboleth',
       }
     end
+    if auth_config.key?('ldap') && auth_config.dig('ldap', 'enable') == true
+      # LDAP as an OmniAuth provider (omniauth-ldap). The request phase serves a
+      # username/password form at /users/auth/ldap; the callback binds against the
+      # directory and maps mail/givenName/sn into auth.info, uid into auth.uid.
+      config.omniauth :ldap,
+                      title: auth_config.dig('ldap', 'title') || 'LDAP login',
+                      host: auth_config.dig('ldap', 'host'),
+                      port: auth_config.dig('ldap', 'port') || 389,
+                      method: (auth_config.dig('ldap', 'method') || 'plain').to_sym,
+                      base: auth_config.dig('ldap', 'base'),
+                      uid: auth_config.dig('ldap', 'uid') || 'uid',
+                      bind_dn: auth_config.dig('ldap', 'bind_dn'),
+                      password: auth_config.dig('ldap', 'password'),
+                      filter: auth_config.dig('ldap', 'filter'),
+                      name_proc: proc { |name| name },
+                      icon: auth_config.dig('ldap', 'icon'),
+                      label: auth_config.dig('ldap', 'label') || 'LDAP'
+    end
     if auth_config.key?('github') && auth_config.dig('github', 'enable') == true
       config.omniauth :github,
                       auth_config.dig('github', 'client_id'), auth_config.dig('github', 'client_secret'),

--- a/spec/controllers/users/omniauth_controller_spec.rb
+++ b/spec/controllers/users/omniauth_controller_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Users::OmniauthController, type: :controller do
+  # The :ldap omniauth route is registered only when the userProvider config enables it,
+  # so append it on top of the real routes (rather than clobbering them with routes.draw,
+  # which would break the devise mailer URL helpers used during user creation).
+  before(:all) do # rubocop:disable RSpec/BeforeAfterAll
+    Rails.application.routes.disable_clear_and_finalize = true
+    Rails.application.routes.draw do
+      devise_scope :user do
+        get 'users/auth/ldap', to: 'users/omniauth#ldap'
+      end
+    end
+    Rails.application.routes.disable_clear_and_finalize = false
+  end
+
+  after(:all) { Rails.application.reload_routes! } # rubocop:disable RSpec/BeforeAfterAll
+
+  before do
+    request.env['devise.mapping'] = Devise.mappings[:user]
+    request.env['omniauth.auth'] = OmniAuth::AuthHash.new(
+      provider: 'ldap',
+      uid: 'jdoe',
+      info: { email: 'jane.doe@bar.de', first_name: 'Jane', last_name: 'Doe' },
+    )
+  end
+
+  describe 'GET #ldap' do
+    context 'when the user does not exist yet' do
+      it 'auto-creates the user' do
+        expect { get :ldap }.to change(User, :count).by(1)
+      end
+
+      it 'provisions the user from the LDAP attributes and redirects' do
+        get :ldap
+
+        expect(User.find_by(email: 'jane.doe@bar.de')).to be_present
+        expect(response).to be_redirect
+      end
+    end
+
+    context 'when the user already exists' do
+      let!(:existing) { create(:person, email: 'jane.doe@bar.de') }
+
+      it 'reuses the existing user without creating a new one' do
+        expect { get :ldap }.not_to change(User, :count)
+        expect(response).to be_redirect
+      end
+
+      it 'links the ldap provider onto the existing user' do
+        get :ldap
+
+        expect(existing.reload.providers['ldap']).to eq('jdoe')
+      end
+    end
+
+    context 'when already signed in' do
+      let(:current) { create(:person) }
+
+      before do
+        allow(controller).to receive_messages(user_signed_in?: true, current_user: current)
+      end
+
+      it 'links the provider to the current user and redirects to root' do
+        get :ldap
+
+        expect(current.reload.providers['ldap']).to eq('jdoe')
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/models/user_omniauth_spec.rb
+++ b/spec/models/user_omniauth_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User do
+  describe '#generate_unique_name_abbreviation' do
+    it 'derives initials and assigns a valid unique abbreviation' do
+      user = described_class.new(
+        type: 'Person', first_name: 'Alice', last_name: 'Brown',
+        email: 'a.brown@bar.de', password: 'testtest'
+      )
+
+      abbr = user.generate_unique_name_abbreviation
+
+      expect(abbr).to eq('ab')
+      expect(user.name_abbreviation).to eq('ab')
+      expect(user).to be_valid
+    end
+
+    it 'appends a suffix when the initials are already taken' do
+      create(:person, first_name: 'Alan', last_name: 'Bell', name_abbreviation: 'ab')
+      user = described_class.new(
+        type: 'Person', first_name: 'Adam', last_name: 'Black',
+        email: 'a.black@bar.de', password: 'testtest'
+      )
+
+      abbr = user.generate_unique_name_abbreviation
+
+      expect(abbr).not_to eq('ab')
+      expect(abbr.length).to be_between(2, 3)
+      expect(user).to be_valid
+    end
+
+    it 'returns nil and leaves the abbreviation blank when the space is exhausted' do
+      user = described_class.new(type: 'Person', first_name: 'Alice', last_name: 'Brown')
+      allow(user).to receive(:name_abbreviation_acceptable?).and_return(false)
+
+      expect(user.generate_unique_name_abbreviation).to be_nil
+      expect(user.name_abbreviation).to be_nil
+    end
+  end
+
+  describe '.find_or_create_from_omniauth!' do
+    let(:params) do
+      {
+        provider: 'ldap', uid: 'abrown', email: 'a.brown@bar.de',
+        first_name: 'Alice', last_name: 'Brown', groups: []
+      }
+    end
+
+    it 'creates a new persisted user' do
+      expect { described_class.find_or_create_from_omniauth!(params) }.to change(described_class, :count).by(1)
+    end
+
+    it 'provisions an active Person with the provider linkage', :aggregate_failures do
+      described_class.find_or_create_from_omniauth!(params)
+      user = described_class.find_by(email: 'a.brown@bar.de')
+
+      expect(user).to be_persisted
+      expect(user.account_active).to be(true)
+      expect(user.providers['ldap']).to eq('abrown')
+    end
+
+    it 'creates the default All collection' do
+      user = described_class.find_or_create_from_omniauth!(params)
+
+      expect(user.collections.where(label: 'All')).to exist
+    end
+
+    it 'links the provider onto an existing user matched by email' do
+      existing = create(:person, email: 'a.brown@bar.de')
+
+      expect { described_class.find_or_create_from_omniauth!(params) }.not_to change(described_class, :count)
+      expect(existing.reload.providers['ldap']).to eq('abrown')
+    end
+
+    it 'returns an unsaved user when no unique abbreviation can be generated' do
+      allow_any_instance_of(described_class).to receive(:generate_unique_name_abbreviation).and_return(nil) # rubocop:disable RSpec/AnyInstance
+
+      user = described_class.find_or_create_from_omniauth!(params)
+
+      expect(user).not_to be_persisted
+    end
+  end
+end

--- a/spec/services/ldap_authentication_service_spec.rb
+++ b/spec/services/ldap_authentication_service_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LdapAuthenticationService do
+  let(:config) do
+    {
+      'enable' => true,
+      'host' => 'ldap.example.org',
+      'port' => 389,
+      'base' => 'dc=example,dc=org',
+      'uid' => 'uid',
+      'bind_dn' => 'cn=service,dc=example,dc=org',
+      'password' => 'service-secret',
+    }
+  end
+
+  let(:entry) do
+    Net::LDAP::Entry.new('uid=jdoe,dc=example,dc=org').tap do |e|
+      e[:uid] = ['jdoe']
+      e[:mail] = ['jane.doe@bar.de']
+      e[:givenname] = ['Jane']
+      e[:sn] = ['Doe']
+    end
+  end
+
+  let(:connection) { instance_double(Net::LDAP) }
+
+  before { allow(Net::LDAP).to receive(:new).and_return(connection) }
+
+  describe '.enabled?' do
+    it 'is true when the ldap config has enable: true' do
+      allow(described_class).to receive(:config).and_return(config)
+      expect(described_class.enabled?).to be(true)
+    end
+
+    it 'is false when there is no ldap config' do
+      allow(described_class).to receive(:config).and_return(nil)
+      expect(described_class.enabled?).to be(false)
+    end
+  end
+
+  describe '#authenticate' do
+    subject(:result) { described_class.new(config).authenticate('jdoe', 'secret') }
+
+    it 'returns normalized attributes on a successful bind' do
+      allow(connection).to receive(:bind_as).and_return([entry])
+
+      expect(result).to eq(
+        provider: 'ldap', uid: 'jdoe', email: 'jane.doe@bar.de',
+        first_name: 'Jane', last_name: 'Doe', groups: []
+      )
+    end
+
+    it 'returns nil when the bind fails' do
+      allow(connection).to receive(:bind_as).and_return(false)
+
+      expect(result).to be_nil
+    end
+
+    it 'returns nil without binding when credentials are blank' do
+      allow(connection).to receive(:bind_as)
+
+      expect(described_class.new(config).authenticate('jdoe', '')).to be_nil
+      expect(connection).not_to have_received(:bind_as)
+    end
+
+    it 'returns nil when ldap is not enabled' do
+      expect(described_class.new(config.merge('enable' => false)).authenticate('jdoe', 'secret')).to be_nil
+    end
+  end
+end

--- a/spec/usecases/authentication/build_token_spec.rb
+++ b/spec/usecases/authentication/build_token_spec.rb
@@ -44,5 +44,46 @@ RSpec.describe Usecases::Authentication::BuildToken do
         expect(excute).to be_nil
       end
     end
+
+    context 'when DB auth fails but LDAP succeeds' do
+      let(:params) { { username: 'jdoe', password: 'ldap-secret' } }
+      let(:ldap_attrs) do
+        {
+          provider: 'ldap', uid: 'jdoe', email: 'jane.doe@bar.de',
+          first_name: 'Jane', last_name: 'Doe', groups: []
+        }
+      end
+
+      before do
+        allow(LdapAuthenticationService).to receive_messages(enabled?: true, authenticate: ldap_attrs)
+      end
+
+      it 'auto-provisions the user and returns a token' do
+        allow(JsonWebToken).to receive(:encode).and_return('ldap-token')
+
+        expect { expect(excute).to eq('ldap-token') }.to change(User, :count).by(1)
+      end
+
+      it 'creates an active person with a unique abbreviation' do
+        excute
+        provisioned = User.find_by(email: 'jane.doe@bar.de')
+
+        expect(provisioned).to be_present
+        expect(provisioned.account_active).to be(true)
+        expect(provisioned.name_abbreviation).to be_present
+      end
+    end
+
+    context 'when LDAP is enabled but the credentials are invalid' do
+      let(:params) { { username: 'jdoe', password: 'bad' } }
+
+      before do
+        allow(LdapAuthenticationService).to receive_messages(enabled?: true, authenticate: nil)
+      end
+
+      it 'returns nil' do
+        expect(excute).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Add LDAP authentication as another **OmniAuth provider**, so it sits alongside the existing
GitHub / ORCID / OpenID Connect / Shibboleth providers and reuses the same
Matrice-driven (`userProvider`) configuration, callback controller, login-button rendering,
and user-provisioning path — no new auth subsystem and no change to local DB accounts.

`omniauth-ldap` was chosen over `devise_ldap_authenticatable` to stay consistent with the
established "every external IdP is an OmniAuth provider" model (the latter integrates LDAP
as a separate Warden strategy, which would need parallel handling for the JWT token
endpoint and provisioning).

## What's included

- **`Gemfile`** — `omniauth-ldap (~> 2.3, >= 2.3.1)` → 2.3.4 (keeps `omniauth` on 1.9.x;
  pulls in `net-ldap`). Lock updated with only the new gem stanzas.
- **`config/initializers/devise.rb`** — register the `:ldap` provider from the
  `userProvider` Matrice config (host/port/method/base/uid/bind_dn/filter/icon/label).
- **`Users::OmniauthController#ldap`** — auto-provision and sign in new users instead of
  routing them to the registration form; extract a shared `auth_params` helper.
- **`User.find_or_create_from_omniauth!`** — persist new OmniAuth users and generate a
  unique, validation-passing `name_abbreviation` (graceful fallback when the constrained
  space is exhausted). Also fixes a `link_omniauth` variable-shadowing bug that prevented
  provider linkage from ever being saved.
- **`LdapAuthenticationService`** — direct `Net::LDAP` bind for non-browser paths.
- **`Usecases::Authentication::BuildToken`** — `POST /api/v1/authentication/token` falls
  back to LDAP after DB auth fails (auto-provisioning on success), so API clients can use
  LDAP credentials too.
- Specs for the service, controller action, model provisioning, and token path.

No frontend or route changes are needed — the "Login with LDAP" button auto-renders from
`Devise.omniauth_configs`, and Devise auto-routes the provider when it is registered.

## Configuration

Enable by adding an `ldap` sub-hash (with `enable: true`) to the `userProvider` Matrice row,
treated as a secret like the other providers' credentials:

```yaml
ldap:
  enable: true
  host: ldap.example.org
  port: 389
  method: plain        # plain | ssl | tls
  base: "dc=example,dc=org"
  uid: uid
  bind_dn: "cn=service,dc=example,dc=org"
  password: "<service-account-password>"
  filter: null         # optional extra LDAP filter
  icon: ldap.svg       # optional, under public/images/providers/
  label: "LDAP"
```

## Testing

- New specs (all green): `spec/services/ldap_authentication_service_spec.rb`,
  `spec/controllers/users/omniauth_controller_spec.rb`, `spec/models/user_omniauth_spec.rb`,
  and an extended `spec/usecases/authentication/build_token_spec.rb`.
- Existing `authentication_api_spec` and `user_spec` still pass; Rubocop clean on changed lines.

## Out of scope (for now)

- LDAP group / `memberOf` → `Group` sync (groups stay manually assigned).
- End-to-end verification against a live directory.
