### PR TITLE
ci: provision converter.yml so the ConverterAPI spec is stable

### DIFF
--- a/.github/workflows/ci-rb.yml
+++ b/.github/workflows/ci-rb.yml
@@ -146,6 +146,7 @@ jobs:
           cp -f shrine.yml.example shrine.yml
           cp -f storage.yml.example storage.yml
           cp -f radar.yml.example radar.yml
+          cp -f converter.yml.example converter.yml
           touch klasses.json
           bundle config set without ''
 


### PR DESCRIPTION
## Problem

The rspec `testing` job intermittently fails **all 14 examples** in `spec/api/chemotion/converter_api_spec.rb` with:

```
Rails::Application::Configuration does not implement: converter
```

The spec's shared `before` hook stubs `Rails.configuration.converter` under `verify_partial_doubles = true` (`spec/spec_helper.rb:256`), which requires the accessor to already exist on the real object.

`config.converter` is defined only by `config/initializers/converter.rb`, guarded on `config/converter.yml` being present:

```ruby
if File.exist? Rails.root.join('config', 'converter.yml')
  ...
  config.converter = ActiveSupport::OrderedOptions.new
  ...
end
```

`config/converter.yml` is gitignored (only `.example` is tracked), and the CI **configure repository** step provisions every other config yml *except* converter. So on CI the accessor is undefined and the verifying double raises before the stub is installed.

It surfaces as flaky rather than always-red because whether `config.converter` is defined depends on process state that CI never pinned — the same spec passed on the introducing PR's own green run and fails on later branches.

## Fix

Copy `converter.yml.example → converter.yml` in the `configure repository` step, alongside the other six configs. The initializer then runs and defines the accessor. The example ships a `test:` section, so `config_for` resolves under `RAILS_ENV=test`; the spec stubs the actual values, so it only needs the accessor to exist.

```diff
           cp -f radar.yml.example radar.yml
+          cp -f converter.yml.example converter.yml
           touch klasses.json
```

## Scope

- One-line CI change; no application or spec code touched.
- The spec was introduced in #3369; this unblocks the `testing` job on every branch built off current `main`, not just any single PR.
- Only `ci-rb.yml` runs this spec, so the other workflows' provisioning lists are left unchanged.

refs: #3369