### PR TITLE
fix(literature): order literature list deterministically by literal id

### DIFF
--- a/app/api/chemotion/literature_api.rb
+++ b/app/api/chemotion/literature_api.rb
@@ -11,7 +11,7 @@ module Chemotion
       def citation_for_elements(id = params[:element_id], type = @element_klass, cat = 'detail')
         return Literature.none if id.blank?
 
-        Literature.by_element_attributes_and_cat(id, type, cat).with_user_info
+        Literature.by_element_attributes_and_cat(id, type, cat).with_user_info.order('literals.id ASC')
       end
     end
 


### PR DESCRIPTION
## Problem

The `GET /api/v1/literatures` endpoint (and the `PUT`/create responses that share the `citation_for_elements` helper) builds its list via `Literature.by_element_attributes_and_cat(...).with_user_info` with **no `ORDER BY`**. Postgres is therefore free to return the rows in an arbitrary order.

This makes `literatures.first` / `literatures.last` non-deterministic and intermittently flakes `spec/api/literature_api_spec.rb:47` ("is able to get literatures by reaction Id"), which asserts `.first` == the first-linked literature and `.last` == the second. Observed in CI as:

```
expected {…:id => 14, :title => "Title 13", :url => "www.13"…}
  to include {:id => 13, :title => "Title 12", :url => "www.12"}
```

(the two records share a `created_at`, so ordering was pure DB chance).

## Fix

Order the list by `literals.id ASC` in `citation_for_elements`, so results follow the order in which the literature was **linked to the element** — stable across runs and matching the spec's first/last expectations. `literals.id` is already selected (as `literal_id`) by the `with_user_info` scope, so no extra join.

Scoped deliberately to the helper rather than the shared `with_user_info` scope, because that scope is also composed with `.group_by_element` elsewhere (a `GROUP BY literatures.id` aggregate) where an `ORDER BY literals.id` would be invalid.

## Verification

- `bundle exec rspec spec/api/literature_api_spec.rb` → 18 examples, 0 failures (including the seed `15714` that reproduced the CI failure).
- Related specs green: `literature_spec.rb`, `literature_entity_spec.rb`, `sample_report_entity_spec.rb`.
- `rubocop app/api/chemotion/literature_api.rb` → no offenses on the changed line.

## Follow-up (not in scope)

`app/api/entities/{reaction,sample}_report_entity.rb` use the same `by_element_attributes_and_cat(...).with_user_info` pattern without an explicit order. Not currently flaky under test, but worth a stable order there too if report output ever depends on it.