### PR TITLE
fix(user-settings): send real HTTP PUT for account/password update

### DIFF
--- a/app/javascript/src/apps/userSettings/UserSettings.js
+++ b/app/javascript/src/apps/userSettings/UserSettings.js
@@ -87,7 +87,7 @@ function AccountSettings({ currentUser }) {
     // Replace with your API call
     setForm('otp_attempt', '');
     const res = await submitAsForm({
-      url: '/users', form, prefix: 'user', method: 'POST'
+      url: '/users', form, prefix: 'user', method: 'PUT'
     }).catch((err) => setErrors(err.messages || ['Something went wrong']));
     const { status } = res;
     let content;


### PR DESCRIPTION
## Summary
- PR #3294's fetcher-unification refactor changed the account-settings form
  submit in `UserSettings.js` from `method: 'PUT'` to `method: 'POST'`.
- `/users` only routes `PUT`/`PATCH` to `Devise::RegistrationsController#update`;
  `POST /users` hits `#create`, which for an already-signed-in user is
  short-circuited by `require_no_authentication` — a `302` redirect to `/`
  before anything is saved.
- The frontend treats `res.redirected` as success, so users see "Successfully
  changed user information" while their email/password is silently never
  updated.
- One-line fix: restore `method: 'PUT'` so the real HTTP verb matches the
  route Devise expects.

## Test plan
- [x] Verified against a running dev instance: `POST /users` returns 302 but
      leaves the password unchanged; `PUT /users` returns 302 and the new
      password actually works for login.
- [ ] Manually re-test in the browser: User Settings → Account → change
      password → confirm network tab shows `PUT /users` and re-login works
      with the new password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)