### PR TITLE
fix(2fa): recover from undecryptable otp_secret instead of crashing

### DIFF
--- a/.dockerenv.example
+++ b/.dockerenv.example
@@ -60,7 +60,8 @@ IMG_INDIGO=epmlsop/indigo-service:1.34.0-rc.1
 #HOST_PORT_APP=3000
 #HOST_PORT_WEBPACK=3035
 
-# One time password secrate key for 2FA
-OTP_SECRET_KEY='secret'
+# One time password secret key for 2FA (attr_encrypted uses aes-256-gcm, which
+# requires a key of at least 32 bytes)
+OTP_SECRET_KEY='change-this-to-a-random-32-byte-or-longer-secret'
 
 

--- a/.env.development
+++ b/.env.development
@@ -11,8 +11,9 @@ SFTP_PASSWORD=sftp_test
 # JWT key for novnc target encryption
 NOVNC_SECRET='secret'
 
-# One time password secrate key for 2FA
-OTP_SECRET_KEY='secret'
+# One time password secret key for 2FA (attr_encrypted uses aes-256-gcm, which
+# requires a key of at least 32 bytes)
+OTP_SECRET_KEY='change-this-to-a-random-32-byte-or-longer-secret'
 
 # Allow unconfirmed email: leave blank for always, or set a number of days (integer);
 # also set 0 to have email being confirmed before first sign in.

--- a/.env.production.example
+++ b/.env.production.example
@@ -22,8 +22,11 @@ SMTP_SSL_MODE='none'
 # disable mail delivery
 # DISABLE_MAIL_DELIVERY='nomail'
 
-# One time password secrate key for 2FA
-OTP_SECRET_KEY='secret'
+# One time password secret key for 2FA (attr_encrypted uses aes-256-gcm, which
+# requires a key of at least 32 bytes). Use a unique, randomly generated value
+# and keep it stable across deploys/rotations, or existing users' stored
+# secrets become undecryptable.
+OTP_SECRET_KEY='change-this-to-a-random-32-byte-or-longer-secret'
 
 
 

--- a/.env.test.example
+++ b/.env.test.example
@@ -8,8 +8,9 @@ MESSAGE_ENABLE=true
 MESSAGE_AUTO_INTERNAL=1000
 MESSAGE_IDLE_TIME=20
 
-# One time password secrate key for 2FA
-OTP_SECRET_KEY='secret'
+# One time password secret key for 2FA (attr_encrypted uses aes-256-gcm, which
+# requires a key of at least 32 bytes)
+OTP_SECRET_KEY='change-this-to-a-random-32-byte-or-longer-secret'
 
 
 # Allow unconfirmed email: leave blank for always, or set a number of days (integer);

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -187,6 +187,7 @@ class User < ApplicationRecord
   def generate_qr_code
     issuer = 'Chemotion'
     label = email
+    discard_undecryptable_otp_secret!
     if otp_secret.blank?
       self.otp_secret = User.generate_otp_secret
       save!
@@ -517,6 +518,19 @@ class User < ApplicationRecord
 
   def user_ids
     [id]
+  end
+
+  # otp_secret raises OpenSSL::Cipher::CipherError if OTP_SECRET_KEY has changed
+  # since the stored secret was encrypted (e.g. a key rotation on redeploy) -
+  # attr_encrypted's setter also re-decrypts the old value internally to check
+  # for dirtiness, so a merely-rescued read is not enough. Wipe the
+  # now-undecryptable ciphertext so the user can simply re-enroll instead of
+  # hitting a 500 on the enable-2FA request.
+  def discard_undecryptable_otp_secret!
+    otp_secret
+  rescue OpenSSL::Cipher::CipherError
+    update_columns(encrypted_otp_secret: nil, encrypted_otp_secret_iv: nil, encrypted_otp_secret_salt: nil)
+    instance_variable_set(:@otp_secret, nil)
   end
 end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -188,6 +188,27 @@ RSpec.describe User do
     end
   end
 
+  describe '#generate_qr_code' do
+    let(:user) { create(:user) }
+
+    it 'generates an otp_secret and a QR code svg' do
+      expect { user.generate_qr_code }.to change { user.reload.encrypted_otp_secret }.from(nil)
+    end
+
+    it 're-enrolls instead of raising when the stored ciphertext can no longer be decrypted' do
+      user.generate_qr_code
+      previous_secret = user.reload.otp_secret
+      # simulate a corrupted/undecryptable ciphertext (e.g. after an OTP_SECRET_KEY rotation)
+      # while keeping the iv/salt otherwise well-formed.
+      user.update_columns(encrypted_otp_secret: user.encrypted_otp_secret.reverse)
+      user.instance_variable_set(:@otp_secret, nil)
+
+      expect { user.generate_qr_code }.not_to raise_error
+      expect(user.reload.otp_secret).to be_present
+      expect(user.otp_secret).not_to eq(previous_secret)
+    end
+  end
+
   describe '#increment_counter' do
     let(:described_method) { :increment_counter }
     let(:element) { described_class::COUNTER_KEYS.sample }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -192,7 +192,9 @@ RSpec.describe User do
     let(:user) { create(:user) }
 
     it 'generates an otp_secret and a QR code svg' do
-      expect { user.generate_qr_code }.to change { user.reload.encrypted_otp_secret }.from(nil)
+      svg = nil
+      expect { svg = user.generate_qr_code }.to change { user.reload.encrypted_otp_secret }.from(nil)
+      expect(svg).to include('<svg')
     end
 
     it 're-enrolls instead of raising when the stored ciphertext can no longer be decrypted' do


### PR DESCRIPTION
## Summary
- `POST /users/two_factor_auth/request_enable` could crash with an unhandled `OpenSSL::Cipher::CipherError` if a user's stored `otp_secret` was encrypted under a different `OTP_SECRET_KEY` than the one currently configured (e.g. after a key rotation across a redeploy). `User#generate_qr_code` now discards a ciphertext it can no longer decrypt and re-enrolls the user with a fresh secret instead of 500ing.
- Fixed the example `OTP_SECRET_KEY` placeholder (`'secret'`, 6 bytes) in `.env.development`, `.env.test.example`, `.env.production.example`, and `.dockerenv.example` — `attr_encrypted` uses `aes-256-gcm`, which requires a key of at least 32 bytes, so 2FA enrollment was broken out of the box on a fresh checkout.

## Test plan
- [x] `bundle exec rspec spec/models/user_spec.rb` — added two regression specs (happy-path enrollment, and re-enrollment after an undecryptable/corrupted secret), all passing
- [x] Manually reproduced the original crash by encrypting under one key and reading under another, confirmed the fix recovers gracefully
- [x] `bundle exec rubocop app/models/user.rb`