### PR TITLE
fix(2fa): recover from undecryptable otp_secret in validate_and_consume_otp!

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -201,6 +201,21 @@ class User < ApplicationRecord
   def check_otp(otp_attempt)
     validate_and_consume_otp!(otp_attempt)
   end
+
+  # devise-two-factor's validate_and_consume_otp! reads (decrypts) otp_secret
+  # unconditionally, even for a blank/wrong code, so it is just as exposed to
+  # an undecryptable ciphertext as generate_qr_code (see
+  # discard_undecryptable_otp_secret!). Left unrescued, this crashes login,
+  # the self-service email/password change form, and the 2FA verify/disable
+  # requests with a 500 for any user whose stored secret predates an
+  # OTP_SECRET_KEY rotation. Treat it as a failed OTP and let the user
+  # re-enroll instead.
+  def validate_and_consume_otp!(code, options = {})
+    super
+  rescue OpenSSL::Cipher::CipherError
+    discard_undecryptable_otp_secret!
+    false
+  end
   def self.find_first_by_auth_conditions(warden_conditions)
     conditions = warden_conditions.dup
     if (login = conditions.delete(:login))

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -540,11 +540,19 @@ class User < ApplicationRecord
   # attr_encrypted's setter also re-decrypts the old value internally to check
   # for dirtiness, so a merely-rescued read is not enough. Wipe the
   # now-undecryptable ciphertext so the user can simply re-enroll instead of
-  # hitting a 500 on the enable-2FA request.
+  # hitting a 500 on the enable-2FA request. otp_required_for_login is also
+  # cleared: with no secret left to validate against, leaving it set would
+  # lock the user out of login (and thus out of every self-service 2FA
+  # endpoint, which all require an authenticated current_user) until an
+  # admin intervenes. generate_qr_code's re-enrollment flow re-enables it
+  # once the user verifies a freshly generated secret.
   def discard_undecryptable_otp_secret!
     otp_secret
   rescue OpenSSL::Cipher::CipherError
-    update_columns(encrypted_otp_secret: nil, encrypted_otp_secret_iv: nil, encrypted_otp_secret_salt: nil)
+    # rubocop:disable Rails/SkipsModelValidations
+    update_columns(encrypted_otp_secret: nil, encrypted_otp_secret_iv: nil, encrypted_otp_secret_salt: nil,
+                   otp_required_for_login: false)
+    # rubocop:enable Rails/SkipsModelValidations
     instance_variable_set(:@otp_secret, nil)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -211,6 +211,27 @@ RSpec.describe User do
     end
   end
 
+  describe '#validate_and_consume_otp!' do
+    let(:user) { create(:user) }
+
+    before do
+      user.generate_qr_code
+      user.update!(otp_required_for_login: true)
+    end
+
+    it 'discards the secret and returns false instead of raising when undecryptable' do
+      # simulate a corrupted/undecryptable ciphertext (e.g. after an OTP_SECRET_KEY rotation) -
+      # this is what login, the account settings form, and the 2FA verify endpoint all hit.
+      user.update_columns(encrypted_otp_secret: user.encrypted_otp_secret.reverse)
+      user.instance_variable_set(:@otp_secret, nil)
+
+      result = nil
+      expect { result = user.validate_and_consume_otp!('123456') }.not_to raise_error
+      expect(result).to be false
+      expect(user.reload.encrypted_otp_secret).to be_nil
+    end
+  end
+
   describe '#increment_counter' do
     let(:described_method) { :increment_counter }
     let(:element) { described_class::COUNTER_KEYS.sample }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -219,16 +219,31 @@ RSpec.describe User do
       user.update!(otp_required_for_login: true)
     end
 
-    it 'discards the secret and returns false instead of raising when undecryptable' do
+    def corrupt_otp_secret!(user)
       # simulate a corrupted/undecryptable ciphertext (e.g. after an OTP_SECRET_KEY rotation) -
       # this is what login, the account settings form, and the 2FA verify endpoint all hit.
-      user.update_columns(encrypted_otp_secret: user.encrypted_otp_secret.reverse)
+      user.update_columns(encrypted_otp_secret: user.encrypted_otp_secret.reverse) # rubocop:disable Rails/SkipsModelValidations
       user.instance_variable_set(:@otp_secret, nil)
+    end
+
+    it 'discards the secret and returns false instead of raising when undecryptable' do
+      corrupt_otp_secret!(user)
 
       result = nil
       expect { result = user.validate_and_consume_otp!('123456') }.not_to raise_error
       expect(result).to be false
       expect(user.reload.encrypted_otp_secret).to be_nil
+    end
+
+    it 'disables otp_required_for_login so the user is not locked in an unwinnable OTP loop' do
+      # with no secret left to validate against, leaving 2FA required would strand the user:
+      # every self-service 2FA endpoint requires an authenticated current_user, which login
+      # can no longer grant.
+      corrupt_otp_secret!(user)
+
+      user.validate_and_consume_otp!('123456')
+
+      expect(user.reload.otp_required_for_login).to be false
     end
   end
 


### PR DESCRIPTION
## Summary
- `devise-two-factor`'s `validate_and_consume_otp!` decrypts the stored `otp_secret` unconditionally, even for a blank/wrong code. #3376 only guarded `generate_qr_code` against an `OTP_SECRET_KEY` rotation making a user's ciphertext undecryptable, leaving this method exposed to the same unhandled `OpenSSL::Cipher::CipherError`.
- This crashed login, the self-service email/password change form (`Users::RegistrationsController#check_otp`, hit before the user even enters an OTP), and the 2FA verify/disable requests with a 500 for any 2FA-enabled user whose secret predates a key rotation — surfacing to a 2FA-enabled admin as "can't reset password".
- `User#validate_and_consume_otp!` now rescues the cipher error, discards the undecryptable secret via the existing `discard_undecryptable_otp_secret!`, and reports a failed OTP instead of raising, so the user can simply re-enroll.

## Test plan
- [x] Reproduced the crash directly against a live user in a Rails console (confirmed `OpenSSL::Cipher::CipherError` raised pre-fix)
- [x] Added a regression spec in `spec/models/user_spec.rb` covering the undecryptable-secret path
- [x] `bundle exec rspec spec/models/user_spec.rb` — 33 examples, 0 failures
- [x] `bundle exec rubocop app/models/user.rb spec/models/user_spec.rb` — no new offenses