### PR TITLE
chore(deps): bump sablon to v0.4.3-1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,7 @@ gem 'puma', '< 6.0.0'
 gem 'rack'
 gem 'rack-cors', require: 'rack/cors'
 gem 'rails', '~> 6.1.7.7'
+gem 'redcarpet' # markdown rendering (welcome mailer, application_helper#markdown)
 gem 'rinchi-gem', git: 'https://github.com/ComPlat/rinchi-gem.git', branch: 'main'
 gem 'rmagick'
 gem 'roo'

--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ gem 'ruby-geometry', require: 'geometry'
 gem 'ruby-mailchecker'
 gem 'ruby-ole'
 
-gem 'sablon', git: 'https://github.com/ComPlat/sablon'
+gem 'sablon', git: 'https://github.com/ComPlat/sablon', tag: 'v0.4.3-1'
 gem 'sassc-rails'
 gem 'scenic'
 gem 'schmooze'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -921,6 +921,7 @@ DEPENDENCIES
   rack
   rack-cors
   rails (~> 6.1.7.7)
+  redcarpet
   rinchi-gem!
   rmagick
   roo

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,12 +14,12 @@ GIT
 
 GIT
   remote: https://github.com/ComPlat/sablon
-  revision: 0bb0e77a8eb5ed2953d81af42558e568845c3777
+  revision: 86831850a43fbc7572015f7e0a215adcb26d3719
+  tag: v0.4.3-1
   specs:
-    sablon (0.0.19)
-      nokogiri (>= 1.6.0)
-      redcarpet (>= 3.4.0)
-      rubyzip (>= 1.1)
+    sablon (0.4.3)
+      nokogiri (>= 1.8.5)
+      rubyzip (>= 1.3.0)
 
 GIT
   remote: https://github.com/datacite/omniauth-orcid

--- a/lib/reporter/delta.rb
+++ b/lib/reporter/delta.rb
@@ -19,7 +19,7 @@ module Reporter
 
     private
     def deltaToHTML(delta)
-      return "<div></div>" if delta['ops'].blank?
+      return "" if delta['ops'].blank?
 
       html = []
       i = 0
@@ -58,7 +58,11 @@ module Reporter
       html = rebuildList(html, "!!!olli!!!", "ol")
       html = rebuildList(html, "!!!ulli!!!", "ul")
 
-      "<div>" + html.join("") + "</div>"
+      # Emit the block elements (<p>/<ol>/<ul>/<hN>) directly. They are valid
+      # children of sablon's top-level document fragment. A wrapping <div>
+      # would be parsed as a single paragraph that may not contain block
+      # children (sablon >= 0.4.3 raises "p is not a valid child of div").
+      html.join("")
     end
 
     def rebuildList html, string, replace_string

--- a/spec/lib/reporter/delta_spec.rb
+++ b/spec/lib/reporter/delta_spec.rb
@@ -5,10 +5,15 @@ require 'rails_helper'
 RSpec.describe Reporter::Delta do
   describe '#getHTML' do
     [nil, {}, { 'ops' => nil }, { 'ops' => [] }].each do |blank_input|
-      it "returns empty div for blank input #{blank_input}" do
+      it "returns an empty string for blank input #{blank_input}" do
         reporter = described_class.new(blank_input)
-        expect(reporter.getHTML).to eq('<div></div>')
+        expect(reporter.getHTML).to eq('')
       end
+    end
+
+    it 'emits block elements without a wrapping <div> (valid sablon fragment)' do
+      delta = { 'ops' => [{ 'insert' => "hello\n" }] }
+      expect(described_class.new(delta).getHTML).to eq('<p>hello</p>')
     end
   end
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -72,6 +72,49 @@ RSpec.describe Report, type: :report do
       expect(docx.class).to eq(String)
       expect(file_name).to include('ELN_Reaction_')
     end
+
+    # Guards against the "Word found unreadable content" warning: every
+    # relationship referenced by the document must be declared and its target
+    # part present, every part extension must have a content type, no merge
+    # field control text may remain, and VML shape ids must be unique.
+    it 'produces an internally consistent OOXML package' do
+      require 'zip'
+      params = { template: 'single_reaction', id: reaction1.id }
+      docx, = described_class.create_reaction_docx(user, [user.id], params)
+
+      entries = {}
+      Zip::File.open_buffer(StringIO.new(docx)) do |zip|
+        zip.each { |e| entries[e.name] = e.get_input_stream.read if e.file? }
+      end
+
+      doc = entries['word/document.xml']
+      rels = entries['word/_rels/document.xml.rels']
+      content_types = entries['[Content_Types].xml']
+
+      # every r:id / r:embed referenced in the document resolves to a declared
+      # relationship whose target part exists in the package
+      ref_rids = doc.scan(/r:(?:id|embed)="(rId\d+)"/).flatten.uniq
+      ref_rids.each do |rid|
+        target = rels[/Id="#{rid}"[^>]*Target="([^"]+)"/, 1] ||
+                 rels[/Target="([^"]+)"[^>]*Id="#{rid}"/, 1]
+        expect(target).to be_present, "rId #{rid} is not declared in document.xml.rels"
+        next if target.start_with?('http', '../') # external/customXml targets
+
+        expect(entries).to have_key("word/#{target}"), "missing part word/#{target}"
+      end
+
+      # every media/embeddings part extension is declared in [Content_Types].xml
+      entries.keys.grep(%r{word/(media|embeddings)/}).each do |part|
+        ext = File.extname(part).delete('.').downcase
+        expect(content_types.downcase).to include(%(extension="#{ext}")),
+                                                  "content type for .#{ext} not declared"
+      end
+
+      # no leftover merge-field control text, and unique VML shape ids
+      expect(doc).not_to include('MERGEFIELD')
+      shape_ids = doc.scan(/<v:shape[^>]*\bid="([^"]+)"/).flatten
+      expect(shape_ids).to eq(shape_ids.uniq), "duplicate v:shape ids: #{shape_ids.inspect}"
+    end
   end
 
   describe '.create_docx' do # rubocop:disable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
## What

Bumps the `sablon` git gem from `0.0.19` (master HEAD, `0bb0e77`) to the [**v0.4.3-1**](https://github.com/ComPlat/sablon/releases/tag/v0.4.3-1) release (`8683185`, head of the `v0.4.3-x` branch), which re-aligns ComPlat's Chem/OLE additions onto upstream sablon `v0.4.3` and stops Word's "found unreadable content" warning on report `.docx` (the old fork hand-rolled OLE relationships/VML rewriting and left embedded-object references inconsistent).

## Two follow-on changes the newer gem requires

**1. Declare `redcarpet` explicitly.** sablon `v0.4.3` drops `redcarpet` from its runtime dependencies (now only `nokogiri >= 1.8.5` and `rubyzip >= 1.3.0`). redcarpet is used **directly** in the app — `app/helpers/application_helper.rb` (`#markdown`) and `app/mailers/welcome_mailer.rb` — so it must be declared directly to keep markdown rendering working.

**2. Stop wrapping `Delta#getHTML` output in `<div>`.** sablon `>= 0.4.3` validates HTML structure and treats `<div>` as a paragraph that may not contain block children, raising `"p is not a valid child element of div"`. `lib/reporter/delta.rb` now emits the `<p>/<ol>/<ul>/<hN>` blocks directly (valid children of sablon's top-level document fragment); blank input yields `""` instead of `"<div></div>"`.

## Changes

- `Gemfile`: pin sablon to `tag: 'v0.4.3-1'`; add explicit `gem 'redcarpet'`.
- `Gemfile.lock`: sablon `0.0.19 → 0.4.3` (deps now `nokogiri >= 1.8.5`, `rubyzip >= 1.3.0`); `redcarpet` added to `DEPENDENCIES`.
- `lib/reporter/delta.rb` + `spec/lib/reporter/delta_spec.rb`: drop the wrapping `<div>`.
- `spec/models/report_spec.rb`: new example asserting the rendered `.docx` is an internally consistent OOXML package — every referenced relationship declared and present, content types declared, no leftover merge fields, unique VML shape ids. This is the regression guard for the Word warning.

Already-resolved `nokogiri (1.15.7)`, `rubyzip (2.4.1)`, and `redcarpet (3.6.1)` all satisfy the new constraints, so no transitive versions change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)