### PR TITLE
fix(converter): relay converter-app profile write errors instead of swallowing them

### DIFF
--- a/app/api/chemotion/converter_api.rb
+++ b/app/api/chemotion/converter_api.rb
@@ -3,26 +3,33 @@
 module Chemotion
   # Overrides the +/api/v1/converter+ routes that {Labimotion::ConverterAPI}
   # cannot serve, or serves without normalizing. Everything else on that
-  # surface (create/delete profile, options, datasets, datasets_units) falls
-  # through to the gem, so this API must stay mounted *before*
-  # +Labimotion::LabimotionAPI+ in {API}.
+  # surface (delete profile, options, datasets, datasets_units) falls through to
+  # the gem, so this API must stay mounted *before* +Labimotion::LabimotionAPI+
+  # in {API}.
   #
   # - +profiles/restore+ and +conversions+ call +Labimotion::Converter.restore+ /
   #   +.test_conversions+, neither of which the gem defines.
   # - +tables+ drops the +ontology+ field that chemotion-converter-client sends
   #   since 0.16.0, which converter-app needs to pick a reader.
-  # - +profiles+ GET/PUT relay converter-app's response verbatim. converter-app
-  #   only runs its profile-schema migration/validation on write (POST/PUT), so a
-  #   profile that predates a schema field (e.g. +tables+) keeps missing it on
-  #   read forever. chemotion-converter-client 0.16.0's +ProfileForm+ assumes
-  #   every array-typed field is always present and reads several of them
-  #   unguarded on mount (+profile.tables.map+ et al.), so a legacy profile
-  #   crashes the whole admin page the moment "Edit" is clicked. Backfilled here
-  #   with the same defaults the client itself uses for a brand-new profile.
+  # - +profiles+ GET normalizes and POST/PUT go through {Chemotion::ConverterClient}
+  #   rather than the gem. converter-app only runs its profile-schema
+  #   migration/validation on write (POST/PUT), so a profile that predates a
+  #   schema field (e.g. +tables+) keeps missing it on read forever.
+  #   chemotion-converter-client 0.16.0's +ProfileForm+ assumes every array-typed
+  #   field is always present and reads several of them unguarded on mount
+  #   (+profile.tables.map+ et al.), so a legacy profile crashes the whole admin
+  #   page the moment "Edit" is clicked — backfilled here with the same defaults
+  #   the client uses for a brand-new profile. On *write*, that same legacy
+  #   profile can fail converter-app's validation (HTTP 400 + errors body); the
+  #   gem's +*_profile+ helpers return +response.parsed_response if response.code
+  #   == 200+ and so collapse that to +nil+, which this proxy would relay as
+  #   200/null and the client's error handler would then crash on
+  #   +Object.values(errors.data)+. Routing writes through the client keeps the
+  #   real status and body so the validation error reaches the user.
   #
   # Delete the +restore+/+conversions+/+tables+ overrides once the gem
   # implements them; delete the +profiles+ overrides once converter-app
-  # migrates/validates on read too.
+  # migrates/validates on read too and the gem stops swallowing write errors.
   class ConverterAPI < Grape::API
     # Array/hash-typed profile fields that chemotion-converter-client 0.16.0
     # always expects present — see AdminApp.js's brand-new-profile defaults.
@@ -43,11 +50,23 @@ module Chemotion
         error!({ error: 'unauthorized' }, 401) unless current_user&.converter_admin == true
       end
 
-      # Relays a converter-app failure instead of surfacing it as a 500.
+      # Relays a converter-app failure instead of surfacing it as a 500. The
+      # upstream body is forwarded verbatim when it is JSON (e.g. converter-app's
+      # +{ Validation:, ValidationMsg: }+ on a legacy profile that no longer
+      # validates) so the client can show *why* the write was rejected; a
+      # non-JSON body degrades to a generic message.
       def with_converter_errors
         yield
       rescue Chemotion::ConverterClient::RequestError => e
-        error!({ error: 'converter request failed' }, e.code)
+        error!(converter_error_body(e.body), e.code)
+      end
+
+      # @return [Hash] converter-app's parsed error body, or a generic fallback
+      def converter_error_body(body)
+        parsed = JSON.parse(body)
+        parsed.is_a?(Hash) ? parsed : { error: 'converter request failed' }
+      rescue JSON::ParserError, TypeError
+        { error: 'converter request failed' }
       end
 
       # The upload arrives as a Rack multipart hash with string keys. Older
@@ -107,6 +126,13 @@ module Chemotion
       end
 
       resource :profiles do
+        desc 'create a profile, relaying converter-app validation errors'
+        post do
+          with_converter_errors do
+            normalize_profile(Chemotion::ConverterClient.create_profile(params))
+          end
+        end
+
         desc 'restore a profile to an earlier version'
         params do
           requires :profile_id, type: String, desc: 'profile id'
@@ -129,7 +155,16 @@ module Chemotion
         route_param :id do
           desc 'update a profile, backfilling fields legacy profiles may be missing'
           put do
-            normalize_profile(Labimotion::Converter.update_profile(params))
+            # Routed through Chemotion::ConverterClient (not the gem's
+            # Labimotion::Converter.update_profile) because the gem returns
+            # +response.parsed_response if response.code == 200+, so a legacy
+            # profile that fails converter-app's write-time json-schema validation
+            # (HTTP 400 + errors body) collapses to nil. This proxy then returned
+            # 200/null, and chemotion-converter-client's error handler crashed on
+            # +Object.values(errors.data)+ with the real error already discarded.
+            with_converter_errors do
+              normalize_profile(Chemotion::ConverterClient.update_profile(params[:id], params))
+            end
           end
         end
       end

--- a/lib/chemotion/converter_client.rb
+++ b/lib/chemotion/converter_client.rb
@@ -24,7 +24,37 @@ module Chemotion
       end
     end
 
+    JSON_HEADERS = { 'Content-Type' => 'application/json' }.freeze
+
     class << self
+      # Creates a profile from +data+.
+      #
+      # converter-app migrates and json-schema-validates the profile on write and
+      # answers 400 with an +errors+ body when it does not validate — a
+      # {RequestError} carrying that body, so the caller can relay it instead of
+      # collapsing it to +nil+ the way {Labimotion::Converter.create_profile} does.
+      #
+      # @param data [Hash] the profile payload
+      # @return [Hash] the created (migrated/validated) profile
+      # @raise [RequestError]
+      def create_profile(data)
+        parse(request(:post, 'profiles', body: data.to_json, headers: JSON_HEADERS))
+      end
+
+      # Updates the profile identified by +profile_id+ with +data+.
+      #
+      # Same write-time migration/validation contract as {.create_profile}: a
+      # legacy profile that no longer validates comes back as a {RequestError}
+      # (HTTP 400 + +errors+ body) rather than a swallowed +nil+.
+      #
+      # @param profile_id [String] the profile id
+      # @param data [Hash] the profile payload
+      # @return [Hash] the updated (migrated/validated) profile
+      # @raise [RequestError]
+      def update_profile(profile_id, data)
+        parse(request(:put, "profiles/#{profile_id}", body: data.to_json, headers: JSON_HEADERS))
+      end
+
       # Restores +profile_id+ to an earlier +version+.
       #
       # @param hard [Boolean] discard the versions newer than +version+

--- a/spec/api/chemotion/converter_api_spec.rb
+++ b/spec/api/chemotion/converter_api_spec.rb
@@ -143,6 +143,55 @@ describe Chemotion::ConverterAPI do
         expect(parsed_json_response['tables']).to eq([])
         expect(parsed_json_response['subjectInstances']).to eq({})
       end
+
+      # Regression: converter-app rejects a legacy profile that no longer
+      # validates with 400 + an errors body. The gem's update_profile collapses
+      # any non-200 to nil, so the proxy used to answer 200/null and the client's
+      # error handler crashed on Object.values(errors.data). The status and body
+      # must now survive to the client so it can show the validation message.
+      it 'relays a converter-app validation failure with its status and body' do
+        errors = { 'Validation' => 'Profile is not valid!', 'ValidationMsg' => "'tables' is a required property" }
+        stub_request(:put, "#{converter_url}profiles/p1").to_return(
+          status: 400,
+          body: errors.to_json,
+          headers: { 'Content-Type' => 'application/json' },
+        )
+
+        put '/api/v1/converter/profiles/p1', params: { title: 'legacy' }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(parsed_json_response).to eq(errors)
+      end
+    end
+
+    describe 'POST /api/v1/converter/profiles' do
+      it 'creates a profile via converter-app' do
+        stub_request(:post, "#{converter_url}profiles").to_return(
+          status: 201,
+          body: { 'id' => 'p2', 'title' => 'New' }.to_json,
+          headers: { 'Content-Type' => 'application/json' },
+        )
+
+        post '/api/v1/converter/profiles', params: { title: 'New' }
+
+        expect(response).to have_http_status(:created)
+        expect(parsed_json_response['id']).to eq('p2')
+        expect(parsed_json_response['tables']).to eq([])
+      end
+
+      it 'relays a converter-app validation failure with its status and body' do
+        errors = { 'Validation' => 'Profile is not valid!' }
+        stub_request(:post, "#{converter_url}profiles").to_return(
+          status: 400,
+          body: errors.to_json,
+          headers: { 'Content-Type' => 'application/json' },
+        )
+
+        post '/api/v1/converter/profiles', params: { title: 'bad' }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(parsed_json_response).to eq(errors)
+      end
     end
 
     describe 'POST /api/v1/converter/tables' do


### PR DESCRIPTION
## Problem

Editing a legacy converter profile as a converter-admin does nothing, and the browser console throws:
```
Uncaught (in promise) TypeError: Cannot convert undefined or null to object
    at Object.values (<anonymous>)   // @complat/chemotion-converter-client bundle
```
Seen on chemotion_ELN v4.0.0-rc with converter-app v1.9.2 / converter-client 0.16.0.

## Root cause

Profile create/update on `/api/v1/converter/profiles` went through `Labimotion::Converter.{create,update}_profile`, which do `response.parsed_response if response.code == 200` — collapsing **any** non-success converter-app response to `nil`. `Chemotion::ConverterAPI` then relayed that `nil` as **HTTP 200 with a null body**, discarding converter-app's real status and error payload. When converter-app rejects a legacy profile on write (its migration/validation), the client received a 200/null and crashed in its error handler (`Object.values(undefined)`), with the real error already gone.

(The upstream converter-app bug that makes legacy profiles fail on write is fixed separately in ComPlat/chemotion-converter-app#242; the client-side crash guard in ComPlat/chemotion-converter-client#170. This PR is the ELN proxy's part: stop swallowing the error.)

## Changes

- `lib/chemotion/converter_client.rb` — add `create_profile` / `update_profile` to `Chemotion::ConverterClient`, raising `RequestError(code, body)` on any non-2xx (consistent with the existing `restore_profile` / `create_tables`).
- `app/api/chemotion/converter_api.rb` — route `POST`/`PUT /converter/profiles` through the client wrapped in `with_converter_errors`, which now **forwards converter-app's JSON error body verbatim** (with its status) instead of a generic string, so the admin UI can show *why* the write was rejected.
- `spec/api/chemotion/converter_api_spec.rb` — specs for the error relay on both create and update, plus create success.

## Testing

`bundle exec rspec spec/api/chemotion/converter_api_spec.rb` → 17 examples, 0 failures. `rubocop` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)