### PR TITLE
fix(collections): use PUT for bulk own-collection update

### DIFF
--- a/app/javascript/src/fetchers/CollectionsFetcher.js
+++ b/app/javascript/src/fetchers/CollectionsFetcher.js
@@ -16,7 +16,7 @@ export default class CollectionsFetcher {
   }
 
   static buldUpdateForOwnCollections(params) {
-    return ApiClient.postJson('/api/v1/collections/bulk_update_own_collections', { body: params })
+    return ApiClient.putJson('/api/v1/collections/bulk_update_own_collections', { body: params })
       .then((json) => json.collections);
   }
 


### PR DESCRIPTION
Bug was introduces here: https://github.com/ComPlat/chemotion_ELN/pull/3294
There, a PUT request was inadvertently changed to a POST.