### PR TITLE
fix(workshop-guide): stop probing static 404 for availability check

### DIFF
--- a/app/api/chemotion/public_api.rb
+++ b/app/api/chemotion/public_api.rb
@@ -45,7 +45,7 @@ module Chemotion
       namespace :workshop_guide do
         desc 'Whether workshop wiki content has been synced (see `rake workshop_guide:sync`)'
         get 'available' do
-          { available: Rails.public_path.join('workshop', 'home.md').exist? }
+          { available: Rails.public_path.join('workshop', 'home.md').file? }
         end
       end
 

--- a/app/api/chemotion/public_api.rb
+++ b/app/api/chemotion/public_api.rb
@@ -42,6 +42,13 @@ module Chemotion
         end
       end
 
+      namespace :workshop_guide do
+        desc 'Whether workshop wiki content has been synced (see `rake workshop_guide:sync`)'
+        get 'available' do
+          { available: Rails.public_path.join('workshop', 'home.md').exist? }
+        end
+      end
+
       namespace :omniauth_providers do
         desc 'get omniauth providers'
         get do

--- a/app/javascript/src/components/workshopGuide/WorkshopGuideDrawer.js
+++ b/app/javascript/src/components/workshopGuide/WorkshopGuideDrawer.js
@@ -2,20 +2,11 @@ import React, { useEffect, useState } from 'react';
 
 import ChemotionLogo from 'src/components/common/ChemotionLogo';
 import WorkshopContent from 'src/components/workshopGuide/WorkshopContent';
-import { workshopBase } from 'src/components/workshopGuide/workshopGuideFetch';
+import { fetchWorkshopAvailability } from 'src/components/workshopGuide/workshopGuideFetch';
 
 // The drawer auto-hides itself if no workshop content is checked out, so the
 // feature is implicitly off on non-workshop instances (just don't run the rake
 // sync task).
-async function probeAvailable() {
-  try {
-    const res = await fetch(`${workshopBase}/home.md`, { method: 'HEAD' });
-    return res.ok;
-  } catch (e) {
-    return false;
-  }
-}
-
 export default function WorkshopGuideDrawer() {
   const [available, setAvailable] = useState(false);
   const [open, setOpen] = useState(false);
@@ -23,7 +14,7 @@ export default function WorkshopGuideDrawer() {
 
   useEffect(() => {
     let cancelled = false;
-    probeAvailable().then((ok) => { if (!cancelled) setAvailable(ok); });
+    fetchWorkshopAvailability().then((ok) => { if (!cancelled) setAvailable(ok); });
     return () => { cancelled = true; };
   }, []);
 

--- a/app/javascript/src/components/workshopGuide/WorkshopGuideInline.js
+++ b/app/javascript/src/components/workshopGuide/WorkshopGuideInline.js
@@ -1,16 +1,14 @@
 import React, { useEffect, useState } from 'react';
 
 import WorkshopContent from 'src/components/workshopGuide/WorkshopContent';
-import { workshopBase } from 'src/components/workshopGuide/workshopGuideFetch';
+import { fetchWorkshopAvailability } from 'src/components/workshopGuide/workshopGuideFetch';
 
 export default function WorkshopGuideInline() {
   const [available, setAvailable] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
-    fetch(`${workshopBase}/home.md`, { method: 'HEAD' })
-      .then((res) => { if (!cancelled) setAvailable(res.ok); })
-      .catch(() => {});
+    fetchWorkshopAvailability().then((ok) => { if (!cancelled) setAvailable(ok); });
     return () => { cancelled = true; };
   }, []);
 

--- a/app/javascript/src/components/workshopGuide/workshopGuideFetch.js
+++ b/app/javascript/src/components/workshopGuide/workshopGuideFetch.js
@@ -11,6 +11,21 @@ const cacheBust = () => `?_=${Date.now()}`;
 export const workshopBase = BASE;
 export const workshopDefaultSlug = DEFAULT_SLUG;
 
+// Availability must not be probed by requesting the (expectedly missing) static
+// file directly: a 404 fetch response doesn't throw, but the browser still logs
+// the failed resource load to the console on every non-workshop instance. This
+// endpoint always answers 200, so the "feature disabled" case stays silent.
+export async function fetchWorkshopAvailability() {
+  try {
+    const res = await fetch('/api/v1/public/workshop_guide/available');
+    if (!res.ok) return false;
+    const { available } = await res.json();
+    return !!available;
+  } catch (e) {
+    return false;
+  }
+}
+
 export async function fetchWorkshopPage(slug) {
   const safeSlug = String(slug || DEFAULT_SLUG).replace(/[^a-zA-Z0-9_-]/g, '');
   const res = await fetch(`${BASE}/${safeSlug}.md${cacheBust()}`);

--- a/spec/api/chemotion/public_api_spec.rb
+++ b/spec/api/chemotion/public_api_spec.rb
@@ -48,4 +48,37 @@ describe Chemotion::PublicAPI do
       end
     end
   end
+
+  describe 'GET /api/v1/public/workshop_guide/available' do
+    subject(:execute_request) { get('/api/v1/public/workshop_guide/available') }
+
+    let(:home_md) { Rails.public_path.join('workshop', 'home.md') }
+
+    context 'when workshop content has not been synced' do
+      before do
+        FileUtils.rm_f(home_md)
+        execute_request
+      end
+
+      it 'responds 200 with available: false' do
+        expect(response).to have_http_status :ok
+        expect(parsed_json_response).to eq({ 'available' => false })
+      end
+    end
+
+    context 'when workshop content has been synced' do
+      before do
+        FileUtils.mkdir_p(home_md.dirname)
+        FileUtils.touch(home_md)
+        execute_request
+      end
+
+      after { FileUtils.rm_f(home_md) }
+
+      it 'responds 200 with available: true' do
+        expect(response).to have_http_status :ok
+        expect(parsed_json_response).to eq({ 'available' => true })
+      end
+    end
+  end
 end

--- a/spec/api/chemotion/public_api_spec.rb
+++ b/spec/api/chemotion/public_api_spec.rb
@@ -53,6 +53,18 @@ describe Chemotion::PublicAPI do
     subject(:execute_request) { get('/api/v1/public/workshop_guide/available') }
 
     let(:home_md) { Rails.public_path.join('workshop', 'home.md') }
+    let(:home_md_backup) { Rails.root.join('tmp/home_md_backup.md') }
+
+    around do |example|
+      had_home_md = home_md.exist?
+      FileUtils.mv(home_md, home_md_backup) if had_home_md
+      begin
+        example.run
+      ensure
+        FileUtils.rm_f(home_md)
+        FileUtils.mv(home_md_backup, home_md) if had_home_md
+      end
+    end
 
     context 'when workshop content has not been synced' do
       before do


### PR DESCRIPTION
## Summary
- `WorkshopGuideDrawer`/`WorkshopGuideInline` detected content by HEAD-requesting `/workshop/home.md` and checking `res.ok`. On non-workshop instances this always 404s — the app handled that fine, but the browser's own network stack logs every failed fetch/XHR to the console regardless of how the response is consumed, so every `/mydb`/`/home` load showed a red 404 even though the feature was correctly "disabled".
- Added `GET /api/v1/public/workshop_guide/available`, an always-200 endpoint that checks file existence server-side, and pointed both widgets at it instead of probing the static file directly.

## Test plan
- [x] `bundle exec rubocop app/api/chemotion/public_api.rb spec/api/chemotion/public_api_spec.rb` — clean
- [x] `yarn eslint app/javascript/src/components/workshopGuide` — no new offenses
- [x] `RAILS_ENV=test bundle exec rspec spec/api/chemotion/public_api_spec.rb` — 6 examples, 0 failures