### PR TITLE
fix(js): restore four fetcher request shapes regressed by the #3294 migration

### DIFF
--- a/app/javascript/src/fetchers/AttachmentFetcher.js
+++ b/app/javascript/src/fetchers/AttachmentFetcher.js
@@ -440,7 +440,7 @@ export default class AttachmentFetcher {
   }
 
   static combineSpectra(jcampIds, curveIdx, extraParams = null) {
-    const extras = decamelizeKeys(extraParams);
+    const extras = JSON.stringify(decamelizeKeys(extraParams));
     return ApiClient.postJson(
       '/api/v1/chemspectra/file/combine_spectra',
       { body: { spectra_ids: jcampIds, front_spectra_idx: curveIdx, extras } }

--- a/app/javascript/src/fetchers/AttachmentFetcher.js
+++ b/app/javascript/src/fetchers/AttachmentFetcher.js
@@ -440,10 +440,13 @@ export default class AttachmentFetcher {
   }
 
   static combineSpectra(jcampIds, curveIdx, extraParams = null) {
-    const extras = JSON.stringify(decamelizeKeys(extraParams));
+    const body = { spectra_ids: jcampIds, front_spectra_idx: curveIdx };
+    if (extraParams != null) {
+      body.extras = JSON.stringify(decamelizeKeys(extraParams));
+    }
     return ApiClient.postJson(
       '/api/v1/chemspectra/file/combine_spectra',
-      { body: { spectra_ids: jcampIds, front_spectra_idx: curveIdx, extras } }
+      { body }
     );
   }
 

--- a/app/javascript/src/fetchers/ChemSpectraFetcher.js
+++ b/app/javascript/src/fetchers/ChemSpectraFetcher.js
@@ -22,7 +22,7 @@ export default class ChemSpectraFetcher {
   }
 
   static fetchUpdatedSpectraLayouts() {
-    return ApiClient.getJson('/data_type', {
+    return ApiClient.getJson('/data_type.json', {
       handleResponseSuccess: (response) => {
         if (response.ok) { return response.json(); }
         return null;

--- a/app/javascript/src/fetchers/MoleculesFetcher.js
+++ b/app/javascript/src/fetchers/MoleculesFetcher.js
@@ -26,7 +26,7 @@ export default class MoleculesFetcher {
   }
 
   static updateNames(id, newMolName = '') {
-    return ApiClient.getJson(`/api/v1/molecules/names?${new URLSearchParams({ id, new_name: escape(newMolName) })}`)
+    return ApiClient.getJson(`/api/v1/molecules/names?${new URLSearchParams({ id, new_name: newMolName })}`)
       .then((json) => json.molecules);
   }
 

--- a/app/javascript/src/fetchers/UserLabelsFetcher.js
+++ b/app/javascript/src/fetchers/UserLabelsFetcher.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import ApiClient from 'src/api_clients/ChemotionApiClient';
 
 export default class UserLabelsFetcher {
@@ -9,11 +10,11 @@ export default class UserLabelsFetcher {
     return ApiClient.putJson('/api/v1/user_labels/save_label', { body: params });
   }
 
-  static bulkUpdate({ uiState, addLabelIds = [], removeLabelIds = [] }) {
+  static bulkUpdate({ ui_state, add_label_ids = [], remove_label_ids = [] }) {
     const body = {
-      ui_state: uiState,
-      add_label_ids: addLabelIds,
-      remove_label_ids: removeLabelIds,
+      ui_state,
+      add_label_ids,
+      remove_label_ids,
     };
 
     return ApiClient.postJson('/api/v1/user_labels/bulk', {

--- a/spec/javascripts/packs/src/fetchers/AttachmentFetcher.spec.js
+++ b/spec/javascripts/packs/src/fetchers/AttachmentFetcher.spec.js
@@ -58,4 +58,14 @@ describe('AttachmentFetcher.combineSpectra', () => {
     expect(body.extras).toEqual(JSON.stringify(decamelizeKeys(extraParams)));
     expect(JSON.parse(body.extras)).toEqual({ shift_ref: 1, integration: { peak_a: 2 } });
   });
+
+  it('omits extras when no extra params are provided', async () => {
+    await AttachmentFetcher.combineSpectra([10, 11], 0);
+
+    sinon.assert.calledOnce(fetchStub);
+    const [, options] = fetchStub.firstCall.args;
+    const body = JSON.parse(options.body);
+    expect(body).toEqual({ spectra_ids: [10, 11], front_spectra_idx: 0 });
+    expect(Object.prototype.hasOwnProperty.call(body, 'extras')).toEqual(false);
+  });
 });

--- a/spec/javascripts/packs/src/fetchers/AttachmentFetcher.spec.js
+++ b/spec/javascripts/packs/src/fetchers/AttachmentFetcher.spec.js
@@ -1,4 +1,5 @@
 import AttachmentFetcher from 'src/fetchers/AttachmentFetcher';
+import { decamelizeKeys } from 'src/utilities/FetcherHelper';
 import expect from 'expect';
 import sinon from 'sinon';
 import {
@@ -27,5 +28,34 @@ describe('AttachmentFetcher.bulkDeleteAttachments', () => {
     // Regression guard: must be {"ids":[1,2,3]}, NOT the lossy CSV "1,2,3"
     expect(options.body).toEqual(JSON.stringify({ ids: [1, 2, 3] }));
     expect(JSON.parse(options.body)).toEqual({ ids: [1, 2, 3] });
+  });
+});
+
+describe('AttachmentFetcher.combineSpectra', () => {
+  let fetchStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch');
+    fetchStub.resolves(new Response(JSON.stringify({}), { status: 200 }));
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+  });
+
+  it('serializes extras as a JSON string the type:String endpoint can relay', async () => {
+    const extraParams = { shiftRef: 1, integration: { peakA: 2 } };
+    await AttachmentFetcher.combineSpectra([10, 11], 0, extraParams);
+
+    sinon.assert.calledOnce(fetchStub);
+    const [url, options] = fetchStub.firstCall.args;
+    expect(url).toEqual('/api/v1/chemspectra/file/combine_spectra');
+    const body = JSON.parse(options.body);
+    // Regression guard: extras must be a JSON *string*, not a nested object,
+    // because the endpoint declares `optional :extras, type: String` and relays
+    // it as a multipart form field to an external service that json.loads() it.
+    expect(typeof body.extras).toEqual('string');
+    expect(body.extras).toEqual(JSON.stringify(decamelizeKeys(extraParams)));
+    expect(JSON.parse(body.extras)).toEqual({ shift_ref: 1, integration: { peak_a: 2 } });
   });
 });

--- a/spec/javascripts/packs/src/fetchers/ChemSpectraFetcher.spec.js
+++ b/spec/javascripts/packs/src/fetchers/ChemSpectraFetcher.spec.js
@@ -93,6 +93,16 @@ describe('ChemSpectraFetcher methods', () => {
       expect(response).toEqual(Object.entries(expectedResponse.datatypes));
     });
 
+    it('requests the static /data_type.json asset (not the routeless /data_type)', async () => {
+      fetchStub.resolves(new Response(JSON.stringify({ datatypes: {} }), { status: 200 }));
+
+      await ChemSpectraFetcher.fetchUpdatedSpectraLayouts();
+
+      sinon.assert.calledOnce(fetchStub);
+      // Regression guard: the asset is public/data_type.json; GET /data_type 404s (no route).
+      expect(fetchStub.firstCall.args[0]).toEqual('/data_type.json');
+    });
+
     it('should handle fetch failure', async () => {
       fetchStub.resolves(new Response(null, { status: 404 }));
       try {

--- a/spec/javascripts/packs/src/fetchers/MoleculesFetcher.spec.js
+++ b/spec/javascripts/packs/src/fetchers/MoleculesFetcher.spec.js
@@ -1,0 +1,41 @@
+import MoleculesFetcher from 'src/fetchers/MoleculesFetcher';
+import expect from 'expect';
+import sinon from 'sinon';
+import {
+  describe, it, beforeEach, afterEach
+} from 'mocha';
+
+describe('MoleculesFetcher.updateNames', () => {
+  let fetchStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch');
+    fetchStub.resolves(new Response(JSON.stringify({ molecules: [] }), { status: 200 }));
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+  });
+
+  it('encodes the new name exactly once (no escape() double-encoding)', async () => {
+    await MoleculesFetcher.updateNames(42, 'a b,c');
+
+    sinon.assert.calledOnce(fetchStub);
+    const url = fetchStub.firstCall.args[0];
+    // URLSearchParams encodes once: space -> '+', comma -> %2C.
+    expect(url).toContain('new_name=a+b%2Cc');
+    // Regression guard: escape() + URLSearchParams produced the doubly-encoded %2520.
+    expect(url).not.toContain('%2520');
+  });
+
+  it('UTF-8 percent-encodes Unicode names so the server can decode them', async () => {
+    await MoleculesFetcher.updateNames(7, '中');
+
+    sinon.assert.calledOnce(fetchStub);
+    const url = fetchStub.firstCall.args[0];
+    // URLSearchParams emits valid UTF-8 (%E4%B8%AD); escape() emitted the
+    // non-standard %u4E2D that Rack cannot decode.
+    expect(url).toContain('new_name=%E4%B8%AD');
+    expect(url).not.toContain('%u');
+  });
+});

--- a/spec/javascripts/packs/src/fetchers/UserLabelsFetcher.spec.js
+++ b/spec/javascripts/packs/src/fetchers/UserLabelsFetcher.spec.js
@@ -1,0 +1,41 @@
+import UserLabelsFetcher from 'src/fetchers/UserLabelsFetcher';
+import expect from 'expect';
+import sinon from 'sinon';
+import {
+  describe, it, beforeEach, afterEach
+} from 'mocha';
+
+describe('UserLabelsFetcher.bulkUpdate', () => {
+  let fetchStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch');
+    fetchStub.resolves(new Response(JSON.stringify({}), { status: 200 }));
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+  });
+
+  it('forwards the snake_case ui_state and id arrays the caller and backend use', async () => {
+    const uiState = { sample: { checkedIds: [1, 2] } };
+    await UserLabelsFetcher.bulkUpdate({
+      ui_state: uiState,
+      add_label_ids: [3, 4],
+      remove_label_ids: [5],
+    });
+
+    sinon.assert.calledOnce(fetchStub);
+    const [url, options] = fetchStub.firstCall.args;
+    expect(url).toEqual('/api/v1/user_labels/bulk');
+    expect(options.method).toEqual('POST');
+    // Regression guard: a camelCase destructure dropped ui_state and emptied the
+    // arrays, so the body went out as { add_label_ids: [], remove_label_ids: [] }
+    // and the endpoint 400'd on the missing required ui_state.
+    expect(JSON.parse(options.body)).toEqual({
+      ui_state: uiState,
+      add_label_ids: [3, 4],
+      remove_label_ids: [5],
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to #3294 (part 2; part 1 was #3321). Fixes four outgoing-request regressions the `ChemotionApiClient` migration introduced, each of which the target endpoint rejects. All are client-only; no server contract changes.

## Fixes

- **`AttachmentFetcher.combineSpectra` — `extras` object vs `type: String`.** `extras` was sent as a nested object, but `combine_spectra` declares `optional :extras, type: String` and relays it as a multipart form field to an external service that `json.loads()` it. Restore the inner `JSON.stringify(decamelizeKeys(extraParams))` so it arrives as a JSON string. Combining spectra with any extra params (shift/reference/integration) was broken.

- **`UserLabelsFetcher.bulkUpdate` — camelCase vs snake_case keys.** The fetcher destructured `{ uiState, addLabelIds, removeLabelIds }`, but the caller and backend both use snake_case. `ui_state` and the id arrays went out empty → `POST /user_labels/bulk` 400s, so every bulk add/remove user-label edit (the #3142 feature) failed. Align the destructure to snake_case.

- **`ChemSpectraFetcher.fetchUpdatedSpectraLayouts` — `/data_type` 404.** The resource is the static file `public/data_type.json`; there is no `/data_type` route, so the admin spectra data-type view 404'd and never loaded. Restore the `.json` suffix. (The sibling `updateDataTypes` `.json` drop is correct — that one is a Grape route — and is left unchanged.)

- **`MoleculesFetcher.updateNames` — double-encoded names.** `escape()` was applied on top of `URLSearchParams`, percent-encoding twice, so any name with a space/punctuation/non-ASCII char was stored corrupted (e.g. `a b` → `a%20b`). Drop `escape()` and let `URLSearchParams` encode once; this also makes Unicode molecule names work (overlaps #3281).

## Tests

Adds request-shape specs (stub `global.fetch`, assert the outgoing URL/body) for all four — each fails before its fix:

- `AttachmentFetcher.spec.js` — `combineSpectra` `extras` is a JSON string
- `UserLabelsFetcher.spec.js` (new) — body carries `ui_state` + the id arrays
- `ChemSpectraFetcher.spec.js` — request URL is `/data_type.json`
- `MoleculesFetcher.spec.js` (new) — single encoding (no `%2520`), Unicode `%E4%B8%AD`

All four specs pass; eslint clean on the touched files.


ref: #3294