### PR TITLE
fix(collections): protect locked collections from create/update/delete

### DIFF
--- a/app/api/chemotion/collection_api.rb
+++ b/app/api/chemotion/collection_api.rb
@@ -6,6 +6,10 @@ module Chemotion
       error!('Collection not found', 404)
     end
 
+    rescue_from Usecases::Collections::Errors::UpdateForbidden do |e|
+      error!(e.message, 403)
+    end
+
     resource :collections do
       get '/' do
         own_collections =
@@ -87,6 +91,7 @@ module Chemotion
       end
       put '/:id' do
         collection = Collection.own_collections_for(current_user).find(params[:id])
+        error!('A locked collection cannot be modified', 403) if collection.is_locked?
         attributes = { label: params[:label], tabs_segment: params[:tabs_segment] }.compact
 
         collection.update(attributes)
@@ -100,6 +105,7 @@ module Chemotion
       end
       delete '/:id' do
         collection = Collection.own_collections_for(current_user).find(params[:id])
+        error!('A locked collection cannot be deleted', 403) if collection.is_locked?
 
         collection.destroy
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -32,6 +32,8 @@
 #
 
 class Collection < ApplicationRecord
+  include LockedCollectionGuard
+
   acts_as_paranoid
   belongs_to :user, optional: true
   belongs_to :inventory, optional: true

--- a/app/models/concerns/locked_collection_guard.rb
+++ b/app/models/concerns/locked_collection_guard.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Protects system-locked collections (the per-user "All", "chemotion-repository.net" and
+# "transferred" roots) from user-facing mutation. Once +is_locked+ is set, no user-facing path may
+# rename the collection, move it in the tree, or clear the locked flag, and it cannot be deleted.
+# System paths that legitimately create or restore such a collection use +create+ /
+# +update_column(s)+, which do not run these guards.
+module LockedCollectionGuard
+  extend ActiveSupport::Concern
+
+  # Attributes that are fixed for the lifetime of a locked collection.
+  LOCKED_IMMUTABLE_ATTRIBUTES = %w[label position ancestry is_locked].freeze
+
+  included do
+    before_destroy :prevent_destroying_locked_collection, prepend: true
+    validate :prevent_modifying_locked_collection, on: :update
+  end
+
+  private
+
+  # Aborts +destroy+ (and soft-delete) of a locked collection. The only path that reaches this is
+  # the user-facing +DELETE /collections/:id+ endpoint — no system path destroys a locked collection
+  # (a +User+'s collections are not +dependent: :destroy+).
+  def prevent_destroying_locked_collection
+    return unless is_locked?
+
+    errors.add(:base, 'A locked collection cannot be deleted')
+    throw(:abort)
+  end
+
+  # Rejects an update that would rename, reposition, or unlock a locked collection. Keyed off the
+  # persisted +is_locked+ value so that clearing the flag is itself blocked. +tabs_segment+ (UI view
+  # state) is intentionally not protected and stays editable on the locked "All" collection.
+  def prevent_modifying_locked_collection
+    return unless is_locked_in_database
+
+    (changed & LOCKED_IMMUTABLE_ATTRIBUTES).each do |attribute|
+      errors.add(attribute, 'cannot be changed on a locked collection')
+    end
+  end
+end

--- a/app/usecases/collections/create.rb
+++ b/app/usecases/collections/create.rb
@@ -19,11 +19,16 @@ module Usecases
           position = current_user.collections.where(ancestry: '/').count + 1
         end
 
+        # is_locked is deliberately forced false: locked collections (the "All", repository and
+        # transferred roots) are system-generated only, and this is the sole user-facing create
+        # path. Hard-coding it here keeps a user from ever minting a locked collection even if the
+        # flag later leaks into the endpoint params.
         current_user.collections.create!(
           parent: parent,
           position: position,
           label: label,
           inventory: inventory,
+          is_locked: false,
         )
       end
 

--- a/app/usecases/collections/update_tree.rb
+++ b/app/usecases/collections/update_tree.rb
@@ -21,8 +21,12 @@ module Usecases
 
       private
 
+      # Locked collections (the "All"/repository/transferred roots) are excluded: their label and
+      # tree position are system-defined, so a bulk tree update may neither move nor rename them.
+      # The frontend already omits them from the payload; a request that includes one anyway is
+      # rejected wholesale via {#add_collection_and_children_to_linear_tree}.
       def collections_permitted_to_update
-        @collections_permitted_to_update ||= Collection.own_collections_for(current_user).ids
+        @collections_permitted_to_update ||= Collection.own_collections_for(current_user).unlocked.ids
       end
 
       def add_collection_and_children_to_linear_tree(collection, position:, parent_ids: [])

--- a/spec/api/chemotion/collection_api_spec.rb
+++ b/spec/api/chemotion/collection_api_spec.rb
@@ -107,6 +107,14 @@ describe Chemotion::CollectionAPI do
         expect(response.status).to eq 201
         expect(parsed_json_response['collection']['ancestry']).to eq '/'
       end
+
+      it 'never creates a locked collection, even when is_locked is passed' do
+        params = { parent_id: nil, label: 'Some collection', is_locked: true }
+        post '/api/v1/collections', params: params
+
+        expect(response.status).to eq 201
+        expect(parsed_json_response['collection']['is_locked']).to be(false)
+      end
     end
 
     context 'when adding a new child collection' do
@@ -208,6 +216,63 @@ describe Chemotion::CollectionAPI do
         expect(updated_collection_BAA).to include('id' => collection_BAA.id, 'label' => 'Collection BAA', 'ancestry' => "/#{collection_ABA.id}/", 'position' => 1)
       expect(updated_collection_B).to include('id' => collection_B.id, 'label' => 'Collection B', 'ancestry' => '/', 'position' => 3)
         expect(updated_collection_BB).to include('id' => collection_BB.id, 'label' => 'Collection BB', 'ancestry' => "/#{collection_B.id}/", 'position' => 1)
+    end
+
+    it 'refuses to relabel or reposition a locked collection' do
+      locked_collection = create(:collection, label: 'All', user: user, position: 1, is_locked: true)
+
+      put '/api/v1/collections/bulk_update_own_collections',
+          params: { collections: [{ id: locked_collection.id, label: 'Hijacked' }] }
+
+      expect(response).to have_http_status(:forbidden)
+      expect(locked_collection.reload).to have_attributes(label: 'All', is_locked: true)
+    end
+  end
+
+  describe 'PUT /api/v1/collections/:id' do
+    context 'when the collection is unlocked' do
+      let(:own_collection) { create(:collection, user: user, label: 'Old label') }
+
+      it 'updates the label' do
+        put "/api/v1/collections/#{own_collection.id}", params: { label: 'New label' }
+
+        expect(response).to have_http_status(:ok)
+        expect(own_collection.reload.label).to eq 'New label'
+      end
+    end
+
+    context 'when the collection is locked' do
+      let(:locked_collection) { create(:collection, user: user, label: 'All', is_locked: true) }
+
+      it 'returns 403 and does not change the collection' do
+        put "/api/v1/collections/#{locked_collection.id}", params: { label: 'Renamed' }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(locked_collection.reload.label).to eq 'All'
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/collections/:id' do
+    context 'when the collection is unlocked' do
+      let(:own_collection) { create(:collection, user: user) }
+
+      it 'deletes the collection' do
+        own_collection
+        expect { delete "/api/v1/collections/#{own_collection.id}" }.to change(Collection, :count).by(-1)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when the collection is locked' do
+      let(:locked_collection) { create(:collection, user: user, label: 'All', is_locked: true) }
+
+      it 'returns 403 and keeps the collection' do
+        locked_collection
+        expect { delete "/api/v1/collections/#{locked_collection.id}" }.not_to change(Collection, :count)
+        expect(response).to have_http_status(:forbidden)
+        expect(locked_collection.reload).to be_present
+      end
     end
   end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -58,6 +58,50 @@ RSpec.describe Collection do
     end
   end
 
+  describe 'protecting locked collections' do
+    let(:locked_collection) { create(:collection, label: 'All', position: 1, is_locked: true) }
+    let(:unlocked_collection) { create(:collection, label: 'Project', position: 2) }
+
+    it 'cannot be destroyed' do
+      locked_collection
+      expect { locked_collection.destroy }.not_to change(described_class, :count)
+      expect(locked_collection.destroyed?).to be(false)
+    end
+
+    it 'rejects a label change' do
+      expect(locked_collection.update(label: 'Renamed')).to be(false)
+      expect(locked_collection.errors[:label]).to include('cannot be changed on a locked collection')
+      expect(locked_collection.reload.label).to eq('All')
+    end
+
+    it 'rejects a position change' do
+      expect(locked_collection.update(position: 99)).to be(false)
+      expect(locked_collection.errors[:position]).to include('cannot be changed on a locked collection')
+    end
+
+    it 'rejects being unlocked' do
+      expect(locked_collection.update(is_locked: false)).to be(false)
+      expect(locked_collection.errors[:is_locked]).to include('cannot be changed on a locked collection')
+      expect(locked_collection.reload.is_locked).to be(true)
+    end
+
+    it 'still allows editing view state (tabs_segment)' do
+      expect(locked_collection.update(tabs_segment: { 'sample' => 1 })).to be(true)
+    end
+
+    it 'does not restrict unlocked collections' do
+      expect(unlocked_collection.update(label: 'Renamed', position: 5)).to be(true)
+      expect { unlocked_collection.destroy }.to change(described_class, :count).by(-1)
+    end
+
+    it 'still allows a locked collection to be created' do
+      owner = create(:person)
+      expect do
+        create(:collection, label: 'All', is_locked: true, user: owner)
+      end.to change(described_class, :count).by(1)
+    end
+  end
+
   describe 'get_all_collection_for_user' do
     let(:user) { create(:user) }
 


### PR DESCRIPTION
## Summary

Locked collections are **system-generated** roots — the per-user "All", the
`chemotion-repository.net` repository collection, and the `transferred` collection. Their
label, tree position, and locked flag are fixed for the lifetime of the collection.

This protection was added in #2001, then **lost in the #2783 rewrite**: that PR replaced the
sync-collection model with the `collection_shares` ACL and rewrote the collection endpoints
around `Collection.own_collections_for`, **which includes locked collections**. As a result a
direct API call could rename, reposition, or delete a locked collection, or clear its
`is_locked` flag via the bulk tree update — only the frontend hid the controls. This restores
the guard on the backend, at every write path, and adds the test coverage that was missing
(there were **no** tests for `PUT`/`DELETE /collections/:id`).

`refs: #2783`

## Changes

- **`LockedCollectionGuard` concern on `Collection`**
  - `before_destroy` aborts destroy (and soft-delete) of a locked collection.
  - an `on: :update` validation rejects changes to `label` / `position` / `ancestry` /
    `is_locked`. Keyed off the **persisted** `is_locked` value, so clearing the flag (unlocking)
    is itself blocked.
  - `tabs_segment` (UI view state) is intentionally left editable. System create/restore paths
    use `create` / `update_column(s)`, which do not run the guard.
- **`Usecases::Collections::Create`** (the sole user-facing create path) forces
  `is_locked: false` — a user can never mint a locked collection, even if the flag leaks into
  the endpoint params. Legitimate system paths (signup's "All", the repository root, seeds) are
  unaffected because they create locked collections directly.
- **`PUT` / `DELETE /collections/:id`** return **403** when the target is locked.
- **`Usecases::Collections::UpdateTree`** excludes locked collections from the permitted set, so
  the bulk tree update cannot relabel or move them; a payload that includes one is rejected
  **403** via a new `rescue_from Errors::UpdateForbidden`. The frontend already omits locked
  collections from this payload, so there is no legitimate-flow regression.

## Coverage matrix (all now enforced + tested)

| verb | before | after |
|---|---|---|
| create | `is_locked` param ignored by omission | forced `false` in the usecase + test |
| update (label/position/ancestry/is_locked) | unguarded | 403 + model validation |
| delete | unguarded | 403 + `before_destroy` abort |
| bulk tree update | unguarded | 403 (locked ids rejected) |

## Testing

- `spec/models/collection_spec.rb` — locked collection: cannot destroy; label/position/unlock
  rejected; `tabs_segment` still editable; unlocked collections unaffected; locked creation
  still works via a system path.
- `spec/api/chemotion/collection_api_spec.rb` — `POST` ignores `is_locked`; `PUT`/`DELETE /:id`
  return 403 when locked (and succeed when unlocked); bulk update refuses to relabel/reposition
  a locked collection.
- Green in the app container: `58 examples, 0 failures` (collection API + model),
  `20 examples, 0 failures` (collections usecases). Rubocop clean on all touched files.
