### PR TITLE
build(dev): install asdf via /tmp to avoid cross-device tar error

### DIFF
--- a/prepare-asdf.sh
+++ b/prepare-asdf.sh
@@ -21,7 +21,10 @@ if command -v asdf ; then
     fi
 else
     echo '>>> Missing asdf. Installing...'
-    curl -sSL https://github.com/asdf-vm/asdf/releases/download/${ASDF_BRANCH}/asdf-${ASDF_BRANCH}-linux-amd64.tar.gz | tar -xz --one-top-level=${ASDF_DIR}/bin/
+    mkdir -p /tmp/asdf-install ${ASDF_DIR}/bin
+    curl -sSL https://github.com/asdf-vm/asdf/releases/download/${ASDF_BRANCH}/asdf-${ASDF_BRANCH}-linux-amd64.tar.gz | tar -xz -C /tmp/asdf-install
+    cp /tmp/asdf-install/asdf ${ASDF_DIR}/bin/asdf
+    rm -rf /tmp/asdf-install
     chmod +x ${ASDF_DIR}/bin/asdf
 fi
 


### PR DESCRIPTION
install asdf with `--one-top-level=${ASDF_DIR}/bin/ ` causes this errors
```
tar: /home/ubuntu/.asdf/bin/asdf: Cannot open: Invalid cross-device link
tar: Exiting with failure status due to previous errors
```

Fix this with adding a tmp folder for installation