### PR TITLE
feat(collections)!: permission-ladder redesign, ownership transfer & share-model fixes

### DIFF
--- a/app/api/chemotion/collection_elements_api.rb
+++ b/app/api/chemotion/collection_elements_api.rb
@@ -24,6 +24,7 @@ module Chemotion
         Usecases::Collections::AddElements.new(current_user).perform!(
           collection_id: params[:collection_id],
           ui_state: params[:ui_state].except(:currentCollection),
+          origin_collection_id: params[:ui_state][:currentCollection]&.dig(:id),
         )
         { status: 204 }
       end

--- a/app/api/chemotion/collection_share_api.rb
+++ b/app/api/chemotion/collection_share_api.rb
@@ -5,6 +5,9 @@ module Chemotion
     rescue_from ActiveRecord::RecordNotFound do
       error!('CollectionShare not found', 404)
     end
+    rescue_from Usecases::Collections::Errors::InsufficientPermissionError do |error|
+      error!(error.message, 403)
+    end
 
     helpers do
       # The collection whose share list the current user may administrate: one they own, or one
@@ -54,6 +57,18 @@ module Chemotion
       def refresh_shared_flag!(collection)
         collection.update!(shared: CollectionShare.exists?(collection: collection))
       end
+
+      # A pass_ownership (5) share is an ownership *offer*: it may only target a single Person (never
+      # a group), and never a locked system collection. Enforced only when that level is the one
+      # being granted; ordinary shares are unaffected.
+      def prevent_invalid_ownership_offer!(collection, user_ids, level)
+        return unless level == CollectionShare.permission_level(:pass_ownership)
+
+        error!('422 Unprocessable Entity: this collection cannot change ownership', 422) if collection.is_locked
+        return if user_ids.size == 1 && User.exists?(id: user_ids, type: 'Person')
+
+        error!('422 Unprocessable Entity: ownership can only be offered to a single person', 422)
+      end
     end
 
     resource :collection_shares do
@@ -99,6 +114,7 @@ module Chemotion
         collection = administrable_collection(params[:collection_id])
         prevent_privilege_escalation!(collection, params[:permission_level])
         prevent_sharing_with_owner!(collection, params[:user_ids])
+        prevent_invalid_ownership_offer!(collection, params[:user_ids], params[:permission_level])
 
         # include_missing: false — otherwise every omitted optional detail level is declared as nil and
         # overwrites the column default, tripping its NOT NULL constraint.
@@ -136,6 +152,7 @@ module Chemotion
         # neither promote someone above themselves nor demote someone who outranks them.
         prevent_privilege_escalation!(collection, params[:permission_level])
         prevent_privilege_escalation!(collection, share.permission_level)
+        prevent_invalid_ownership_offer!(collection, [share.shared_with_id], params[:permission_level])
 
         # include_missing: false keeps this a partial update; see the note on the create endpoint.
         share.update!(declared(params, include_missing: false).except(:id))
@@ -169,6 +186,19 @@ module Chemotion
 
         status 204
         body false
+      end
+
+      desc 'Accept a pending pass-ownership offer and take ownership of the collection (and subtree)'
+      namespace :take_ownership do
+        params do
+          requires :collection_id, type: Integer
+        end
+        post '/:collection_id' do
+          collection = Collection.find(params[:collection_id])
+          transferred = Usecases::Collections::TransferOwnership.new(current_user).perform!(collection: collection)
+
+          present transferred, with: Entities::OwnCollectionEntity, root: :collection
+        end
       end
     end
   end

--- a/app/api/chemotion/collection_share_api.rb
+++ b/app/api/chemotion/collection_share_api.rb
@@ -6,13 +6,63 @@ module Chemotion
       error!('CollectionShare not found', 404)
     end
 
+    helpers do
+      # The collection whose share list the current user may administrate: one they own, or one
+      # shared to them at :manage_shares or above (delegated ACL admin).
+      #
+      # @param collection_id [Integer]
+      # @return [Collection, nil]
+      def find_administrable_collection(collection_id)
+        Collection.own_collections_for(current_user).find_by(id: collection_id) ||
+          Collection.shared_with_minimum_permission_level(
+            current_user,
+            CollectionShare.permission_level(:manage_shares),
+          ).find_by(id: collection_id)
+      end
+
+      # @raise [ActiveRecord::RecordNotFound] when the user administrates neither
+      def administrable_collection(collection_id)
+        find_administrable_collection(collection_id) || raise(ActiveRecord::RecordNotFound)
+      end
+
+      # The effective level the current user holds on +collection+: the maximum across their own
+      # share and their groups' shares, or the owner sentinel. Owners outrank every rung.
+      #
+      # @return [Integer]
+      def effective_permission_level(collection)
+        collection.detail_levels_for_user(current_user)[:permission_level]
+      end
+
+      # A delegated admin must not mint or revoke a share more powerful than their own, otherwise
+      # :manage_shares would be a self-escalation path to :pass_ownership. Owners are unconstrained.
+      def prevent_privilege_escalation!(collection, level)
+        return if level.nil?
+        return if level <= effective_permission_level(collection)
+
+        error!('403 Forbidden: cannot act on a permission level above your own', 403)
+      end
+
+      # Sharing a collection back to its own owner would leave the owner holding a (weaker) share row
+      # on their own collection, which every policy then has to disambiguate. Refuse it outright.
+      def prevent_sharing_with_owner!(collection, user_ids)
+        return unless user_ids.include?(collection.user_id)
+
+        error!('422 Unprocessable Entity: cannot share a collection with its owner', 422)
+      end
+
+      # collections.shared mirrors "has at least one CollectionShare".
+      def refresh_shared_flag!(collection)
+        collection.update!(shared: CollectionShare.exists?(collection: collection))
+      end
+    end
+
     resource :collection_shares do
       desc 'Get all collection shares by filter'
       params do
         requires :collection_id
       end
       get '/' do
-        collection = Collection.own_collections_for(current_user).find(params[:collection_id])
+        collection = administrable_collection(params[:collection_id])
 
         present collection.collection_shares, with: Entities::CollectionShareEntity, root: :collection_shares
       end
@@ -34,7 +84,7 @@ module Chemotion
       params do
         requires :collection_id, type: Integer
         requires :user_ids, type: Array[Integer]
-        optional :permission_level, type: Integer
+        optional :permission_level, type: Integer, values: CollectionShare::PERMISSION_LEVELS.values
         optional :celllinesample_detail_level, type: Integer
         optional :devicedescription_detail_level, type: Integer
         optional :element_detail_level, type: Integer
@@ -46,15 +96,21 @@ module Chemotion
         optional :wellplate_detail_level, type: Integer
       end
       post do
-        collection = Collection.own_collections_for(current_user).find(params[:collection_id])
+        collection = administrable_collection(params[:collection_id])
+        prevent_privilege_escalation!(collection, params[:permission_level])
+        prevent_sharing_with_owner!(collection, params[:user_ids])
+
+        # include_missing: false — otherwise every omitted optional detail level is declared as nil and
+        # overwrites the column default, tripping its NOT NULL constraint.
+        attributes = declared(params, include_missing: false).except(:collection_id, :user_ids)
 
         params[:user_ids].each do |user_id|
           share = CollectionShare.find_or_initialize_by(collection: collection, shared_with_id: user_id)
-          share.assign_attributes(declared(params).except(:collection_id, :user_ids))
-          share.save
+          share.assign_attributes(attributes)
+          share.save!
         end
 
-        collection.update(shared: true)
+        refresh_shared_flag!(collection)
 
         { status: 204 }
       end
@@ -62,7 +118,7 @@ module Chemotion
       desc 'Update a collection share'
       params do
         requires :id, type: Integer
-        optional :permission_level, type: Integer
+        optional :permission_level, type: Integer, values: CollectionShare::PERMISSION_LEVELS.values
         optional :celllinesample_detail_level, type: Integer
         optional :devicedescription_detail_level, type: Integer
         optional :element_detail_level, type: Integer
@@ -74,9 +130,15 @@ module Chemotion
         optional :wellplate_detail_level, type: Integer
       end
       put '/:id' do
-        share = CollectionShare.shared_by(current_user).find(params[:id])
+        share = CollectionShare.find(params[:id])
+        collection = administrable_collection(share.collection_id)
+        # Guard both the level being granted and the level being overwritten: a delegated admin may
+        # neither promote someone above themselves nor demote someone who outranks them.
+        prevent_privilege_escalation!(collection, params[:permission_level])
+        prevent_privilege_escalation!(collection, share.permission_level)
 
-        share.update(declared(params).except(:id))
+        # include_missing: false keeps this a partial update; see the note on the create endpoint.
+        share.update!(declared(params, include_missing: false).except(:id))
 
         present share, with: Entities::CollectionShareEntity, root: :collection_share
       end
@@ -86,18 +148,24 @@ module Chemotion
         requires :id
       end
       delete '/:id' do
-        # The owner may remove any share on their collection; a recipient may only reject the share
-        # addressed to them personally. `shared_with` would also match a share held by one of the
-        # user's *groups*, letting any member revoke the collection for every other member.
-        share = CollectionShare.shared_by(current_user).find_by(id: params[:id])
-        share ||= CollectionShare.shared_directly_with(current_user).find_by(id: params[:id])
-        error!('403 Forbidden', 403) if share.nil?
+        share = CollectionShare.find(params[:id])
+
+        # A user may always reject the share addressed to them personally. `shared_with` would also
+        # match a share held by one of their *groups*; revoking that would drop the collection for
+        # every other member, so it is not theirs to reject — they leave the group instead.
+        unless CollectionShare.shared_directly_with(current_user).exists?(id: share.id)
+          # Otherwise they must administrate the collection, and must not revoke a share that
+          # outranks them.
+          collection = find_administrable_collection(share.collection_id)
+          error!('403 Forbidden', 403) if collection.nil?
+
+          prevent_privilege_escalation!(collection, share.permission_level)
+        end
 
         collection = share.collection
+        share.destroy!
 
-        share.destroy
-
-        collection.update(shared: false) if CollectionShare.where(collection: collection).none?
+        refresh_shared_flag!(collection)
 
         status 204
         body false

--- a/app/api/chemotion/element_api.rb
+++ b/app/api/chemotion/element_api.rb
@@ -11,17 +11,6 @@ module Chemotion
     helpers CollectionHelpers
     helpers LiteratureHelpers
 
-    # The :ui_state namespace has exactly two routes: a DELETE that destroys the selected element
-    # records, and a read-only POST /load_report.
-    #
-    # NOTE: the DELETE threshold sits *under* the one ElementPolicy#destroy? requires for a single
-    # record (delete_elements). Preserved as-is; reconciling the two is a permission-model decision
-    # tracked separately.
-    UI_STATE_PERMISSION_LEVELS = {
-      'POST' => CollectionShare.permission_level(:read_elements),
-      'DELETE' => CollectionShare.permission_level(:share_collection),
-    }.freeze
-
     namespace :ui_state do
       desc 'Delete elements by UI state'
       params do
@@ -71,17 +60,19 @@ module Chemotion
         elsif (@collection = Collection.own_collections_for(current_user).find_by(id: collection_id))
           # empty block body to keep rubocop happy
         elsif (collection = Collection.accessible_for(current_user).find_by(id: collection_id))
-          # A user can hold several shares on one collection — their own plus one per group. The
-          # effective level is their maximum; picking whichever row the database returned first made
-          # the outcome depend on row order.
-          effective_level = collection.detail_levels_for_user(current_user)[:permission_level]
-          # Unknown verb (a route added later) falls back to the strictest level we gate on here,
-          # rather than raising or silently letting the request through.
-          required_level = UI_STATE_PERMISSION_LEVELS.fetch(
-            request.request_method, UI_STATE_PERMISSION_LEVELS.values.max
-          )
+          # We only reach here when the user is not an owner. DELETE in this namespace destroys the
+          # element records themselves (destroy_all), which is owner-only — see ElementPolicy#destroy?.
+          # A sharee unlinks elements from the collection instead (Usecases::Collections::RemoveElements).
+          # The only other route here, POST load_report, just reads.
+          error!('403 Forbidden', 403) if request.delete?
 
-          error!('403 Forbidden', 403) unless effective_level >= required_level
+          # A user can hold several shares on one collection — their own plus one per group — and they
+          # may disagree. The effective level is their maximum, so the outcome no longer depends on
+          # which share row the database happened to return first.
+          effective_level = collection.detail_levels_for_user(current_user)[:permission_level]
+          error!('403 Forbidden', 403) unless
+            effective_level >= CollectionShare.permission_level(:read_elements)
+
           @collection = collection
         end
         error!('404 Record Not Found', 404) unless @collection

--- a/app/api/chemotion/element_api.rb
+++ b/app/api/chemotion/element_api.rb
@@ -60,10 +60,12 @@ module Chemotion
         elsif (@collection = Collection.own_collections_for(current_user).find_by(id: collection_id))
           # empty block body to keep rubocop happy
         elsif (collection = Collection.accessible_for(current_user).find_by(id: collection_id))
-          # We only reach here when the user is not an owner. DELETE in this namespace destroys the
-          # element records themselves (destroy_all), which is owner-only — see ElementPolicy#destroy?.
-          # A sharee unlinks elements from the collection instead (Usecases::Collections::RemoveElements).
-          # The only other route here, POST load_report, just reads.
+          # We only reach here when the user is not an owner. DELETE in this namespace withdraws the
+          # selection from the user's *own* collections and destroys only records left orphaned
+          # (Usecases::Collections::WithdrawElements); a pure sharee has no own-collection membership
+          # to withdraw here, so a shared-collection view still 403s — they use Remove-from-current
+          # (Usecases::Collections::RemoveElements) instead. The only other route here, POST
+          # load_report, just reads.
           error!('403 Forbidden', 403) if request.delete?
 
           # A user can hold several shares on one collection — their own plus one per group — and they
@@ -78,38 +80,15 @@ module Chemotion
         error!('404 Record Not Found', 404) unless @collection
       end
 
-      desc 'delete element from ui state selection.'
+      desc 'Withdraw the ui-state selection from all of the user\'s collections (destroying orphans)'
       delete do
-        deleted = { 'sample' => [] }
-        API::ELEMENTS.each do |element|
-          next unless params[element]
-          next unless params[element][:checkedAll] || params[element][:checkedIds].present?
+        removed = Usecases::Collections::WithdrawElements.new(current_user).perform!(
+          source_collection: @collection,
+          ui_state: params,
+          options: params[:options] || {},
+        )
 
-          element_model = API::ELEMENT_CLASS[element].model_name
-          deleted[element_model.param_key] =
-            @collection.send(element_model.route_key).by_ui_state(params[element]).destroy_all.map(&:id)
-        end
-
-        # explicit inner join on reactions_samples to get soft deleted reactions_samples entries
-
-        sql_join = 'inner join reactions_samples on reactions_samples.sample_id = samples.id'
-        unless params[:options][:deleteSubsamples]
-          sql_join += " and reactions_samples.type in ('ReactionsSolventSample','ReactionsReactantSample')"
-        end
-        deleted['sample'] += Sample.joins(sql_join).joins(:collections)
-                                   .where(
-                                     collections: { id: @collection.id },
-                                     reactions_samples: { reaction_id: deleted['reaction'] },
-                                   )
-                                   .destroy_all.map(&:id)
-        Labimotion::ElementKlass.find_each do |klass|
-          klass_name = params[klass.name]
-          next unless klass_name.present? && (klass_name[:checkedAll] || klass_name[:checkedIds].present?)
-
-          deleted[klass.name] = @collection.send(:elements).by_ui_state(params[klass.name]).destroy_all.map(&:id)
-        end
-
-        { selecteds: params[:selecteds].reject { |sel| deleted.fetch(sel['type'], []).include?(sel['id']) } }
+        { selecteds: params[:selecteds].reject { |sel| removed.fetch(sel['type'], []).include?(sel['id']) } }
       end
 
       namespace :load_report do

--- a/app/api/chemotion/permission_api.rb
+++ b/app/api/chemotion/permission_api.rb
@@ -40,13 +40,18 @@ module Chemotion
 
           deletion_allowed = true
           sharing_allowed = true
+          # Unlinking from a shared collection (not destroying the record) is granted at
+          # :remove_elements, independently of the owner-only destroy gate above.
+          remove_allowed = true
 
           if collection.user != current_user # collection was shared to user
             # set deletion_allowed to false if any of the elements is not allowed to be mass deleted
             [Sample, Reaction, Screen, Wellplate].each do |element_class|
               next if selected_elements[element_class].none?
 
-              deletion_allowed &&= ElementsPolicy.new(current_user, selected_elements[element_class]).destroy_all?
+              policy = ElementsPolicy.new(current_user, selected_elements[element_class])
+              deletion_allowed &&= policy.destroy_all?
+              remove_allowed &&= policy.remove_all?
             end
 
             # permission for deletion includes permission for sharing,
@@ -61,7 +66,8 @@ module Chemotion
             end
           end
 
-          { deletion_allowed: deletion_allowed, sharing_allowed: sharing_allowed, is_top_secret: is_top_secret }
+          { deletion_allowed: deletion_allowed, sharing_allowed: sharing_allowed,
+            remove_allowed: remove_allowed, is_top_secret: is_top_secret }
         end
       end
     end

--- a/app/javascript/src/apps/mydb/collections/CollectionManagementMenu.js
+++ b/app/javascript/src/apps/mydb/collections/CollectionManagementMenu.js
@@ -40,7 +40,7 @@ function CollectionManagementMenu() {
     } = currentCollection;
     const newIsDisabled = (
       (label === 'All' && isLocked)
-      || (shared === true && permissionLevel < PermissionConst.ImportElements)
+      || (shared === true && permissionLevel < PermissionConst.AddElements)
     );
     setIsDisabled(newIsDisabled);
     setHasRadar(storeHasRadar);

--- a/app/javascript/src/apps/mydb/collections/CollectionSubtree.js
+++ b/app/javascript/src/apps/mydb/collections/CollectionSubtree.js
@@ -13,6 +13,7 @@ import { aviatorNavigationWithCollectionId } from 'src/utilities/routesUtils';
 import { observer } from 'mobx-react';
 import { StoreContext } from 'src/stores/mobx/RootStore';
 import CollectionSubtreeFunctions from 'src/apps/mydb/collections/CollectionSubtreeFunctions';
+import { PermissionConst } from 'src/utilities/PermissionConst';
 
 function CollectionSubtree({
   root,
@@ -59,8 +60,13 @@ function CollectionSubtree({
     return () => UIStore.unlisten(onUiStoreChange);
   }, [currentCollection, sharedWithMe, isExpanded]);
 
+  // A collection shared to the user at the top rung (pass_ownership) is a pending ownership offer.
+  const canTakeOwnership = () => sharedWithMe && root.permission_level === PermissionConst.PassOwnership;
+
   const handleTakeOwnership = () => {
-    // TODO: determine what should happen if take ownership is possible
+    // eslint-disable-next-line no-alert
+    if (!window.confirm(`Take ownership of "${root.label}" and all its sub collections?`)) return;
+    collectionsStore.takeOwnership(root.id);
   };
 
   const toggleExpansion = (e, node) => {
@@ -90,8 +96,6 @@ function CollectionSubtree({
       aviatorNavigationWithCollectionId(node.id, element?.type, (element?.isNew ? 'new' : element?.id), true, true);
     }
   };
-
-  const canTakeOwnership = () => false;
 
   const handleTakeOwnershipKeyDown = (e) => {
     if (e.key === 'Enter' || e.key === ' ') {
@@ -176,6 +180,7 @@ CollectionSubtree.propTypes = {
     inventory_prefix: PropTypes.string,
     shared: PropTypes.bool,
     owner: PropTypes.string,
+    permission_level: PropTypes.number,
   }).isRequired,
   level: PropTypes.number.isRequired,
 };

--- a/app/javascript/src/apps/mydb/collections/PermissionIcons.js
+++ b/app/javascript/src/apps/mydb/collections/PermissionIcons.js
@@ -1,19 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { PermissionConst } from 'src/utilities/PermissionConst';
+
+// The ladder is cumulative, so every rung at or below `pl` gets an icon.
+const RUNGS = [
+  { level: PermissionConst.EditElements, icon: 'fa-pencil-square-o', title: 'Edit elements' },
+  { level: PermissionConst.AddElements, icon: 'fa-plus-square-o', title: 'Add elements' },
+  { level: PermissionConst.RemoveElements, icon: 'fa-trash', title: 'Remove elements' },
+  { level: PermissionConst.ManageShares, icon: 'fa-users', title: 'Manage shares' },
+  { level: PermissionConst.PassOwnership, icon: 'fa-exchange', title: 'Pass ownership' },
+];
 
 const PermissionIcons = ({ pl }) => {
-  return (pl > -1)
-    ? (
-      <>
-        <i className="fa fa-newspaper-o" />
-        {pl > 0 && <i className="fa fa-pencil-square-o" />}
-        {pl > 1 && <i className="fa fa-share-alt" />}
-        {pl > 2 && <i className="fa fa-trash" />}
-        {pl > 3 && <i className="fa fa-download" />}
-        {pl > 4 && <i className="fa fa-exchange" />}
-      </>
-    )
-    : null;
+  if (pl < PermissionConst.ReadElements) return null;
+
+  return (
+    <>
+      <i className="fa fa-newspaper-o" title="Read elements" />
+      {RUNGS.filter((rung) => pl >= rung.level).map((rung) => (
+        <i key={rung.icon} className={`fa ${rung.icon}`} title={rung.title} />
+      ))}
+    </>
+  );
 };
 
 PermissionIcons.propTypes = {

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionActions.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionActions.js
@@ -167,14 +167,17 @@ export default class SelectionActions extends React.Component {
   }
 
   render() {
-    const { currentCollection, sharing_allowed, deletion_allowed, hasSel } = this.state;
+    const {
+      currentCollection, sharing_allowed, deletion_allowed, remove_allowed, hasSel
+    } = this.state;
     const { is_locked, label } = currentCollection;
     const isAll = is_locked && label === 'All';
     const noSel = !hasSel
 
-    const moveDisabled = noSel || isAll;
+    // Move unlinks from the current collection, so it needs remove permission on the source.
+    const moveDisabled = noSel || isAll || !remove_allowed;
     const assignDisabled = noSel;
-    const removeDisabled = noSel || isAll || !deletion_allowed; //!remove_allowed
+    const removeDisabled = noSel || isAll || !remove_allowed;
     const deleteDisabled = noSel || !deletion_allowed;
     const shareDisabled = noSel || !sharing_allowed;
     const literatureDisabled = noSel;

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionDeleteModal.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionDeleteModal.js
@@ -38,20 +38,25 @@ export default class SelectionDeleteModal extends React.Component {
       <AppModal
         show
         onHide={onHide}
-        title="Delete from all Collections?"
-        primaryActionLabel="Delete"
+        title="Remove from all Collections?"
+        primaryActionLabel="Remove"
         onPrimaryAction={this.handleClick}
       >
         <Form>
+          <p>
+            Removes the selection from all of your collections. An element that is not present in
+            anyone else&apos;s collection is then permanently deleted; one still shared into another
+            user&apos;s collection is only removed from your view.
+          </p>
           <Form.Group className="mb-3">
             <Form.Check
               type="checkbox"
               onChange={this.handleCheck}
               checked={deleteSubsamples}
-              label="Also delete reaction associated samples&nbsp;"
+              label="Also remove reaction associated samples&nbsp;"
             />
             <Form.Text>
-              If left unchecked, only the solvent and reactant samples of the selected reactions will be deleted
+              If left unchecked, only the solvent and reactant samples of the selected reactions will be removed
             </Form.Text>
           </Form.Group>
         </Form>

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionShareModal.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionShareModal.js
@@ -15,6 +15,7 @@ import { StoreContext } from 'src/stores/mobx/RootStore';
 
 import { selectUserOptionFormater } from 'src/utilities/selectHelper';
 import { filterParamsFromUIState } from 'src/utilities/collectionUtilities';
+import { PermissionConst } from 'src/utilities/PermissionConst';
 
 function SelectionShareModal({
   title = 'Sharing of Elements',
@@ -40,7 +41,7 @@ function SelectionShareModal({
 
   const currentUser = (UserStore.getState() && UserStore.getState().currentUser) || {};
   const uiState = UIStore.getState();
-  const displayWarning = permissions.permissionLevel === '5';
+  const displayWarning = Number(permissions.permissionLevel) === PermissionConst.PassOwnership;
   const canSubmit = !showUserSelect || (selectedUsers != null && selectedUsers.length > 0);
   const submitTitle = shareType === 'edit' ? 'Edit Permissions' : 'Create Shared Collection';
 
@@ -116,7 +117,8 @@ function SelectionShareModal({
   };
 
   const handlePermissionLevelChange = (e) => {
-    const val = e.target.value;
+    // <option value> is always a string; the API and the shortcuts both deal in integers.
+    const val = Number(e.target.value);
     setPermissions({ ...permissions, permissionLevel: val });
     setRole(defaultRole);
   };
@@ -189,14 +191,14 @@ function SelectionShareModal({
           <Form.Label>Permission level</Form.Label>
           <Form.Select
             onChange={(e) => handlePermissionLevelChange(e)}
-            value={permissions.permissionLevel || ''}
+            value={permissions.permissionLevel ?? ''}
           >
-            <option value="0">Read</option>
-            <option value="1">Write</option>
-            <option value="2">Share</option>
-            <option value="3">Delete</option>
-            <option value="4">Import Elements</option>
-            <option value="5">Pass ownership</option>
+            <option value={PermissionConst.ReadElements}>Read elements</option>
+            <option value={PermissionConst.EditElements}>Edit elements</option>
+            <option value={PermissionConst.AddElements}>Add elements</option>
+            <option value={PermissionConst.RemoveElements}>Remove elements</option>
+            <option value={PermissionConst.ManageShares}>Manage shares</option>
+            <option value={PermissionConst.PassOwnership}>Pass ownership</option>
           </Form.Select>
           {displayWarning && (
             <Form.Text>

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionSharingShortcuts.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionSharingShortcuts.js
@@ -1,7 +1,9 @@
+import { PermissionConst } from 'src/utilities/PermissionConst';
+
 export default class SharingShortcuts {
   static user() {
     return {
-      permissionLevel: 3,
+      permissionLevel: PermissionConst.RemoveElements,
       sampleDetailLevel: 10,
       reactionDetailLevel: 10,
       wellplateDetailLevel: 10,
@@ -9,9 +11,10 @@ export default class SharingShortcuts {
     }
   }
 
+  // A partner edits existing content. Adding new elements is a separate, higher rung.
   static partner() {
     return {
-      permissionLevel: 1,
+      permissionLevel: PermissionConst.EditElements,
       sampleDetailLevel: 10,
       reactionDetailLevel: 0,
       wellplateDetailLevel: 10,
@@ -21,7 +24,7 @@ export default class SharingShortcuts {
 
   static collaborator() {
     return {
-      permissionLevel: 0,
+      permissionLevel: PermissionConst.ReadElements,
       sampleDetailLevel: 1,
       reactionDetailLevel: 0,
       wellplateDetailLevel: 0,
@@ -31,7 +34,7 @@ export default class SharingShortcuts {
 
   static reviewer() {
     return {
-      permissionLevel: 0,
+      permissionLevel: PermissionConst.ReadElements,
       sampleDetailLevel: 2,
       reactionDetailLevel: 10,
       wellplateDetailLevel: 1,
@@ -39,9 +42,10 @@ export default class SharingShortcuts {
     }
   }
 
+  // A supervisor administrates the collection's share list on the owner's behalf.
   static supervisor() {
     return {
-      permissionLevel: 4,
+      permissionLevel: PermissionConst.ManageShares,
       sampleDetailLevel: 10,
       reactionDetailLevel: 10,
       wellplateDetailLevel: 10,

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionSharingShortcuts.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionSharingShortcuts.js
@@ -8,7 +8,7 @@ export default class SharingShortcuts {
       reactionDetailLevel: 10,
       wellplateDetailLevel: 10,
       screenDetailLevel: 10
-    }
+    };
   }
 
   // A partner edits existing content. Adding new elements is a separate, higher rung.
@@ -19,7 +19,7 @@ export default class SharingShortcuts {
       reactionDetailLevel: 0,
       wellplateDetailLevel: 10,
       screenDetailLevel: 1
-    }
+    };
   }
 
   static collaborator() {
@@ -29,7 +29,7 @@ export default class SharingShortcuts {
       reactionDetailLevel: 0,
       wellplateDetailLevel: 0,
       screenDetailLevel: 0
-    }
+    };
   }
 
   static reviewer() {
@@ -39,7 +39,7 @@ export default class SharingShortcuts {
       reactionDetailLevel: 10,
       wellplateDetailLevel: 1,
       screenDetailLevel: 0
-    }
+    };
   }
 
   // A supervisor administrates the collection's share list on the owner's behalf.
@@ -50,6 +50,6 @@ export default class SharingShortcuts {
       reactionDetailLevel: 10,
       wellplateDetailLevel: 10,
       screenDetailLevel: 10
-    }
+    };
   }
 }

--- a/app/javascript/src/components/common/CopyElementModal.js
+++ b/app/javascript/src/components/common/CopyElementModal.js
@@ -125,7 +125,7 @@ export default class CopyElementModal extends React.Component {
           <Form.Label>Copy to Collection</Form.Label>
           <CollectionSelect
             value={selectedCol}
-            withShared={false}
+            withShared
             onChange={this.onColSelectChange}
           />
         </AppModal>

--- a/app/javascript/src/components/navigation/CreateElementButton.js
+++ b/app/javascript/src/components/navigation/CreateElementButton.js
@@ -140,8 +140,9 @@ export default class CreateElementButton extends React.Component {
       permission_level
     } = currentCollection;
 
+    // Creating an element adds it to the collection, so it needs AddElements — not merely EditElements.
     const newIsDisabled = permission_level !== undefined
-      ? (collection_share_id && permission_level < PermissionConst.Write)
+      ? (collection_share_id && permission_level < PermissionConst.AddElements)
       : (label === 'All' && is_locked);
 
     this.setState({ isDisabled: newIsDisabled });

--- a/app/javascript/src/fetchers/CollectionSharesFetcher.js
+++ b/app/javascript/src/fetchers/CollectionSharesFetcher.js
@@ -17,6 +17,13 @@ export default class CollectionSharesFetcher {
     return ApiClient.postJson('/api/v1/collection_shares', { body: params });
   }
 
+  // Accept a pending pass-ownership offer: transfers the collection (and its subtree) to the
+  // current user. Returns the now-owned collection.
+  static takeOwnership(collectionId) {
+    return ApiClient.postJson(`/api/v1/collection_shares/take_ownership/${collectionId}`, { body: {} })
+      .then((json) => json.collection);
+  }
+
   static updateCollectionShare(collectionShareId, params) {
     return ApiClient.putJson(`/api/v1/collection_shares/${collectionShareId}`, { body: params })
       .then((json) => json.collection_share);

--- a/app/javascript/src/stores/alt/actions/ElementActions.js
+++ b/app/javascript/src/stores/alt/actions/ElementActions.js
@@ -270,7 +270,11 @@ class ElementActions {
     return (dispatch) => {
       GenericElsFetcher.create(params)
         .then((result) => { dispatch(result); })
-        .catch((errorMessage) => { console.log(errorMessage); });
+        .catch((errorMessage) => {
+          console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
+        });
     };
   }
 
@@ -278,7 +282,11 @@ class ElementActions {
     return (dispatch) => {
       GenericElsFetcher.update(params)
         .then((result) => { dispatch({ element: result, closeView }); })
-        .catch((errorMessage) => { console.log(errorMessage); });
+        .catch((errorMessage) => {
+          console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
+        });
     };
   }
 
@@ -541,6 +549,8 @@ class ElementActions {
           dispatch(result);
         }).catch((errorMessage) => {
           console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
         });
     };
   }
@@ -827,6 +837,8 @@ class ElementActions {
           dispatch(result);
         }).catch((errorMessage) => {
           console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
         });
     };
   }
@@ -849,6 +861,8 @@ class ElementActions {
           dispatch(result);
         }).catch((errorMessage) => {
           console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
         });
     };
   }
@@ -925,6 +939,8 @@ class ElementActions {
           dispatch(result);
         }).catch((errorMessage) => {
           console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
         });
     };
   }
@@ -936,6 +952,8 @@ class ElementActions {
           dispatch(result);
         }).catch((errorMessage) => {
           console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
         });
     };
   }
@@ -960,6 +978,8 @@ class ElementActions {
           dispatch(result);
         }).catch((errorMessage) => {
           console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
         });
     };
   }
@@ -971,6 +991,8 @@ class ElementActions {
           dispatch(result);
         }).catch((errorMessage) => {
           console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
         });
     };
   }
@@ -990,6 +1012,8 @@ class ElementActions {
           dispatch(result);
         }).catch((errorMessage) => {
           console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
         });
     };
   }
@@ -1032,6 +1056,8 @@ class ElementActions {
           dispatch(result);
         }).catch((errorMessage) => {
           console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
         });
     };
   }
@@ -1047,6 +1073,8 @@ class ElementActions {
           dispatch(result);
         }).catch((errorMessage) => {
           console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
         });
     };
   }
@@ -1110,6 +1138,8 @@ class ElementActions {
           dispatch(result);
         }).catch((errorMessage) => {
           console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
         });
     };
   }
@@ -1122,6 +1152,8 @@ class ElementActions {
           dispatch(result);
         }).catch((errorMessage) => {
           console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
         });
     };
   }
@@ -1165,6 +1197,8 @@ class ElementActions {
           dispatch(result);
         }).catch((errorMessage) => {
           console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
         });
     };
   }
@@ -1177,6 +1211,8 @@ class ElementActions {
         })
         .catch((errorMessage) => {
           console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
         });
     };
   }
@@ -1201,6 +1237,8 @@ class ElementActions {
           dispatch(result);
         }).catch((errorMessage) => {
           console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
         });
     };
   }
@@ -1216,6 +1254,8 @@ class ElementActions {
           dispatch(result);
         }).catch((errorMessage) => {
           console.log(errorMessage);
+          // Ensure loading stops even on error
+          LoadingActions.stop();
         });
     };
   }

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -227,6 +227,12 @@ export const CollectionsStore = types
         self.createSharingMessage(currentUser, params.user_ids)
       }
     }),
+    takeOwnership: flow(function* takeOwnership(collectionId) {
+      const collection = yield CollectionSharesFetcher.takeOwnership(collectionId);
+      if (collection) {
+        self.fetchCollections();
+      }
+    }),
     updateCollectionShare: flow(function* updateCollectionShare(collectionShareId, params) {
       const collectionShare = yield CollectionSharesFetcher.updateCollectionShare(collectionShareId, params)
       if (collectionShare) {

--- a/app/javascript/src/utilities/PermissionConst.js
+++ b/app/javascript/src/utilities/PermissionConst.js
@@ -1,8 +1,10 @@
+// Mirror of CollectionShare::PERMISSION_LEVELS (app/models/collection_share.rb), which is the
+// source of truth. Cumulative: a share at level N grants every capability below it.
 export const PermissionConst = {
-  Read: 0,
-  Write: 1,
-  Share: 2,
-  Delete: 3,
-  ImportElements: 4,
-  PassOwnerShip: 5
+  ReadElements: 0,
+  EditElements: 1,
+  AddElements: 2,
+  RemoveElements: 3,
+  ManageShares: 4,
+  PassOwnership: 5
 };

--- a/app/javascript/src/utilities/collectionUtilities.js
+++ b/app/javascript/src/utilities/collectionUtilities.js
@@ -1,4 +1,5 @@
 import { elementNames, allElnElements } from 'src/apps/generic/Utils';
+import { PermissionConst } from 'src/utilities/PermissionConst';
 
 const isElementSelectionEmpty = (element) => !element.checkedAll
     && element.checkedIds.size === 0
@@ -55,7 +56,10 @@ const collectionOptions = (store, showSharedCollections) => {
   let shared = [];
   if (showSharedCollections) {
     const sharedWithMeCollections = store.shared_with_me_collections;
-    shared = sharedWithMeCollections.flatMap((c) => c.children).filter((c) => c.permission_level >= 1);
+    // Only offer shared collections the user may actually assign elements into.
+    shared = sharedWithMeCollections
+      .flatMap((c) => c.children)
+      .filter((c) => c.permission_level >= PermissionConst.AddElements);
   }
 
   return [

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -92,8 +92,10 @@ class Collection < ApplicationRecord
     end,
   )
 
-  # returns collections the user may create elements in: own collections and those
-  # shared with at least write_elements permission (permission_level >= 1)
+  # returns collections the user may create elements in: own collections and those shared with at
+  # least add_elements permission. Creating an element inserts a collections_<element> row, so it is
+  # an "add", not an "edit" — a sharee at :edit_elements may change existing content but not inject
+  # new records into someone else's collection.
   scope(
     :writable_by,
     lambda do |user|
@@ -105,7 +107,7 @@ class Collection < ApplicationRecord
         where(
           collection_shares: {
             shared_with_id: user_and_group_ids,
-            permission_level: CollectionShare::PERMISSION_LEVELS[:write_elements]..,
+            permission_level: CollectionShare.permission_level(:add_elements)..,
           },
         ),
       )

--- a/app/models/collection_share.rb
+++ b/app/models/collection_share.rb
@@ -32,15 +32,27 @@
 #  fk_rails_...  (shared_with_id => users.id)
 #
 class CollectionShare < ApplicationRecord
-  # most permission levels are directed at the elements, except pass ownership, this refers to the collection itself
+  # Cumulative permission ladder, ordered by how destructive the capability is. A check is always
+  # "a share exists with permission_level >= N", so every rung silently grants the ones below it.
+  #
+  # 0 read_elements   read the collection and its elements
+  # 1 edit_elements   + edit element content (audited via logidze)
+  # 2 add_elements    + create new elements, add/import existing ones, propagate elements onward
+  # 3 remove_elements + unlink any element from this collection (NOT destroy the element record —
+  #                     destroying is owner-only, see ElementPolicy#destroy?)
+  # 4 manage_shares   + CRUD on this collection's collection_shares rows (delegated ACL admin)
+  # 5 pass_ownership  + transfer ownership of the collection (no endpoint yet)
+  #
+  # The frontend mirrors this in app/javascript/src/utilities/PermissionConst.js — keep in sync.
   PERMISSION_LEVELS = {
     read_elements: 0,
-    write_elements: 1,
-    share_collection: 2,
-    delete_elements: 3,
-    import_elements: 4,
-    pass_ownership: 6,
+    edit_elements: 1,
+    add_elements: 2,
+    remove_elements: 3,
+    manage_shares: 4,
+    pass_ownership: 5,
   }.freeze
+
   belongs_to :collection
   belongs_to :shared_with, class_name: 'User'
 
@@ -62,7 +74,10 @@ class CollectionShare < ApplicationRecord
     ->(detail_level_field, detail_level) { where("#{detail_level_field} >= ?", detail_level) },
   )
 
+  # @param key [Symbol] one of {PERMISSION_LEVELS}' keys
+  # @return [Integer] the level for +key+
+  # @raise [KeyError] if +key+ is not a known permission level
   def self.permission_level(key)
-    PERMISSION_LEVELS[key] || -1
+    PERMISSION_LEVELS.fetch(key)
   end
 end

--- a/app/policies/element_policy.rb
+++ b/app/policies/element_policy.rb
@@ -16,32 +16,38 @@ class ElementPolicy
   def read?
     return false unless user_and_record_present?
 
-    record_is_in_own_collection? || record_shared_with_minimum_permission_level?(0)
+    record_is_in_own_collection? || record_shared_with_at_least?(:read_elements)
   end
 
   def update?
     return false unless user_and_record_present?
 
-    record_is_in_own_collection? || record_shared_with_minimum_permission_level?(1)
+    record_is_in_own_collection? || record_shared_with_at_least?(:edit_elements)
   end
 
   def copy?
     return false unless user_and_record_present?
 
     record_is_in_own_collection? ||
-      (record_shared_with_minimum_permission_level?(1) && record_shared_with_minimum_detail_level?(1))
+      (record_shared_with_at_least?(:edit_elements) && record_shared_with_minimum_detail_level?(1))
   end
 
+  # "Propagate this element onward" — the right to carry it into another collection. Bundled with
+  # add_elements: being allowed to add an element somewhere is the same right as being allowed to
+  # take it from where it is.
   def share?
     return false unless user_and_record_present?
 
-    record_is_in_own_collection? || record_shared_with_minimum_permission_level?(2)
+    record_is_in_own_collection? || record_shared_with_at_least?(:add_elements)
   end
 
+  # Destroying the element *record* (soft-delete) is owner-only. A sharee at :remove_elements may
+  # unlink the element from the shared collection (Usecases::Collections::RemoveElements) but never
+  # destroy it out from under the owner.
   def destroy?
     return false unless user_and_record_present?
 
-    record_is_in_own_collection? || record_shared_with_minimum_permission_level?(3)
+    record_is_in_own_collection?
   end
 
   def read_dataset?
@@ -53,13 +59,13 @@ class ElementPolicy
   def import?
     return false unless user_and_record_present?
 
-    record_is_in_own_collection? || record_shared_with_minimum_permission_level?(4)
+    record_is_in_own_collection? || record_shared_with_at_least?(:add_elements)
   end
 
   def pass_ownership?
     return false unless user_and_record_present?
 
-    record_is_in_own_collection? || record_shared_with_minimum_permission_level?(6)
+    record_is_in_own_collection? || record_shared_with_at_least?(:pass_ownership)
   end
 
   private
@@ -72,10 +78,11 @@ class ElementPolicy
     record.collections.where(user: user).any?
   end
 
-  def record_shared_with_minimum_permission_level?(permission_level)
+  # @param level_key [Symbol] a {CollectionShare::PERMISSION_LEVELS} key
+  def record_shared_with_at_least?(level_key)
     record
       .collections
-      .shared_with_minimum_permission_level(user, permission_level)
+      .shared_with_minimum_permission_level(user, CollectionShare.permission_level(level_key))
       .any?
   end
 

--- a/app/policies/elements_policy.rb
+++ b/app/policies/elements_policy.rb
@@ -65,15 +65,23 @@ class ElementsPolicy
     record_ids_from_shared_collections.none?
   end
 
+  # A collection owned by one of the user's groups counts as their own, matching Collection#owned_by?,
+  # writable_by and the group-aware WithdrawElements/RemoveElements use cases. Without the group ids
+  # here, a group member acting on a group-owned collection would see every record fall through to
+  # "inaccessible", so remove_all?/destroy_all? would wrongly deny an action the backend permits.
+  def own_user_ids
+    @own_user_ids ||= [user.id, *user.group_ids]
+  end
+
   def scope_for_own_records
-    records_scope.joins(:collections).where(collections: { user: user }).distinct
+    records_scope.joins(:collections).where(collections: { user_id: own_user_ids }).distinct
   end
 
   def scope_for_shared_records
     records_scope
       .joins(collections: [:collection_shares])
-      .where.not(collections: { user: user }) # to prevent looking at circular shares
-      .where(collection_shares: { shared_with: user })
+      .where.not(collections: { user_id: own_user_ids }) # to prevent looking at circular shares
+      .where(collection_shares: { shared_with_id: own_user_ids })
       .distinct
   end
 

--- a/app/policies/elements_policy.rb
+++ b/app/policies/elements_policy.rb
@@ -19,6 +19,12 @@ class ElementsPolicy
     allowed?(CollectionShare.permission_level(:add_elements))
   end
 
+  # Bulk counterpart of unlinking an element from a collection: a sharee at :remove_elements may
+  # remove the selection from the shared collection (Usecases::Collections::RemoveElements).
+  def remove_all?
+    allowed?(CollectionShare.permission_level(:remove_elements))
+  end
+
   # Destroying element records is owner-only, mirroring ElementPolicy#destroy?. A sharee may unlink
   # elements from a shared collection at :remove_elements, but that goes through
   # Usecases::Collections::RemoveElements, not here.

--- a/app/policies/elements_policy.rb
+++ b/app/policies/elements_policy.rb
@@ -7,19 +7,26 @@ class ElementsPolicy
   end
 
   def read_all?
-    allowed?(0)
+    allowed?(CollectionShare.permission_level(:read_elements))
   end
 
   def update_all?
-    allowed?(1)
+    allowed?(CollectionShare.permission_level(:edit_elements))
   end
 
+  # Bulk counterpart of ElementPolicy#share? — propagating elements onward, bundled with add_elements.
   def share_all?
-    allowed?(2)
+    allowed?(CollectionShare.permission_level(:add_elements))
   end
 
+  # Destroying element records is owner-only, mirroring ElementPolicy#destroy?. A sharee may unlink
+  # elements from a shared collection at :remove_elements, but that goes through
+  # Usecases::Collections::RemoveElements, not here.
   def destroy_all?
-    allowed?(3)
+    return false unless user_and_scope_present?
+    return false if record_ids_that_should_be_inaccessible.any?
+
+    records_only_from_own_collections?
   end
 
   def allowed?(level)

--- a/app/services/inbox_search_elements.rb
+++ b/app/services/inbox_search_elements.rb
@@ -41,7 +41,7 @@ class InboxSearchElements
   def samples
     collection_ids = Collection.own_collections_for(@current_user).ids
     collection_ids += Collection.shared_with_minimum_permission_level(
-      @current_user, CollectionShare.permission_level(:write)
+      @current_user, CollectionShare.permission_level(:edit_elements)
     ).ids
 
     exact = Sample.by_exact_name(normalize_for_exact_name(@search_string))

--- a/app/usecases/collections/add_elements.rb
+++ b/app/usecases/collections/add_elements.rb
@@ -20,7 +20,7 @@ module Usecases
         @collection = Collection.own_collections_for(current_user).find_by(id: collection_id)
         @collection ||= Collection.shared_with_minimum_permission_level(
           current_user,
-          CollectionShare.permission_level(:import_elements),
+          CollectionShare.permission_level(:add_elements),
         ).find_by(id: collection_id)
 
         return unless @collection.nil?

--- a/app/usecases/collections/add_elements.rb
+++ b/app/usecases/collections/add_elements.rb
@@ -10,10 +10,26 @@ module Usecases
         @collection = nil
       end
 
-      def perform!(collection_id:, ui_state:)
+      def perform!(collection_id:, ui_state:, origin_collection_id: nil)
         find_collection(collection_id)
+        enforce_same_owner_origin!(origin_collection_id)
         check_access_to_elements(ui_state)
         add_elements_to_collection(ui_state)
+      end
+
+      # When a sharee moves/assigns an element *out of* a collection they do not own, the target must
+      # be owned by the same user as that origin — they may rearrange the owner's element among the
+      # owner's collections (with add_elements), but never pull it into their own or another owner's
+      # space. Own or unknown origin ⇒ no constraint.
+      def enforce_same_owner_origin!(origin_collection_id)
+        return if origin_collection_id.blank?
+
+        origin = Collection.find_by(id: origin_collection_id)
+        return if origin.nil? || origin.owned_by?(current_user)
+        return if @collection.user_id == origin.user_id
+
+        raise Errors::InsufficientPermissionError,
+              "Elements from a shared collection can only be moved within the same owner's collections"
       end
 
       def find_collection(collection_id)

--- a/app/usecases/collections/remove_elements.rb
+++ b/app/usecases/collections/remove_elements.rb
@@ -21,7 +21,7 @@ module Usecases
         @collection = Collection.own_collections_for(current_user).find_by(id: collection_id)
         @collection ||= Collection.shared_with_minimum_permission_level(
           current_user,
-          CollectionShare.permission_level(:delete_elements),
+          CollectionShare.permission_level(:remove_elements),
         ).find_by(id: collection_id)
 
         return if @collection

--- a/app/usecases/collections/transfer_ownership.rb
+++ b/app/usecases/collections/transfer_ownership.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+module Usecases
+  module Collections
+    # Second step of "pass ownership": the recipient of a pending pass_ownership (level 5) offer
+    # accepts it, transferring the collection — and its whole subtree — to them.
+    #
+    # The former owner is demoted to a manage_shares (4) sharee: they keep full access and share
+    # administration but no longer own the collection. Elements move with the collection — each is
+    # added to the new owner's "All", and removed from the old owner's "All" only when it is no
+    # longer in any of the old owner's other collections (an element also in a private collection of
+    # the old owner stays theirs, and becomes dual-owned).
+    class TransferOwnership
+      FULL_DETAIL_LEVEL = 10 # every *_detail_level column at max — the demotee was the owner
+
+      attr_reader :current_user
+
+      def initialize(current_user)
+        @current_user = current_user
+      end
+
+      # @param collection [Collection] the offered collection (transfers with its subtree)
+      # @raise [Usecases::Collections::Errors::InsufficientPermissionError] when the caller holds no
+      #   pass_ownership offer, or the caller/collection is ineligible
+      # @return [Collection] the collection, reloaded under its new owner
+      def perform!(collection:)
+        validate!(collection)
+        old_owner = collection.user
+
+        ActiveRecord::Base.transaction do
+          subtree_ids = collection.subtree.pluck(:id)
+          reassign_subtree(collection, subtree_ids)
+          move_elements(subtree_ids, old_owner)
+          demote_former_owner(collection, old_owner)
+          collection.update!(shared: CollectionShare.exists?(collection: collection))
+        end
+
+        notify(collection, old_owner)
+        collection.reload
+      end
+
+      private
+
+      def validate!(collection)
+        raise Errors::InsufficientPermissionError, 'Only a person can take ownership' unless current_user.is_a?(Person)
+        raise Errors::InsufficientPermissionError, 'This collection cannot change ownership' if collection.is_locked
+        return if held_offer(collection).exists?
+
+        raise Errors::InsufficientPermissionError, 'You have not been offered ownership of this collection'
+      end
+
+      # The pending offer: a direct pass_ownership share addressed to the accepting user.
+      def held_offer(collection)
+        CollectionShare
+          .shared_directly_with(current_user)
+          .where(collection: collection, permission_level: CollectionShare.permission_level(:pass_ownership))
+      end
+
+      # Re-root the offered collection to the new owner's top level (has_ancestry rewrites the
+      # descendants' ancestry), then hand the whole subtree to the new owner.
+      def reassign_subtree(collection, subtree_ids)
+        collection.update!(parent: nil) unless collection.root?
+        Collection.where(id: subtree_ids).update_all(user_id: current_user.id) # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      def move_elements(subtree_ids, old_owner)
+        @old_all = Collection.get_all_collection_for_user(old_owner.id)
+        @new_all = Collection.get_all_collection_for_user(current_user.id)
+        # Collections the old owner still owns after the transfer (the subtree is the new owner's now).
+        @other_old_ids = Collection.where(user_id: old_owner.id).where.not(id: @old_all&.id).pluck(:id)
+
+        element_join_tables.each do |klass, join_table|
+          move_element_class(klass, join_table, subtree_ids)
+        end
+      end
+
+      def move_element_class(klass, join_table, subtree_ids)
+        ids = klass.joins(:collections).where(collections: { id: subtree_ids }).distinct.ids
+        return if ids.empty?
+
+        join_table.create_in_collection(ids, @new_all.id) if @new_all
+        return unless @old_all
+
+        still_theirs = klass.where(id: ids).joins(:collections).where(collections: { id: @other_old_ids }).distinct.ids
+        join_table.delete_in_collection(ids - still_theirs, @old_all.id)
+      end
+
+      def demote_former_owner(collection, old_owner)
+        # Drop the consumed offer (and any other direct share to the new owner — they own it now).
+        CollectionShare.where(collection: collection, shared_with_id: current_user.id).delete_all
+        CollectionShare.create!(
+          { collection: collection, shared_with: old_owner,
+            permission_level: CollectionShare.permission_level(:manage_shares) }.merge(full_detail_levels),
+        )
+      end
+
+      def notify(collection, old_owner)
+        Message.create_msg_notification(
+          channel_subject: Channel::COLLECTION_TAKE_OWNERSHIP,
+          message_from: current_user.id,
+          message_to: [old_owner.id],
+          data_args: { new_owner: current_user.name, collection_name: collection.label },
+          level: 'info',
+        )
+      rescue StandardError => e
+        Rails.logger.warn("TransferOwnership notification failed: #{e.message}")
+      end
+
+      # { ModelClass => join model } for every element type plus Labimotion generics.
+      def element_join_tables
+        tables = API::ELEMENT_CLASS.values.index_with(&:collections_element_class)
+        tables[Labimotion::Element] = Labimotion::CollectionsElement
+        tables
+      end
+
+      def full_detail_levels
+        Collection::DETAIL_LEVEL_KEYS.reject { |key| key == :permission_level }.index_with { FULL_DETAIL_LEVEL }
+      end
+    end
+  end
+end

--- a/app/usecases/collections/withdraw_elements.rb
+++ b/app/usecases/collections/withdraw_elements.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module Usecases
+  module Collections
+    # "Remove from all Collections": unlink the selection from every collection the acting user
+    # personally owns (including their locked "All"), then destroy only the records left in no
+    # collection at all.
+    #
+    # This replaces the previous record-level +destroy_all+, which — because destroying a record
+    # drops it from *every* owner's collections — let one owner wipe a dual-owned element out of
+    # another owner's private collections (see
+    # analyses/add-sample-permission-behavior.md). Withdrawing is scoped to the actor's own
+    # collections, so a shared/dual-owned element survives for its other owner; destruction only
+    # happens as a consequence of sole ownership (the element was left nowhere else).
+    class WithdrawElements
+      # Join models whose unlink is association-aware — they refuse to drop an element still bound
+      # to a reaction/wellplate/screen in the same collection (see D1 in the plan). The rest unlink
+      # unconditionally.
+      FILTERED_JOINS = [
+        CollectionsSample,
+        CollectionsWellplate,
+        CollectionsSequenceBasedMacromoleculeSample,
+      ].freeze
+
+      attr_reader :current_user
+
+      def initialize(current_user)
+        @current_user = current_user
+        @owned_collection_ids = []
+      end
+
+      # @param source_collection [Collection] the collection the selection was made in; scopes the
+      #   +by_ui_state+ resolution (a +checkedAll+ selection means "everything in this collection").
+      # @param ui_state [Hash] the raw request params: one selection hash per element key, plus
+      #   +:options+ (+:deleteSubsamples+).
+      # @return [Hash{String=>Array<Integer>}] the ids that left the user's view (unlinked from all
+      #   of their collections, whether or not the record was destroyed), keyed by the model
+      #   +param_key+ — the shape the endpoint needs to close the matching detail tabs.
+      def perform!(source_collection:, ui_state:, options: {})
+        # The user's own collections, spanning the groups they belong to (a group member could
+        # already destroy group-collection elements, so withdrawal keeps that reach). Restricting
+        # group-owned withdrawal to group-admins is a deliberate future refinement, not done here.
+        @owned_collection_ids = Collection.where(user_id: [current_user.id, *current_user.group_ids]).pluck(:id)
+        removed = Hash.new { |hash, key| hash[key] = [] }
+
+        withdrawn_reaction_ids = withdraw_selected_elements(source_collection, ui_state, removed)
+        removed['sample'] |= withdraw_reaction_subsamples(withdrawn_reaction_ids, options)
+        withdraw_generic_elements(source_collection, ui_state, removed)
+        removed
+      end
+
+      private
+
+      # @return [Array<Integer>] ids of the reactions that left the user's view (for subsample handling)
+      def withdraw_selected_elements(source_collection, ui_state, removed)
+        reaction_ids = []
+        API::ELEMENT_CLASS.each do |ui_key, klass|
+          selection = ui_state[ui_key] || ui_state[ui_key.to_sym]
+          next unless selected?(selection)
+
+          ids = source_collection.send(klass.model_name.route_key).by_ui_state(selection).ids
+          left_view = withdraw(klass, klass.collections_element_class, ids)
+          removed[klass.model_name.param_key] = left_view
+          reaction_ids = left_view if klass == Reaction
+        end
+        reaction_ids
+      end
+
+      # Mirror by_ui_state, which accepts both the current (checkedAll/checkedIds) and the legacy
+      # (all/included_ids) selection shapes.
+      def selected?(selection)
+        return false if selection.blank?
+
+        (selection[:checkedAll] || selection[:all]) ||
+          (selection[:checkedIds] || selection[:included_ids]).present?
+      end
+
+      # Unlink +ids+ from every personally-owned collection, then destroy the records left orphaned.
+      #
+      # @return [Array<Integer>] ids that are no longer in any of the user's own collections. Ids
+      #   kept by the association guard (still bound to a reaction/wellplate in one of the user's
+      #   collections) are not included — they remain visible and are not destroyed.
+      def withdraw(klass, join_table, ids)
+        actionable = own_membership_ids(klass, ids)
+        return [] if actionable.empty?
+
+        if FILTERED_JOINS.include?(join_table)
+          join_table.delete_in_collection_with_filter(actionable, @owned_collection_ids)
+        else
+          join_table.delete_in_collection(actionable, @owned_collection_ids)
+        end
+        join_table.update_tag_by_element_ids(actionable)
+
+        left_view = []
+        klass.where(id: actionable).find_each do |element|
+          next if element.collections.exists?(id: @owned_collection_ids) # kept by the guard
+
+          element.destroy unless element.collections.exists? # orphaned everywhere ⇒ sole owner
+          left_view << element.id
+        end
+        left_view
+      end
+
+      # Standing: only act on elements the user actually owns — those in at least one of their own
+      # collections. An element reachable only through a foreign share is left untouched.
+      def own_membership_ids(klass, ids)
+        return [] if ids.blank?
+
+        klass.where(id: ids)
+             .joins(:collections)
+             .where(collections: { id: @owned_collection_ids })
+             .distinct.ids
+      end
+
+      # The withdrawn reactions' associated samples: solvents/reactants only unless the caller asked
+      # to remove every subsample. Mirrors the pre-existing +deleteSubsamples+ contract.
+      def withdraw_reaction_subsamples(reaction_ids, options)
+        return [] if reaction_ids.blank?
+
+        scope = ReactionsSample.where(reaction_id: reaction_ids)
+        unless options[:deleteSubsamples] || options['deleteSubsamples']
+          scope = scope.where(type: %w[ReactionsSolventSample ReactionsReactantSample])
+        end
+        withdraw(Sample, CollectionsSample, scope.pluck(:sample_id))
+      end
+
+      def withdraw_generic_elements(source_collection, ui_state, removed)
+        Labimotion::ElementKlass.find_each do |klass|
+          selection = ui_state[klass.name] || ui_state[klass.name.to_sym]
+          next unless selected?(selection)
+
+          ids = source_collection.elements.by_ui_state(selection).ids
+          removed[klass.name] = withdraw(Labimotion::Element, Labimotion::CollectionsElement, ids)
+        end
+      end
+    end
+  end
+end

--- a/app/usecases/collections/withdraw_elements.rb
+++ b/app/usecases/collections/withdraw_elements.rb
@@ -114,10 +114,15 @@ module Usecases
 
       # The withdrawn reactions' associated samples: solvents/reactants only unless the caller asked
       # to remove every subsample. Mirrors the pre-existing +deleteSubsamples+ contract.
+      #
+      # +with_deleted+ is load-bearing: withdraw_selected_elements has already destroyed the reactions,
+      # and Reaction's +dependent: :destroy+ soft-deletes their (acts_as_paranoid) reactions_samples.
+      # The default scope would hide exactly those rows, so their sample_ids must be read through the
+      # unscoped relation — the reason the code this replaced used a raw inner join here.
       def withdraw_reaction_subsamples(reaction_ids, options)
         return [] if reaction_ids.blank?
 
-        scope = ReactionsSample.where(reaction_id: reaction_ids)
+        scope = ReactionsSample.with_deleted.where(reaction_id: reaction_ids)
         unless options[:deleteSubsamples] || options['deleteSubsamples']
           scope = scope.where(type: %w[ReactionsSolventSample ReactionsReactantSample])
         end

--- a/app/usecases/wellplates/create.rb
+++ b/app/usecases/wellplates/create.rb
@@ -46,12 +46,17 @@ module Usecases
                         raise(ActiveRecord::RecordNotFound)
       end
 
+      # Group-aware, matching Collection.writable_by (collection.rb) which admitted this collection:
+      # a collection owned by one of the user's groups counts as owned, and a share addressed to a
+      # group the user belongs to counts as shared. A group-owned collection routes to the owned
+      # branch, so the wellplate lands in the creator's "All".
       def collection_is_owned_by_user?
-        @collection.user == current_user
+        @collection.owned_by?(current_user)
       end
 
       def collection_is_shared_to_user?
-        @collection.user != current_user && CollectionShare.exists?(collection: @collection, shared_with: current_user)
+        !@collection.owned_by?(current_user) &&
+          CollectionShare.shared_with(current_user).exists?(collection: @collection)
       end
 
       def all_collection_of_sharer

--- a/db/migrate/20260709150000_renumber_collection_share_permission_levels.rb
+++ b/db/migrate/20260709150000_renumber_collection_share_permission_levels.rb
@@ -11,14 +11,17 @@
 #   5 pass ownership (frontend value)   5 pass_ownership
 #   6 pass ownership (backend value)
 #
-# The redesign swaps the relative order of "share" and "add", so no mapping is capability-preserving.
-# The one below never grants a *more destructive* capability than the row already held:
+# The mapping is capability-preserving and never grants a *more destructive* capability than the row
+# already held. The key fact is that the legacy write gate (Collection.writable_by) admitted *every*
+# rung at or above legacy 1, so legacy write(1) and share(2) holders could already create elements in
+# the shared collection. The redesign gates creation at add_elements(2), so those holders must land on
+# rung 2 to keep the create right they had — dropping them to edit_elements(1) would silently strip it:
 #
 #   0 -> 0  identity
-#   1 -> 1  identity
-#   2 -> 1  legacy "share" only propagated elements; it could neither add to nor unlink from the
-#           collection. Propagation is now bundled into rung 2 (add_elements), so granting new 2
-#           would hand these shares an add-right they never had. Drop to edit instead.
+#   1 -> 2  legacy "write" could create elements (writable_by admitted level >= 1); rung 2 preserves
+#           that create/add right without granting unlink or destroy.
+#   2 -> 2  legacy "share" likewise could create; propagation is now bundled into add_elements(2), so
+#           this is exactly the right home for it.
 #   3 -> 3  legacy "delete" could unlink; it gains add_elements, which is strictly less destructive
 #           than the unlink it already held.
 #   4 -> 3  legacy "import" could add *and* unlink -> exactly new rung 3.
@@ -28,15 +31,17 @@
 # Separately, everyone who held legacy 3 or 4 loses the ability to destroy element records:
 # destruction became owner-only (ElementPolicy#destroy?). Unlinking from the collection is unaffected.
 #
-# The map is idempotent: it only ever produces {0, 1, 3, 5}, each of which is its own fixed point.
-# (New rungs 2 and 4 are simply unused by migrated data until someone grants them explicitly.)
+# The map is idempotent: it only ever produces {0, 2, 3, 5}, each of which is its own fixed point.
+# (New rung 4 (manage_shares) and 1 (edit_elements) are simply unused by migrated data until someone
+# grants them explicitly.)
 class RenumberCollectionSharePermissionLevels < ActiveRecord::Migration[6.1]
-  UP_MAP = { 0 => 0, 1 => 1, 2 => 1, 3 => 3, 4 => 3, 5 => 5, 6 => 5 }.freeze
+  UP_MAP = { 0 => 0, 1 => 2, 2 => 2, 3 => 3, 4 => 3, 5 => 5, 6 => 5 }.freeze
 
-  # Best-effort inverse. Lossy: the up-map collapses 2->1, 4->3 and 6->5, so those origins are gone.
-  # New rung 2 (add_elements) maps back to legacy 4 (import) and new rung 4 (manage_shares) has no
-  # legacy equivalent, so it also lands on legacy 4 — the highest legacy non-ownership rung.
-  DOWN_MAP = { 0 => 0, 1 => 1, 2 => 4, 3 => 3, 4 => 4, 5 => 6 }.freeze
+  # Best-effort inverse. Lossy: the up-map collapses 1->2, 2->2, 4->3 and 6->5, so those origins are
+  # gone. Each new rung maps to the nearest legacy value that grants no more than it did — never the
+  # over-granting legacy "import"(4) for add_elements. new 4 (manage_shares) has no legacy equivalent,
+  # so it lands on legacy 4 (import), the highest legacy non-ownership rung.
+  DOWN_MAP = { 0 => 0, 1 => 1, 2 => 2, 3 => 3, 4 => 4, 5 => 6 }.freeze
 
   def up
     apply_map(UP_MAP)

--- a/db/migrate/20260709150000_renumber_collection_share_permission_levels.rb
+++ b/db/migrate/20260709150000_renumber_collection_share_permission_levels.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Renumbers collection_shares.permission_level from the legacy ladder onto the redesigned one.
+#
+#   legacy                              new
+#   0 read                              0 read_elements
+#   1 write                             1 edit_elements
+#   2 share (propagate elements only)   2 add_elements
+#   3 delete                            3 remove_elements
+#   4 import                            4 manage_shares
+#   5 pass ownership (frontend value)   5 pass_ownership
+#   6 pass ownership (backend value)
+#
+# The redesign swaps the relative order of "share" and "add", so no mapping is capability-preserving.
+# The one below never grants a *more destructive* capability than the row already held:
+#
+#   0 -> 0  identity
+#   1 -> 1  identity
+#   2 -> 1  legacy "share" only propagated elements; it could neither add to nor unlink from the
+#           collection. Propagation is now bundled into rung 2 (add_elements), so granting new 2
+#           would hand these shares an add-right they never had. Drop to edit instead.
+#   3 -> 3  legacy "delete" could unlink; it gains add_elements, which is strictly less destructive
+#           than the unlink it already held.
+#   4 -> 3  legacy "import" could add *and* unlink -> exactly new rung 3.
+#   5 -> 5  identity
+#   6 -> 5  the post-#2783 backend value for pass_ownership; the gap at 5 is now closed.
+#
+# Separately, everyone who held legacy 3 or 4 loses the ability to destroy element records:
+# destruction became owner-only (ElementPolicy#destroy?). Unlinking from the collection is unaffected.
+#
+# The map is idempotent: it only ever produces {0, 1, 3, 5}, each of which is its own fixed point.
+# (New rungs 2 and 4 are simply unused by migrated data until someone grants them explicitly.)
+class RenumberCollectionSharePermissionLevels < ActiveRecord::Migration[6.1]
+  UP_MAP = { 0 => 0, 1 => 1, 2 => 1, 3 => 3, 4 => 3, 5 => 5, 6 => 5 }.freeze
+
+  # Best-effort inverse. Lossy: the up-map collapses 2->1, 4->3 and 6->5, so those origins are gone.
+  # New rung 2 (add_elements) maps back to legacy 4 (import) and new rung 4 (manage_shares) has no
+  # legacy equivalent, so it also lands on legacy 4 — the highest legacy non-ownership rung.
+  DOWN_MAP = { 0 => 0, 1 => 1, 2 => 4, 3 => 3, 4 => 4, 5 => 6 }.freeze
+
+  def up
+    apply_map(UP_MAP)
+    say "renumbered #{report_counts} (legacy -> redesigned ladder)"
+    say 'shares at legacy 3/4 keep unlink rights but lose element destruction (now owner-only)'
+  end
+
+  def down
+    apply_map(DOWN_MAP)
+    say "reverted #{report_counts} (redesigned -> legacy ladder; lossy, see migration comment)"
+  end
+
+  private
+
+  # Rewrites every row in one statement so no value is remapped twice.
+  def apply_map(map)
+    cases = map.map { |from, to| "WHEN #{from.to_i} THEN #{to.to_i}" }.join(' ')
+    execute(<<~SQL.squish)
+      UPDATE collection_shares
+      SET permission_level = CASE permission_level #{cases} ELSE permission_level END
+    SQL
+  end
+
+  def report_counts
+    rows = select_all(
+      'SELECT permission_level, COUNT(*) AS count FROM collection_shares GROUP BY permission_level ORDER BY 1',
+    )
+    return 'no collection_shares' if rows.count.zero?
+
+    rows.map { |row| "#{row['count']}x level #{row['permission_level']}" }.join(', ')
+  end
+end

--- a/spec/api/chemotion/cell_line_api_spec.rb
+++ b/spec/api/chemotion/cell_line_api_spec.rb
@@ -257,7 +257,7 @@ describe Chemotion::CellLineAPI do
       let(:writable_collection) do
         create(:collection, user: other_user).tap do |c|
           create(:collection_share, collection: c, shared_with: user,
-                                    permission_level: CollectionShare::PERMISSION_LEVELS[:write_elements])
+                                    permission_level: CollectionShare::PERMISSION_LEVELS[:add_elements])
         end
       end
       let(:params) do

--- a/spec/api/chemotion/collection_elements_api_spec.rb
+++ b/spec/api/chemotion/collection_elements_api_spec.rb
@@ -61,7 +61,7 @@ describe Chemotion::CollectionElementsAPI do
         :collection_share,
         collection: target_collection,
         shared_with: user,
-        permission_level: CollectionShare.permission_level(:import_elements) - 1,
+        permission_level: CollectionShare.permission_level(:add_elements) - 1,
       )
 
       expect(sample1.collections).not_to include(target_collection)
@@ -79,7 +79,7 @@ describe Chemotion::CollectionElementsAPI do
         :collection_share,
         collection: target_collection,
         shared_with: user,
-        permission_level: CollectionShare.permission_level(:import_elements),
+        permission_level: CollectionShare.permission_level(:add_elements),
       )
 
       expect(sample1.collections).not_to include(target_collection)
@@ -105,7 +105,7 @@ describe Chemotion::CollectionElementsAPI do
         :collection_share,
         collection: source_collection,
         shared_with: user,
-        permission_level: CollectionShare.permission_level(:share_collection) - 1,
+        permission_level: CollectionShare.permission_level(:add_elements) - 1,
       )
 
       expect(sample1.collections).not_to include(target_collection)
@@ -123,7 +123,7 @@ describe Chemotion::CollectionElementsAPI do
         :collection_share,
         collection: source_collection,
         shared_with: user,
-        permission_level: CollectionShare.permission_level(:share_collection),
+        permission_level: CollectionShare.permission_level(:add_elements),
       )
 
       expect(sample1.collections).not_to include(target_collection)

--- a/spec/api/chemotion/collection_share_api_spec.rb
+++ b/spec/api/chemotion/collection_share_api_spec.rb
@@ -13,7 +13,7 @@ describe Chemotion::CollectionShareAPI do
       {
         collection_id: collection.id,
         user_ids: [other_user.id, third_user.id],
-        permission_level: CollectionShare.permission_level(:pass_ownership),
+        permission_level: CollectionShare.permission_level(:manage_shares),
         celllinesample_detail_level: 5,
         devicedescription_detail_level: 5,
         element_detail_level: 5,
@@ -293,6 +293,60 @@ describe Chemotion::CollectionShareAPI do
       post '/api/v1/collection_shares/', params: { collection_id: collection.id, user_ids: [third_user.id] }
 
       expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'offering ownership (pass_ownership share)' do
+    let(:pass_ownership) { CollectionShare.permission_level(:pass_ownership) }
+
+    it 'refuses to offer ownership to a group' do
+      collection = create(:collection, user: user)
+      group = create(:group)
+
+      post '/api/v1/collection_shares/',
+           params: { collection_id: collection.id, user_ids: [group.id], permission_level: pass_ownership }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'refuses a manage_shares delegate offering ownership (above their own level)' do
+      collection = create(:collection, user: other_user)
+      create(:collection_share, collection: collection, shared_with: user,
+                                permission_level: CollectionShare.permission_level(:manage_shares))
+
+      post '/api/v1/collection_shares/',
+           params: { collection_id: collection.id, user_ids: [third_user.id], permission_level: pass_ownership }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'POST /api/v1/collection_shares/take_ownership/:collection_id' do
+    let(:collection) { create(:collection, user: other_user) }
+
+    context 'when the user holds a pass-ownership offer' do
+      before do
+        create(:collection_share, collection: collection, shared_with: user,
+                                  permission_level: CollectionShare.permission_level(:pass_ownership))
+      end
+
+      it 'transfers ownership to the user and demotes the former owner' do
+        post "/api/v1/collection_shares/take_ownership/#{collection.id}"
+
+        expect(response).to have_http_status(:created)
+        expect(collection.reload.user_id).to eq(user.id)
+        expect(CollectionShare.find_by(collection: collection, shared_with_id: other_user.id).permission_level)
+          .to eq(CollectionShare.permission_level(:manage_shares))
+      end
+    end
+
+    context 'without an offer' do
+      it 'is forbidden' do
+        expect { post "/api/v1/collection_shares/take_ownership/#{collection.id}" }
+          .not_to(change { collection.reload.user_id })
+
+        expect(response).to have_http_status(:forbidden)
+      end
     end
   end
 end

--- a/spec/api/chemotion/collection_share_api_spec.rb
+++ b/spec/api/chemotion/collection_share_api_spec.rb
@@ -13,7 +13,7 @@ describe Chemotion::CollectionShareAPI do
       {
         collection_id: collection.id,
         user_ids: [other_user.id, third_user.id],
-        permission_level: 5,
+        permission_level: CollectionShare.permission_level(:pass_ownership),
         celllinesample_detail_level: 5,
         devicedescription_detail_level: 5,
         element_detail_level: 5,
@@ -38,7 +38,7 @@ describe Chemotion::CollectionShareAPI do
   describe 'PUT /api/v1/collection_shares' do
     let(:update_params) do
       {
-        permission_level: 5,
+        permission_level: CollectionShare.permission_level(:pass_ownership),
         celllinesample_detail_level: 5,
         devicedescription_detail_level: 5,
         element_detail_level: 5,
@@ -93,7 +93,12 @@ describe Chemotion::CollectionShareAPI do
     context 'when the share belongs to one of the requesters groups' do
       let(:collection) { create(:collection, user: other_user) }
       let(:group) { create(:group, users: [user]) }
-      let(:group_share) { create(:collection_share, collection: collection, shared_with: group) }
+      # Below :manage_shares on purpose — a group share at or above that rung would make every member
+      # a delegated administrator of the collection, which is a different situation entirely.
+      let(:group_share) do
+        create(:collection_share, collection: collection, shared_with: group,
+                                  permission_level: CollectionShare.permission_level(:read_elements))
+      end
 
       before { group_share }
 
@@ -163,7 +168,7 @@ describe Chemotion::CollectionShareAPI do
     context 'when the collection reaches the user through a group' do
       before do
         create(:collection_share, collection: collection, shared_with: group,
-                                  permission_level: CollectionShare.permission_level(:write_elements))
+                                  permission_level: CollectionShare.permission_level(:edit_elements))
       end
 
       it 'returns the group share' do
@@ -176,7 +181,7 @@ describe Chemotion::CollectionShareAPI do
         create(:collection_share, collection: collection, shared_with: user,
                                   permission_level: CollectionShare.permission_level(:read_elements))
         create(:collection_share, collection: collection, shared_with: group,
-                                  permission_level: CollectionShare.permission_level(:write_elements))
+                                  permission_level: CollectionShare.permission_level(:edit_elements))
       end
 
       it 'returns both contributing shares' do
@@ -194,6 +199,100 @@ describe Chemotion::CollectionShareAPI do
       it 'returns nothing and does not leak the other recipients share' do
         expect(shares).to be_empty
       end
+    end
+  end
+
+  describe 'permission_level validation' do
+    it 'rejects a level that is not on the ladder' do
+      post '/api/v1/collection_shares/',
+           params: { collection_id: collection.id, user_ids: [other_user.id], permission_level: 42 }
+
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
+  describe 'sharing a collection with its own owner' do
+    it 'is refused' do
+      post '/api/v1/collection_shares/', params: { collection_id: collection.id, user_ids: [user.id] }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  # `user` (the authenticated requester) is not the owner here — they hold a delegated
+  # :manage_shares share on another user's collection.
+  describe 'delegated share management (:manage_shares)' do
+    let(:collection) { create(:collection, user: other_user) }
+    let(:manage_shares) { CollectionShare.permission_level(:manage_shares) }
+
+    before do
+      create(:collection_share, collection: collection, shared_with: user, permission_level: manage_shares)
+    end
+
+    it 'lets the delegate list the collection shares' do
+      get '/api/v1/collection_shares', params: { collection_id: collection.id }
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'lets the delegate share the collection onward at or below their own level' do
+      expect do
+        post '/api/v1/collection_shares/',
+             params: { collection_id: collection.id, user_ids: [third_user.id], permission_level: manage_shares }
+      end.to change(CollectionShare, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+    end
+
+    it 'refuses to let the delegate grant a level above their own' do
+      expect do
+        post '/api/v1/collection_shares/',
+             params: {
+               collection_id: collection.id,
+               user_ids: [third_user.id],
+               permission_level: CollectionShare.permission_level(:pass_ownership),
+             }
+      end.not_to change(CollectionShare, :count)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'refuses to let the delegate revoke a share that outranks them' do
+      superior = create(
+        :collection_share,
+        collection: collection,
+        shared_with: third_user,
+        permission_level: CollectionShare.permission_level(:pass_ownership),
+      )
+
+      expect { delete "/api/v1/collection_shares/#{superior.id}" }.not_to change(CollectionShare, :count)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'still lets any sharee reject their own share, whatever its level' do
+      own_share = CollectionShare.find_by(collection: collection, shared_with: user)
+
+      expect { delete "/api/v1/collection_shares/#{own_share.id}" }.to change(CollectionShare, :count).by(-1)
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+
+  describe 'a sharee below :manage_shares' do
+    let(:collection) { create(:collection, user: other_user) }
+
+    before do
+      create(
+        :collection_share,
+        collection: collection,
+        shared_with: user,
+        permission_level: CollectionShare.permission_level(:remove_elements),
+      )
+    end
+
+    it 'cannot administrate the share list' do
+      post '/api/v1/collection_shares/', params: { collection_id: collection.id, user_ids: [third_user.id] }
+
+      expect(response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/api/chemotion/element_api_spec.rb
+++ b/spec/api/chemotion/element_api_spec.rb
@@ -41,52 +41,41 @@ describe Chemotion::ElementAPI do
       end
     end
 
-    context 'when the collection is shared with the user above the threshold' do
-      let(:collection) { create(:collection, user: other_user) }
+    # Destroying the element records themselves is owner-only: a sharee unlinks them from the
+    # collection instead (Usecases::Collections::RemoveElements). No rung on the ladder grants this.
+    CollectionShare::PERMISSION_LEVELS.each_key do |level_key|
+      context "when the collection is only shared with the user at :#{level_key}" do
+        let(:collection) { create(:collection, user: other_user) }
 
-      before do
-        create(:collection_share, collection: collection, shared_with: user,
-                                  permission_level: CollectionShare.permission_level(:share_collection))
-      end
+        before do
+          create(:collection_share, collection: collection, shared_with: user,
+                                    permission_level: CollectionShare.permission_level(level_key))
+        end
 
-      it 'deletes the selected element' do
-        expect { delete '/api/v1/ui_state/', params: params, as: :json }
-          .to change(Sample, :count).by(-1)
-      end
-    end
+        it 'is forbidden' do
+          expect { delete '/api/v1/ui_state/', params: params, as: :json }
+            .not_to change(Sample, :count)
 
-    context 'when the collection is shared with the user below the threshold' do
-      let(:collection) { create(:collection, user: other_user) }
-
-      before do
-        create(:collection_share, collection: collection, shared_with: user,
-                                  permission_level: CollectionShare.permission_level(:write_elements))
-      end
-
-      it 'is forbidden' do
-        expect { delete '/api/v1/ui_state/', params: params, as: :json }
-          .not_to change(Sample, :count)
-
-        expect(response).to have_http_status(:forbidden)
+          expect(response).to have_http_status(:forbidden)
+        end
       end
     end
 
-    # The user holds two shares. The permissive one is their own; the group's alone would forbid the
-    # request. Resolving to the maximum makes the outcome independent of which row the DB returns
-    # first — previously a bare find_by picked either.
-    context 'when the user holds both a permissive direct share and a restrictive group share' do
+    context 'when the user holds both a direct and a group share, at the highest rung' do
       let(:collection) { create(:collection, user: other_user) }
 
       before do
         create(:collection_share, collection: collection, shared_with: group,
                                   permission_level: CollectionShare.permission_level(:read_elements))
         create(:collection_share, collection: collection, shared_with: user,
-                                  permission_level: CollectionShare.permission_level(:import_elements))
+                                  permission_level: CollectionShare.permission_level(:pass_ownership))
       end
 
-      it 'deletes the selected element, whichever share the database yields first' do
+      it 'is still forbidden — no share destroys the owner\'s records' do
         expect { delete '/api/v1/ui_state/', params: params, as: :json }
-          .to change(Sample, :count).by(-1)
+          .not_to change(Sample, :count)
+
+        expect(response).to have_http_status(:forbidden)
       end
     end
 

--- a/spec/api/chemotion/permission_api_spec.rb
+++ b/spec/api/chemotion/permission_api_spec.rb
@@ -104,17 +104,29 @@ describe Chemotion::PermissionAPI do
         post '/api/v1/permissions/status', params: params
       end
 
-      context 'when the permission level is high enough for deletion' do
-        let(:permission_level) { CollectionShare.permission_level(:delete_elements) }
+      # Destroying element records is owner-only, so `deletion_allowed` is false at every shared rung.
+      # A sharee at :remove_elements may unlink elements from the collection, which is a different
+      # operation (CollectionElementsAPI), not mass deletion.
+      context 'when the permission level is the highest non-ownership rung' do
+        let(:permission_level) { CollectionShare.permission_level(:manage_shares) }
 
-        it 'returns deletion_allowed=true and sharing_allowed=true' do
-          expect(parsed_json_response['deletion_allowed']).to be true
+        it 'returns deletion_allowed=false and sharing_allowed=true' do
+          expect(parsed_json_response['deletion_allowed']).to be false
           expect(parsed_json_response['sharing_allowed']).to be true
         end
       end
 
-      context 'when the permission level is only sufficient for sharing' do
-        let(:permission_level) { CollectionShare.permission_level(:share_collection) }
+      context 'when the permission level allows removing elements from the collection' do
+        let(:permission_level) { CollectionShare.permission_level(:remove_elements) }
+
+        it 'still returns deletion_allowed=false, because destroying records is owner-only' do
+          expect(parsed_json_response['deletion_allowed']).to be false
+          expect(parsed_json_response['sharing_allowed']).to be true
+        end
+      end
+
+      context 'when the permission level is only sufficient for sharing elements onward' do
+        let(:permission_level) { CollectionShare.permission_level(:add_elements) }
 
         it 'returns deletion_allowed=false and sharing_allowed=true' do
           expect(parsed_json_response['deletion_allowed']).to be false
@@ -123,7 +135,7 @@ describe Chemotion::PermissionAPI do
       end
 
       context 'when the permission level is too low' do
-        let(:permission_level) { CollectionShare.permission_level(:write_elements) }
+        let(:permission_level) { CollectionShare.permission_level(:edit_elements) }
 
         it 'returns deletion_allowed=false and sharing_allowed=false' do
           expect(parsed_json_response['deletion_allowed']).to be false

--- a/spec/api/chemotion/permission_api_spec.rb
+++ b/spec/api/chemotion/permission_api_spec.rb
@@ -54,6 +54,7 @@ describe Chemotion::PermissionAPI do
           'is_top_secret' => false,
           'sharing_allowed' => true,
           'deletion_allowed' => true,
+          'remove_allowed' => true,
         }
         expect(parsed_json_response).to eq expected_result
       end
@@ -82,6 +83,7 @@ describe Chemotion::PermissionAPI do
           'is_top_secret' => true,
           'sharing_allowed' => true,
           'deletion_allowed' => true,
+          'remove_allowed' => true,
         }
         expect(parsed_json_response).to eq expected_result
       end
@@ -119,7 +121,8 @@ describe Chemotion::PermissionAPI do
       context 'when the permission level allows removing elements from the collection' do
         let(:permission_level) { CollectionShare.permission_level(:remove_elements) }
 
-        it 'still returns deletion_allowed=false, because destroying records is owner-only' do
+        it 'returns remove_allowed=true (unlink is granted) but deletion_allowed=false (destroy is owner-only)' do
+          expect(parsed_json_response['remove_allowed']).to be true
           expect(parsed_json_response['deletion_allowed']).to be false
           expect(parsed_json_response['sharing_allowed']).to be true
         end
@@ -128,7 +131,8 @@ describe Chemotion::PermissionAPI do
       context 'when the permission level is only sufficient for sharing elements onward' do
         let(:permission_level) { CollectionShare.permission_level(:add_elements) }
 
-        it 'returns deletion_allowed=false and sharing_allowed=true' do
+        it 'returns remove_allowed=false, deletion_allowed=false and sharing_allowed=true' do
+          expect(parsed_json_response['remove_allowed']).to be false
           expect(parsed_json_response['deletion_allowed']).to be false
           expect(parsed_json_response['sharing_allowed']).to be true
         end

--- a/spec/api/chemotion/reaction_api_spec.rb
+++ b/spec/api/chemotion/reaction_api_spec.rb
@@ -697,7 +697,7 @@ describe Chemotion::ReactionAPI do
       let(:writable_collection) do
         create(:collection, user: other_user).tap do |c|
           create(:collection_share, collection: c, shared_with: user,
-                                    permission_level: CollectionShare::PERMISSION_LEVELS[:write_elements])
+                                    permission_level: CollectionShare::PERMISSION_LEVELS[:add_elements])
         end
       end
       let(:params) do

--- a/spec/api/chemotion/sample_api_spec.rb
+++ b/spec/api/chemotion/sample_api_spec.rb
@@ -653,12 +653,22 @@ describe Chemotion::SampleAPI do
         end
       end
 
+      # can_publish is gated on ElementPolicy#destroy?, which is owner-only: a sharee never publishes
+      # someone else's sample, at any rung.
       context 'when permission_level = 3' do
         let(:permission_level) { 3 }
 
         it 'returns correct can_publish & can_update' do
           expect(JSON.parse(response.body)['sample']['can_update']).to be true
-          expect(JSON.parse(response.body)['sample']['can_publish']).to be true
+          expect(JSON.parse(response.body)['sample']['can_publish']).to be false
+        end
+      end
+
+      context 'when permission_level is the highest rung' do
+        let(:permission_level) { CollectionShare.permission_level(:pass_ownership) }
+
+        it 'still cannot publish, because publishing is owner-only' do
+          expect(JSON.parse(response.body)['sample']['can_publish']).to be false
         end
       end
     end
@@ -951,7 +961,7 @@ describe Chemotion::SampleAPI do
       let(:writable_collection) do
         create(:collection, user: other_user).tap do |c|
           create(:collection_share, collection: c, shared_with: user,
-                                    permission_level: CollectionShare::PERMISSION_LEVELS[:write_elements])
+                                    permission_level: CollectionShare::PERMISSION_LEVELS[:add_elements])
         end
       end
       let(:params) do

--- a/spec/api/chemotion/sample_api_spec.rb
+++ b/spec/api/chemotion/sample_api_spec.rb
@@ -79,7 +79,9 @@ describe Chemotion::SampleAPI do
       }
     end
 
-    let(:subsamples) { Sample.where(name: %w[s1 s2]).where.not(id: [s1.id, s2.id]) }
+    # order(:id) — the example indexes subsamples[0]/[1] and pairs them with s1/s2, so the rows must
+    # come back in creation order rather than whatever order Postgres happens to return.
+    let(:subsamples) { Sample.where(name: %w[s1 s2]).where.not(id: [s1.id, s2.id]).order(:id) }
 
     before do
       s1

--- a/spec/api/chemotion/screen_api_spec.rb
+++ b/spec/api/chemotion/screen_api_spec.rb
@@ -17,7 +17,7 @@ describe Chemotion::ScreenAPI do
   let(:other_user_collection) { create(:collection, user_id: other_user.id) }
   let(:other_shared_collection) do
     create(:collection, user_id: other_user.id).tap do |collection|
-      create(:collection_share, collection: collection, shared_with: user, permission_level: 3)
+      create(:collection_share, collection: collection, shared_with: user, permission_level: CollectionShare.permission_level(:remove_elements))
     end
   end
 
@@ -241,7 +241,7 @@ describe Chemotion::ScreenAPI do
       let(:writable_collection) do
         create(:collection, user: other_user).tap do |c|
           create(:collection_share, collection: c, shared_with: user,
-                                    permission_level: CollectionShare::PERMISSION_LEVELS[:write_elements])
+                                    permission_level: CollectionShare::PERMISSION_LEVELS[:add_elements])
         end
       end
       let(:params) do

--- a/spec/api/chemotion/screen_api_spec.rb
+++ b/spec/api/chemotion/screen_api_spec.rb
@@ -17,7 +17,12 @@ describe Chemotion::ScreenAPI do
   let(:other_user_collection) { create(:collection, user_id: other_user.id) }
   let(:other_shared_collection) do
     create(:collection, user_id: other_user.id).tap do |collection|
-      create(:collection_share, collection: collection, shared_with: user, permission_level: CollectionShare.permission_level(:remove_elements))
+      create(
+        :collection_share,
+        collection: collection,
+        shared_with: user,
+        permission_level: CollectionShare.permission_level(:remove_elements),
+      )
     end
   end
 

--- a/spec/api/chemotion/wellplate_api_spec.rb
+++ b/spec/api/chemotion/wellplate_api_spec.rb
@@ -278,6 +278,26 @@ describe Chemotion::WellplateAPI do
         expect(response.parsed_body).to eq({ 'error' => 'height does not have a valid value' })
       end
     end
+
+    # Regression: a collection reachable only through the user's group must still attach the new
+    # wellplate to the sharer's "All" collection. Before the predicates spanned groups, both the
+    # owned and shared checks returned false and no "All" row was written for anyone.
+    context 'when the collection is shared with the user through a group' do
+      let(:group) { create(:group, users: [user]) }
+      let(:collection) do
+        create(:collection, user: other_user).tap do |shared_collection|
+          create(:collection_share, collection: shared_collection, shared_with: group,
+                                    permission_level: CollectionShare.permission_level(:add_elements))
+        end
+      end
+
+      it "attaches the wellplate to the sharer's All collection" do
+        wellplate = Wellplate.find_by(name: name)
+        all_collection = Collection.get_all_collection_for_user(other_user.id)
+
+        expect(all_collection.wellplates).to include(wellplate)
+      end
+    end
   end
 
   describe 'POST /api/v1/wellplates/subwellplates' do

--- a/spec/api/chemotion/wellplate_api_spec.rb
+++ b/spec/api/chemotion/wellplate_api_spec.rb
@@ -16,7 +16,7 @@ describe Chemotion::WellplateAPI do
         :collection_share,
         collection: collection,
         shared_with: user,
-        permission_level: 3,
+        permission_level: CollectionShare.permission_level(:remove_elements),
         wellplate_detail_level: 10,
       )
     end
@@ -130,14 +130,28 @@ describe Chemotion::WellplateAPI do
   describe 'DELETE /api/v1/wellplates' do
     let(:wellplate) { create(:wellplate, name: 'test') }
 
-    before do
-      CollectionsWellplate.create!(wellplate: wellplate, collection: collection_shared_with_user)
+    context 'when the wellplate is in a collection the user owns' do
+      before { CollectionsWellplate.create!(wellplate: wellplate, collection: collection) }
+
+      it 'is able to delete a wellplate by id' do
+        expect do
+          delete "/api/v1/wellplates/#{wellplate.id}"
+        end.to change(Wellplate, :count).by(-1)
+      end
     end
 
-    it 'is able to delete a wellplate by id' do
-      expect do
-        delete "/api/v1/wellplates/#{wellplate.id}"
-      end.to change(Wellplate, :count).by(-1)
+    # Destroying an element record is owner-only — a sharee may unlink it from the shared collection
+    # instead (CollectionElementsAPI).
+    context 'when the wellplate is only in a collection shared with the user' do
+      before { CollectionsWellplate.create!(wellplate: wellplate, collection: collection_shared_with_user) }
+
+      it 'refuses to delete it, whatever the permission level' do
+        expect do
+          delete "/api/v1/wellplates/#{wellplate.id}"
+        end.not_to change(Wellplate, :count)
+
+        expect(response).to have_http_status :unauthorized
+      end
     end
   end
 

--- a/spec/api/research_plan_api_spec.rb
+++ b/spec/api/research_plan_api_spec.rb
@@ -104,7 +104,7 @@ describe Chemotion::ResearchPlanAPI do
         let(:writable_collection) do
           create(:collection, user: other_user).tap do |c|
             create(:collection_share, collection: c, shared_with: user,
-                                      permission_level: CollectionShare::PERMISSION_LEVELS[:write_elements])
+                                      permission_level: CollectionShare::PERMISSION_LEVELS[:add_elements])
           end
         end
         let(:params) do

--- a/spec/db/migrate/20260709150000_renumber_collection_share_permission_levels_spec.rb
+++ b/spec/db/migrate/20260709150000_renumber_collection_share_permission_levels_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe 'migration 20260709150000: RenumberCollectionSharePermissionLevel
 
   let(:owner) { create(:person) }
 
-  # permission_level is validated nowhere at the model layer (deliberately — the data migration that
-  # seeds collection_shares writes legacy values), so legacy levels can be written directly.
+  # Writes a raw legacy level, bypassing the factory's (redesigned) default. update_column is the
+  # point here: these rows are what a pre-migration database actually holds.
   def share_with_level(level)
     collection = create(:collection, user: owner)
     share = create(:collection_share, collection: collection, shared_with: create(:person))
-    share.update_column(:permission_level, level)
+    share.update_column(:permission_level, level) # rubocop:disable Rails/SkipsModelValidations
     share
   end
 

--- a/spec/db/migrate/20260709150000_renumber_collection_share_permission_levels_spec.rb
+++ b/spec/db/migrate/20260709150000_renumber_collection_share_permission_levels_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+load 'db/migrate/20260709150000_renumber_collection_share_permission_levels.rb'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'migration 20260709150000: RenumberCollectionSharePermissionLevels' do
+  subject(:migration) { RenumberCollectionSharePermissionLevels.new }
+
+  let(:owner) { create(:person) }
+
+  # permission_level is validated nowhere at the model layer (deliberately — the data migration that
+  # seeds collection_shares writes legacy values), so legacy levels can be written directly.
+  def share_with_level(level)
+    collection = create(:collection, user: owner)
+    share = create(:collection_share, collection: collection, shared_with: create(:person))
+    share.update_column(:permission_level, level)
+    share
+  end
+
+  describe '#up' do
+    # legacy stored value => redesigned value
+    {
+      0 => 0, # read           -> read_elements
+      1 => 1, # write          -> edit_elements
+      2 => 1, # share          -> edit_elements (propagation is now bundled into add_elements)
+      3 => 3, # delete         -> remove_elements
+      4 => 3, # import         -> remove_elements (import implied delete)
+      5 => 5, # pass ownership -> pass_ownership (frontend value)
+      6 => 5, # pass ownership -> pass_ownership (post-#2783 backend value)
+    }.each do |legacy, expected|
+      it "maps legacy level #{legacy} to #{expected}" do
+        share = share_with_level(legacy)
+
+        migration.up
+
+        expect(share.reload.permission_level).to eq(expected)
+      end
+    end
+
+    it 'remaps every row in one pass, without cascading a value through the map twice' do
+      shares = (0..6).map { |level| [level, share_with_level(level)] }
+
+      migration.up
+
+      expect(shares.map { |level, share| [level, share.reload.permission_level] })
+        .to eq([[0, 0], [1, 1], [2, 1], [3, 3], [4, 3], [5, 5], [6, 5]])
+    end
+
+    it 'is idempotent — re-running does not shift already-migrated levels' do
+      shares = (0..6).map { |level| share_with_level(level) }
+
+      migration.up
+      once = shares.map { |share| share.reload.permission_level }
+      migration.up
+
+      expect(shares.map { |share| share.reload.permission_level }).to eq(once)
+    end
+
+    it 'only ever produces levels that exist on the redesigned ladder' do
+      (0..6).each { |level| share_with_level(level) }
+
+      migration.up
+
+      expect(CollectionShare.distinct.pluck(:permission_level))
+        .to all(be_in(CollectionShare::PERMISSION_LEVELS.values))
+    end
+
+    it 'does nothing when there are no shares' do
+      expect { migration.up }.not_to raise_error
+    end
+  end
+
+  describe '#down' do
+    {
+      0 => 0, # read_elements   -> read
+      1 => 1, # edit_elements   -> write
+      2 => 4, # add_elements    -> import (the legacy add rung)
+      3 => 3, # remove_elements -> delete
+      4 => 4, # manage_shares   -> import (no legacy equivalent; highest non-ownership rung)
+      5 => 6, # pass_ownership  -> the post-#2783 backend value
+    }.each do |current, expected|
+      it "maps level #{current} back to legacy #{expected}" do
+        share = share_with_level(current)
+
+        migration.down
+
+        expect(share.reload.permission_level).to eq(expected)
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/db/migrate/20260709150000_renumber_collection_share_permission_levels_spec.rb
+++ b/spec/db/migrate/20260709150000_renumber_collection_share_permission_levels_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe 'migration 20260709150000: RenumberCollectionSharePermissionLevel
     # legacy stored value => redesigned value
     {
       0 => 0, # read           -> read_elements
-      1 => 1, # write          -> edit_elements
-      2 => 1, # share          -> edit_elements (propagation is now bundled into add_elements)
+      1 => 2, # write          -> add_elements (legacy write could create; preserve that right)
+      2 => 2, # share          -> add_elements (propagation is now bundled into add_elements)
       3 => 3, # delete         -> remove_elements
       4 => 3, # import         -> remove_elements (import implied delete)
       5 => 5, # pass ownership -> pass_ownership (frontend value)
@@ -45,7 +45,18 @@ RSpec.describe 'migration 20260709150000: RenumberCollectionSharePermissionLevel
       migration.up
 
       expect(shares.map { |level, share| [level, share.reload.permission_level] })
-        .to eq([[0, 0], [1, 1], [2, 1], [3, 3], [4, 3], [5, 5], [6, 5]])
+        .to eq([[0, 0], [1, 2], [2, 2], [3, 3], [4, 3], [5, 5], [6, 5]])
+    end
+
+    it 'preserves the element-creation right of legacy write/share holders (they land at add_elements)' do
+      write_share = share_with_level(1)
+      share_share = share_with_level(2)
+
+      migration.up
+
+      add_elements = CollectionShare.permission_level(:add_elements)
+      expect(write_share.reload.permission_level).to eq(add_elements)
+      expect(share_share.reload.permission_level).to eq(add_elements)
     end
 
     it 'is idempotent — re-running does not shift already-migrated levels' do
@@ -76,7 +87,7 @@ RSpec.describe 'migration 20260709150000: RenumberCollectionSharePermissionLevel
     {
       0 => 0, # read_elements   -> read
       1 => 1, # edit_elements   -> write
-      2 => 4, # add_elements    -> import (the legacy add rung)
+      2 => 2, # add_elements    -> share (non-over-granting legacy add rung; not import, which unlinked)
       3 => 3, # remove_elements -> delete
       4 => 4, # manage_shares   -> import (no legacy equivalent; highest non-ownership rung)
       5 => 6, # pass_ownership  -> the post-#2783 backend value

--- a/spec/factories/collection_shares.rb
+++ b/spec/factories/collection_shares.rb
@@ -5,7 +5,8 @@ FactoryBot.define do
     collection { build(:collection) }
     shared_with { build(:person) }
 
-    permission_level { 10 }
+    # the highest real rung — the factory grants every capability by default
+    permission_level { CollectionShare.permission_level(:pass_ownership) }
     celllinesample_detail_level { 10 }
     devicedescription_detail_level { 10 }
     element_detail_level { 10 }

--- a/spec/features/copy_reaction_spec.rb
+++ b/spec/features/copy_reaction_spec.rb
@@ -96,7 +96,7 @@ describe 'Copy reaction' do
         :collection_share,
         collection: collection,
         shared_with: user1,
-        permission_level: 10,
+        permission_level: CollectionShare.permission_level(:pass_ownership),
         sample_detail_level: 10,
         reaction_detail_level: 10,
       )
@@ -108,7 +108,7 @@ describe 'Copy reaction' do
         :collection_share,
         collection: collection,
         shared_with: user1,
-        permission_level: 10,
+        permission_level: CollectionShare.permission_level(:pass_ownership),
         sample_detail_level: 10,
         reaction_detail_level: 10,
       )

--- a/spec/javascripts/packs/src/utilities/PermissionConst.spec.js
+++ b/spec/javascripts/packs/src/utilities/PermissionConst.spec.js
@@ -1,0 +1,27 @@
+import { describe, it } from 'mocha';
+import expect from 'expect';
+
+import { PermissionConst } from 'src/utilities/PermissionConst';
+
+// PermissionConst mirrors CollectionShare::PERMISSION_LEVELS (app/models/collection_share.rb).
+// The two silently drifted apart once before — the frontend kept the pre-#2783 scale and went on
+// posting a permission level the backend had left undefined. Pin the values so that can't recur.
+describe('PermissionConst', () => {
+  it('matches the backend ladder exactly', () => {
+    expect(PermissionConst).toEqual({
+      ReadElements: 0,
+      EditElements: 1,
+      AddElements: 2,
+      RemoveElements: 3,
+      ManageShares: 4,
+      PassOwnership: 5,
+    });
+  });
+
+  it('is a gapless, strictly ascending ordinal starting at zero', () => {
+    const levels = Object.values(PermissionConst);
+
+    expect(levels).toEqual([...levels].sort((a, b) => a - b));
+    expect(levels).toEqual(levels.map((_, index) => index));
+  });
+});

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Collection do
         create(:collection_share, collection: shared_collection, shared_with: group,
                                   permission_level: CollectionShare.permission_level(:read_elements))
         create(:collection_share, collection: shared_collection, shared_with: recipient,
-                                  permission_level: CollectionShare.permission_level(:delete_elements))
+                                  permission_level: CollectionShare.permission_level(:remove_elements))
       end
 
       it 'returns the collection exactly once' do
@@ -92,7 +92,7 @@ RSpec.describe Collection do
 
       it 'reports the highest of the two permission levels, matching what the policies enforce' do
         expect(rows_for(recipient).first.permission_level)
-          .to eq(CollectionShare.permission_level(:delete_elements))
+          .to eq(CollectionShare.permission_level(:remove_elements))
       end
 
       it 'exposes the recipients own share, never the groups' do

--- a/spec/policies/element_policy_spec.rb
+++ b/spec/policies/element_policy_spec.rb
@@ -177,23 +177,17 @@ describe ElementPolicy do
       end
     end
 
-    context 'when the record is in a collection shared to me with a permission level of 2 or lower' do
-      let(:permission_level) { 2 }
+    # Destroying an element record is owner-only. A sharee at :remove_elements may unlink it from the
+    # shared collection (Usecases::Collections::RemoveElements), but never destroy it.
+    CollectionShare::PERMISSION_LEVELS.each_value do |level|
+      context "when the record is in a collection shared to me with a permission level of #{level}" do
+        let(:permission_level) { level }
 
-      before { shared_collection_of_other_user.screens << screen }
+        before { shared_collection_of_other_user.screens << screen }
 
-      it 'returns false' do
-        expect(element_policy.destroy?).to be false
-      end
-    end
-
-    context 'when the record is in a collection shared to me with a permission level of 3 or higher' do
-      let(:permission_level) { 3 }
-
-      before { shared_collection_of_other_user.screens << screen }
-
-      it 'returns true' do
-        expect(element_policy.destroy?).to be true
+        it 'returns false' do
+          expect(element_policy.destroy?).to be false
+        end
       end
     end
 
@@ -217,8 +211,8 @@ describe ElementPolicy do
       end
     end
 
-    context 'when the record is in a collection shared to me with a permission level of 3 or lower' do
-      let(:permission_level) { 3 }
+    context 'when the record is in a collection shared to me below :add_elements' do
+      let(:permission_level) { CollectionShare.permission_level(:edit_elements) }
 
       before { shared_collection_of_other_user.screens << screen }
 
@@ -227,8 +221,8 @@ describe ElementPolicy do
       end
     end
 
-    context 'when the record is in a collection shared to me with a permission level of 4 or higher' do
-      let(:permission_level) { 4 }
+    context 'when the record is in a collection shared to me at :add_elements or higher' do
+      let(:permission_level) { CollectionShare.permission_level(:add_elements) }
 
       before { shared_collection_of_other_user.screens << screen }
 
@@ -257,8 +251,8 @@ describe ElementPolicy do
       end
     end
 
-    context 'when the record is in a collection shared to me with a permission level of 5 or lower' do
-      let(:permission_level) { 5 }
+    context 'when the record is in a collection shared to me below :pass_ownership' do
+      let(:permission_level) { CollectionShare.permission_level(:manage_shares) }
 
       before { shared_collection_of_other_user.screens << screen }
 
@@ -267,8 +261,8 @@ describe ElementPolicy do
       end
     end
 
-    context 'when the record is in a collection shared to me with a permission level of 6 or higher' do
-      let(:permission_level) { 6 }
+    context 'when the record is in a collection shared to me at :pass_ownership' do
+      let(:permission_level) { CollectionShare.permission_level(:pass_ownership) }
 
       before { shared_collection_of_other_user.screens << screen }
 

--- a/spec/policies/elements_policy_spec.rb
+++ b/spec/policies/elements_policy_spec.rb
@@ -30,7 +30,12 @@ RSpec.describe ElementsPolicy do
     create(:collection_share, collection: user_2_collection, shared_with: user_1, permission_level: permission_level)
   end
   let(:collection_shared_to_user_2) do
-    create(:collection_share, collection: user_3_collection, shared_with: user_2, permission_level: CollectionShare.permission_level(:add_elements))
+    create(
+      :collection_share,
+      collection: user_3_collection,
+      shared_with: user_2,
+      permission_level: CollectionShare.permission_level(:add_elements),
+    )
   end
 
   before do

--- a/spec/policies/elements_policy_spec.rb
+++ b/spec/policies/elements_policy_spec.rb
@@ -148,5 +148,28 @@ RSpec.describe ElementsPolicy do
       end
     end
   end
+
+  # Regression: a collection owned by one of the user's groups is their own (Collection#owned_by?),
+  # so a group member may remove/destroy its elements. Without a group-aware own scope the policy
+  # denied it, and SelectionActions greyed out Move for every group collection.
+  describe 'a group-owned collection' do
+    let(:group) { create(:group, users: [user_1]) }
+    let(:group_collection) { create(:collection, user: group) }
+    let(:group_sample) { create(:sample, creator: user_1, collections: [group_collection]) }
+
+    before { group_sample }
+
+    it 'counts as the member\'s own for #remove_all?' do
+      policy = described_class.new(user_1, Sample.where(id: [group_sample.id]))
+
+      expect(policy.remove_all?).to be true
+    end
+
+    it 'counts as the member\'s own for #destroy_all?' do
+      policy = described_class.new(user_1, Sample.where(id: [group_sample.id]))
+
+      expect(policy.destroy_all?).to be true
+    end
+  end
 end
 # rubocop:enable RSpec/MultipleMemoizedHelpers, RSpec/IndexedLet, Naming/VariableNumber

--- a/spec/policies/elements_policy_spec.rb
+++ b/spec/policies/elements_policy_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ElementsPolicy do
     create(:collection_share, collection: user_2_collection, shared_with: user_1, permission_level: permission_level)
   end
   let(:collection_shared_to_user_2) do
-    create(:collection_share, collection: user_3_collection, shared_with: user_2, permission_level: 2)
+    create(:collection_share, collection: user_3_collection, shared_with: user_2, permission_level: CollectionShare.permission_level(:add_elements))
   end
 
   before do
@@ -93,6 +93,25 @@ RSpec.describe ElementsPolicy do
         expect(policy.allowed?(3)).to be true
         expect(policy.allowed?(4)).to be true
         expect(policy.allowed?(5)).to be false
+      end
+    end
+  end
+
+  describe '#destroy_all?' do
+    it 'returns true when every record is in an own collection' do
+      policy = described_class.new(user_1, Sample.where(id: [sample_1, sample_2, sample_3]))
+
+      expect(policy.destroy_all?).to be true
+    end
+
+    # Destroying element records is owner-only, at every rung — including the top one.
+    context 'when the records are shared, even at the highest permission level' do
+      let(:permission_level) { CollectionShare.permission_level(:pass_ownership) }
+
+      it 'returns false' do
+        policy = described_class.new(user_1, Sample.where(id: [sample_4, sample_5, sample_6]))
+
+        expect(policy.destroy_all?).to be false
       end
     end
   end

--- a/spec/policies/elements_policy_spec.rb
+++ b/spec/policies/elements_policy_spec.rb
@@ -120,5 +120,33 @@ RSpec.describe ElementsPolicy do
       end
     end
   end
+
+  describe '#remove_all?' do
+    it 'returns true when every record is in an own collection' do
+      policy = described_class.new(user_1, Sample.where(id: [sample_1, sample_2, sample_3]))
+
+      expect(policy.remove_all?).to be true
+    end
+
+    context 'when the shared records are at :remove_elements' do
+      let(:permission_level) { CollectionShare.permission_level(:remove_elements) }
+
+      it 'returns true' do
+        policy = described_class.new(user_1, Sample.where(id: [sample_4, sample_5, sample_6]))
+
+        expect(policy.remove_all?).to be true
+      end
+    end
+
+    context 'when the shared records are below :remove_elements' do
+      let(:permission_level) { CollectionShare.permission_level(:add_elements) }
+
+      it 'returns false' do
+        policy = described_class.new(user_1, Sample.where(id: [sample_4, sample_5, sample_6]))
+
+        expect(policy.remove_all?).to be false
+      end
+    end
+  end
 end
 # rubocop:enable RSpec/MultipleMemoizedHelpers, RSpec/IndexedLet, Naming/VariableNumber

--- a/spec/usecases/collections/add_elements_spec.rb
+++ b/spec/usecases/collections/add_elements_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Usecases::Collections::AddElements do
+  let(:sharee) { create(:person) }
+  let(:owner)  { create(:person) }
+  let(:add)    { CollectionShare.permission_level(:add_elements) }
+
+  let(:origin) { create(:collection, user: owner, label: 'origin (owner)') }
+  let(:same_owner_target) { create(:collection, user: owner, label: 'target (owner)') }
+  let(:sharee_collection) { create(:collection, user: sharee, label: 'my collection') }
+  let(:sample) { create(:sample, creator: owner, collections: [origin]) }
+
+  before do
+    create(:collection_share, collection: origin, shared_with: sharee, permission_level: add)
+    create(:collection_share, collection: same_owner_target, shared_with: sharee, permission_level: add)
+    sample
+  end
+
+  def perform(target, origin_collection_id)
+    described_class.new(sharee).perform!(
+      collection_id: target.id,
+      ui_state: { sample: { checkedIds: [sample.id] } }.with_indifferent_access,
+      origin_collection_id: origin_collection_id,
+    )
+  end
+
+  context 'when a sharee moves an element out of a shared (non-owned) collection' do
+    it 'allows a target owned by the same owner as the origin' do
+      expect { perform(same_owner_target, origin.id) }
+        .to change { sample.reload.collections.exists?(id: same_owner_target.id) }.from(false).to(true)
+    end
+
+    it 'refuses a target owned by someone else (the sharee themself)' do
+      expect { perform(sharee_collection, origin.id) }
+        .to raise_error(Usecases::Collections::Errors::InsufficientPermissionError)
+      expect(sample.reload.collections.exists?(id: sharee_collection.id)).to be false
+    end
+  end
+
+  context "when the origin is the sharee's own collection" do
+    let(:own_sample) { create(:sample, creator: sharee, collections: [sharee_collection]) }
+
+    it 'is unconstrained — the element may be added to a collection of another owner they can add to' do
+      described_class.new(sharee).perform!(
+        collection_id: same_owner_target.id,
+        ui_state: { sample: { checkedIds: [own_sample.id] } }.with_indifferent_access,
+        origin_collection_id: sharee_collection.id,
+      )
+      expect(own_sample.reload.collections.exists?(id: same_owner_target.id)).to be true
+    end
+  end
+end

--- a/spec/usecases/collections/transfer_ownership_spec.rb
+++ b/spec/usecases/collections/transfer_ownership_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Usecases::Collections::TransferOwnership do
+  let(:old_owner) { create(:person) }
+  let(:new_owner) { create(:person) }
+  let(:old_all) { Collection.get_all_collection_for_user(old_owner.id) }
+  let(:new_all) { Collection.get_all_collection_for_user(new_owner.id) }
+  let(:collection) { create(:collection, user: old_owner, label: 'Project X') }
+  let(:offer) do
+    create(:collection_share, collection: collection, shared_with: new_owner,
+                              permission_level: CollectionShare.permission_level(:pass_ownership))
+  end
+
+  before { offer }
+
+  def transfer
+    described_class.new(new_owner).perform!(collection: collection)
+  end
+
+  describe 'the collection subtree' do
+    let!(:child) { create(:collection, user: old_owner, parent: collection, label: 'sub') }
+
+    it 'reassigns the collection and its descendants to the new owner' do
+      transfer
+      expect(collection.reload.user_id).to eq(new_owner.id)
+      expect(child.reload.user_id).to eq(new_owner.id)
+    end
+  end
+
+  describe 'the former owner' do
+    it 'is demoted to a manage_shares sharee and the offer is consumed' do
+      transfer
+      shares = CollectionShare.where(collection: collection)
+      expect(shares.where(shared_with_id: new_owner.id)).to be_empty
+      expect(shares.find_by(shared_with_id: old_owner.id).permission_level)
+        .to eq(CollectionShare.permission_level(:manage_shares))
+    end
+  end
+
+  describe 'an element exclusive to the transferred collection' do
+    let!(:sample) { create(:sample, creator: old_owner, collections: [old_all, collection]) }
+
+    it "moves from the old owner's All to the new owner's All" do
+      transfer
+      cols = sample.reload.collections
+      expect(cols.where(id: new_all.id)).to be_present
+      expect(cols.where(id: old_all.id)).to be_empty
+    end
+  end
+
+  describe 'an element also in another collection the old owner keeps' do
+    let(:other) { create(:collection, user: old_owner, label: 'Y') }
+    let!(:sample) { create(:sample, creator: old_owner, collections: [old_all, collection, other]) }
+
+    it "stays in the old owner's All and is added to the new owner's All (dual-owned)" do
+      transfer
+      cols = sample.reload.collections
+      expect(cols.where(id: old_all.id)).to be_present
+      expect(cols.where(id: new_all.id)).to be_present
+      expect(cols.where(id: other.id)).to be_present
+    end
+  end
+
+  describe 'guards' do
+    it 'refuses when the caller holds no offer' do
+      CollectionShare.where(collection: collection, shared_with_id: new_owner.id).delete_all
+      expect { transfer }.to raise_error(Usecases::Collections::Errors::InsufficientPermissionError)
+    end
+
+    it 'refuses to transfer a locked collection' do
+      collection.update!(is_locked: true)
+      expect { transfer }.to raise_error(Usecases::Collections::Errors::InsufficientPermissionError)
+    end
+  end
+end

--- a/spec/usecases/collections/withdraw_elements_spec.rb
+++ b/spec/usecases/collections/withdraw_elements_spec.rb
@@ -82,6 +82,40 @@ RSpec.describe Usecases::Collections::WithdrawElements do
     end
   end
 
+  describe 'a sole-owned reaction with associated subsamples' do
+    let(:reaction) { create(:reaction, creator: user, collections: [user_all, user_sub]) }
+    let(:solvent) { create(:sample, creator: user, collections: [user_all, user_sub]) }
+    let(:reactant) { create(:sample, creator: user, collections: [user_all, user_sub]) }
+
+    before do
+      ReactionsSolventSample.create!(reaction: reaction, sample: solvent, reference: false)
+      ReactionsReactantSample.create!(reaction: reaction, sample: reactant, reference: false)
+    end
+
+    def withdraw_reaction(options: {})
+      described_class.new(user).perform!(
+        source_collection: user_sub,
+        ui_state: { reaction: { all: false, included_ids: [reaction.id] } }.with_indifferent_access,
+        options: options,
+      )
+    end
+
+    # Regression: withdraw destroys the reaction first, and Reaction's dependent: :destroy soft-deletes
+    # its (acts_as_paranoid) reactions_samples. The subsample cleanup must still resolve them through
+    # with_deleted, otherwise the solvent/reactant samples are silently orphaned.
+    it 'also withdraws and destroys the orphaned solvent/reactant subsamples' do
+      expect { withdraw_reaction }
+        .to change(Reaction, :count).by(-1)
+        .and change(Sample, :count).by(-2)
+      expect(Sample.where(id: [solvent.id, reactant.id])).to be_empty
+    end
+
+    it 'reports the subsample ids as having left the view' do
+      result = withdraw_reaction
+      expect(result['sample']).to contain_exactly(solvent.id, reactant.id)
+    end
+  end
+
   describe 'a group member withdrawing a group-owned element' do
     let(:group) { create(:group, users: [user]) }
     let(:group_all) { Collection.get_all_collection_for_user(group.id) }

--- a/spec/usecases/collections/withdraw_elements_spec.rb
+++ b/spec/usecases/collections/withdraw_elements_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Usecases::Collections::WithdrawElements do
+  let(:user) { create(:person) }
+  let(:other_user) { create(:person) }
+  let(:user_all) { Collection.get_all_collection_for_user(user.id) }
+  let(:user_sub) { create(:collection, user: user, label: 'sub') }
+
+  # mirror Grape's indifferent-access params (by_ui_state reads symbol keys)
+  def selection_for(sample)
+    { sample: { all: false, included_ids: [sample.id] } }.with_indifferent_access
+  end
+
+  def withdraw_from(collection, sample, options: {})
+    described_class.new(user).perform!(
+      source_collection: collection, ui_state: selection_for(sample), options: options
+    )
+  end
+
+  describe 'a sole-owned sample' do
+    let(:sample) { create(:sample, creator: user, collections: [user_all, user_sub]) }
+
+    before { sample }
+
+    it 'is unlinked from all the owner\'s collections and destroyed as an orphan' do
+      expect { withdraw_from(user_sub, sample) }.to change(Sample, :count).by(-1)
+      expect(sample.reload.collections.where(id: [user_all.id, user_sub.id])).to be_empty
+    end
+
+    it 'reports the id as having left the view' do
+      result = withdraw_from(user_sub, sample)
+      expect(result['sample']).to contain_exactly(sample.id)
+    end
+  end
+
+  describe 'a dual-owned sample (also in another user\'s collection)' do
+    let(:foreign) { create(:collection, user: other_user, label: 'foreign') }
+    let(:sample) { create(:sample, creator: user, collections: [user_all, user_sub, foreign]) }
+
+    before { sample }
+
+    it 'is withdrawn from the owner\'s collections but NOT destroyed — the other owner keeps it' do
+      expect { withdraw_from(user_sub, sample) }.not_to change(Sample, :count)
+
+      cols = sample.reload.collections
+      expect(cols.where(id: [user_all.id, user_sub.id])).to be_empty # gone from the actor's tree
+      expect(cols.where(id: foreign.id)).to be_present               # still in the other owner's collection
+    end
+  end
+
+  describe 'a sample that is only in a foreign collection (actor has no ownership)' do
+    let(:foreign) { create(:collection, user: other_user) }
+    let(:sample) { create(:sample, creator: other_user, collections: [foreign]) }
+
+    before do
+      sample
+      # the actor sees it via a share, but has no own-collection membership
+      create(:collection_share, collection: foreign, shared_with: user,
+                                permission_level: CollectionShare.permission_level(:read_elements))
+    end
+
+    it 'is left untouched (no standing to withdraw it)' do
+      expect { withdraw_from(foreign, sample) }.not_to change(Sample, :count)
+      expect(sample.reload.collections.where(id: foreign.id)).to be_present
+    end
+  end
+
+  describe 'a sample kept by the reaction association guard' do
+    let(:reaction) { create(:reaction, creator: user, collections: [user_sub]) }
+    let(:sample) { create(:sample, creator: user, collections: [user_all, user_sub]) }
+
+    before do
+      # sample is a reactant of a reaction living in the same collection
+      ReactionsReactantSample.create!(reaction: reaction, sample: sample, reference: false)
+    end
+
+    it 'is not unlinked from a collection that still holds its reaction, and is not destroyed' do
+      expect { withdraw_from(user_sub, sample) }.not_to change(Sample, :count)
+      expect(sample.reload.collections.where(id: user_sub.id)).to be_present
+    end
+  end
+
+  describe 'a group member withdrawing a group-owned element' do
+    let(:group) { create(:group, users: [user]) }
+    let(:group_all) { Collection.get_all_collection_for_user(group.id) }
+    let(:group_col) { create(:collection, user: group, label: 'group project') }
+    let(:sample) { create(:sample, creator: user, collections: [group_col]) }
+
+    before { sample }
+
+    it 'withdraws (and destroys the orphan) because group-owned collections count as owned' do
+      expect { withdraw_from(group_col, sample) }.to change(Sample, :count).by(-1)
+    end
+  end
+end

--- a/spec/usecases/collections/withdraw_elements_spec.rb
+++ b/spec/usecases/collections/withdraw_elements_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Usecases::Collections::WithdrawElements do
 
   def withdraw_from(collection, sample, options: {})
     described_class.new(user).perform!(
-      source_collection: collection, ui_state: selection_for(sample), options: options
+      source_collection: collection, ui_state: selection_for(sample), options: options,
     )
   end
 


### PR DESCRIPTION
## Summary

A follow-on to the shared-collection refactor (PR #2783) and its v3.1.2 upgrade fixes
(PR #3337, now on `main`). This bundles a redesign of the collection-share **permission
ladder** with several correctness fixes in the share/ownership model, and **restores
pass-ownership** — which #2783 had dropped.

## 1. Permission-ladder redesign (breaking)

Renames and reorders the `collection_shares.permission_level` ladder so it runs strictly
from least- to most-powerful and is gapless:

| level | key | grants (cumulative) |
|------:|-----|---------------------|
| 0 | `read_elements` | read the collection and its elements |
| 1 | `edit_elements` | + edit existing element content (audited) |
| 2 | `add_elements` | + create/add/import elements, propagate them onward |
| 3 | `remove_elements` | + unlink an element from **this** collection |
| 4 | `manage_shares` | + delegated CRUD on this collection's shares |
| 5 | `pass_ownership` | + transfer ownership (now implemented — see §2) |

- **Destroying an element is owner-only** (`ElementPolicy#destroy?` / `ElementsPolicy#destroy_all?`); a sharee at `remove_elements` unlinks instead. Knock-on: `can_publish` and bulk delete become owner-only.
- Delegated share admins (`manage_shares`) can neither grant nor revoke a share above their own level.
- `PermissionConst.js` mirrors the backend and is pinned by a JS spec.
- Migration `20260709150000_renumber_collection_share_permission_levels` remaps stored values idempotently (never to a more destructive capability); a reversible `down` is included.

## 2. Restore pass-ownership (two-step transfer)

`pass_ownership` was a no-op rung; the "Pass ownership" UI just stored a level-5 share.
Restored as a consent-based two-step on the ACL:

- **Offer** — the existing `POST /collection_shares` at level 5 is the offer; a new guard restricts it to a single **Person** (never a group) and never a locked collection. Only an owner can mint it.
- **Accept** — new `POST /collection_shares/take_ownership/:collection_id` runs `Usecases::Collections::TransferOwnership`: reassigns the collection subtree to the new owner, demotes the former owner to a `manage_shares` sharee, and moves each element into the new owner's "All", removing it from the old owner's "All" only when it is no longer in any of their other collections (an element also in a private collection stays, becoming dual-owned). The `CollectionSubtree` "Take ownership" action is wired to it.

## 3. "Remove from all Collections" → withdraw, not global destroy

`DELETE /ui_state` previously ran `destroy_all` on the element records, which — because
ownership is derived from collection membership — let one owner destroy an element out of
another owner's private collections. It now **unlinks the selection from the caller's own
collections and destroys only records left orphaned** (`Usecases::Collections::WithdrawElements`):
identical outcome for a sole owner, safe for shared/dual-owned elements.

## 4. Wellplate "All" attachment for group-shared collections

`Usecases::Wellplates::Create` decided the target "All" with predicates blind to group
membership, so a wellplate created in a group-shared/owned collection was attached to no
"All". Routed through the group-aware `Collection#owned_by?` + `CollectionShare.shared_with`.

## 5. Stop the loading spinner on a rejected save (#1369)

A read-only sharee editing a Research Plan and saving spun forever: the backend correctly
rejects with 401, but several Alt `ElementActions` `.catch()` blocks never called
`LoadingActions.stop()`. Added the guard to all 18 element create/update save actions.

Fixes #1369.

## Testing

- New: `transfer_ownership_spec`, `withdraw_elements_spec`, the renumber-migration spec, `PermissionConst.spec.js`, plus API-spec additions (ownership offer/accept, dual-ownership, delegation guards).
- Full targeted RSpec suites green; `yarn test` 1320 passing; rubocop + eslint clean on changed lines. Migrations validated in order against a real v3.1.2-derived DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
