### PR TITLE
chore: port v3.x - 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,9 @@
 
 /public/editors/*
 !/public/editors/.keep
+
+/public/workshop/*
+!/public/workshop/.keep
 /public/favicon.ico
 
 # written by Labimotion gem

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -53,6 +53,7 @@
 @import "components/SearchResult";
 @import "components/SelectionActions";
 @import "components/Sidebar_Topbar";
+@import "components/WorkshopGuide";
 @import "components/TabLayoutEditor";
 @import "components/CollectionTabLayoutEditor";
 @import "components/svg_with_popver";

--- a/app/assets/stylesheets/components/WorkshopGuide.scss
+++ b/app/assets/stylesheets/components/WorkshopGuide.scss
@@ -1,0 +1,210 @@
+.workshop-guide-fab {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  z-index: 1080;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  background: #fff;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
+  cursor: pointer;
+
+  &:hover {
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.2);
+  }
+
+  &__label {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #4f5659;
+  }
+}
+
+.workshop-guide-drawer {
+  position: fixed;
+  bottom: 4.5rem;
+  left: 1rem;
+  z-index: 1079;
+  width: 720px;
+  max-width: calc(100vw - 2rem);
+  height: 720px;
+  max-height: calc(100vh - 6rem);
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 8px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  &--hidden {
+    display: none;
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    background: #f6f8fa;
+  }
+
+  &__close {
+    border: 0;
+    background: transparent;
+    font-size: 1.25rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  &__body {
+    flex: 1 1 auto;
+    overflow: hidden;
+  }
+}
+
+.workshop-guide {
+  display: flex;
+  height: 100%;
+
+  &--embedded {
+    height: auto;
+  }
+
+  &__nav {
+    flex: 0 0 180px;
+    overflow-y: auto;
+    padding: 0.75rem 0.5rem;
+    border-right: 1px solid rgba(0, 0, 0, 0.08);
+    background: #fafbfc;
+
+    ul {
+      list-style: none;
+      margin: 0 0 0.75rem 0;
+      padding: 0;
+    }
+  }
+
+  &__nav-title {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: #6a737d;
+    margin: 0.5rem 0 0.25rem;
+  }
+
+  &__nav-link {
+    width: 100%;
+    text-align: left;
+    border: 0;
+    background: transparent;
+    padding: 0.25rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.875rem;
+    color: #24292e;
+    cursor: pointer;
+
+    &:hover {
+      background: rgba(36, 149, 207, 0.08);
+    }
+
+    &.is-active {
+      background: rgba(36, 149, 207, 0.15);
+      font-weight: 600;
+    }
+  }
+
+  &__body {
+    flex: 1 1 auto;
+    overflow: auto;
+    padding: 0.75rem 1rem;
+  }
+
+  &__loading,
+  &__error {
+    color: #6a737d;
+    font-size: 0.875rem;
+  }
+
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 0.5rem 0 1rem;
+
+    th, td {
+      border: 1px solid rgba(0, 0, 0, 0.12);
+      padding: 0.25rem 0.5rem;
+      font-size: 0.875rem;
+    }
+
+    th {
+      background: #f6f8fa;
+    }
+  }
+
+  code {
+    background: rgba(27, 31, 35, 0.06);
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+    font-size: 0.85em;
+  }
+
+  pre {
+    background: rgba(27, 31, 35, 0.04);
+    padding: 0.75rem;
+    border-radius: 4px;
+    overflow-x: auto;
+    margin: 0;
+
+    code {
+      background: transparent;
+      padding: 0;
+      font-size: 0.85em;
+    }
+  }
+
+  &__code,
+  &__quote {
+    position: relative;
+    margin: 0.5rem 0 1rem;
+
+    blockquote {
+      margin: 0;
+      padding: 0.5rem 0.75rem;
+      border-left: 3px solid rgba(36, 149, 207, 0.4);
+      background: rgba(36, 149, 207, 0.05);
+      color: #24292e;
+    }
+  }
+
+  &__copy {
+    position: absolute;
+    top: 0.35rem;
+    right: 0.35rem;
+    z-index: 1;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    background: #fff;
+    color: #4f5659;
+    padding: 0.1rem 0.45rem;
+    font-size: 0.7rem;
+    border-radius: 3px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.1s;
+
+    &:hover {
+      background: #f6f8fa;
+    }
+  }
+
+  &__code:hover &__copy,
+  &__quote:hover &__copy,
+  &__copy:focus {
+    opacity: 1;
+  }
+}

--- a/app/assets/stylesheets/legacy/sample.scss
+++ b/app/assets/stylesheets/legacy/sample.scss
@@ -24,6 +24,15 @@
   }
 }
 
+@supports (field-sizing: content) {
+  .sample-description-auto {
+    field-sizing: content;
+    min-height: 2lh;
+    resize: none;
+    overflow: hidden;
+  }
+}
+
 .sample-form,
 .additional-form {
   margin-bottom: 0px !important;

--- a/app/javascript/src/apps/home/Home.js
+++ b/app/javascript/src/apps/home/Home.js
@@ -2,12 +2,14 @@ import React from 'react';
 
 import BaseNavigation from 'src/components/navigation/BaseNavigation';
 import WelcomeMessage from 'src/apps/home/WelcomeMessage';
+import WorkshopGuideInline from 'src/components/workshopGuide/WorkshopGuideInline';
 
 export default function Home() {
   return (
     <div>
       <BaseNavigation />
       <WelcomeMessage />
+      <WorkshopGuideInline />
     </div>
   );
 }

--- a/app/javascript/src/apps/mydb/App.js
+++ b/app/javascript/src/apps/mydb/App.js
@@ -12,6 +12,7 @@ import LoadingModal from 'src/components/common/LoadingModal';
 import ProgressModal from 'src/components/common/ProgressModal';
 import Notifications from 'src/components/Notifications';
 import SampleTaskInbox from 'src/components/sampleTaskInbox/SampleTaskInbox';
+import WorkshopGuideDrawer from 'src/components/workshopGuide/WorkshopGuideDrawer';
 import UIActions from 'src/stores/alt/actions/UIActions';
 import UserActions from 'src/stores/alt/actions/UserActions';
 import OnEventListen from 'src/utilities/UserTemplatesHelpers';
@@ -96,6 +97,7 @@ class App extends Component {
         <InboxModal />
         <SampleTaskInbox />
         <Calendar />
+        <WorkshopGuideDrawer />
       </>
     );
   }

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -1229,6 +1229,7 @@ export default class SampleForm extends React.Component {
         <Form.Label>Description</Form.Label>
         <Form.Control
           as="textarea"
+          className="sample-description-auto"
           placeholder={sample.description}
           value={sample.description || ''}
           onChange={(e) => this.handleFieldChanged('description', e.target.value)}

--- a/app/javascript/src/components/workshopGuide/WorkshopContent.js
+++ b/app/javascript/src/components/workshopGuide/WorkshopContent.js
@@ -1,0 +1,217 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import gfm from 'remark-gfm';
+
+import {
+  expandWikiLinks,
+  fetchWorkshopPage,
+  fetchWorkshopSidebar,
+  parseSidebar,
+  slugFromHref,
+  workshopBase,
+  workshopDefaultSlug,
+} from 'src/components/workshopGuide/workshopGuideFetch';
+
+const remarkPlugins = [gfm];
+
+function extractText(node) {
+  if (node == null) return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(extractText).join('');
+  if (node.props && node.props.children) return extractText(node.props.children);
+  return '';
+}
+
+// Works on http://… origins too (navigator.clipboard requires a secure context).
+async function copyText(text) {
+  if (navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (e) { /* fall through to legacy path */ }
+  }
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.setAttribute('readonly', '');
+  ta.style.position = 'fixed';
+  ta.style.top = '-1000px';
+  ta.style.left = '0';
+  ta.style.opacity = '0';
+  document.body.appendChild(ta);
+  ta.focus();
+  ta.select();
+  let ok = false;
+  try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
+  document.body.removeChild(ta);
+  return ok;
+}
+
+function CopyButton({ getText }) {
+  const [state, setState] = useState('idle');
+  const onClick = async () => {
+    const ok = await copyText(getText());
+    setState(ok ? 'copied' : 'failed');
+    setTimeout(() => setState('idle'), 1500);
+  };
+  let label = 'Copy';
+  if (state === 'copied') label = 'Copied';
+  else if (state === 'failed') label = 'Press Ctrl+C';
+  return (
+    <button
+      type="button"
+      className="workshop-guide__copy"
+      onClick={onClick}
+      aria-label="Copy to clipboard"
+    >
+      {label}
+    </button>
+  );
+}
+
+function PreWithCopy({ children }) {
+  return (
+    <div className="workshop-guide__code">
+      <CopyButton getText={() => extractText(children).replace(/\n$/, '')} />
+      <pre>{children}</pre>
+    </div>
+  );
+}
+
+function BlockquoteWithCopy({ children }) {
+  return (
+    <div className="workshop-guide__quote">
+      <CopyButton getText={() => extractText(children).trim()} />
+      <blockquote>{children}</blockquote>
+    </div>
+  );
+}
+
+// Resolve a markdown link's href to either a known wiki slug or a fully
+// qualified URL. Returns `{ slug }` for internal navigation, `{ href }` for
+// asset links / external links.
+function resolveHref(href, knownSlugs) {
+  if (!href) return { href };
+  if (/^[a-z]+:\/\//i.test(href) || href.startsWith('mailto:')) return { href, external: true };
+  const slug = slugFromHref(href);
+  if (slug && knownSlugs.has(slug)) return { slug };
+  if (href.startsWith('/')) return { href };
+  return { href: `${workshopBase}/${href.replace(/^\.\//, '')}` };
+}
+
+export default function WorkshopContent({ initialSlug, embedded }) {
+  const [slug, setSlug] = useState(initialSlug || workshopDefaultSlug);
+  const [content, setContent] = useState('');
+  const [groups, setGroups] = useState([]);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchWorkshopSidebar()
+      .then((md) => { if (!cancelled) setGroups(parseSidebar(md)); })
+      .catch(() => { /* sidebar is optional */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchWorkshopPage(slug)
+      .then((md) => {
+        if (cancelled) return;
+        setContent(expandWikiLinks(md));
+        setLoading(false);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e);
+        setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [slug]);
+
+  const knownSlugs = useMemo(() => {
+    const set = new Set();
+    groups.forEach((g) => g.items.forEach((it) => it.slug && set.add(it.slug)));
+    return set;
+  }, [groups]);
+
+  const navigate = useCallback((next) => {
+    if (!next) return;
+    setSlug(next);
+  }, []);
+
+  const renderers = useMemo(() => ({
+    a: ({ href, children }) => {
+      const resolved = resolveHref(href, knownSlugs);
+      if (resolved.slug) {
+        return (
+          <a
+            href={`#${resolved.slug}`}
+            onClick={(e) => { e.preventDefault(); navigate(resolved.slug); }}
+          >
+            {children}
+          </a>
+        );
+      }
+      return (
+        <a href={resolved.href} target="_blank" rel="noopener noreferrer">
+          {children}
+        </a>
+      );
+    },
+    img: ({ src, alt }) => {
+      const resolved = resolveHref(src, knownSlugs);
+      return <img src={resolved.href || src} alt={alt || ''} style={{ maxWidth: '100%' }} />;
+    },
+    pre: PreWithCopy,
+    blockquote: BlockquoteWithCopy,
+  }), [knownSlugs, navigate]);
+
+  const sidebar = groups.length ? (
+    <nav className="workshop-guide__nav">
+      {groups.map((g) => (
+        <div key={g.title || 'group'} className="workshop-guide__nav-group">
+          {g.title && <div className="workshop-guide__nav-title">{g.title}</div>}
+          <ul>
+            {g.items.map((it) => (
+              <li key={it.slug}>
+                <button
+                  type="button"
+                  className={`workshop-guide__nav-link${it.slug === slug ? ' is-active' : ''}`}
+                  onClick={() => navigate(it.slug)}
+                >
+                  {it.title}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </nav>
+  ) : null;
+
+  return (
+    <div className={`workshop-guide${embedded ? ' workshop-guide--embedded' : ''}`}>
+      {sidebar}
+      <div className="workshop-guide__body">
+        {loading && <div className="workshop-guide__loading">Loading…</div>}
+        {error && (
+          <div className="workshop-guide__error">
+            <p>Could not load workshop page <code>{slug}</code>.</p>
+            <p>
+              Ask the operator to run <code>rake workshop_guide:sync</code>, or
+              open the wiki directly.
+            </p>
+          </div>
+        )}
+        {!loading && !error && (
+          <ReactMarkdown remarkPlugins={remarkPlugins} components={renderers}>
+            {content}
+          </ReactMarkdown>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/javascript/src/components/workshopGuide/WorkshopGuideDrawer.js
+++ b/app/javascript/src/components/workshopGuide/WorkshopGuideDrawer.js
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+
+import ChemotionLogo from 'src/components/common/ChemotionLogo';
+import WorkshopContent from 'src/components/workshopGuide/WorkshopContent';
+import { workshopBase } from 'src/components/workshopGuide/workshopGuideFetch';
+
+// The drawer auto-hides itself if no workshop content is checked out, so the
+// feature is implicitly off on non-workshop instances (just don't run the rake
+// sync task).
+async function probeAvailable() {
+  try {
+    const res = await fetch(`${workshopBase}/home.md`, { method: 'HEAD' });
+    return res.ok;
+  } catch (e) {
+    return false;
+  }
+}
+
+export default function WorkshopGuideDrawer() {
+  const [available, setAvailable] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [openedOnce, setOpenedOnce] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    probeAvailable().then((ok) => { if (!cancelled) setAvailable(ok); });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (!available) return null;
+
+  const toggle = () => {
+    setOpen((v) => {
+      if (!v) setOpenedOnce(true);
+      return !v;
+    });
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        className="workshop-guide-fab"
+        title={open ? 'Hide Workshop Guide' : 'Show Workshop Guide'}
+        aria-label="Workshop Guide"
+        onClick={toggle}
+      >
+        <ChemotionLogo collapsed />
+        <span className="workshop-guide-fab__label">Workshop&nbsp;Guide</span>
+      </button>
+      {openedOnce && (
+        <div
+          className={`workshop-guide-drawer${open ? '' : ' workshop-guide-drawer--hidden'}`}
+          role="dialog"
+          aria-label="Workshop Guide"
+          aria-hidden={!open}
+        >
+          <div className="workshop-guide-drawer__header">
+            <strong>Workshop Guide</strong>
+            <button
+              type="button"
+              className="workshop-guide-drawer__close"
+              onClick={() => setOpen(false)}
+              aria-label="Close"
+            >
+              ×
+            </button>
+          </div>
+          <div className="workshop-guide-drawer__body">
+            <WorkshopContent />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/javascript/src/components/workshopGuide/WorkshopGuideInline.js
+++ b/app/javascript/src/components/workshopGuide/WorkshopGuideInline.js
@@ -1,0 +1,24 @@
+import React, { useEffect, useState } from 'react';
+
+import WorkshopContent from 'src/components/workshopGuide/WorkshopContent';
+import { workshopBase } from 'src/components/workshopGuide/workshopGuideFetch';
+
+export default function WorkshopGuideInline() {
+  const [available, setAvailable] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`${workshopBase}/home.md`, { method: 'HEAD' })
+      .then((res) => { if (!cancelled) setAvailable(res.ok); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  if (!available) return null;
+
+  return (
+    <div className="bg-light p-5 m-3 workshop-guide--inline-wrap">
+      <WorkshopContent embedded />
+    </div>
+  );
+}

--- a/app/javascript/src/components/workshopGuide/workshopGuideFetch.js
+++ b/app/javascript/src/components/workshopGuide/workshopGuideFetch.js
@@ -1,0 +1,89 @@
+// Same-origin fetch helpers for the workshop guide content checked out into
+// /public/workshop by `rake workshop_guide:sync`. The wiki repo is private,
+// but the cloned files are served as static public assets by Rails.
+
+const BASE = '/workshop';
+const SIDEBAR = `${BASE}/_sidebar.md`;
+const DEFAULT_SLUG = 'home';
+
+const cacheBust = () => `?_=${Date.now()}`;
+
+export const workshopBase = BASE;
+export const workshopDefaultSlug = DEFAULT_SLUG;
+
+export async function fetchWorkshopPage(slug) {
+  const safeSlug = String(slug || DEFAULT_SLUG).replace(/[^a-zA-Z0-9_-]/g, '');
+  const res = await fetch(`${BASE}/${safeSlug}.md${cacheBust()}`);
+  if (!res.ok) {
+    const err = new Error(`Workshop page "${safeSlug}" not found (${res.status})`);
+    err.status = res.status;
+    throw err;
+  }
+  return res.text();
+}
+
+export async function fetchWorkshopSidebar() {
+  const res = await fetch(`${SIDEBAR}${cacheBust()}`);
+  if (!res.ok) return null;
+  return res.text();
+}
+
+// Parse a GitLab `_sidebar.md` into nav groups.
+// Recognises markdown headings as group titles, list items `- [Title](slug)`
+// and the `[[slug]]` wiki-link form. Returns `[{ title, items: [{ title, slug }] }]`.
+export function parseSidebar(markdown) {
+  if (!markdown) return [];
+  const groups = [];
+  let current = { title: null, items: [] };
+  const linkRe = /\[([^\]]+)\]\(([^)\s]+)\)/;
+  const wikiRe = /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/;
+
+  markdown.split(/\r?\n/).forEach((raw) => {
+    const line = raw.trim();
+    if (!line) return;
+
+    if (/^#{1,6}\s+/.test(line)) {
+      if (current.items.length) groups.push(current);
+      current = { title: line.replace(/^#+\s+/, ''), items: [] };
+      return;
+    }
+
+    if (/^[-*+]\s+/.test(line)) {
+      const content = line.replace(/^[-*+]\s+/, '');
+      let m = content.match(linkRe);
+      if (m) {
+        current.items.push({ title: m[1], slug: slugFromHref(m[2]) });
+        return;
+      }
+      m = content.match(wikiRe);
+      if (m) {
+        const slug = slugFromHref(m[1]);
+        current.items.push({ title: m[2] || m[1], slug });
+      }
+    }
+  });
+
+  if (current.items.length) groups.push(current);
+  return groups;
+}
+
+// Normalise a link target to a slug. Drops anchors, strips `.md`,
+// rejects anything that looks absolute/external.
+export function slugFromHref(href) {
+  if (!href) return null;
+  if (/^[a-z]+:\/\//i.test(href) || href.startsWith('mailto:')) return null;
+  let s = href.split('#')[0].split('?')[0];
+  s = s.replace(/^\.?\//, '').replace(/\.md$/i, '').trim();
+  return s || null;
+}
+
+// Replace `[[slug]]` / `[[slug|Title]]` wiki-links with standard markdown links
+// so react-markdown picks them up. Idempotent on standard `[a](b)` links.
+export function expandWikiLinks(markdown) {
+  if (!markdown) return markdown;
+  return markdown.replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (_match, target, label) => {
+    const t = target.trim();
+    const text = (label || t).trim();
+    return `[${text}](${t})`;
+  });
+}

--- a/app/usecases/attachments/copy.rb
+++ b/app/usecases/attachments/copy.rb
@@ -21,7 +21,7 @@ module Usecases
           copy_attach.file_path = copy_io.path
           copy_attach.save
 
-          update_annotation(original_attach.id, copy_attach.id)
+          update_annotation(original_attach, copy_attach.id)
 
           if element.instance_of?(::ResearchPlan)
             element.update_body_attachments(original_attach.identifier, copy_attach.identifier)
@@ -29,9 +29,14 @@ module Usecases
         end
       end
 
-      def self.update_annotation(original_attach_id, copy_attach_id)
+      def self.update_annotation(original_attach, copy_attach_id)
+        # Only image attachments carry an :annotation derivative. For PDFs and other
+        # non-annotatable files it is nil, and the loader would raise NoMethodError
+        # ("undefined method `url' for nil"), aborting the whole research-plan copy.
+        return if original_attach.attachment(:annotation).blank?
+
         loader = Usecases::Attachments::Annotation::AnnotationLoader.new
-        svg = loader.get_annotation_of_attachment(original_attach_id)
+        svg = loader.get_annotation_of_attachment(original_attach.id)
 
         updater = Usecases::Attachments::Annotation::AnnotationUpdater.new
         updater.updated_annotated_string(svg, copy_attach_id)

--- a/lib/tasks/workshop_guide.rake
+++ b/lib/tasks/workshop_guide.rake
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Enabling / disabling the in-app Workshop Guide is content-driven, not a flag:
+#   * Enable  -> run `workshop_guide:sync` so wiki content lands in public/workshop;
+#               the /mydb drawer and /home inline block detect it and appear.
+#   * Disable -> remove the checkout (rm -rf public/workshop, keeping .keep).
+#               With no content present both widgets render nothing, so the
+#               app is the usual ELN.
+# public/workshop is gitignored, so the content is a runtime checkout only.
+namespace :workshop_guide do
+  desc 'Clone or update the Chemotion workshop wiki into public/workshop. ' \
+       'Configure via env: WORKSHOP_GUIDE_REPO (required, the git URL of a ' \
+       'wiki repo, e.g. https://oauth2:<token>@<git-host>/<group>/<project>.wiki.git), ' \
+       'WORKSHOP_GUIDE_BRANCH (optional, defaults to master).'
+  task :sync do
+    repo = ENV['WORKSHOP_GUIDE_REPO']
+    abort 'WORKSHOP_GUIDE_REPO env var is required' if repo.nil? || repo.empty?
+
+    branch = ENV.fetch('WORKSHOP_GUIDE_BRANCH', 'master')
+    target = Rails.public_path.join('workshop')
+
+    if target.join('.git').exist?
+      puts "Updating #{target}"
+      system('git', '-C', target.to_s, 'fetch', '--depth=1', 'origin', branch, exception: true)
+      system('git', '-C', target.to_s, 'reset', '--hard', "origin/#{branch}", exception: true)
+    else
+      puts "Cloning into #{target}"
+      target.rmtree if target.exist?
+      system('git', 'clone', '--depth=1', '--branch', branch, repo, target.to_s, exception: true)
+    end
+
+    puts 'Workshop guide synced.'
+  end
+end

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "react-input-autosize": "1.1.0",
     "react-json-editor-ajrm": "^2.5.10",
     "react-markdown": "^6.0.2",
+    "remark-gfm": "^1.0.0",
     "react-molviewer": "^1.1.3",
     "react-notification-system": "^0.2.7",
     "react-papaparse": "^3.17.2",

--- a/spec/usecases/attachments/copy_spec.rb
+++ b/spec/usecases/attachments/copy_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Usecases::Attachments::Copy do
+  let(:user) { create(:user) }
+  let(:research_plan) { create(:research_plan) }
+
+  describe '.execute!' do
+    let(:attachments) { [{ id: source.id }] }
+
+    before do
+      described_class.execute!(attachments, research_plan, user.id)
+    end
+
+    context 'when the attachment is a non-annotatable file (e.g. PDF)' do
+      # A PDF gets a :thumbnail derivative but never an :annotation derivative.
+      # Regression for NoMethodError: undefined method `url' for nil:NilClass
+      # raised from AnnotationLoader when copying a research plan (Sentry).
+      let(:source) { create(:attachment, :with_pdf, attachable: research_plan) }
+
+      it 'copies the attachment without attempting to copy an annotation' do
+        copy = Attachment.where(attachable: research_plan).where.not(id: source.id).last
+
+        expect(copy).to be_present
+        expect(copy.filename).to eq(source.filename)
+        expect(copy.attachment(:annotation)).to be_nil
+      end
+    end
+
+    context 'when the attachment is an annotatable image' do
+      let(:source) { create(:attachment, :with_png_image, attachable: research_plan) }
+
+      it 'copies the attachment and its annotation derivative' do
+        copy = Attachment.where(attachable: research_plan).where.not(id: source.id).last
+
+        expect(copy).to be_present
+        expect(copy.attachment(:annotation)).to be_present
+      end
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -5504,6 +5504,11 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
 
+ccount@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
+  integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
+
 chai@^5.2.0:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/chai/-/chai-5.3.3.tgz#dd3da955e270916a4bd3f625f4b919996ada7e06"
@@ -10831,6 +10836,11 @@ log-update@^6.1.0:
     strip-ansi "^7.1.0"
     wrap-ansi "^9.0.0"
 
+longest-streak@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
+  integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
+
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz"
@@ -10947,6 +10957,13 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-table@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-2.0.0.tgz#194a90ced26d31fe753d8b9434430214c011865b"
+  integrity sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==
+  dependencies:
+    repeat-string "^1.0.0"
+
 math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
@@ -10974,6 +10991,15 @@ mdast-util-definitions@^4.0.0:
   dependencies:
     unist-util-visit "^2.0.0"
 
+mdast-util-find-and-replace@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz#b7db1e873f96f66588c321f1363069abf607d1b5"
+  integrity sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==
+  dependencies:
+    escape-string-regexp "^4.0.0"
+    unist-util-is "^4.0.0"
+    unist-util-visit-parents "^3.0.0"
+
 mdast-util-from-markdown@^0.8.0:
   version "0.8.5"
   resolved "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz"
@@ -10984,6 +11010,48 @@ mdast-util-from-markdown@^0.8.0:
     micromark "~2.11.0"
     parse-entities "^2.0.0"
     unist-util-stringify-position "^2.0.0"
+
+mdast-util-gfm-autolink-literal@^0.1.0:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-0.1.3.tgz#9c4ff399c5ddd2ece40bd3b13e5447d84e385fb7"
+  integrity sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==
+  dependencies:
+    ccount "^1.0.0"
+    mdast-util-find-and-replace "^1.1.0"
+    micromark "^2.11.3"
+
+mdast-util-gfm-strikethrough@^0.2.0:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz#45eea337b7fff0755a291844fbea79996c322890"
+  integrity sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==
+  dependencies:
+    mdast-util-to-markdown "^0.6.0"
+
+mdast-util-gfm-table@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz#af05aeadc8e5ee004eeddfb324b2ad8c029b6ecf"
+  integrity sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==
+  dependencies:
+    markdown-table "^2.0.0"
+    mdast-util-to-markdown "~0.6.0"
+
+mdast-util-gfm-task-list-item@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz#70c885e6b9f543ddd7e6b41f9703ee55b084af10"
+  integrity sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==
+  dependencies:
+    mdast-util-to-markdown "~0.6.0"
+
+mdast-util-gfm@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm/-/mdast-util-gfm-0.1.2.tgz#8ecddafe57d266540f6881f5c57ff19725bd351c"
+  integrity sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==
+  dependencies:
+    mdast-util-gfm-autolink-literal "^0.1.0"
+    mdast-util-gfm-strikethrough "^0.2.0"
+    mdast-util-gfm-table "^0.1.0"
+    mdast-util-gfm-task-list-item "^0.1.0"
+    mdast-util-to-markdown "^0.6.1"
 
 mdast-util-to-hast@^10.2.0:
   version "10.2.0"
@@ -10998,6 +11066,18 @@ mdast-util-to-hast@^10.2.0:
     unist-util-generated "^1.0.0"
     unist-util-position "^3.0.0"
     unist-util-visit "^2.0.0"
+
+mdast-util-to-markdown@^0.6.0, mdast-util-to-markdown@^0.6.1, mdast-util-to-markdown@~0.6.0:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz#b33f67ca820d69e6cc527a93d4039249b504bebe"
+  integrity sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    longest-streak "^2.0.0"
+    mdast-util-to-string "^2.0.0"
+    parse-entities "^2.0.0"
+    repeat-string "^1.0.0"
+    zwitch "^1.0.0"
 
 mdast-util-to-string@^2.0.0:
   version "2.0.0"
@@ -11069,7 +11149,52 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
 
-micromark@~2.11.0:
+micromark-extension-gfm-autolink-literal@~0.5.0:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-0.5.7.tgz#53866c1f0c7ef940ae7ca1f72c6faef8fed9f204"
+  integrity sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==
+  dependencies:
+    micromark "~2.11.3"
+
+micromark-extension-gfm-strikethrough@~0.6.5:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-0.6.5.tgz#96cb83356ff87bf31670eefb7ad7bba73e6514d1"
+  integrity sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==
+  dependencies:
+    micromark "~2.11.0"
+
+micromark-extension-gfm-table@~0.4.0:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-table/-/micromark-extension-gfm-table-0.4.3.tgz#4d49f1ce0ca84996c853880b9446698947f1802b"
+  integrity sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==
+  dependencies:
+    micromark "~2.11.0"
+
+micromark-extension-gfm-tagfilter@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-0.3.0.tgz#d9f26a65adee984c9ccdd7e182220493562841ad"
+  integrity sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q==
+
+micromark-extension-gfm-task-list-item@~0.3.0:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz#d90c755f2533ed55a718129cee11257f136283b8"
+  integrity sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==
+  dependencies:
+    micromark "~2.11.0"
+
+micromark-extension-gfm@^0.3.0:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz#36d1a4c089ca8bdfd978c9bd2bf1a0cb24e2acfe"
+  integrity sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==
+  dependencies:
+    micromark "~2.11.0"
+    micromark-extension-gfm-autolink-literal "~0.5.0"
+    micromark-extension-gfm-strikethrough "~0.6.5"
+    micromark-extension-gfm-table "~0.4.0"
+    micromark-extension-gfm-tagfilter "~0.3.0"
+    micromark-extension-gfm-task-list-item "~0.3.0"
+
+micromark@^2.11.3, micromark@~2.11.0, micromark@~2.11.3:
   version "2.11.4"
   resolved "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz"
   integrity sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==
@@ -14161,6 +14286,14 @@ release-zalgo@^1.0.0:
   dependencies:
     es6-error "^4.0.1"
 
+remark-gfm@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-1.0.0.tgz#9213643001be3f277da6256464d56fd28c3b3c0d"
+  integrity sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==
+  dependencies:
+    mdast-util-gfm "^0.1.0"
+    micromark-extension-gfm "^0.3.0"
+
 remark-parse@^9.0.0:
   version "9.0.0"
   resolved "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz"
@@ -14202,10 +14335,10 @@ repeat-element@^1.1.2:
   resolved "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz"
   integrity sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==
 
-repeat-string@^1.6.1:
+repeat-string@^1.0.0, repeat-string@^1.6.1:
   version "1.6.1"
-  resolved "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-  integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
+  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+  integrity sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==
 
 request-progress@^3.0.0:
   version "3.0.0"
@@ -16888,3 +17021,8 @@ zustand@^4.4.1:
   integrity sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==
   dependencies:
     use-sync-external-store "^1.2.2"
+
+zwitch@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-1.0.5.tgz#d11d7381ffed16b742f6af7b3f223d5cd9fe9920"
+  integrity sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==


### PR DESCRIPTION
Ports the commits landed on `v3.x` since the `v3.1.2` tag that are not yet on `main`.

Type (Context) | Title | PR | Hash v3 | Hash port
-- | -- | -- | -- | --
style(sample) | auto-resize description textarea to content | #3017 | cbb08cb70 | a2b38d43c
feat(workshop-guide) | add in-app drawer for the workshop wiki |   | 2f6bd4fa3 | 94dcbb1ae
fix(attachments) | skip annotation copy for non-image attachments | #3338 | 2243e1d53 | ebae41807

## Notes
- `fix(attachments)` fixes a live crash (`NoMethodError: undefined method 'url' for nil:NilClass`) that also affects `main` today when copying a research plan with a non-image (e.g. PDF) attachment.
- `feat(workshop-guide)` is self-hiding when no `public/workshop` content is checked out, so it's inert on non-workshop instances — flagging for awareness since it has no prior PR/review trail on `main`.