### PR TITLE
feat(variations): send reaction variations to OpenStats and display statistical summaries

### DIFF
--- a/app/api/chemotion/third_party_app_api.rb
+++ b/app/api/chemotion/third_party_app_api.rb
@@ -34,6 +34,29 @@ module Chemotion
           end
         end
       end
+
+      resource :third_party_app_variations, requirements: { token: %r{[^\/]+} } do
+        route_param :token, regexp: /^[\w-]+\.[\w-]+\.[\w-]+$/ do
+          after_validation do
+            parse_variations_payload(JsonWebToken.decode(params[:token]))
+          end
+          desc 'download reaction variations JSON to 3rd party app'
+          get '/' do
+            download_variations_to_third_party_app
+          end
+
+          desc 'upload reaction-variations statistics result (a zip) from 3rd party app'
+          params do
+            requires :file, type: File,
+                     desc: 'result.zip bundling the statistics workbook (.xlsx) and the summary tables (.json)'
+            optional :request_id, type: String, desc: 'echoed request_id; validated against the token when present'
+            optional :id, type: String, desc: 'echoed reaction id; validated against the token when present'
+          end
+          post '/' do
+            upload_variations_result_from_third_party_app
+          end
+        end
+      end
     end
 
     resource :third_party_apps do
@@ -107,6 +130,22 @@ module Chemotion
 
         # redirect url with callback url to {down,up}load file: NB path should match the public endpoint
         "#{@app.url}?url=#{CGI.escape(token_uri.to_s)}"
+      end
+
+      desc 'create token for sending reaction variations to a 3rd party app'
+      params do
+        requires :reactionID, type: Integer, desc: 'Reaction ID'
+        requires :appID, type: Integer, desc: 'id of the third party app'
+        requires :variationUuids, type: Array[String], desc: 'UUIDs of variation rows to send'
+        optional :columnOrder, type: Array[String],
+                 desc: 'array of strings describing the order of the columns'
+      end
+
+      get 'variations_token' do
+        prepare_variations_payload
+        parse_variations_payload
+        encode_and_cache_token
+        "#{@app.url}?url=#{CGI.escape(variations_token_uri.to_s)}&method=VariationStatistics"
       end
 
       desc 'get chemotion handler url'

--- a/app/api/entities/reaction_variation_entity.rb
+++ b/app/api/entities/reaction_variation_entity.rb
@@ -105,6 +105,11 @@ module Entities
       :vesselVolume,
       :materialType,
       :density,
+      # Human-readable identifiers injected server-side at TPA download time
+      # (see ThirdPartyAppHelpers#annotate_material_names!). nil when the
+      # underlying sample no longer exists.
+      :name,
+      :shortLabel,
     )
   end
 

--- a/app/api/helpers/third_party_app_helpers.rb
+++ b/app/api/helpers/third_party_app_helpers.rb
@@ -43,6 +43,41 @@ module ThirdPartyAppHelpers
     error!('Record not found', 404)
   end
 
+  # ---------------------------------------------------------------------------
+  # Reaction-variations flow (parallel to the attachment helpers above).
+  # ---------------------------------------------------------------------------
+
+  # desc: prepare the token payload for the reaction-variations flow.
+  # `columnOrder` carries the grid's visible columns in display order (their
+  # colIds); it lives only in the browser, so the frontend must hand it to us
+  # here to reach the TPA.
+  def prepare_variations_payload
+    @payload = {
+      'appID' => params[:appID],
+      'userID' => current_user.id,
+      'reactionID' => params[:reactionID],
+      'variationUuids' => params[:variationUuids] || [],
+      'columnOrder' => params[:columnOrder] || [],
+      'requestID' => SecureRandom.uuid,
+    }
+  end
+
+  # desc: find records from a variations payload and set @cache_key to a
+  # reaction-namespaced key (so reaction ids can't collide with attachment ids).
+  def parse_variations_payload(payload = @payload)
+    @user = User.find(payload['userID']&.to_i)
+    @app = payload['appID'].to_i.zero? ? ThirdPartyApp.new : ThirdPartyApp.find(payload['appID']&.to_i)
+    @reaction = Reaction.find(payload['reactionID']&.to_i)
+    @variation_uuids = Array(payload['variationUuids'])
+    @column_order = Array(payload['columnOrder'])
+    @request_id = payload['requestID']
+    @cache_key = "reaction/#{@reaction&.id}/#{@user&.id}/#{@app&.id}/#{@request_id}"
+
+    error!('No read access to reaction', 403) unless ElementPolicy.new(@user, @reaction).read?
+  rescue ActiveRecord::RecordNotFound
+    error!('Record not found', 404)
+  end
+
   # desc: decrement the counters / check if token permission is expired
   def update_cache(key)
     return error!('Invalid token', 403) if cached_token.nil? || cached_token[:token] != params[:token]
@@ -53,6 +88,150 @@ module ThirdPartyAppHelpers
 
     cached_token[key] -= 1
     cache.write(cache_key, cached_token)
+  end
+
+  # desc: return reaction variations JSON for download to third-party app.
+  def download_variations_to_third_party_app
+    update_cache(:download)
+    return error!('No read access to reaction', 403) unless ElementPolicy.new(@user, @reaction).read?
+
+    selected = @reaction.variations
+                        .select { |v| @variation_uuids.include?(v['uuid']) }
+                        .map(&:deep_symbolize_keys)
+
+    labels = reaction_sample_labels(@reaction)
+    selected.each { |row| annotate_material_names!(row, labels) }
+
+    content_type 'application/json'
+    {
+      id: @reaction.id.to_s,
+      request_id: @request_id,
+      columnOrder: @column_order,
+      variations: Entities::ReactionVariationEntity.represent(selected, serializable: true),
+    }
+  end
+
+  # desc: store the statistics result POSTed back by the third-party app.
+  def upload_variations_result_from_third_party_app
+    update_cache(:upload)
+    verify_variations_result_envelope!
+    return error!('No write access to reaction', 403) unless ElementPolicy.new(@user, @reaction).update?
+
+    ensure_reaction_container!
+
+    dataset = @reaction.container.analyses_container.create_analysis_with_dataset!(name: 'Statistical Analysis')
+    analysis = dataset.parent
+
+    store_variations_result_files(dataset, params[:file])
+
+    {
+      message: 'Statistical analysis stored successfully',
+      analysis_id: analysis.id,
+      request_id: @request_id,
+    }
+  end
+
+  # desc: integrity check on the echoed envelope.
+  def verify_variations_result_envelope!
+    if params[:request_id].present? && params[:request_id] != @request_id
+      error!('request_id does not match the token', 422)
+    end
+    return if params[:id].blank? || params[:id].to_s == @reaction.id.to_s
+
+    error!('id does not match the token', 422)
+  end
+
+  # desc: a reaction created through the API always carries a container, but be
+  # defensive — build the root (+ analyses child) tree if one is somehow missing,
+  # so the upload can't 500 on a container-less reaction.
+  def ensure_reaction_container!
+    return if @reaction.container
+
+    @reaction.container = Container.create_root_container
+    @reaction.save!
+  end
+
+  # desc: unpack the result.zip POSTed by OpenStats and attach its inner files to
+  # the dataset.
+  def store_variations_result_files(dataset, file)
+    return error!('No result file uploaded', 422) if file.blank?
+
+    excel = nil
+    plot_index = 0
+    Zip::File.open(file[:tempfile].path) do |zip|
+      zip.each do |entry|
+        next if entry.ftype == :directory
+
+        case File.extname(entry.name).downcase
+        when '.xlsx', '.xls'
+          excel = attach_variations_entry(dataset, entry, "statistical_analysis#{File.extname(entry.name).downcase}")
+        when '.json'
+          attach_variations_entry(dataset, entry, 'variations_summary.json')
+        when '.png'
+          plot_index += 1
+          attach_variations_entry(dataset, entry, "variations_plot_#{plot_index}.png")
+        end
+      end
+    end
+    notify_variations_result_uploaded(excel) if excel
+  rescue Zip::Error
+    error!('Uploaded result file is not a valid zip', 422)
+  end
+
+  # desc: materialise a single zip entry as a dataset Attachment under `filename`.
+  def attach_variations_entry(dataset, entry, filename)
+    tempfile = Tempfile.new(['variations_result', File.extname(filename)])
+    begin
+      tempfile.binmode
+      tempfile.write(entry.get_input_stream.read)
+      tempfile.flush
+      Attachment.create!(
+        attachable: dataset,
+        created_by: @user.id,
+        created_for: @user.id,
+        filename: filename,
+        file_path: tempfile.path,
+      )
+    ensure
+      tempfile.close
+      tempfile.unlink
+    end
+  end
+
+  # desc: reuse the existing TPA attachment-arrival notification.
+  def notify_variations_result_uploaded(attachment)
+    Message.create_msg_notification(
+      channel_subject: Channel::SEND_TPA_ATTACHMENT_NOTIFICATION,
+      message_from: @user.id,
+      attachment: Entities::NotificationAttachmentEntity.represent(attachment).as_json,
+      data_args: { app: @app.name },
+    )
+  end
+
+  # desc: map sample id => { name:, shortLabel: } for every sample in the reaction.
+  def reaction_sample_labels(reaction)
+    reaction.samples.each_with_object({}) do |sample, map|
+      map[sample.id] = {
+        name: sample.preferred_label.presence || sample.short_label,
+        shortLabel: sample.short_label,
+      }
+    end
+  end
+
+  # desc: inject the resolved name/shortLabel into each material's aux.
+  def annotate_material_names!(row, labels)
+    %i[startingMaterials reactants products solvents].each do |material_type|
+      row[material_type]&.each do |sample_id, material|
+        next unless material[:aux]
+
+        label = labels[sample_id.to_s.to_i]
+        next unless label
+
+        material[:aux][:name] = label[:name]
+        material[:aux][:shortLabel] = label[:shortLabel]
+      end
+    end
+    row
   end
 
   # desc: return file for download to third party app
@@ -120,6 +299,17 @@ module ThirdPartyAppHelpers
     url = URI.parse Rails.application.config.root_url
     url.path = Pathname.new(url.path)
                        .join('/', API.prefix.to_s, API.version, 'public/third_party_apps', @token)
+                       .to_s
+
+    url
+  end
+
+  # Build the url for the public reaction-variations endpoint.
+  def variations_token_uri
+    url = URI.parse Rails.application.config.root_url
+    url.path = Pathname.new(url.path)
+                       .join('/', API.prefix.to_s, API.version,
+                             'public/third_party_app_variations', @token)
                        .to_s
 
     url

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariations.js
@@ -28,9 +28,25 @@ import {
   ColumnSelection,
   RemoveVariationsModal
 } from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents';
+import ReactionVariationsSummary
+  from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsSummary';
 import columnDefinitionsReducer
   from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsReducers';
 import GasPhaseReactionStore from 'src/stores/alt/stores/GasPhaseReactionStore';
+import UIStore from 'src/stores/alt/stores/UIStore';
+import NotificationActions from 'src/stores/alt/actions/NotificationActions';
+import ThirdPartyAppFetcher from 'src/fetchers/ThirdPartyAppFetcher';
+
+const OPENSTATS_TPA_NAME = 'OpenStats';
+
+const notify = ({ title, message, level }) => NotificationActions.add({
+  title,
+  message,
+  level,
+  dismissible: 'button',
+  autoDismiss: 10,
+  position: 'tr',
+});
 
 export default function ReactionVariations({ reaction, onReactionChange }) {
   if (reaction.isNew) {
@@ -124,6 +140,39 @@ export default function ReactionVariations({ reaction, onReactionChange }) {
     );
   };
 
+  const sendToOpenStats = () => {
+    const selectedCols = gridRef.current.api.getColumnState();
+
+    const columnOrder = selectedCols.filter(
+      (col) => !col.hide && col.colId !== 'ag-Grid-SelectionColumn' && col.colId !== 'tools'
+    ).map((col) => col.colId);
+
+    const selectedRows = gridRef.current.api.getSelectedRows();
+    const variationUuids = selectedRows.map((row) => row.uuid).filter(Boolean);
+    if (variationUuids.length === 0) {
+      notify({
+        title: 'Nothing to send',
+        message: 'Select at least one variation row before sending to OpenStats.',
+        level: 'warning',
+      });
+      return;
+    }
+
+    const { thirdPartyApps = [] } = UIStore.getState() ?? {};
+    const openStats = thirdPartyApps.find((tpa) => tpa.name === OPENSTATS_TPA_NAME);
+    if (!openStats) {
+      notify({
+        title: 'OpenStats not configured',
+        message: `Third-party app "${OPENSTATS_TPA_NAME}" is not registered on this instance. Ask an admin to add it.`,
+        level: 'error',
+      });
+      return;
+    }
+
+    ThirdPartyAppFetcher.fetchVariationsToken(reaction.id, openStats.id, variationUuids, columnOrder)
+      .then((url) => window.open(url, '_blank'));
+  };
+
   const copyRow = useCallback((data) => {
     const copiedRow = copyVariationsRow(data, reactionVariations);
     setReactionVariations(
@@ -209,6 +258,22 @@ export default function ReactionVariations({ reaction, onReactionChange }) {
       <Button size="sm" onClick={addRow} className="mb-2">
         <i className="fa fa-plus me-1" />
         Add variation
+      </Button>
+    </OverlayTrigger>
+  );
+
+  const sendToTPA = () => (
+    <OverlayTrigger
+      placement="bottom"
+      overlay={(
+        <Tooltip>
+          Send data to OpenStats
+        </Tooltip>
+          )}
+    >
+      <Button size="sm" onClick={sendToOpenStats} className="mb-2">
+        <i className="fa fa-external-link me-1" aria-hidden="true" />
+        Send to OpenStats
       </Button>
     </OverlayTrigger>
   );
@@ -363,6 +428,7 @@ export default function ReactionVariations({ reaction, onReactionChange }) {
     <div>
       <ButtonGroup>
         {addVariation()}
+        {sendToTPA()}
         {exportTable()}
         <ColumnSelection
           selectedColumns={selectedColumns}
@@ -386,6 +452,8 @@ export default function ReactionVariations({ reaction, onReactionChange }) {
           rowData={reactionVariations}
           getRowId={(params) => params.data.id}
           rowDragManaged
+          rowSelection={{ mode: 'multiRow', checkboxes: true, headerCheckbox: true }}
+          selectionColumnDef={{ pinned: 'left', width: 50 }}
           columnDefs={columnDefinitions}
           suppressPropertyNamesCheck
           defaultColDef={{
@@ -436,6 +504,13 @@ export default function ReactionVariations({ reaction, onReactionChange }) {
           onRowDragEnd={(event) => handleRowDrag(event)}
         />
       </div>
+      {/*
+      The statistics OpenStats sends back are rendered here, below the grid.
+      We pass the whole `reaction` (not just its variations) because the summary
+      lives on the reaction's "Statistical Analysis" attachments, which the
+      component reads + fetches itself.
+      */}
+      <ReactionVariationsSummary reaction={reaction} />
     </div>
   );
 }

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsComponents.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/display-name */
 import React, {
-  useState, useEffect, useMemo, useRef, useCallback
+  useState, useEffect, useMemo, useRef
 } from 'react';
 import Select from 'react-select';
 import {
@@ -207,7 +207,7 @@ function MaterialFormatter({ value: cellData, colDef }) {
 }
 
 function GroupCellEditor({
-  value, onValueChange, stopEditing, onKeyDown
+  value, onValueChange, stopEditing
 }) {
   const [currentValue, setCurrentValue] = useState(() => {
     const group = value?.group ?? 1;
@@ -217,49 +217,27 @@ function GroupCellEditor({
 
   const inputRef = useRef(null);
 
-  const focusInput = useCallback(() => {
-    requestAnimationFrame(() => {
-      if (inputRef.current) {
-        inputRef.current.focus();
-        inputRef.current.select();
-      }
-    });
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
   }, []);
 
+  // Push the parsed value to ag-grid on every change so it's
+  // already in sync when stopEditing fires (avoids v33 race).
   useEffect(() => {
-    // Focus on mount
-    focusInput();
-  }, [focusInput]);
-
-  const commitValue = () => {
-    const parts = currentValue.split('.');
-
-    const groupStr = parts[0] || '';
-    const subGroupStr = parts[1] || '';
-
+    const [groupStr = '', subGroupStr = ''] = currentValue.split('.');
     let group = parseInt(groupStr, 10);
     let subgroup = parseInt(subGroupStr, 10);
-
-    if (Number.isNaN(group) || group <= 0) {
-      group = 1;
-    }
-
-    if (Number.isNaN(subgroup) || subgroup <= 0) {
-      subgroup = 1;
-    }
-
+    if (Number.isNaN(group) || group <= 0) group = 1;
+    if (Number.isNaN(subgroup) || subgroup <= 0) subgroup = 1;
     onValueChange({ group, subgroup });
-    stopEditing();
-  };
+  }, [currentValue]);
 
   const handleKeyDown = (e) => {
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' || e.key === 'Escape') {
       e.preventDefault();
-      commitValue();
-    } else if (e.key === 'Escape') {
       stopEditing();
     }
-    if (onKeyDown) onKeyDown(e);
   };
 
   return (
@@ -268,8 +246,7 @@ function GroupCellEditor({
       type="text"
       value={currentValue}
       onChange={(e) => setCurrentValue(sanitizeGroupEntry(e.target.value))}
-      onBlurCapture={commitValue}
-      onKeyDownCapture={handleKeyDown}
+      onKeyDown={handleKeyDown}
     />
   );
 }
@@ -280,8 +257,7 @@ GroupCellEditor.propTypes = {
     subgroup: PropTypes.number,
   }).isRequired,
   onValueChange: PropTypes.func.isRequired,
-  onKeyDown: PropTypes.func.isRequired,
-  stopEditing: PropTypes.bool.isRequired,
+  stopEditing: PropTypes.func.isRequired,
 };
 
 function GroupCellRenderer({ value: cellData }) {

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsSummary.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsSummary.js
@@ -1,0 +1,219 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Alert, Spinner, Badge, Table, Collapse, Button
+} from 'react-bootstrap';
+import Reaction from 'src/models/Reaction';
+import AttachmentFetcher from 'src/fetchers/AttachmentFetcher';
+import UIActions from 'src/stores/alt/actions/UIActions';
+import {
+  collectSummaryGroups, getColumns, formatCell
+} from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsSummaryUtils';
+
+function SummaryTable({ table }) {
+  const items = table.items ?? [];
+  if (items.length === 0) {
+    return null;
+  }
+  const columns = getColumns(items);
+
+  return (
+    <div className="mt-2" style={{ overflowX: 'auto' }}>
+      <Table bordered hover size="sm" className="bg-white mb-0">
+        <thead className="bg-light">
+          <tr>
+            {columns.map((column) => (
+              <th key={column}>{column}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((row, rowIndex) => (
+            <tr key={rowIndex}>
+              {columns.map((column) => (
+                <td key={column}>{formatCell(row[column])}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  );
+}
+
+SummaryTable.propTypes = {
+  table: PropTypes.shape({
+    id: PropTypes.string,
+    items: PropTypes.arrayOf(PropTypes.objectOf(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool])
+    )),
+  }).isRequired,
+};
+
+function PlotsSection({ plots }) {
+  const [open, setOpen] = useState(false);
+  if (plots.length === 0) {
+    return null;
+  }
+  return (
+    <div className="mt-2">
+      <Button
+        variant="link"
+        size="sm"
+        className="p-0 text-decoration-none"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+      >
+        <i className={`fa fa-caret-${open ? 'down' : 'right'} me-1`} aria-hidden="true" />
+        {`Plots (${plots.length})`}
+      </Button>
+      <Collapse in={open}>
+        <div>
+          {plots.map((plot) => (
+            <img
+              key={plot.id}
+              src={`/api/v1/attachments/image/${plot.id}`}
+              alt={plot.filename}
+              className="img-fluid d-block mt-2"
+              style={{ maxWidth: '1000px' }}
+            />
+          ))}
+        </div>
+      </Collapse>
+    </div>
+  );
+}
+
+PlotsSection.propTypes = {
+  plots: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    filename: PropTypes.string,
+  })).isRequired,
+};
+
+export default function ReactionVariationsSummary({ reaction }) {
+  const [summariesById, setSummariesById] = useState({});
+  const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState(null);
+  const [freshContainer, setFreshContainer] = useState(null);
+
+  const container = freshContainer ?? reaction.container;
+  const summaryGroups = collectSummaryGroups(container);
+  const attachmentIds = summaryGroups
+    .flatMap((group) => group.attachments.map((attachment) => attachment.id))
+    .join(',');
+
+  useEffect(() => {
+    const ids = attachmentIds ? attachmentIds.split(',') : [];
+    if (ids.length === 0) {
+      setSummariesById({});
+      return undefined;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    Promise.all(
+      ids.map((id) => AttachmentFetcher
+        .fetchAttachmentText(id)
+        .then((text) => {
+          const data = JSON.parse(text);
+          return [id, typeof data === 'string' ? JSON.parse(data) : data];
+        }))
+    )
+      .then((entries) => { if (!cancelled) setSummariesById(Object.fromEntries(entries)); })
+      .catch(() => { if (!cancelled) setError('Could not load the statistics summary.'); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+
+    return () => { cancelled = true; };
+  }, [attachmentIds]);
+
+  const refreshResults = () => {
+    setRefreshing(true);
+    setError(null);
+    fetch(`/api/v1/reactions/${reaction.id}.json`, { credentials: 'same-origin' })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to reload reaction ${reaction.id}`);
+        }
+        return response.json();
+      })
+      .then((json) => setFreshContainer(json?.reaction?.container ?? null))
+      .catch(() => setError('Could not reload the reaction.'))
+      .finally(() => setRefreshing(false));
+  };
+
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') {
+        refreshResults();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => document.removeEventListener('visibilitychange', onVisible);
+  }, [reaction.id]);
+
+  const analysisIndex = (analysisId) => reaction.analysisContainers()
+    .findIndex((analysis) => analysis.id === analysisId);
+
+  const openAnalysis = (analysisId) => {
+    const index = analysisIndex(analysisId);
+    if (index === -1) {
+      return;
+    }
+    UIActions.selectActiveAnalysis({ type: 'reaction', analysisIndex: index });
+    UIActions.selectActiveAnalysisTab(4.1);
+    UIActions.selectTab({ type: 'reaction', tabKey: 'analyses' });
+  };
+
+  const busySpinner = (loading || refreshing)
+    ? <Spinner animation="border" size="sm" className="ms-2" /> : null;
+
+  return (
+    <div className="mt-3">
+      <div className="d-flex align-items-center mb-1">
+        <h5 className="mb-0">Statistics summary</h5>
+        {busySpinner}
+      </div>
+      {error && <Alert variant="warning">{error}</Alert>}
+      {summaryGroups.length === 0 && (
+        <span className="text-body-secondary">
+          No statistics results yet.
+        </span>
+      )}
+      {/*
+      Only the `Output` array is displayed; the envelope fields (id, request_id,
+      element_info) are not shown. Each Output entry becomes its own read-only table.
+      */}
+      {summaryGroups.map((group) => (
+        <div key={group.analysisId} className="border rounded p-2 mb-3">
+          <div className="d-flex align-items-center gap-2 mb-1">
+            <strong>{group.analysisName}</strong>
+            <Badge
+              bg="info"
+              role="button"
+              onClick={() => openAnalysis(group.analysisId)}
+            >
+              Open analysis
+              {' '}
+              <i className="fa fa-external-link" aria-hidden="true" />
+            </Badge>
+          </div>
+          {group.attachments.flatMap((attachment) => {
+            const summary = summariesById[attachment.id];
+            return (summary?.Output ?? []).map((table) => (
+              <SummaryTable key={`${attachment.id}-${table.id}`} table={table} />
+            ));
+          })}
+          <PlotsSection plots={group.plots} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+ReactionVariationsSummary.propTypes = {
+  reaction: PropTypes.instanceOf(Reaction).isRequired,
+};

--- a/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsSummaryUtils.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsSummaryUtils.js
@@ -1,0 +1,53 @@
+// Pure helpers for the reaction-variations statistics summary.
+//
+// Kept free of React/model imports so they can be unit-tested in isolation
+// (importing the summary component would pull in the Reaction model and its
+// heavy dependency chain). See ReactionVariationsSummary.js for the rendering.
+
+export const STATISTICAL_ANALYSIS_NAME = 'Statistical Analysis';
+export const SUMMARY_FILENAME = 'variations_summary.json';
+
+// Walk a reaction container tree and group the OpenStats results by analysis:
+// one entry per "Statistical Analysis" analysis, with its dataset attachments
+// split into the summary json and the .png plots. Groups with neither are dropped.
+export function collectSummaryGroups(container) {
+  if (!container) {
+    return [];
+  }
+  const analysesContainers = (container.children ?? [])
+    .filter((child) => child.container_type === 'analyses');
+  const analyses = analysesContainers
+    .flatMap((analysesContainer) => analysesContainer.children ?? [])
+    .filter((child) => child.container_type === 'analysis' && child.name === STATISTICAL_ANALYSIS_NAME);
+  return analyses
+    .map((analysis) => {
+      const allAttachments = (analysis.children ?? [])
+        .filter((child) => child.container_type === 'dataset')
+        .flatMap((dataset) => dataset.attachments ?? []);
+      const attachments = allAttachments.filter((attachment) => attachment.filename === SUMMARY_FILENAME);
+      const plots = allAttachments.filter((attachment) => attachment.filename.endsWith('.png'));
+      return {
+        analysisId: analysis.id, analysisName: analysis.name, attachments, plots,
+      };
+    })
+    .filter((group) => group.attachments.length > 0 || group.plots.length > 0);
+}
+
+// Order-preserving union of all keys across the given rows.
+export function getColumns(items) {
+  const columns = [];
+  items.forEach((row) => Object.keys(row).forEach((key) => {
+    if (!columns.includes(key)) {
+      columns.push(key);
+    }
+  }));
+  return columns;
+}
+
+// Render a cell value, showing a dash for blank values.
+export function formatCell(value) {
+  if (value === null || value === undefined || value === '') {
+    return '-';
+  }
+  return String(value);
+}

--- a/app/javascript/src/fetchers/AttachmentFetcher.js
+++ b/app/javascript/src/fetchers/AttachmentFetcher.js
@@ -325,6 +325,19 @@ export default class AttachmentFetcher {
     return Promise.all(tasks).then(() => this.uploadCompleted(file.name, key, checksum)());
   }
 
+  // Download a stored attachment's raw bytes by id and return them as text.
+  // Used to read small JSON sidecar files (e.g. the OpenStats variations summary).
+  static fetchAttachmentText(id) {
+    return fetch(`/api/v1/attachments/${id}`, {
+      credentials: 'same-origin',
+    }).then((response) => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch attachment ${id} (${response.status})`);
+      }
+      return response.text();
+    });
+  }
+
   static getFileContent(file) {
     const promise = new Promise((resolve) => {
       const reader = new FileReader();

--- a/app/javascript/src/fetchers/ThirdPartyAppFetcher.js
+++ b/app/javascript/src/fetchers/ThirdPartyAppFetcher.js
@@ -57,4 +57,15 @@ export default class ThirdPartyAppFetcher {
     }).then((response) => response.json())
       .catch((errorMessage) => { console.log(errorMessage); });
   }
+
+  static fetchVariationsToken(reactionID, appID, variationUuids, columnOrder = []) {
+    const params = new URLSearchParams({ reactionID, appID });
+    variationUuids.forEach((uuid) => params.append('variationUuids[]', uuid));
+    columnOrder.forEach((col) => params.append('columnOrder[]', col));
+    const url = `${TPA_ENDPOINT}/variations_token?${params.toString()}`;
+    return fetch(url, {
+      credentials: 'same-origin'
+    }).then((response) => response.json())
+      .catch((errorMessage) => { console.log(errorMessage); });
+  }
 }

--- a/spec/api/chemotion/third_party_app_api_spec.rb
+++ b/spec/api/chemotion/third_party_app_api_spec.rb
@@ -428,5 +428,284 @@ describe Chemotion::ThirdPartyAppAPI do
       end
     end
   end
+
+  describe 'reaction-variations TPA flow' do
+    let(:collection) { create(:collection, user: admin1) }
+    let(:tpa) { create(:third_party_app, name: 'OpenStats') }
+    let(:starting_material) { create(:valid_sample) }
+    let(:reaction) do
+      create(
+        :reaction_with_variations,
+        creator: admin1,
+        collections: [collection],
+        starting_materials: [starting_material],
+        reactants: [create(:valid_sample)],
+        products: [create(:valid_sample)],
+        solvents: [create(:valid_sample)],
+      ).reload
+    end
+    let(:variation_uuids) { reaction.variations.map { |variation| variation['uuid'] } }
+    let(:cache) { ActiveSupport::Cache::FileStore.new('tmp/ThirdPartyApp', expires_in: 1.hour) }
+
+    # The token endpoint returns a JSON-encoded URL "<app.url>?url=<escaped>&method=...".
+    # Pull the escaped public-endpoint URL back out and take its last path segment (the JWT).
+    def token_from(json_url)
+      escaped = json_url[/url=([^&]+)/, 1]
+      CGI.unescape(escaped).split('/').last
+    end
+
+    describe 'GET /api/v1/third_party_apps/variations_token' do
+      let(:body) { JSON.parse(response.body) }
+      let(:token) { token_from(body) }
+      let(:payload) { JsonWebToken.decode(token) }
+
+      context 'when the user may read the reaction' do
+        before do
+          get '/api/v1/third_party_apps/variations_token',
+              params: {
+                reactionID: reaction.id, appID: tpa.id,
+                variationUuids: variation_uuids, columnOrder: %w[a b]
+              }
+        end
+
+        it 'status of get request 200?' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'points at the OpenStats app with the VariationStatistics method' do
+          expect(body).to start_with("#{tpa.url}?url=")
+          expect(body).to end_with('&method=VariationStatistics')
+        end
+
+        it 'encodes the request context into the token payload' do
+          expect(payload['reactionID']).to eq reaction.id
+          expect(payload['userID']).to eq admin1.id
+          expect(payload['appID']).to eq tpa.id
+          expect(payload['variationUuids']).to match_array(variation_uuids)
+          expect(payload['columnOrder']).to eq %w[a b]
+          expect(payload['requestID']).to be_present
+        end
+      end
+
+      context 'when the user may not read the reaction' do
+        let(:collection) { create(:collection, user: create(:person)) }
+
+        before do
+          get '/api/v1/third_party_apps/variations_token',
+              params: { reactionID: reaction.id, appID: tpa.id, variationUuids: variation_uuids }
+        end
+
+        it 'status code is 403' do
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    describe 'GET /api/v1/public/third_party_app_variations/{token}' do
+      let(:sent_uuids) { variation_uuids }
+      let(:token) { token_from(JSON.parse(response.body)) }
+      let(:request_id) { JsonWebToken.decode(token)['requestID'] }
+      let(:cache_key) { "reaction/#{reaction.id}/#{admin1.id}/#{tpa.id}/#{request_id}" }
+      let(:body) { JSON.parse(response.body) }
+
+      before do
+        get '/api/v1/third_party_apps/variations_token',
+            params: { reactionID: reaction.id, appID: tpa.id, variationUuids: sent_uuids, columnOrder: %w[a b] }
+      end
+
+      context 'when all variations are requested' do
+        before { get "/api/v1/public/third_party_app_variations/#{token}" }
+
+        it 'status of get request 200?' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'returns the identity envelope alongside the variations' do
+          expect(body.keys).to match_array(%w[id request_id columnOrder variations])
+          expect(body['id']).to eq reaction.id.to_s
+          expect(body['request_id']).to eq request_id
+          expect(body['columnOrder']).to eq %w[a b]
+        end
+
+        it 'returns every requested variation' do
+          expect(body['variations'].length).to eq variation_uuids.length
+        end
+
+        it 'annotates each material with its human-readable name and short label' do
+          aux = body['variations'].first['startingMaterials'].values.first['aux']
+          expect(aux['shortLabel']).to eq starting_material.short_label
+          expect(aux['name']).to eq(starting_material.preferred_label.presence || starting_material.short_label)
+        end
+
+        it 'decrements the download counter' do
+          expect(cache.read(cache_key)[:download]).to eq 2
+        end
+      end
+
+      context 'when only a subset of variations is requested' do
+        let(:sent_uuids) { [variation_uuids.first] }
+
+        before { get "/api/v1/public/third_party_app_variations/#{token}" }
+
+        it 'returns only the requested variation' do
+          expect(body['variations'].length).to eq 1
+        end
+      end
+
+      context 'when the download counter is exhausted' do
+        before do
+          cache.write(cache_key, { token: token, download: -1 })
+          get "/api/v1/public/third_party_app_variations/#{token}"
+        end
+
+        it 'status code is 403' do
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      context 'when read access is revoked after minting the token' do
+        before do
+          reaction.collections = []
+          reaction.save
+          get "/api/v1/public/third_party_app_variations/#{token}"
+        end
+
+        it 'status code is 403' do
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    describe 'POST /api/v1/public/third_party_app_variations/{token}' do
+      let(:request_id) { SecureRandom.uuid }
+      let(:payload) do
+        {
+          'appID' => tpa.id,
+          'userID' => admin1.id,
+          'reactionID' => reaction.id,
+          'variationUuids' => variation_uuids,
+          'columnOrder' => [],
+          'requestID' => request_id,
+        }
+      end
+      let(:secret) { Rails.application.secrets.secret_key_base }
+      let(:token) { JWT.encode(payload, secret, 'HS256') }
+      let(:cache_key) { "reaction/#{reaction.id}/#{admin1.id}/#{tpa.id}/#{request_id}" }
+      let(:upload_counter) { 10 }
+
+      # OpenStats bundles the workbook, summary tables and plots into a single
+      # result.zip under throwaway R tempfile names.
+      let(:result_zip) do
+        file = Tempfile.new(['tpa_result', '.zip'])
+        file.close
+        Zip::OutputStream.open(file.path) do |zip|
+          zip.put_next_entry('tmp/RtmpAbc/workbook.xlsx')
+          zip.write('fake-xlsx-bytes')
+          zip.put_next_entry('tmp/RtmpAbc/summary.json')
+          zip.write('{"id":"x","request_id":"y","element_info":[],"Output":[]}')
+          zip.put_next_entry('tmp/RtmpAbc/plot.png')
+          zip.write('fake-png-bytes')
+        end
+        file
+      end
+      let(:uploaded_file) { Rack::Test::UploadedFile.new(result_zip.path, 'application/zip') }
+      let(:upload_params) { { file: uploaded_file } }
+
+      before do
+        cache.write(cache_key, { token: token, upload: upload_counter })
+        allow(Message).to receive(:create_msg_notification)
+        post "/api/v1/public/third_party_app_variations/#{token}", params: upload_params
+      end
+
+      context 'when the result is a valid zip and the user may write' do
+        let(:analysis) do
+          reaction.reload.container.analyses_container.children
+                  .find { |child| child.name == 'Statistical Analysis' }
+        end
+        let(:dataset) { analysis.children.first }
+
+        it 'status code is 201' do
+          expect(response).to have_http_status(:created)
+        end
+
+        it 'creates a Statistical Analysis analysis on the reaction' do
+          expect(analysis).to be_present
+        end
+
+        it 'attaches the workbook, summary and plot under stable filenames' do
+          expect(dataset.attachments.map(&:filename)).to contain_exactly(
+            'statistical_analysis.xlsx',
+            'variations_summary.json',
+            'variations_plot_1.png',
+          )
+        end
+
+        it 'echoes the analysis id and request id' do
+          expect(JSON.parse(response.body)).to include(
+            'analysis_id' => analysis.id,
+            'request_id' => request_id,
+          )
+        end
+
+        it 'triggers the TPA attachment notification' do
+          expect(Message).to have_received(:create_msg_notification)
+            .with(hash_including(channel_subject: Channel::SEND_TPA_ATTACHMENT_NOTIFICATION))
+        end
+      end
+
+      context 'when the echoed request_id does not match the token' do
+        let(:upload_params) { { file: uploaded_file, request_id: 'not-the-request-id' } }
+
+        it 'status code is 422' do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+
+      context 'when the echoed id does not match the token' do
+        let(:upload_params) { { file: uploaded_file, id: '0' } }
+
+        it 'status code is 422' do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+
+      context 'when the uploaded file is not a valid zip' do
+        let(:uploaded_file) do
+          file = Tempfile.new(['not_a_zip', '.zip'])
+          file.write('this is plainly not a zip archive')
+          file.rewind
+          Rack::Test::UploadedFile.new(file.path, 'application/zip')
+        end
+
+        it 'status code is 422' do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+
+      context 'when the user lacks access to the reaction' do
+        let(:collection) { create(:collection, user: create(:person)) }
+
+        it 'status code is 403' do
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      context 'when the upload counter is exhausted' do
+        let(:upload_counter) { -1 }
+
+        it 'status code is 403' do
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      context 'when no file is uploaded' do
+        let(:upload_params) { {} }
+
+        it 'status code is 400' do
+          expect(response).to have_http_status(:bad_request)
+        end
+      end
+    end
+  end
 end
 # rubocop:enable RSpec/LetSetup,RSpec/MultipleExpectations,RSpec/NestedGroups,RSpec/MultipleMemoizedHelpers

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsSummaryUtils.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsSummaryUtils.spec.js
@@ -1,0 +1,102 @@
+import expect from 'expect';
+import { describe, it } from 'mocha';
+import {
+  collectSummaryGroups,
+  getColumns,
+  formatCell,
+} from 'src/apps/mydb/elements/details/reactions/variationsTab/ReactionVariationsSummaryUtils';
+
+// A reaction container tree carrying two "Statistical Analysis" analyses and one
+// unrelated analysis. Mirrors the shape the API serves: root.children -> analyses
+// -> analysis -> dataset -> attachments.
+const buildContainer = () => ({
+  children: [
+    {
+      container_type: 'analyses',
+      children: [
+        {
+          container_type: 'analysis',
+          id: 'a1',
+          name: 'Statistical Analysis',
+          children: [
+            {
+              container_type: 'dataset',
+              attachments: [
+                { id: 1, filename: 'variations_summary.json' },
+                { id: 2, filename: 'variations_plot_1.png' },
+                { id: 3, filename: 'statistical_analysis.xlsx' },
+              ],
+            },
+          ],
+        },
+        {
+          container_type: 'analysis',
+          id: 'a2',
+          name: 'Some Other Analysis',
+          children: [
+            { container_type: 'dataset', attachments: [{ id: 4, filename: 'variations_summary.json' }] },
+          ],
+        },
+        {
+          container_type: 'analysis',
+          id: 'a3',
+          name: 'Statistical Analysis',
+          children: [
+            { container_type: 'dataset', attachments: [{ id: 5, filename: 'statistical_analysis.xlsx' }] },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+describe('ReactionVariationsSummary helpers', () => {
+  describe('collectSummaryGroups', () => {
+    it('keeps only analyses named "Statistical Analysis"', () => {
+      const groups = collectSummaryGroups(buildContainer());
+      expect(groups.map((group) => group.analysisId)).toEqual(['a1']);
+    });
+
+    it('splits dataset attachments into summary json and png plots', () => {
+      const [group] = collectSummaryGroups(buildContainer());
+      expect(group.attachments.map((attachment) => attachment.id)).toEqual([1]);
+      expect(group.plots.map((attachment) => attachment.id)).toEqual([2]);
+    });
+
+    it('drops groups that have neither a summary nor a plot', () => {
+      // a3 only carries an .xlsx, so it must not appear.
+      const groups = collectSummaryGroups(buildContainer());
+      expect(groups.some((group) => group.analysisId === 'a3')).toBe(false);
+    });
+
+    it('returns an empty array for a missing container', () => {
+      expect(collectSummaryGroups(null)).toEqual([]);
+      expect(collectSummaryGroups(undefined)).toEqual([]);
+    });
+  });
+
+  describe('getColumns', () => {
+    it('returns the order-preserving union of row keys', () => {
+      expect(getColumns([{ a: 1, b: 2 }, { b: 3, c: 4 }])).toEqual(['a', 'b', 'c']);
+    });
+
+    it('returns an empty array for no rows', () => {
+      expect(getColumns([])).toEqual([]);
+    });
+  });
+
+  describe('formatCell', () => {
+    it('renders blank values as a dash', () => {
+      expect(formatCell(null)).toEqual('-');
+      expect(formatCell(undefined)).toEqual('-');
+      expect(formatCell('')).toEqual('-');
+    });
+
+    it('stringifies non-blank values, including falsy ones', () => {
+      expect(formatCell(0)).toEqual('0');
+      expect(formatCell(false)).toEqual('false');
+      expect(formatCell(1.5)).toEqual('1.5');
+      expect(formatCell('text')).toEqual('text');
+    });
+  });
+});

--- a/spec/javascripts/packs/src/fetchers/AttachmentFetcher.spec.js
+++ b/spec/javascripts/packs/src/fetchers/AttachmentFetcher.spec.js
@@ -1,0 +1,44 @@
+import 'whatwg-fetch';
+import expect from 'expect';
+import sinon from 'sinon';
+import {
+  describe, it, beforeEach, afterEach
+} from 'mocha';
+import AttachmentFetcher from 'src/fetchers/AttachmentFetcher';
+
+describe('AttachmentFetcher.fetchAttachmentText', () => {
+  let fetchStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+  });
+
+  it('fetches the attachment by id and resolves with its raw text', async () => {
+    fetchStub.resolves(new Response('{"Output":[]}'));
+
+    const text = await AttachmentFetcher.fetchAttachmentText(42);
+
+    sinon.assert.calledOnce(fetchStub);
+    sinon.assert.calledWithExactly(fetchStub, '/api/v1/attachments/42', { credentials: 'same-origin' });
+    expect(text).toEqual('{"Output":[]}');
+  });
+
+  it('rejects with a descriptive error on a non-ok response', async () => {
+    fetchStub.resolves(new Response('nope', { status: 404 }));
+
+    let caught;
+    try {
+      await AttachmentFetcher.fetchAttachmentText(42);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeTruthy();
+    expect(caught.message).toContain('Failed to fetch attachment 42');
+    expect(caught.message).toContain('404');
+  });
+});

--- a/spec/javascripts/packs/src/fetchers/ThirdPartyAppFetcher.spec.js
+++ b/spec/javascripts/packs/src/fetchers/ThirdPartyAppFetcher.spec.js
@@ -1,0 +1,47 @@
+import 'whatwg-fetch';
+import expect from 'expect';
+import sinon from 'sinon';
+import {
+  describe, it, beforeEach, afterEach
+} from 'mocha';
+import ThirdPartyAppFetcher from 'src/fetchers/ThirdPartyAppFetcher';
+
+describe('ThirdPartyAppFetcher.fetchVariationsToken', () => {
+  let fetchStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+  });
+
+  it('builds the request URL with repeated array params and returns the parsed body', async () => {
+    fetchStub.resolves(new Response(JSON.stringify('https://openstats?url=encoded&method=VariationStatistics')));
+
+    const result = await ThirdPartyAppFetcher.fetchVariationsToken(7, 3, ['u1', 'u2'], ['colA', 'colB']);
+
+    sinon.assert.calledOnce(fetchStub);
+    const [calledUrl, calledOpts] = fetchStub.firstCall.args;
+    const parsed = new URL(calledUrl, 'http://localhost');
+
+    expect(parsed.pathname).toEqual('/api/v1/third_party_apps/variations_token');
+    expect(parsed.searchParams.get('reactionID')).toEqual('7');
+    expect(parsed.searchParams.get('appID')).toEqual('3');
+    expect(parsed.searchParams.getAll('variationUuids[]')).toEqual(['u1', 'u2']);
+    expect(parsed.searchParams.getAll('columnOrder[]')).toEqual(['colA', 'colB']);
+    expect(calledOpts).toEqual({ credentials: 'same-origin' });
+    expect(result).toEqual('https://openstats?url=encoded&method=VariationStatistics');
+  });
+
+  it('omits columnOrder params when none are given', async () => {
+    fetchStub.resolves(new Response(JSON.stringify('https://openstats')));
+
+    await ThirdPartyAppFetcher.fetchVariationsToken(1, 2, ['only-one']);
+
+    const parsed = new URL(fetchStub.firstCall.args[0], 'http://localhost');
+    expect(parsed.searchParams.getAll('variationUuids[]')).toEqual(['only-one']);
+    expect(parsed.searchParams.getAll('columnOrder[]')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Added a button in the reaction variations tab to send variation data to OpenStats (a third-party statistical app)
- OpenStats computes statistical summaries and POSTs the results (xlsx workbook, JSON summary tables, PNG plots) back to the ELN via a tokenized endpoint
- Results are stored as a new **Statistical Analysis** in the reaction's analyses and displayed below the variations table
- Summary tables and plots are grouped per analysis, with a link to open the analysis directly

## Changes

- **Backend:** new `GET /variations_token` endpoint to mint a JWT for the round-trip; new `POST /public/third_party_app_variations/:token` endpoint to receive OpenStats results and attach them to the reaction; helper methods in `third_party_app_helpers.rb` for payload preparation, download, and upload
- **Frontend:** new `ReactionVariationsSummary.js` component renders summary tables and plots below the variations grid; `ReactionVariationsComponents.js` gets a "Send to OpenStats" button; auto-refresh on tab focus picks up results posted out-of-band
- **Tests:** RSpec spec covering the full round-trip (token mint, download, upload, error cases); JS specs for `ReactionVariationsSummaryUtils`, `AttachmentFetcher`, and `ThirdPartyAppFetcher`

## Test plan

- [ ] JS tests: `npx yarn test` — 1066 passing, 0 failures
- [ ] Ruby tests: `RAILS_ENV=test bundle exec rspec spec/api/chemotion/third_party_app_api_spec.rb` — 53 examples, 0 failures