### PR TITLE
fix(attachments): skip annotation copy for non-image attachments

### DIFF
--- a/app/usecases/attachments/copy.rb
+++ b/app/usecases/attachments/copy.rb
@@ -21,7 +21,7 @@ module Usecases
           copy_attach.file_path = copy_io.path
           copy_attach.save
 
-          update_annotation(original_attach.id, copy_attach.id)
+          update_annotation(original_attach, copy_attach.id)
 
           if element.instance_of?(::ResearchPlan)
             element.update_body_attachments(original_attach.identifier, copy_attach.identifier)
@@ -29,9 +29,14 @@ module Usecases
         end
       end
 
-      def self.update_annotation(original_attach_id, copy_attach_id)
+      def self.update_annotation(original_attach, copy_attach_id)
+        # Only image attachments carry an :annotation derivative. For PDFs and other
+        # non-annotatable files it is nil, and the loader would raise NoMethodError
+        # ("undefined method `url' for nil"), aborting the whole research-plan copy.
+        return if original_attach.attachment(:annotation).blank?
+
         loader = Usecases::Attachments::Annotation::AnnotationLoader.new
-        svg = loader.get_annotation_of_attachment(original_attach_id)
+        svg = loader.get_annotation_of_attachment(original_attach.id)
 
         updater = Usecases::Attachments::Annotation::AnnotationUpdater.new
         updater.updated_annotated_string(svg, copy_attach_id)

--- a/spec/usecases/attachments/copy_spec.rb
+++ b/spec/usecases/attachments/copy_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Usecases::Attachments::Copy do
+  let(:user) { create(:user) }
+  let(:research_plan) { create(:research_plan) }
+
+  describe '.execute!' do
+    let(:attachments) { [{ id: source.id }] }
+
+    before do
+      described_class.execute!(attachments, research_plan, user.id)
+    end
+
+    context 'when the attachment is a non-annotatable file (e.g. PDF)' do
+      # A PDF gets a :thumbnail derivative but never an :annotation derivative.
+      # Regression for NoMethodError: undefined method `url' for nil:NilClass
+      # raised from AnnotationLoader when copying a research plan (Sentry).
+      let(:source) { create(:attachment, :with_pdf, attachable: research_plan) }
+
+      it 'copies the attachment without attempting to copy an annotation' do
+        copy = Attachment.where(attachable: research_plan).where.not(id: source.id).last
+
+        expect(copy).to be_present
+        expect(copy.filename).to eq(source.filename)
+        expect(copy.attachment(:annotation)).to be_nil
+      end
+    end
+
+    context 'when the attachment is an annotatable image' do
+      let(:source) { create(:attachment, :with_png_image, attachable: research_plan) }
+
+      it 'copies the attachment and its annotation derivative' do
+        copy = Attachment.where(attachable: research_plan).where.not(id: source.id).last
+
+        expect(copy).to be_present
+        expect(copy.attachment(:annotation)).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Copying a research plan (`POST /api/v1/research_plans`) crashes when any of its attachments is a non-image file (PDF, Office document, etc.).

`Usecases::Attachments::Copy.execute!` calls `update_annotation` for **every** attachment. That path goes through `AnnotationLoader#get_annotation_of_attachment`, which does:

```ruby
location_of_annotation = att.attachment(:annotation).url
```

Only image attachments get an `:annotation` derivative (`AnnotationCreator` supports `bmp jpg png svg tif tiff`). For a PDF, `att.attachment(:annotation)` is `nil`, so `.url` raises:

```
NoMethodError: undefined method `url' for nil:NilClass
  app/usecases/attachments/annotation/annotation_loader.rb:14
```

A single non-image attachment aborts the **entire** copy.

## Fix

`update_annotation` now returns early when the original attachment has no `:annotation` derivative. This is format-agnostic: PDFs, gifs, Office docs and plain files are skipped, while annotated images still have their annotation copied. The copied attachment regenerates its own derivatives on save regardless.

## Tests

Added `spec/usecases/attachments/copy_spec.rb`:
- PDF attachment → copied without attempting to copy an annotation (regression for the crash)
- PNG attachment → copy keeps its annotation derivative

Both pass; `rubocop` clean on the changed files. Verified the regression by removing the guard — the PDF case reproduces the exact `NoMethodError` at `annotation_loader.rb:14`.