### PR TITLE
feat(collections): shared-with-me tree UX and sharee/delegate capabilities

### DIFF
--- a/app/api/chemotion/collection_api.rb
+++ b/app/api/chemotion/collection_api.rb
@@ -121,13 +121,10 @@ module Chemotion
         # Own collections may always be exported. A sharee may export a collection shared to them
         # only when they hold FULL detail access on it (every element detail level at max): the
         # export path serializes full element content and ignores detail levels, so admitting a
-        # partial-detail share would leak data the share deliberately withheld. Both queries are
+        # partial-detail share would leak data the share deliberately withheld. Both lookups are
         # scoped to the requested ids — this only needs to know the requested set is authorised.
         owned_ids = Collection.own_collections_for(current_user).where(id: collection_ids).pluck(:id)
-        shared = Collection.shared_with_minimum_permission_level(
-          current_user, CollectionShare.permission_level(:read_elements)
-        ).where(id: collection_ids - owned_ids)
-        shared_ids = shared.select { |collection| collection.full_detail_access_for?(current_user) }.map(&:id)
+        shared_ids = Collection.full_detail_access_ids(current_user, collection_ids - owned_ids)
         allowed_ids = owned_ids + shared_ids
 
         error!('401 Unauthorized', 401) if (collection_ids - allowed_ids).any?

--- a/app/api/chemotion/collection_api.rb
+++ b/app/api/chemotion/collection_api.rb
@@ -116,10 +116,15 @@ module Chemotion
       end
       post '/export' do
         collection_ids = params[:collection_ids].uniq
-        all_collection_ids = Collection.own_collections_for(current_user).pluck(:id)
+        # A sharee may export a collection shared to them at any level (read_elements+), in addition
+        # to their own collections.
+        allowed_ids = Collection.own_collections_for(current_user).pluck(:id) +
+                      Collection.shared_with_minimum_permission_level(
+                        current_user, CollectionShare.permission_level(:read_elements)
+                      ).pluck(:id)
 
         error!('Select the collections you want to export.', 403) if collection_ids.empty?
-        error!('401 Unauthorized', 401) if all_collection_ids & collection_ids != collection_ids
+        error!('401 Unauthorized', 401) if (collection_ids - allowed_ids).any?
 
         ExportCollectionsJob.perform_later(collection_ids, 'zip', false, current_user.id)
 

--- a/app/api/chemotion/collection_api.rb
+++ b/app/api/chemotion/collection_api.rb
@@ -116,14 +116,20 @@ module Chemotion
       end
       post '/export' do
         collection_ids = params[:collection_ids].uniq
-        # A sharee may export a collection shared to them at any level (read_elements+), in addition
-        # to their own collections.
-        allowed_ids = Collection.own_collections_for(current_user).pluck(:id) +
-                      Collection.shared_with_minimum_permission_level(
-                        current_user, CollectionShare.permission_level(:read_elements)
-                      ).pluck(:id)
-
         error!('Select the collections you want to export.', 403) if collection_ids.empty?
+
+        # Own collections may always be exported. A sharee may export a collection shared to them
+        # only when they hold FULL detail access on it (every element detail level at max): the
+        # export path serializes full element content and ignores detail levels, so admitting a
+        # partial-detail share would leak data the share deliberately withheld. Both queries are
+        # scoped to the requested ids — this only needs to know the requested set is authorised.
+        owned_ids = Collection.own_collections_for(current_user).where(id: collection_ids).pluck(:id)
+        shared = Collection.shared_with_minimum_permission_level(
+          current_user, CollectionShare.permission_level(:read_elements)
+        ).where(id: collection_ids - owned_ids)
+        shared_ids = shared.select { |collection| collection.full_detail_access_for?(current_user) }.map(&:id)
+        allowed_ids = owned_ids + shared_ids
+
         error!('401 Unauthorized', 401) if (collection_ids - allowed_ids).any?
 
         ExportCollectionsJob.perform_later(collection_ids, 'zip', false, current_user.id)

--- a/app/api/chemotion/collection_share_api.rb
+++ b/app/api/chemotion/collection_share_api.rb
@@ -76,12 +76,46 @@ module Chemotion
         error!('422 Unprocessable Entity: ownership can only be offered to a single person', 422)
       end
 
+      # Whether a share write should cascade to sub-collections. A :pass_ownership share is an
+      # ownership *offer*, and accepting it already transfers the whole subtree atomically (see
+      # {Usecases::Collections::TransferOwnership}); cascading the offer itself would instead mint an
+      # independent take-ownership offer on every sub-collection, fragmenting the tree. So the offer
+      # is never cascaded, whatever the checkbox says.
+      def cascade_requested?(apply_to_subcollections, permission_level)
+        apply_to_subcollections && permission_level != CollectionShare.permission_level(:pass_ownership)
+      end
+
       # The collections a share should be written to: the root, plus (when requested) every
-      # descendant the caller may administer.
+      # descendant the caller may administer. The administrable set is resolved in two queries for
+      # the whole subtree rather than one +find_administrable_collection+ per descendant.
       def cascade_targets(root, apply_to_subcollections)
         return [root] unless apply_to_subcollections
 
-        [root, *root.descendants.select { |sub| find_administrable_collection(sub.id) }]
+        descendants = root.descendants.to_a
+        administrable_ids = administrable_collection_ids(descendants.map(&:id))
+        [root, *descendants.select { |sub| administrable_ids.include?(sub.id) }]
+      end
+
+      # The administrable descendants of +root+ that ALREADY hold a share for +shared_with_id+ — the
+      # only targets an *edit* cascade may touch (it edits existing shares, never mints new ones).
+      # Resolved with a single membership query, not one per descendant.
+      def shared_descendants(root, shared_with_id)
+        descendants = cascade_targets(root, true).drop(1)
+        already_shared = CollectionShare.where(collection_id: descendants.map(&:id), shared_with_id: shared_with_id)
+                                        .pluck(:collection_id).to_set
+        descendants.select { |sub| already_shared.include?(sub.id) }
+      end
+
+      # The subset of +ids+ the current user may administer — owned, or shared to them at
+      # :manage_shares+. Set form of {#find_administrable_collection} for the cascade.
+      #
+      # @return [Set<Integer>]
+      def administrable_collection_ids(ids)
+        owned = Collection.own_collections_for(current_user).where(id: ids).pluck(:id)
+        delegated = Collection.shared_with_minimum_permission_level(
+          current_user, CollectionShare.permission_level(:manage_shares)
+        ).where(id: ids).pluck(:id)
+        (owned + delegated).to_set
       end
 
       # Run the share guards for every target. Kept separate from — and always called BEFORE — the
@@ -93,6 +127,12 @@ module Chemotion
           prevent_privilege_escalation!(target, permission_level)
           prevent_sharing_with_owner!(target, user_ids)
           prevent_invalid_ownership_offer!(target, user_ids, permission_level)
+          # Guard the level being overwritten too, not just the one being granted: a delegate may
+          # not alter a share that already outranks them on this target (mirrors the root PUT's
+          # second escalation check — see the put '/:id' handler).
+          CollectionShare.where(collection: target, shared_with_id: user_ids)
+                         .pluck(:permission_level)
+                         .each { |existing_level| prevent_privilege_escalation!(target, existing_level) }
         end
       end
 
@@ -160,7 +200,8 @@ module Chemotion
         attributes = declared(params, include_missing: false)
                      .except(:collection_id, :user_ids, :apply_to_subcollections)
 
-        targets = cascade_targets(collection, params[:apply_to_subcollections])
+        cascade = cascade_requested?(params[:apply_to_subcollections], params[:permission_level])
+        targets = cascade_targets(collection, cascade)
         validate_share_targets!(targets, params[:user_ids], params[:permission_level])
         # requires_new: true so the cascade rolls back to a savepoint even when nested in an outer
         # transaction (e.g. transactional test fixtures) — without it a mid-cascade failure would
@@ -200,8 +241,11 @@ module Chemotion
 
         # Optionally apply the same edit to the descendants the caller may administer, for THIS
         # share's sharee. Guards run before the transaction (see validate_share_targets!); the target
-        # update and the cascade then commit together.
-        descendants = params[:apply_to_subcollections] ? cascade_targets(collection, true).drop(1) : []
+        # update and the cascade then commit together. Unlike the create cascade this only *edits*
+        # existing sub-collection shares for the sharee — it never mints a new one, so ticking the box
+        # can widen a level but never grant access to a sub-collection that was not already shared.
+        cascade = cascade_requested?(params[:apply_to_subcollections], params[:permission_level])
+        descendants = cascade ? shared_descendants(collection, share.shared_with_id) : []
         validate_share_targets!(descendants, [share.shared_with_id], params[:permission_level])
         # requires_new: true — see the note on the create endpoint (atomic under nested transactions).
         ActiveRecord::Base.transaction(requires_new: true) do

--- a/app/api/chemotion/collection_share_api.rb
+++ b/app/api/chemotion/collection_share_api.rb
@@ -8,6 +8,12 @@ module Chemotion
     rescue_from Usecases::Collections::Errors::InsufficientPermissionError do |error|
       error!(error.message, 403)
     end
+    # A share write can still fail at the DB (e.g. a user_id with no matching user → InvalidForeignKey,
+    # or a model validation → RecordInvalid). Surface it as a 422 rather than an unhandled 500; the
+    # cascade below runs its writes in a transaction, so a mid-cascade failure leaves nothing behind.
+    rescue_from ActiveRecord::RecordInvalid, ActiveRecord::InvalidForeignKey do |error|
+      error!(error.message, 422)
+    end
 
     helpers do
       # The collection whose share list the current user may administrate: one they own, or one
@@ -69,6 +75,40 @@ module Chemotion
 
         error!('422 Unprocessable Entity: ownership can only be offered to a single person', 422)
       end
+
+      # The collections a share should be written to: the root, plus (when requested) every
+      # descendant the caller may administer.
+      def cascade_targets(root, apply_to_subcollections)
+        return [root] unless apply_to_subcollections
+
+        [root, *root.descendants.select { |sub| find_administrable_collection(sub.id) }]
+      end
+
+      # Run the share guards for every target. Kept separate from — and always called BEFORE — the
+      # write transaction: the guards call Grape +error!+ (+throw :error+), and on Rails 6.1 a
+      # non-local exit out of an ActiveRecord transaction block commits rather than rolls back, so a
+      # guard tripping inside the transaction would leak partial writes.
+      def validate_share_targets!(targets, user_ids, permission_level)
+        targets.each do |target|
+          prevent_privilege_escalation!(target, permission_level)
+          prevent_sharing_with_owner!(target, user_ids)
+          prevent_invalid_ownership_offer!(target, user_ids, permission_level)
+        end
+      end
+
+      # Upsert the share (per user) onto each target and refresh its shared flag. No transaction of
+      # its own — the caller wraps this (together with any sibling write, e.g. the PUT target update)
+      # in a single ActiveRecord::Base.transaction so the whole cascade is atomic.
+      def write_shares!(targets, user_ids, attributes)
+        targets.each do |target|
+          user_ids.each do |user_id|
+            share = CollectionShare.find_or_initialize_by(collection: target, shared_with_id: user_id)
+            share.assign_attributes(attributes)
+            share.save!
+          end
+          refresh_shared_flag!(target)
+        end
+      end
     end
 
     resource :collection_shares do
@@ -120,25 +160,12 @@ module Chemotion
         attributes = declared(params, include_missing: false)
                      .except(:collection_id, :user_ids, :apply_to_subcollections)
 
-        # The offered collection, plus (optionally) each descendant the caller may administer.
-        targets = [collection]
-        if params[:apply_to_subcollections]
-          targets += collection.descendants.select { |sub| find_administrable_collection(sub.id) }
-        end
-
-        targets.each do |target|
-          prevent_privilege_escalation!(target, params[:permission_level])
-          prevent_sharing_with_owner!(target, params[:user_ids])
-          prevent_invalid_ownership_offer!(target, params[:user_ids], params[:permission_level])
-
-          params[:user_ids].each do |user_id|
-            share = CollectionShare.find_or_initialize_by(collection: target, shared_with_id: user_id)
-            share.assign_attributes(attributes)
-            share.save!
-          end
-
-          refresh_shared_flag!(target)
-        end
+        targets = cascade_targets(collection, params[:apply_to_subcollections])
+        validate_share_targets!(targets, params[:user_ids], params[:permission_level])
+        # requires_new: true so the cascade rolls back to a savepoint even when nested in an outer
+        # transaction (e.g. transactional test fixtures) — without it a mid-cascade failure would
+        # leave the earlier writes behind.
+        ActiveRecord::Base.transaction(requires_new: true) { write_shares!(targets, params[:user_ids], attributes) }
 
         { status: 204 }
       end
@@ -156,6 +183,8 @@ module Chemotion
         optional :screen_detail_level, type: Integer
         optional :sequencebasedmacromoleculesample_detail_level, type: Integer
         optional :wellplate_detail_level, type: Integer
+        optional :apply_to_subcollections, type: Boolean, default: false,
+                                           desc: 'Also apply this edit to the descendant collections'
       end
       put '/:id' do
         share = CollectionShare.find(params[:id])
@@ -167,7 +196,18 @@ module Chemotion
         prevent_invalid_ownership_offer!(collection, [share.shared_with_id], params[:permission_level])
 
         # include_missing: false keeps this a partial update; see the note on the create endpoint.
-        share.update!(declared(params, include_missing: false).except(:id))
+        attributes = declared(params, include_missing: false).except(:id, :apply_to_subcollections)
+
+        # Optionally apply the same edit to the descendants the caller may administer, for THIS
+        # share's sharee. Guards run before the transaction (see validate_share_targets!); the target
+        # update and the cascade then commit together.
+        descendants = params[:apply_to_subcollections] ? cascade_targets(collection, true).drop(1) : []
+        validate_share_targets!(descendants, [share.shared_with_id], params[:permission_level])
+        # requires_new: true — see the note on the create endpoint (atomic under nested transactions).
+        ActiveRecord::Base.transaction(requires_new: true) do
+          share.update!(attributes)
+          write_shares!(descendants, [share.shared_with_id], attributes)
+        end
 
         present share, with: Entities::CollectionShareEntity, root: :collection_share
       end

--- a/app/api/chemotion/collection_share_api.rb
+++ b/app/api/chemotion/collection_share_api.rb
@@ -109,24 +109,36 @@ module Chemotion
         optional :screen_detail_level, type: Integer
         optional :sequencebasedmacromoleculesample_detail_level, type: Integer
         optional :wellplate_detail_level, type: Integer
+        optional :apply_to_subcollections, type: Boolean, default: false,
+                                           desc: 'Also apply this share to the descendant collections'
       end
       post do
         collection = administrable_collection(params[:collection_id])
-        prevent_privilege_escalation!(collection, params[:permission_level])
-        prevent_sharing_with_owner!(collection, params[:user_ids])
-        prevent_invalid_ownership_offer!(collection, params[:user_ids], params[:permission_level])
 
         # include_missing: false — otherwise every omitted optional detail level is declared as nil and
         # overwrites the column default, tripping its NOT NULL constraint.
-        attributes = declared(params, include_missing: false).except(:collection_id, :user_ids)
+        attributes = declared(params, include_missing: false)
+                     .except(:collection_id, :user_ids, :apply_to_subcollections)
 
-        params[:user_ids].each do |user_id|
-          share = CollectionShare.find_or_initialize_by(collection: collection, shared_with_id: user_id)
-          share.assign_attributes(attributes)
-          share.save!
+        # The offered collection, plus (optionally) each descendant the caller may administer.
+        targets = [collection]
+        if params[:apply_to_subcollections]
+          targets += collection.descendants.select { |sub| find_administrable_collection(sub.id) }
         end
 
-        refresh_shared_flag!(collection)
+        targets.each do |target|
+          prevent_privilege_escalation!(target, params[:permission_level])
+          prevent_sharing_with_owner!(target, params[:user_ids])
+          prevent_invalid_ownership_offer!(target, params[:user_ids], params[:permission_level])
+
+          params[:user_ids].each do |user_id|
+            share = CollectionShare.find_or_initialize_by(collection: target, shared_with_id: user_id)
+            share.assign_attributes(attributes)
+            share.save!
+          end
+
+          refresh_shared_flag!(target)
+        end
 
         { status: 204 }
       end

--- a/app/api/chemotion/permission_api.rb
+++ b/app/api/chemotion/permission_api.rb
@@ -45,11 +45,14 @@ module Chemotion
           remove_allowed = true
 
           if collection.user != current_user # collection was shared to user
-            # set deletion_allowed to false if any of the elements is not allowed to be mass deleted
-            [Sample, Reaction, Screen, Wellplate].each do |element_class|
-              next if selected_elements[element_class].none?
+            # Every selected element type is policed, not just the four legacy ones. A selection the
+            # loop skipped (research_plan / cell_line / vessel / device_description / SBMM) would keep
+            # the flag at its permissive default, and the UI would offer a Move/Remove/Delete the
+            # server then refuses.
+            selected_elements.each_value do |scope|
+              next if scope.none?
 
-              policy = ElementsPolicy.new(current_user, selected_elements[element_class])
+              policy = ElementsPolicy.new(current_user, scope)
               deletion_allowed &&= policy.destroy_all?
               remove_allowed &&= policy.remove_all?
             end
@@ -58,10 +61,10 @@ module Chemotion
             # so we have to check if the lower permissions for sharing are satisfied
             # when mass deletion is forbidden
             unless deletion_allowed
-              [Sample, Reaction, Screen, Wellplate].each do |element_class|
-                next if selected_elements[element_class].none?
+              selected_elements.each_value do |scope|
+                next if scope.none?
 
-                sharing_allowed &&= ElementsPolicy.new(current_user, selected_elements[element_class]).share_all?
+                sharing_allowed &&= ElementsPolicy.new(current_user, scope).share_all?
               end
             end
           end

--- a/app/javascript/src/apps/mydb/collections/ModalExportCollection.js
+++ b/app/javascript/src/apps/mydb/collections/ModalExportCollection.js
@@ -9,6 +9,8 @@ function ModalExportCollection({ onHide }) {
   const collectionsStore = useContext(StoreContext).collections;
   const lockedCollections = collectionsStore.locked_collection;
   const ownCollections = collectionsStore.own_collections;
+  // The real shared collections live under the per-owner root nodes of the shared-with-me tree.
+  const sharedCollections = collectionsStore.shared_with_me_collections.flatMap((owner) => owner.children || []);
   const allCollections = [];
   const currentUser = (UserStore.getState() && UserStore.getState().currentUser) || {};
   const [checkedCollections, setCheckedCollections] = useState({});
@@ -138,6 +140,7 @@ function ModalExportCollection({ onHide }) {
       <div className="export-collections-modal">
         {renderCollections('Global Collections', lockedCollections)}
         {renderCollections('My Collections', ownCollections)}
+        {renderCollections('Shared with me', sharedCollections)}
       </div>
       {renderCheckAll()}
     </AppModal>

--- a/app/javascript/src/apps/mydb/collections/SharedWithMeCollections.js
+++ b/app/javascript/src/apps/mydb/collections/SharedWithMeCollections.js
@@ -1,12 +1,27 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import Tree from 'react-ui-tree';
 import { Button, ButtonGroup, OverlayTrigger, Popover } from 'react-bootstrap';
+import SelectionShareModal from 'src/apps/mydb/elements/list/selectionActions/SelectionShareModal';
+import CollectionSharesEditModal from 'src/apps/mydb/collections/CollectionSharesEditModal';
+import { PermissionConst } from 'src/utilities/PermissionConst';
 import { observer } from 'mobx-react';
 import { StoreContext } from 'src/stores/mobx/RootStore';
+
+const defaultPermissions = {
+  permissionLevel: 0,
+  sampleDetailLevel: 10,
+  reactionDetailLevel: 10,
+  wellplateDetailLevel: 10,
+  screenDetailLevel: 10,
+  elementDetailLevel: 10,
+};
 
 function SharedWithMeCollections() {
   const collectionsStore = useContext(StoreContext).collections;
   const tree = collectionsStore.shared_with_me_collection_tree;
+  const [sharesModal, setSharesModal] = useState({ action: null, show: false, node: {} });
+  const [sharesEditModal, setSharesEditModal] = useState({ show: false, node: {} });
+  const [permissions, setPermissions] = useState(defaultPermissions);
 
   const handleChange = (tree) => {
     collectionsStore.setSharedWithMeCollectionTree(tree);
@@ -15,6 +30,75 @@ function SharedWithMeCollections() {
   const rejectShared = (node) => {
     collectionsStore.deleteCollectionShare(node.collection_share_id, node.id);
   }
+
+  // A delegate holding :manage_shares (or higher) on a shared collection may administer its shares.
+  const canManageShares = (node) => node.permission_level >= PermissionConst.ManageShares;
+
+  const openCollectionSharesModal = (node) => {
+    setPermissions(defaultPermissions);
+    setSharesModal({ action: 'create', show: true, node });
+  };
+
+  const closeCollectionSharesModal = () => {
+    setPermissions(defaultPermissions);
+    setSharesModal({ action: null, show: false, node: {} });
+  };
+
+  const editCollectionShares = (node, collectionShare) => {
+    setPermissions({
+      permissionLevel: collectionShare.permission_level,
+      sampleDetailLevel: collectionShare.sample_detail_level,
+      reactionDetailLevel: collectionShare.reaction_detail_level,
+      wellplateDetailLevel: collectionShare.wellplate_detail_level,
+      screenDetailLevel: collectionShare.screen_detail_level,
+      elementDetailLevel: collectionShare.element_detail_level,
+    });
+    setSharesModal({
+      action: 'edit',
+      show: true,
+      node: { ...node, collectionShareId: collectionShare.id, sharedWith: collectionShare.shared_with },
+    });
+  };
+
+  const deleteCollectionShares = (node, collectionShare) => {
+    collectionsStore.deleteCollectionShare(collectionShare.id, node.id);
+  };
+
+  const openCollectionSharesEditModal = (node) => {
+    setSharesEditModal({ show: true, node: { id: node.id, label: node.label } });
+  };
+
+  const closeCollectionSharesEditModal = () => {
+    setSharesEditModal({ show: false, node: {} });
+  };
+
+  const manageShareButtons = (node) => {
+    if (!canManageShares(node)) { return null; }
+    return (
+      <>
+        <Button
+          size="sm"
+          variant="warning"
+          title="Manage shares"
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={() => openCollectionSharesEditModal(node)}
+        >
+          <i className="fa fa-users" />
+          <i className="fa fa-share-alt ms-1" />
+        </Button>
+        <Button
+          size="sm"
+          variant="primary"
+          title="Add share"
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={() => openCollectionSharesModal(node)}
+        >
+          <i className="fa fa-plus" />
+          <i className="fa fa-share-alt ms-1" />
+        </Button>
+      </>
+    );
+  };
 
   const renderNode = (node) => {
     if (node.id === -1) { 
@@ -82,8 +166,9 @@ function SharedWithMeCollections() {
               />
             )}
           </div>
-          {canReject && (
-            <ButtonGroup>
+          <ButtonGroup>
+            {manageShareButtons(node)}
+            {canReject && (
               <OverlayTrigger
                 animation
                 placement="bottom"
@@ -95,8 +180,8 @@ function SharedWithMeCollections() {
                   <i className="fa fa-trash-o" />
                 </Button>
               </OverlayTrigger>
-            </ButtonGroup>
-          )}
+            )}
+          </ButtonGroup>
         </div>
       );
     }
@@ -110,6 +195,27 @@ function SharedWithMeCollections() {
         onChange={handleChange}
         renderNode={renderNode}
       />
+      {Object.keys(sharesModal.node).length >= 1 && sharesModal.show && (
+        <SelectionShareModal
+          title={sharesModal.action === 'create'
+            ? `Share "${sharesModal.node.label}"`
+            : `Edit Permissions of "${sharesModal.node.sharedWith}" at "${sharesModal.node.label}"`}
+          collectionId={sharesModal.node.id}
+          collectionShareId={sharesModal.node?.collectionShareId}
+          onHide={closeCollectionSharesModal}
+          collectionPermissions={permissions}
+          showUserSelect={sharesModal.action === 'create'}
+          shareType={sharesModal.action}
+        />
+      )}
+      {Object.keys(sharesEditModal.node).length >= 1 && sharesEditModal.show && (
+        <CollectionSharesEditModal
+          node={sharesEditModal.node}
+          updateNode={editCollectionShares}
+          deleteNode={deleteCollectionShares}
+          onHide={closeCollectionSharesEditModal}
+        />
+      )}
     </div>
   );
 

--- a/app/javascript/src/apps/mydb/collections/SharedWithMeCollections.js
+++ b/app/javascript/src/apps/mydb/collections/SharedWithMeCollections.js
@@ -195,7 +195,7 @@ function SharedWithMeCollections() {
         onChange={handleChange}
         renderNode={renderNode}
       />
-      {Object.keys(sharesModal.node).length >= 1 && sharesModal.show && (
+      {sharesModal.show && (
         <SelectionShareModal
           title={sharesModal.action === 'create'
             ? `Share "${sharesModal.node.label}"`
@@ -208,7 +208,7 @@ function SharedWithMeCollections() {
           shareType={sharesModal.action}
         />
       )}
-      {Object.keys(sharesEditModal.node).length >= 1 && sharesEditModal.show && (
+      {sharesEditModal.show && (
         <CollectionSharesEditModal
           node={sharesEditModal.node}
           updateNode={editCollectionShares}

--- a/app/javascript/src/apps/mydb/elements/labels/ElementCollectionLabels.js
+++ b/app/javascript/src/apps/mydb/elements/labels/ElementCollectionLabels.js
@@ -15,6 +15,7 @@ const CollectionToggle = React.forwardRef(({
   onClick,
   labelsCount,
   totalSharedCollections,
+  isDualOwned,
   size,
   variant,
 }, ref) => (
@@ -23,6 +24,7 @@ const CollectionToggle = React.forwardRef(({
     size={size}
     variant={variant}
     className="text-nowrap"
+    title={isDualOwned ? 'This element is also in a collection you do not own' : undefined}
     onClick={(e) => {
       e.preventDefault();
       e.stopPropagation();
@@ -32,8 +34,10 @@ const CollectionToggle = React.forwardRef(({
     <i className="fa fa-list" />
     {` ${labelsCount} `}
     {' | '}
-    <i className="fa fa-share-alt" />
-    {`${totalSharedCollections} `}
+    <span className={isDualOwned ? 'text-warning' : undefined}>
+      <i className="fa fa-share-alt" />
+      {`${totalSharedCollections} `}
+    </span>
   </Button>
 ));
 CollectionToggle.displayName = 'CollectionToggle';
@@ -41,10 +45,12 @@ CollectionToggle.propTypes = {
   onClick: PropTypes.func.isRequired,
   labelsCount: PropTypes.number.isRequired,
   totalSharedCollections: PropTypes.number.isRequired,
+  isDualOwned: PropTypes.bool,
   size: PropTypes.string,
   variant: PropTypes.string,
 };
 CollectionToggle.defaultProps = {
+  isDualOwned: false,
   size: 'xxsm',
   variant: 'light',
 };
@@ -103,6 +109,7 @@ const ElementCollectionLabels = ({ element, size, variant }) => {
         id="dropdown-custom-components"
         labelsCount={ownCollections.length}
         totalSharedCollections={sharedCollections.length}
+        isDualOwned={ownCollections.length > 0 && sharedCollections.length > 0}
         size={size}
         variant={variant}
       />

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionShareModal.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionShareModal.js
@@ -7,6 +7,7 @@ import { AsyncSelect } from 'src/components/common/Select';
 import CollectionSelect from 'src/components/common/CollectionSelect';
 
 import SelectionSharingShortcuts from 'src/apps/mydb/elements/list/selectionActions/SelectionSharingShortcuts';
+import PermissionIcons from 'src/apps/mydb/collections/PermissionIcons';
 
 import UIStore from 'src/stores/alt/stores/UIStore';
 import UserStore from 'src/stores/alt/stores/UserStore';
@@ -87,6 +88,7 @@ function SelectionShareModal({
       // edit permissions of collection share
       const params = {
         id: collectionShareId,
+        apply_to_subcollections: applyToSubcollections,
         ...permissionsParams
       };
       collectionsStore.updateCollectionShare(collectionShareId, params);
@@ -222,20 +224,25 @@ function SelectionShareModal({
             value={permissions.permissionLevel ?? ''}
           >
             <option value={PermissionConst.ReadElements}>Read elements</option>
-            <option value={PermissionConst.EditElements}>Edit elements</option>
-            <option value={PermissionConst.AddElements}>Add elements</option>
-            <option value={PermissionConst.RemoveElements}>Remove elements</option>
-            <option value={PermissionConst.ManageShares}>Manage shares</option>
-            <option value={PermissionConst.PassOwnership}>Pass ownership</option>
+            <option value={PermissionConst.EditElements}>Edit elements (+ read)</option>
+            <option value={PermissionConst.AddElements}>Add elements (+ read, edit)</option>
+            <option value={PermissionConst.RemoveElements}>Remove elements (+ read, edit, add)</option>
+            <option value={PermissionConst.ManageShares}>Manage shares (+ read, edit, add, remove)</option>
+            <option value={PermissionConst.PassOwnership}>Pass ownership (+ all of the above)</option>
           </Form.Select>
+          <Form.Text className="d-block">
+            <span className="me-2">Grants:</span>
+            <PermissionIcons pl={Number(permissions.permissionLevel) || 0} />
+            <span className="ms-2 text-muted">Each level includes all levels above it.</span>
+          </Form.Text>
           {displayWarning && (
-            <Form.Text>
+            <Form.Text className="d-block">
               <i className="fa fa-exclamation-circle ms-1" aria-hidden="true" />
               Transfering ownership applies for all sub collections.
             </Form.Text>
           )}
         </Form.Group>
-        {shareType === 'create' && (
+        {(shareType === 'create' || shareType === 'edit') && (
           <Form.Group className="mb-3" controlId="applyToSubcollections">
             <Form.Check
               type="checkbox"

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionShareModal.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionShareModal.js
@@ -233,12 +233,12 @@ function SelectionShareModal({
           <Form.Text className="d-block">
             <span className="me-2">Grants:</span>
             <PermissionIcons pl={Number(permissions.permissionLevel) || 0} />
-            <span className="ms-2 text-muted">Each level includes all levels above it.</span>
+            <span className="ms-2 text-muted">Each level also grants all the levels below it.</span>
           </Form.Text>
           {displayWarning && (
             <Form.Text className="d-block">
               <i className="fa fa-exclamation-circle ms-1" aria-hidden="true" />
-              Transfering ownership applies for all sub collections.
+              Transferring ownership applies to all sub-collections.
             </Form.Text>
           )}
         </Form.Group>

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionShareModal.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionShareModal.js
@@ -39,6 +39,7 @@ function SelectionShareModal({
   const [selectedUsers, setSelectedUsers] = useState([]);
   const [newCollectionLabel, setNewCollectionLabel] = useState('');
   const [parentCollection, setParentCollection] = useState(null);
+  const [applyToSubcollections, setApplyToSubcollections] = useState(false);
   const defaultRole = 'Pick a sharing role';
   const [role, setRole] = useState(defaultRole);
 
@@ -78,6 +79,7 @@ function SelectionShareModal({
       const params = {
         collection_id: collectionId,
         user_ids: selectedUsers.map((u) => u.id),
+        apply_to_subcollections: applyToSubcollections,
         ...permissionsParams
       };
       collectionsStore.addCollectionShare(params, currentUser, false);
@@ -233,6 +235,16 @@ function SelectionShareModal({
             </Form.Text>
           )}
         </Form.Group>
+        {shareType === 'create' && (
+          <Form.Group className="mb-3" controlId="applyToSubcollections">
+            <Form.Check
+              type="checkbox"
+              label="Apply these share settings to all sub-collections"
+              checked={applyToSubcollections}
+              onChange={(e) => setApplyToSubcollections(e.target.checked)}
+            />
+          </Form.Group>
+        )}
         <Form.Group className="mb-3" controlId="sampleDetailLevelSelect">
           <Form.Label>Sample detail level</Form.Label>
           <Form.Select

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionShareModal.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionShareModal.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Form } from 'react-bootstrap';
 import AppModal from 'src/components/common/AppModal';
 import { AsyncSelect } from 'src/components/common/Select';
+import CollectionSelect from 'src/components/common/CollectionSelect';
 
 import SelectionSharingShortcuts from 'src/apps/mydb/elements/list/selectionActions/SelectionSharingShortcuts';
 
@@ -36,6 +37,8 @@ function SelectionShareModal({
   const collectionsStore = useContext(StoreContext).collections;
   const [permissions, setPermissions] = useState(collectionPermissions);
   const [selectedUsers, setSelectedUsers] = useState([]);
+  const [newCollectionLabel, setNewCollectionLabel] = useState('');
+  const [parentCollection, setParentCollection] = useState(null);
   const defaultRole = 'Pick a sharing role';
   const [role, setRole] = useState(defaultRole);
 
@@ -65,6 +68,8 @@ function SelectionShareModal({
         uiState: filterParamsFromUIState(uiState),
         users: selectedUsers,
         permissions: permissionsParams,
+        label: newCollectionLabel.trim(),
+        parentId: parentCollection?.id ?? null,
         currentUser,
       };
       collectionsStore.collectionShareForElements(params);
@@ -172,6 +177,27 @@ function SelectionShareModal({
       primaryActionDisabled={!canSubmit}
     >
       <Form>
+        {shareType === 'new' && (
+          <>
+            <Form.Group className="mb-3" controlId="newCollectionLabel">
+              <Form.Label>New collection name</Form.Label>
+              <Form.Control
+                type="text"
+                placeholder="Leave empty to use “My project with …”"
+                value={newCollectionLabel}
+                onChange={(e) => setNewCollectionLabel(e.target.value)}
+              />
+            </Form.Group>
+            <Form.Group className="mb-3" controlId="newCollectionParent">
+              <Form.Label>Parent collection (optional)</Form.Label>
+              <CollectionSelect
+                value={parentCollection}
+                withShared={false}
+                onChange={setParentCollection}
+              />
+            </Form.Group>
+          </>
+        )}
         <Form.Group className="mb-3" controlId="shortcutSelect">
           <Form.Label>Role</Form.Label>
           <Form.Select

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -365,6 +365,8 @@ export const CollectionsStore = types
     setSharedWithMeCollections(collections) {
       // group shared collections by owner
       const sharedWithMeCollections = self.presortSharedWithMeCollections(collections)
+      // The set of collections actually shared with the user — used to decide truncation below.
+      const sharedIds = new Set(sharedWithMeCollections.map((collection) => collection.id));
 
       sharedWithMeCollections.forEach((collection, i) => {
         if (i === 0 || i > 0 && sharedWithMeCollections[i - 1].owner !== collection.owner) {
@@ -379,7 +381,12 @@ export const CollectionsStore = types
         }
         const parentOwnerIndex = self.shared_with_me_collections.findIndex(element => element.owner == collection.owner)
         if (parentOwnerIndex !== -1) {
-          self.shared_with_me_collections[parentOwnerIndex].addChild(collection)
+          const node = Collection.create(collection);
+          // Preserve the hierarchy when the parent is also shared; when it is not (the branch is
+          // "skipped"), truncate by showing this collection at the top level under its owner.
+          const directParentId = node.ancestorIds[node.ancestorIds.length - 1];
+          if (directParentId == null || !sharedIds.has(directParentId)) { node.resetAncestry(); }
+          self.addCollectionToTree(node, self.shared_with_me_collections[parentOwnerIndex].children);
         }
       });
     },

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -319,9 +319,16 @@ export const CollectionsStore = types
       }
     }),
     collectionShareForElements(params) {
+      const hasCustomLabel = params.label && params.label.length > 0;
+      const multipleRecipients = params.users.length > 1;
       params.users.forEach((user) => {
-        self.addElementsToCollectionAndShare(user, params)
-      })
+        // One shared collection is created per recipient. The default "My project with <name>" is
+        // already unique per recipient, but a single custom label shared with several people would
+        // create identically-named collections — suffix it with the recipient's name to keep them
+        // distinguishable.
+        const label = hasCustomLabel && multipleRecipients ? `${params.label} – ${user.name}` : params.label;
+        self.addElementsToCollectionAndShare(user, { ...params, label });
+      });
     },
     createSharingMessage(currentUser, userIds) {
       const messageParams = {

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -295,7 +295,11 @@ export const CollectionsStore = types
       }
     }),
     addElementsToCollectionAndShare: flow(function* addElementsToCollectionAndShare(user, params) {
-      const collectionParams = { label: `My project with ${user.name}`, parent_id: '', inventory_id: '' }
+      const collectionParams = {
+        label: (params.label && params.label.length > 0) ? params.label : `My project with ${user.name}`,
+        parent_id: params.parentId ?? '',
+        inventory_id: '',
+      };
       const newCollection = yield self.addCollection(collectionParams, false)
 
       if (newCollection) {

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -297,18 +297,27 @@ class Collection < ApplicationRecord
     DETAIL_LEVEL_KEYS.index_with { |key| shares.pluck(key).compact.max || 0 }
   end
 
-  # Whether +user+ holds the maximum detail level ({OWNER_LEVEL}) on every element type here — i.e.
-  # they can already see full-fidelity content. Used to gate the raw export path (which serializes
-  # full element content, ignoring detail levels): a sharee below full detail on any element type
-  # must not be able to export a collection and read data their share deliberately withheld. The
-  # +permission_level+ rung is not a detail level and is excluded. Owners trivially qualify.
+  # The subset of +collection_ids+ on which +user+ holds FULL detail access: the maximum
+  # ({OWNER_LEVEL}) on every element detail level, aggregated across all their shares (direct and
+  # group) exactly as {#detail_levels_for_user} reduces them. Used to gate the raw export path,
+  # which serializes full element content ignoring detail levels — a sharee below full detail on
+  # any element type must not export a collection and read data their share deliberately withheld.
+  # Resolved in one grouped query rather than a predicate per collection. Owners are authorised
+  # separately and are not considered here.
   #
   # @param user [User]
-  # @return [Boolean]
-  def full_detail_access_for?(user)
-    detail_levels_for_user(user)
-      .except(:permission_level)
-      .values.all? { |level| level >= OWNER_LEVEL }
+  # @param collection_ids [Array<Integer>]
+  # @return [Array<Integer>] the ids among +collection_ids+ the user may fully read
+  def self.full_detail_access_ids(user, collection_ids)
+    return [] if collection_ids.blank?
+
+    detail_columns = DETAIL_LEVEL_KEYS - [:permission_level]
+    having = detail_columns.map { |column| "MAX(#{column}) >= #{OWNER_LEVEL}" }.join(' AND ')
+    CollectionShare.shared_with(user)
+                   .where(collection_id: collection_ids)
+                   .group(:collection_id)
+                   .having(Arel.sql(having))
+                   .pluck(:collection_id)
   end
 end
 # rubocop:enable Rails/HasManyOrHasOneDependent

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -296,5 +296,19 @@ class Collection < ApplicationRecord
 
     DETAIL_LEVEL_KEYS.index_with { |key| shares.pluck(key).compact.max || 0 }
   end
+
+  # Whether +user+ holds the maximum detail level ({OWNER_LEVEL}) on every element type here — i.e.
+  # they can already see full-fidelity content. Used to gate the raw export path (which serializes
+  # full element content, ignoring detail levels): a sharee below full detail on any element type
+  # must not be able to export a collection and read data their share deliberately withheld. The
+  # +permission_level+ rung is not a detail level and is excluded. Owners trivially qualify.
+  #
+  # @param user [User]
+  # @return [Boolean]
+  def full_detail_access_for?(user)
+    detail_levels_for_user(user)
+      .except(:permission_level)
+      .values.all? { |level| level >= OWNER_LEVEL }
+  end
 end
 # rubocop:enable Rails/HasManyOrHasOneDependent

--- a/app/usecases/collections/transfer_ownership.rb
+++ b/app/usecases/collections/transfer_ownership.rb
@@ -110,24 +110,30 @@ module Usecases
       # the former owner a manage_shares sharee so they keep access there. Sub-collections that were
       # never shared to the new owner transfer ownership without leaving the former owner a share.
       def demote_former_owner(subtree_ids, old_owner)
-        Collection.where(id: subtree_ids).find_each do |collection|
-          new_owner_shares = CollectionShare.where(collection: collection, shared_with_id: current_user.id)
-          next unless new_owner_shares.exists?
+        # The subtree collections that were shared to the new owner — exactly the ones whose share
+        # switches to the former owner. Resolved in one query instead of a per-collection exists?.
+        switch_ids = CollectionShare.where(collection_id: subtree_ids, shared_with_id: current_user.id)
+                                    .distinct.pluck(:collection_id)
+        return if switch_ids.empty?
 
-          new_owner_shares.delete_all
-          grant_manage_shares(collection, old_owner)
-        end
+        # Drop the new owner's now-redundant shares (they own these now), then grant the former owner
+        # a manage_shares sharee on each — both set-based across the whole subtree.
+        CollectionShare.where(collection_id: switch_ids, shared_with_id: current_user.id).delete_all
+        grant_manage_shares(switch_ids, old_owner)
       end
 
-      # Ensure the former owner holds a manage_shares sharee on +collection+ (idempotent — the old
-      # owner held no share on their own collection before, but find_or_initialize keeps it safe
-      # against the unique (collection_id, shared_with_id) index).
-      def grant_manage_shares(collection, old_owner)
-        share = CollectionShare.find_or_initialize_by(collection: collection, shared_with_id: old_owner.id)
-        share.assign_attributes(
-          { permission_level: CollectionShare.permission_level(:manage_shares) }.merge(full_detail_levels),
-        )
-        share.save!
+      # Grant the former owner a manage_shares sharee on each of +collection_ids+ in one statement.
+      # upsert_all bypasses callbacks (CollectionShare has none) so created_at/updated_at are set
+      # explicitly; unique_by resurrects any pre-existing (collection_id, shared_with_id) row rather
+      # than colliding (in practice all inserts — the old owner held no share on their own collection).
+      def grant_manage_shares(collection_ids, old_owner)
+        now = Time.current
+        rows = collection_ids.map do |collection_id|
+          { collection_id: collection_id, shared_with_id: old_owner.id,
+            permission_level: CollectionShare.permission_level(:manage_shares),
+            created_at: now, updated_at: now, **full_detail_levels }
+        end
+        CollectionShare.upsert_all(rows, unique_by: %i[collection_id shared_with_id]) # rubocop:disable Rails/SkipsModelValidations
       end
 
       def notify(collection, old_owner)

--- a/app/usecases/collections/transfer_ownership.rb
+++ b/app/usecases/collections/transfer_ownership.rb
@@ -5,11 +5,15 @@ module Usecases
     # Second step of "pass ownership": the recipient of a pending pass_ownership (level 5) offer
     # accepts it, transferring the collection — and its whole subtree — to them.
     #
-    # The former owner is demoted to a manage_shares (4) sharee: they keep full access and share
-    # administration but no longer own the collection. Elements move with the collection — each is
-    # added to the new owner's "All", and removed from the old owner's "All" only when it is no
-    # longer in any of the old owner's other collections (an element also in a private collection of
-    # the old owner stays theirs, and becomes dual-owned).
+    # Ownership of the whole subtree moves to the new owner. Shares are switched only where a
+    # matching share to the new owner already existed: the offered root (which holds the accepted
+    # offer) and any sub-collection that was itself shared to the new owner have that share dropped
+    # (the new owner owns it now) and gain a manage_shares (4) share for the former owner, so the
+    # former owner keeps access there. Sub-collections that were not shared to the new owner
+    # transfer ownership without leaving the former owner a share. Elements move with the collection
+    # — each is added to the new owner's "All", and removed from the old owner's "All" only when it
+    # is no longer in any of the old owner's other collections (an element also in a private
+    # collection of the old owner stays theirs, and becomes dual-owned).
     class TransferOwnership
       FULL_DETAIL_LEVEL = 10 # every *_detail_level column at max — the demotee was the owner
 
@@ -31,7 +35,7 @@ module Usecases
           subtree_ids = collection.subtree.pluck(:id)
           reassign_subtree(collection, subtree_ids)
           move_elements(subtree_ids, old_owner)
-          demote_former_owner(collection, old_owner)
+          demote_former_owner(subtree_ids, old_owner)
           collection.update!(shared: CollectionShare.exists?(collection: collection))
         end
 
@@ -82,16 +86,48 @@ module Usecases
         return unless @old_all
 
         still_theirs = klass.where(id: ids).joins(:collections).where(collections: { id: @other_old_ids }).distinct.ids
-        join_table.delete_in_collection(ids - still_theirs, @old_all.id)
+        detach_from_old_all(join_table, ids - still_theirs)
       end
 
-      def demote_former_owner(collection, old_owner)
-        # Drop the consumed offer (and any other direct share to the new owner — they own it now).
-        CollectionShare.where(collection: collection, shared_with_id: current_user.id).delete_all
-        CollectionShare.create!(
-          { collection: collection, shared_with: old_owner,
-            permission_level: CollectionShare.permission_level(:manage_shares) }.merge(full_detail_levels),
+      # Unlink from the old owner's "All", honouring the same association guard WithdrawElements
+      # applies: a sample/wellplate still bound to a reaction/wellplate/screen kept in that "All"
+      # is not detached (WithdrawElements::FILTERED_JOINS is the single source of truth for which
+      # join tables carry that guard). All other join tables detach unconditionally.
+      def detach_from_old_all(join_table, ids)
+        return if ids.empty?
+
+        if WithdrawElements::FILTERED_JOINS.include?(join_table)
+          join_table.delete_in_collection_with_filter(ids, @old_all.id)
+        else
+          join_table.delete_in_collection(ids, @old_all.id)
+        end
+      end
+
+      # Switch owner/sharee across the transferred subtree, but only where a matching share to the
+      # new owner already existed. The offered root always qualifies (it holds the accepted offer);
+      # a sub-collection qualifies only if it was itself shared to the new owner. For each such
+      # collection: drop the new owner's now-redundant direct share(s) — they own it now — and grant
+      # the former owner a manage_shares sharee so they keep access there. Sub-collections that were
+      # never shared to the new owner transfer ownership without leaving the former owner a share.
+      def demote_former_owner(subtree_ids, old_owner)
+        Collection.where(id: subtree_ids).find_each do |collection|
+          new_owner_shares = CollectionShare.where(collection: collection, shared_with_id: current_user.id)
+          next unless new_owner_shares.exists?
+
+          new_owner_shares.delete_all
+          grant_manage_shares(collection, old_owner)
+        end
+      end
+
+      # Ensure the former owner holds a manage_shares sharee on +collection+ (idempotent — the old
+      # owner held no share on their own collection before, but find_or_initialize keeps it safe
+      # against the unique (collection_id, shared_with_id) index).
+      def grant_manage_shares(collection, old_owner)
+        share = CollectionShare.find_or_initialize_by(collection: collection, shared_with_id: old_owner.id)
+        share.assign_attributes(
+          { permission_level: CollectionShare.permission_level(:manage_shares) }.merge(full_detail_levels),
         )
+        share.save!
       end
 
       def notify(collection, old_owner)

--- a/app/usecases/collections/withdraw_elements.rb
+++ b/app/usecases/collections/withdraw_elements.rb
@@ -81,7 +81,7 @@ module Usecases
       #   kept by the association guard (still bound to a reaction/wellplate in one of the user's
       #   collections) are not included — they remain visible and are not destroyed.
       def withdraw(klass, join_table, ids)
-        actionable = own_membership_ids(klass, ids)
+        actionable = membership_ids(klass, ids, @owned_collection_ids)
         return [] if actionable.empty?
 
         if FILTERED_JOINS.include?(join_table)
@@ -91,25 +91,27 @@ module Usecases
         end
         join_table.update_tag_by_element_ids(actionable)
 
-        left_view = []
-        klass.where(id: actionable).find_each do |element|
-          next if element.collections.exists?(id: @owned_collection_ids) # kept by the guard
+        # Two set-based membership queries instead of a per-element N+1. Both must run AFTER the
+        # delete: delete_in_collection_with_filter may have kept some ids (still bound to a
+        # reaction/wellplate in one of our collections), and that decision is only visible by asking
+        # membership again — never derivable from `actionable`.
+        still_ours = membership_ids(klass, actionable, @owned_collection_ids) # guard-kept ⇒ stay visible
+        left_view = actionable - still_ours
+        orphaned = left_view - membership_ids(klass, left_view, nil)          # in no collection ⇒ sole owner
 
-          element.destroy unless element.collections.exists? # orphaned everywhere ⇒ sole owner
-          left_view << element.id
-        end
+        klass.where(id: orphaned).find_each(&:destroy) # per-record destroy keeps paranoia/callbacks
         left_view
       end
 
-      # Standing: only act on elements the user actually owns — those in at least one of their own
-      # collections. An element reachable only through a foreign share is left untouched.
-      def own_membership_ids(klass, ids)
+      # Ids among +ids+ whose element is still in at least one collection. Restricted to
+      # +collection_ids+ when given; pass +nil+ for "any collection at all". The join goes through
+      # the element's (non-deleted) collections association, so it only counts live memberships.
+      def membership_ids(klass, ids, collection_ids)
         return [] if ids.blank?
 
-        klass.where(id: ids)
-             .joins(:collections)
-             .where(collections: { id: @owned_collection_ids })
-             .distinct.ids
+        scope = klass.where(id: ids).joins(:collections)
+        scope = scope.where(collections: { id: collection_ids }) if collection_ids
+        scope.distinct.ids
       end
 
       # The withdrawn reactions' associated samples: solvents/reactants only unless the caller asked

--- a/db/migrate/20260713120000_backfill_missing_all_collection_memberships.rb
+++ b/db/migrate/20260713120000_backfill_missing_all_collection_memberships.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class BackfillMissingAllCollectionMemberships < ActiveRecord::Migration[6.1]
+  # Every element owned by a user — present in some collection whose `user_id` is that user — must
+  # also sit in that owner's locked "All" collection. The element create paths append the owner's
+  # "All", but data drift (older imports, the collection-share refactor, moves) can leave an element
+  # in an owned collection without the matching "All" row, which the ownership-derived logic relies
+  # on. This backfills the missing (element, owner's-All) join rows straight from the join tables.
+  #
+  # Idempotent: NOT EXISTS skips memberships already present, and ON CONFLICT resurrects a
+  # soft-deleted "All" row rather than colliding. Vessels are excluded (uuid-keyed, and the create
+  # paths never maintain a vessel "All").
+
+  # [join table, element foreign key]
+  JOIN_TABLES = [
+    %w[collections_samples sample_id],
+    %w[collections_reactions reaction_id],
+    %w[collections_wellplates wellplate_id],
+    %w[collections_screens screen_id],
+    %w[collections_research_plans research_plan_id],
+    %w[collections_celllines cellline_sample_id],
+    %w[collections_device_descriptions device_description_id],
+    %w[collections_sequence_based_macromolecule_samples sequence_based_macromolecule_sample_id],
+    %w[collections_elements element_id],
+  ].freeze
+
+  def up
+    JOIN_TABLES.each do |join_table, fk|
+      say_with_time "backfilling missing All memberships for #{join_table}" do
+        execute(<<~SQL.squish)
+          INSERT INTO #{join_table} (#{fk}, collection_id)
+          SELECT DISTINCT cj.#{fk}, all_c.id
+          FROM #{join_table} cj
+          JOIN collections owner_c ON owner_c.id = cj.collection_id
+                                  AND owner_c.deleted_at IS NULL
+          JOIN collections all_c   ON all_c.user_id = owner_c.user_id
+                                  AND all_c.label = 'All' AND all_c.is_locked
+                                  AND all_c.deleted_at IS NULL
+          WHERE cj.deleted_at IS NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM #{join_table} ex
+              WHERE ex.#{fk} = cj.#{fk}
+                AND ex.collection_id = all_c.id
+                AND ex.deleted_at IS NULL
+            )
+          ON CONFLICT (#{fk}, collection_id) DO UPDATE SET deleted_at = NULL;
+        SQL
+      end
+    end
+  end
+
+  def down
+    # Irreversible: the inserted "All" memberships are indistinguishable from legitimately-present
+    # ones, so there is nothing safe to delete.
+    say 'BackfillMissingAllCollectionMemberships is not reversible (membership rows cannot be safely removed).'
+  end
+end

--- a/spec/api/chemotion/collection_api_spec.rb
+++ b/spec/api/chemotion/collection_api_spec.rb
@@ -215,12 +215,20 @@ describe Chemotion::CollectionAPI do
     before do
       collection
       collection_with_shares
+      collection_shared_with_user
       other_users_collection
     end
 
     context 'when exporting collections' do
       it 'exports the collections' do
         params = { collection_ids: [collection.id, collection_with_shares.id] }
+        post '/api/v1/collections/export', params: params
+
+        expect(parsed_json_response['status']).to eq 204
+      end
+
+      it 'exports a collection shared with the user' do
+        params = { collection_ids: [collection_shared_with_user.id] }
         post '/api/v1/collections/export', params: params
 
         expect(parsed_json_response['status']).to eq 204

--- a/spec/api/chemotion/collection_api_spec.rb
+++ b/spec/api/chemotion/collection_api_spec.rb
@@ -247,6 +247,19 @@ describe Chemotion::CollectionAPI do
 
         expect(response.status).to eq 401
       end
+
+      # The export path serializes full element content ignoring detail levels, so a sharee below
+      # full detail on any element type must not be able to export it and read withheld data.
+      it 'does not export a collection shared below full detail access' do
+        partially_shared = create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare.permission_level(:read_elements),
+                                    sample_detail_level: 0)
+        end
+        post '/api/v1/collections/export', params: { collection_ids: [partially_shared.id] }
+
+        expect(response.status).to eq 401
+      end
     end
   end
 

--- a/spec/api/chemotion/collection_share_api_spec.rb
+++ b/spec/api/chemotion/collection_share_api_spec.rb
@@ -51,6 +51,19 @@ describe Chemotion::CollectionShareAPI do
 
         expect(CollectionShare.exists?(collection: child, shared_with_id: other_user.id)).to be false
       end
+
+      # A pass_ownership share is an offer; accepting it transfers the whole subtree atomically, so
+      # the offer itself must land only on the root — cascading it would mint an independent
+      # take-ownership offer on every sub-collection.
+      it 'does not cascade a pass_ownership offer to descendants' do
+        post '/api/v1/collection_shares/',
+             params: create_params.merge(user_ids: [other_user.id],
+                                         permission_level: CollectionShare.permission_level(:pass_ownership),
+                                         apply_to_subcollections: true)
+
+        expect(CollectionShare.exists?(collection: collection, shared_with_id: other_user.id)).to be true
+        expect(CollectionShare.exists?(collection: child, shared_with_id: other_user.id)).to be false
+      end
     end
 
     context 'when a share write fails mid-cascade (transactional, 422 not 500)' do
@@ -103,14 +116,26 @@ describe Chemotion::CollectionShareAPI do
 
       before { child }
 
-      it 'cascades the edit to descendant collections for the same sharee' do
+      it 'cascades the edit to a descendant already shared with the same sharee' do
+        create(:collection_share, collection: child, shared_with: other_user,
+                                  permission_level: CollectionShare.permission_level(:read_elements))
+
         put "/api/v1/collection_shares/#{collection_share.id}",
             params: update_params.merge(permission_level: CollectionShare.permission_level(:manage_shares),
                                         apply_to_subcollections: true)
 
         child_share = CollectionShare.find_by(collection: child, shared_with_id: other_user.id)
-        expect(child_share).to be_present
         expect(child_share.permission_level).to eq(CollectionShare.permission_level(:manage_shares))
+      end
+
+      # An edit propagates to existing sub-collection shares only — it never grants NEW access to a
+      # sub-collection the sharee was not already on (that would be a silent over-grant).
+      it 'does not mint a new share on a descendant that was not already shared with the sharee' do
+        put "/api/v1/collection_shares/#{collection_share.id}",
+            params: update_params.merge(permission_level: CollectionShare.permission_level(:manage_shares),
+                                        apply_to_subcollections: true)
+
+        expect(CollectionShare.exists?(collection: child, shared_with_id: other_user.id)).to be false
       end
     end
   end
@@ -326,6 +351,41 @@ describe Chemotion::CollectionShareAPI do
 
       expect { delete "/api/v1/collection_shares/#{own_share.id}" }.to change(CollectionShare, :count).by(-1)
       expect(response).to have_http_status(:no_content)
+    end
+  end
+
+  # A delegate may edit a root share and cascade it, but the cascade must not let them overwrite a
+  # sub-collection share that outranks their own level there — the same guard the root PUT applies.
+  describe 'delegated cascade cannot overwrite a superior descendant share' do
+    let(:collection) { create(:collection, user: other_user) }
+    let(:child) { create(:collection, user: other_user, parent: collection) }
+    let(:manage_shares) { CollectionShare.permission_level(:manage_shares) }
+    # third_user holds a pass_ownership share on the child — above the delegate's own level there.
+    let(:child_superior_share) do
+      create(:collection_share, collection: child, shared_with: third_user,
+                                permission_level: CollectionShare.permission_level(:pass_ownership))
+    end
+    # the root share the delegate is about to edit and cascade
+    let(:root_share) do
+      create(:collection_share, collection: collection, shared_with: third_user,
+                                permission_level: CollectionShare.permission_level(:read_elements))
+    end
+
+    before do
+      # `user` is a manage_shares delegate on both the root and the child.
+      create(:collection_share, collection: collection, shared_with: user, permission_level: manage_shares)
+      create(:collection_share, collection: child, shared_with: user, permission_level: manage_shares)
+      child_superior_share
+    end
+
+    it 'refuses (403) and leaves the superior descendant share untouched' do
+      expect do
+        put "/api/v1/collection_shares/#{root_share.id}",
+            params: { permission_level: CollectionShare.permission_level(:edit_elements),
+                      apply_to_subcollections: true }
+      end.not_to(change { child_superior_share.reload.permission_level })
+
+      expect(response).to have_http_status(:forbidden)
     end
   end
 

--- a/spec/api/chemotion/collection_share_api_spec.rb
+++ b/spec/api/chemotion/collection_share_api_spec.rb
@@ -33,6 +33,25 @@ describe Chemotion::CollectionShareAPI do
       end.to change(CollectionShare, :count).by(create_params[:user_ids].length)
          .and change(collection, :shared?).from(false).to(true)
     end
+
+    context 'with apply_to_subcollections' do
+      let(:child) { create(:collection, user: user, parent: collection) }
+
+      before { child }
+
+      it 'also shares the descendant collections' do
+        post '/api/v1/collection_shares/', params: create_params.merge(apply_to_subcollections: true)
+
+        expect(CollectionShare.exists?(collection: collection, shared_with_id: other_user.id)).to be true
+        expect(CollectionShare.exists?(collection: child, shared_with_id: other_user.id)).to be true
+      end
+
+      it 'leaves descendants untouched when the flag is false' do
+        post '/api/v1/collection_shares/', params: create_params.merge(apply_to_subcollections: false)
+
+        expect(CollectionShare.exists?(collection: child, shared_with_id: other_user.id)).to be false
+      end
+    end
   end
 
   describe 'PUT /api/v1/collection_shares' do

--- a/spec/api/chemotion/collection_share_api_spec.rb
+++ b/spec/api/chemotion/collection_share_api_spec.rb
@@ -52,6 +52,23 @@ describe Chemotion::CollectionShareAPI do
         expect(CollectionShare.exists?(collection: child, shared_with_id: other_user.id)).to be false
       end
     end
+
+    context 'when a share write fails mid-cascade (transactional, 422 not 500)' do
+      let(:child) { create(:collection, user: user, parent: collection) }
+
+      before { child }
+
+      it 'rolls the whole cascade back and responds 422 when a user_id has no matching user' do
+        bogus_id = other_user.id + 1_000 # no such user (ids are sequential and nowhere near this)
+
+        expect do
+          post '/api/v1/collection_shares/',
+               params: create_params.merge(user_ids: [other_user.id, bogus_id], apply_to_subcollections: true)
+        end.not_to change(CollectionShare, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
   end
 
   describe 'PUT /api/v1/collection_shares' do
@@ -79,6 +96,22 @@ describe Chemotion::CollectionShareAPI do
       expected_result = update_params.dup.stringify_keys
 
       expect(result).to include(expected_result)
+    end
+
+    context 'with apply_to_subcollections' do
+      let(:child) { create(:collection, user: user, parent: collection) }
+
+      before { child }
+
+      it 'cascades the edit to descendant collections for the same sharee' do
+        put "/api/v1/collection_shares/#{collection_share.id}",
+            params: update_params.merge(permission_level: CollectionShare.permission_level(:manage_shares),
+                                        apply_to_subcollections: true)
+
+        child_share = CollectionShare.find_by(collection: child, shared_with_id: other_user.id)
+        expect(child_share).to be_present
+        expect(child_share.permission_level).to eq(CollectionShare.permission_level(:manage_shares))
+      end
     end
   end
 

--- a/spec/api/chemotion/permission_api_spec.rb
+++ b/spec/api/chemotion/permission_api_spec.rb
@@ -146,6 +146,26 @@ describe Chemotion::PermissionAPI do
           expect(parsed_json_response['sharing_allowed']).to be false
         end
       end
+
+      # Regression (S5): element types outside the legacy [Sample, Reaction, Screen, Wellplate] set
+      # must be policed too — otherwise a sharee selecting only such an element keeps the permissive
+      # default (remove_allowed/deletion_allowed = true) and the UI offers a Move/Remove the server
+      # then refuses.
+      context 'when the selection is only a research plan (an element type outside the legacy four)' do
+        let(:research_plan) { create(:research_plan, collections: [shared_collection_of_other_user]) }
+        let(:permission_level) { CollectionShare.permission_level(:add_elements) }
+        let(:params) do
+          {
+            currentCollection: { id: shared_collection_of_other_user.id },
+            research_plan: { checkedAll: false, checkedIds: [research_plan.id], uncheckedIds: [] },
+          }
+        end
+
+        it 'polices the research plan: remove_allowed=false and deletion_allowed=false at :add_elements' do
+          expect(parsed_json_response['remove_allowed']).to be false
+          expect(parsed_json_response['deletion_allowed']).to be false
+        end
+      end
     end
   end
 end

--- a/spec/db/migrate/20260713120000_backfill_missing_all_collection_memberships_spec.rb
+++ b/spec/db/migrate/20260713120000_backfill_missing_all_collection_memberships_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+load 'db/migrate/20260713120000_backfill_missing_all_collection_memberships.rb'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'migration 20260713120000: BackfillMissingAllCollectionMemberships' do
+  let(:owner) { create(:person) }
+  let(:all_collection) { Collection.get_all_collection_for_user(owner.id) }
+  let(:sub) { create(:collection, user: owner, label: 'sub') }
+  let!(:sample) { create(:sample, creator: owner, collections: [sub]) }
+
+  def membership_exists?
+    CollectionsSample.exists?(sample_id: sample.id, collection_id: all_collection.id)
+  end
+
+  it 'inserts the missing (element, owner-All) membership' do
+    all_collection # ensure the "All" collection exists
+    expect(membership_exists?).to be false
+
+    described_class_constant.new.up
+
+    expect(membership_exists?).to be true
+  end
+
+  it 'is idempotent' do
+    described_class_constant.new.up
+    expect { described_class_constant.new.up }
+      .not_to(change { CollectionsSample.where(sample_id: sample.id, collection_id: all_collection.id).count })
+  end
+
+  it 'leaves an element already present in All untouched' do
+    CollectionsSample.create!(sample: sample, collection: all_collection)
+
+    expect { described_class_constant.new.up }.not_to change(CollectionsSample, :count)
+  end
+
+  def described_class_constant
+    BackfillMissingAllCollectionMemberships
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/usecases/collections/transfer_ownership_spec.rb
+++ b/spec/usecases/collections/transfer_ownership_spec.rb
@@ -63,6 +63,46 @@ RSpec.describe Usecases::Collections::TransferOwnership do
     end
   end
 
+  describe 'sub-collection shares on transfer (only where a matching share existed)' do
+    let!(:shared_child) { create(:collection, user: old_owner, parent: collection, label: 'shared child') }
+    let!(:plain_child) { create(:collection, user: old_owner, parent: collection, label: 'plain child') }
+
+    # shared_child was already shared to the future new owner; plain_child was not.
+    before do
+      create(:collection_share, collection: shared_child, shared_with: new_owner,
+                                permission_level: CollectionShare.permission_level(:add_elements))
+    end
+
+    it 'switches owner/sharee on a sub-collection that was already shared to the new owner' do
+      transfer
+      shares = CollectionShare.where(collection: shared_child)
+      expect(shares.where(shared_with_id: new_owner.id)).to be_empty # S3: new owner's stale share dropped
+      expect(shares.find_by(shared_with_id: old_owner.id)&.permission_level) # S1: former owner keeps access here
+        .to eq(CollectionShare.permission_level(:manage_shares))
+    end
+
+    it 'leaves the former owner no share on a sub-collection that was not shared to the new owner' do
+      transfer
+      expect(plain_child.reload.user_id).to eq(new_owner.id) # still transferred to the new owner
+      expect(CollectionShare.where(collection: plain_child, shared_with_id: old_owner.id)).to be_empty
+    end
+  end
+
+  describe 'a moved sample still bound to a reaction the old owner keeps (S2 association guard)' do
+    let(:other) { create(:collection, user: old_owner, label: 'Y') }
+    let!(:reaction) { create(:reaction, creator: old_owner, collections: [old_all, other]) }
+    let!(:sample) { create(:sample, creator: old_owner, collections: [old_all, collection]) }
+
+    before { ReactionsReactantSample.create!(reaction: reaction, sample: sample, reference: false) }
+
+    it "keeps the sample in the old owner's All (its reaction still lives there) while adding it to the new All" do
+      transfer
+      cols = sample.reload.collections
+      expect(cols.where(id: old_all.id)).to be_present # filtered detach kept it — reaction still in old All
+      expect(cols.where(id: new_all.id)).to be_present
+    end
+  end
+
   describe 'guards' do
     it 'refuses when the caller holds no offer' do
       CollectionShare.where(collection: collection, shared_with_id: new_owner.id).delete_all


### PR DESCRIPTION
## Summary

Follow-on to the collection-share permission-ladder work (#3374, now on `main`). This
batch builds out the **shared-with-me** experience and the capabilities a sharee /
`manage_shares` delegate has, plus a data migration that backfills owner "All"
memberships. No changes to the permission model itself — everything here rides on the
ladder and guards introduced in #3374.

## What's in it

1. **Dual-owned element badge** — when an element sits in both a collection you own and
   one shared to you (owned by someone else), the collection-label badge highlights the
   shared count and tooltips it, so you can tell the element also lives in a not-owned
   collection.

2. **Name & parent a shared collection created from a selection** — the "share as new
   collection" flow no longer hardcodes the label and top-level placement; the share modal
   (`shareType: 'new'`) gains optional new-collection name and parent inputs, threaded
   through to `addElementsToCollectionAndShare` (falling back to the previous
   label/top-level when left empty).

3. **Export collections shared with you** — export was owner-only; the backend gate now
   also accepts collections you hold any share on (`read_elements`+), and the export modal
   lists shared-with-me collections.

4. **Nest & truncate shared sub-collections in the shared-with-me tree** — the tree used to
   flatten every shared collection under its owner root. It now builds the real hierarchy:
   a shared sub-collection nests under its parent when that parent is also shared, and is
   promoted to the top level under its owner when the parent is not (truncating the branch).

5. **Backfill missing owner "All"-collection memberships** — data migration inserting the
   missing `(element, owner's-All)` join rows for any element present in an owned collection
   but absent from that owner's locked "All". Set-based per join table (8 tables; vessels
   excluded — uuid-keyed, no "All" in the create paths), `NOT EXISTS` + `ON CONFLICT DO
   UPDATE SET deleted_at = NULL` so it is idempotent and resurrects soft-deleted rows.
   Irreversible `down` (documented).

6. **Cascade a share to sub-collections** — `POST /collection_shares` gains
   `apply_to_subcollections`: when set, the same share (level + detail levels, per user) is
   upserted onto every descendant collection the caller may administer. The share modal
   exposes an "Apply these share settings to all sub-collections" checkbox on the create
   flow. The per-descendant guards (privilege escalation, share-with-owner, ownership-offer)
   still apply to each row.

7. **Share management on the shared-with-me tree for `manage_shares` delegates** — the
   backend already authorizes a `manage_shares` (4) delegate to administer a collection's
   shares, but the controls lived only in MyCollections. Adds "Add share" / "Manage shares"
   buttons (and the modal wiring) to shared-with-me nodes where the user's
   `permission_level >= manage_shares`, next to the existing reject-share control.

## Testing

- New/extended specs: `collection_api_spec` (sharee export gate), `collection_share_api_spec`
  (cascade-to-subcollections), and the backfill-migration spec.
- Targeted suites green in the app container (`collection_share_api_spec`,
  `collection_api_spec`, backfill migration — 44 examples, 0 failures); rebased cleanly onto
  the merged #3374.
