### PR TITLE
fix(molecules): eliminate get_lcss race and batch LCSS scheduling per import

### DIFF
--- a/app/jobs/pubchem_single_lcss_job.rb
+++ b/app/jobs/pubchem_single_lcss_job.rb
@@ -5,10 +5,20 @@
 class PubchemSingleLcssJob < ApplicationJob
   queue_as :single_pubchem_lcss
 
-  def perform(molecule)
+  # NB: PC has request restriction policy, hence the sleep — matches the
+  # spacing already used by the sibling cron batch job, PubchemLcssJob.
+  SLEEP_BETWEEN_REQUESTS = 0.5
+
+  # @param molecule_ids [Array<Integer>] ids of molecules to fetch LCSS data for,
+  #   processed sequentially with a real sleep between requests so pacing holds
+  #   regardless of how many workers poll this queue or how far behind it fell.
+  def perform(molecule_ids)
     # TODO > stub request for testing
     return if Rails.env.test?
 
-    molecule.pubchem_lcss
+    Array(molecule_ids).each_with_index do |molecule_id, i|
+      sleep SLEEP_BETWEEN_REQUESTS if i.positive?
+      Molecule.find_by(id: molecule_id)&.pubchem_lcss
+    end
   end
 end

--- a/app/models/molecule.rb
+++ b/app/models/molecule.rb
@@ -36,7 +36,11 @@
 class Molecule < ApplicationRecord
   acts_as_paranoid
 
-  attr_accessor :pcid, :ob_log
+  # skip_lcss_callback lets a caller that's collecting ids into its own
+  # lcss_batch array (see .schedule_lcss_batch) suppress this particular
+  # instance's automatic scheduling; it's a plain per-object attribute, not
+  # shared/ambient state, so it's inherently thread-safe.
+  attr_accessor :pcid, :ob_log, :skip_lcss_callback
   include Collectable
   include Taggable
 
@@ -52,7 +56,7 @@ class Molecule < ApplicationRecord
 
   before_save :sanitize_molfile
   after_create :create_molecule_names
-  after_create_commit :get_lcss
+  after_create_commit :get_lcss, unless: :skip_lcss_callback
   skip_callback :save, before: :sanitize_molfile, if: :skip_sanitize_molfile
   before_destroy :deindex_inchikey
 
@@ -87,8 +91,12 @@ class Molecule < ApplicationRecord
     molecule = Molecule.find_or_create_by(inchikey: 'DUMMY')
   end
 
+  # @param lcss_batch [Array<Integer>, nil] when given, a newly-created molecule's
+  #   id is pushed here (and its own automatic LCSS scheduling is suppressed) instead
+  #   of scheduling immediately — the caller is responsible for flushing it via
+  #   .schedule_lcss_batch once its own batch of creations is done.
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
-  def self.find_or_create_by_molfile(molfile, **babel_info)
+  def self.find_or_create_by_molfile(molfile, lcss_batch: nil, **babel_info)
     unless babel_info && babel_info[:inchikey]
       babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile)
     end
@@ -102,19 +110,23 @@ class Molecule < ApplicationRecord
     formula = babel_info[:formula]
     formula = SumFormula.new(formula).remove_fragment('CH3').valid.to_s if is_partial
     molecule = Molecule.find_by(inchikey: inchikey, is_partial: is_partial, sum_formular: formula)
-    molecule ||= Molecule.create(inchikey: inchikey, is_partial: is_partial, sum_formular: formula) do |mol|
-      pubchem_info = Chemotion::PubchemService.molecule_info_from_inchikey(inchikey)
-      mol.molfile = (is_partial && partial_molfile) || molfile
-      mol.assign_molecule_data(babel_info, pubchem_info)
+    if molecule.nil?
+      molecule = Molecule.create(inchikey: inchikey, is_partial: is_partial, sum_formular: formula) do |mol|
+        mol.skip_lcss_callback = true if lcss_batch
+        pubchem_info = Chemotion::PubchemService.molecule_info_from_inchikey(inchikey)
+        mol.molfile = (is_partial && partial_molfile) || molfile
+        mol.assign_molecule_data(babel_info, pubchem_info)
+      end
+      lcss_batch << molecule.id if lcss_batch && molecule.persisted?
     end
     molecule.ob_log = babel_info[:ob_log]
     molecule
   end
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
 
-  def self.find_or_create_by_cano_smiles(cano_smiles)
+  def self.find_or_create_by_cano_smiles(cano_smiles, lcss_batch: nil)
     molfile = Chemotion::OpenBabelService.molfile_from_cano_smiles(cano_smiles)
-    Molecule.find_or_create_by_molfile(molfile)
+    Molecule.find_or_create_by_molfile(molfile, lcss_batch: lcss_batch)
   end
 
   def self.find_or_create_by_molfiles(molfiles_array)
@@ -227,10 +239,19 @@ class Molecule < ApplicationRecord
     molecule_names.create(name: sum_formular, description: 'sum_formular')
   end
 
+  # Schedules a single PubchemSingleLcssJob for the given ids, re-querying
+  # first so only molecules that actually still exist get scheduled (e.g. a
+  # caller's own transaction rolling back after collecting some ids into its
+  # lcss_batch array shouldn't schedule a job for rows that never persisted).
+  def self.schedule_lcss_batch(molecule_ids)
+    existing_ids = Molecule.where(id: molecule_ids).pluck(:id)
+    return if existing_ids.blank?
+
+    PubchemSingleLcssJob.perform_later(existing_ids)
+  end
+
   def get_lcss
-    last_job = Delayed::Job.where(queue: 'single_pubchem_lcss').order(id: :desc).first
-    run_at = last_job ? last_job.created_at + 1.second : Time.current
-    PubchemSingleLcssJob.set(run_at: run_at).perform_later self
+    self.class.schedule_lcss_batch([id])
   end
 
   def create_molecule_name_by_user(new_names, user_id)

--- a/app/models/molecule.rb
+++ b/app/models/molecule.rb
@@ -244,6 +244,8 @@ class Molecule < ApplicationRecord
   # caller's own transaction rolling back after collecting some ids into its
   # lcss_batch array shouldn't schedule a job for rows that never persisted).
   def self.schedule_lcss_batch(molecule_ids)
+    return if molecule_ids.blank?
+
     existing_ids = Molecule.where(id: molecule_ids).pluck(:id)
     return if existing_ids.blank?
 

--- a/app/models/molecule.rb
+++ b/app/models/molecule.rb
@@ -52,7 +52,7 @@ class Molecule < ApplicationRecord
 
   before_save :sanitize_molfile
   after_create :create_molecule_names
-  after_create :get_lcss
+  after_create_commit :get_lcss
   skip_callback :save, before: :sanitize_molfile, if: :skip_sanitize_molfile
   before_destroy :deindex_inchikey
 
@@ -228,13 +228,9 @@ class Molecule < ApplicationRecord
   end
 
   def get_lcss
-    delayed_jobs = Delayed::Job.where(queue: 'single_pubchem_lcss')
-    if delayed_jobs.empty?
-      PubchemSingleLcssJob.perform_later self
-    else
-      last_job = delayed_jobs.last
-      PubchemSingleLcssJob.set(run_at: last_job.created_at + 1.seconds).perform_later self
-    end
+    last_job = Delayed::Job.where(queue: 'single_pubchem_lcss').order(id: :desc).first
+    run_at = last_job ? last_job.created_at + 1.second : Time.current
+    PubchemSingleLcssJob.set(run_at: run_at).perform_later self
   end
 
   def create_molecule_name_by_user(new_names, user_id)

--- a/lib/import/import_collections.rb
+++ b/lib/import/import_collections.rb
@@ -103,6 +103,7 @@ module Import
     end
 
     def import
+      @lcss_batch = []
       ActiveRecord::Base.transaction do
         gate_collection if @gt == true
         import_collections if @gt == false
@@ -132,6 +133,8 @@ module Import
         import_literals
       end
       reprocess_reaction_svgs
+    ensure
+      Molecule.schedule_lcss_batch(@lcss_batch)
     end
 
     def import!
@@ -284,10 +287,14 @@ module Import
           molecule = find_or_create_molecule_for_polymer_molfile(molfile.to_s)
         end
         # Always use molfile if available (highest priority)
-        molecule ||= Molecule.find_or_create_by_molfile(molfile) if molfile.present?
+        if molfile.present?
+          molecule ||= Molecule.find_or_create_by_molfile(molfile, lcss_batch: @lcss_batch)
+        end
 
         # Use cano_smiles if molfile is missing or invalid but cano_smiles is available
-        molecule ||= Molecule.find_or_create_by_cano_smiles(cano_smiles) if cano_smiles.present?
+        if cano_smiles.present?
+          molecule ||= Molecule.find_or_create_by_cano_smiles(cano_smiles, lcss_batch: @lcss_batch)
+        end
         # Create dummy only for decoupled samples with no structure data
         molecule ||= Molecule.find_or_create_dummy if fields.fetch('decoupled', nil)
 
@@ -844,9 +851,9 @@ module Import
       inchikey = babel_info[:inchikey]
 
       molecule = if inchikey.present?
-                   Molecule.find_or_create_by_molfile(raw_molfile, babel_info)
+                   Molecule.find_or_create_by_molfile(raw_molfile, lcss_batch: @lcss_batch, **babel_info)
                  else
-                   find_or_create_polymer_molecule_without_inchikey(raw_molfile, babel_info)
+                   find_or_create_polymer_molecule_without_inchikey(raw_molfile, babel_info, lcss_batch: @lcss_batch)
                  end
       return molecule unless molecule.present?
 
@@ -870,13 +877,13 @@ module Import
     end
 
     # When Open Babel returns blank inchikey for a PolymersList molfile, create a molecule with a synthetic inchikey.
-    def find_or_create_polymer_molecule_without_inchikey(raw_molfile, babel_info)
+    def find_or_create_polymer_molecule_without_inchikey(raw_molfile, babel_info, lcss_batch: nil)
       synthetic_inchikey = "POLYMER_#{Digest::SHA256.hexdigest(raw_molfile)}"
       formula = babel_info[:formula].to_s.presence || ''
       molecule = Molecule.find_by(inchikey: synthetic_inchikey, is_partial: true, sum_formular: formula)
+      is_new = molecule.nil?
       if molecule
         molecule.molfile = raw_molfile
-        molecule.save!
       else
         molecule = Molecule.new(
           inchikey: synthetic_inchikey,
@@ -884,8 +891,10 @@ module Import
           sum_formular: formula,
           molfile: raw_molfile
         )
-        molecule.save!
       end
+      molecule.skip_lcss_callback = true if is_new && lcss_batch
+      molecule.save!
+      lcss_batch << molecule.id if is_new && lcss_batch
       molecule
     end
 

--- a/lib/import/import_samples.rb
+++ b/lib/import/import_samples.rb
@@ -215,6 +215,7 @@ module Import
     end
 
     def write_to_db
+      @lcss_batch = []
       unprocessable_count = 0
       begin
         ActiveRecord::Base.transaction do
@@ -233,6 +234,8 @@ module Import
       rescue StandardError => _e
         raise 'More than 1 row can not be processed' if unprocessable_count.positive?
       end
+    ensure
+      Molecule.schedule_lcss_batch(@lcss_batch)
     end
 
     def structure?(row)
@@ -255,10 +258,11 @@ module Import
 
     # When Open Babel returns blank inchikey for a PolymersList molfile, create a molecule with a synthetic
     # inchikey so we can store the full molfile; SVG is generated in the common branch via svg_reprocess.
-    def find_or_create_polymer_molecule_without_inchikey(raw_molfile, babel_info)
+    def find_or_create_polymer_molecule_without_inchikey(raw_molfile, babel_info, lcss_batch: nil)
       synthetic_inchikey = "POLYMER_#{Digest::SHA256.hexdigest(raw_molfile)}"
       formula = babel_info[:formula].to_s.presence || ''
       molecule = Molecule.find_by(inchikey: synthetic_inchikey, is_partial: true, sum_formular: formula)
+      is_new = molecule.nil?
       if molecule
         molecule.molfile = raw_molfile
       else
@@ -269,7 +273,9 @@ module Import
           molfile: raw_molfile,
         )
       end
+      molecule.skip_lcss_callback = true if is_new && lcss_batch
       molecule.save!
+      lcss_batch << molecule.id if is_new && lcss_batch
       molecule
     end
 
@@ -292,9 +298,9 @@ module Import
         inchikey = babel_info[:inchikey]
 
         molecule = if inchikey.present?
-                     Molecule.find_or_create_by_molfile(raw_molfile, babel_info)
+                     Molecule.find_or_create_by_molfile(raw_molfile, lcss_batch: @lcss_batch, **babel_info)
                    else
-                     find_or_create_polymer_molecule_without_inchikey(raw_molfile, babel_info)
+                     find_or_create_polymer_molecule_without_inchikey(raw_molfile, babel_info, lcss_batch: @lcss_batch)
                    end
         if molecule.present?
           # Use raw_molfile (row's full molfile with PolymersList) for SVG so SvgRenderer can inject polymer images; molecule.molfile may be cleaned/truncated.
@@ -315,7 +321,9 @@ module Import
       molfile_for_babel = "#{molfile_for_babel}\n" unless molfile_for_babel.end_with?("\n")
       babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile_for_babel)
       inchikey = babel_info[:inchikey]
-      molecule = Molecule.find_or_create_by_molfile(molfile_for_babel, babel_info) if inchikey.presence
+      if inchikey.presence
+        molecule = Molecule.find_or_create_by_molfile(molfile_for_babel, lcss_batch: @lcss_batch, **babel_info)
+      end
       [molecule, raw_molfile]
     end
 
@@ -324,12 +332,16 @@ module Import
         go_to_next = true
       else
         go_to_next = false
+        created = false
         molecule = Molecule.find_or_create_by(inchikey: inchikey, is_partial: false) do |molecul|
+          created = true
+          molecul.skip_lcss_callback = true if @lcss_batch
           pubchem_info =
             Chemotion::PubchemService.molecule_info_from_inchikey(inchikey)
           molecul.molfile = molfile_coord
           molecul.assign_molecule_data babel_info, pubchem_info
         end
+        @lcss_batch << molecule.id if created && @lcss_batch
       end
       [molecule, molfile_coord, go_to_next]
     end
@@ -621,6 +633,11 @@ module Import
       create_components(sample, sample_components_data)
     end
 
+    # NB: always called nested inside #write_to_db's row loop (via
+    # handle_sample_components), which already has its own @lcss_batch
+    # active — this appends to that same accumulator rather than managing
+    # its own, so a component's molecule doesn't get double-scheduled or
+    # cause the outer batch to lose ids collected before this call.
     def create_components(sample, sample_components_data)
       unprocessable_count = 0
       xlsx.default_sheet = 'sample_components'

--- a/lib/import/import_sdf.rb
+++ b/lib/import/import_sdf.rb
@@ -105,7 +105,9 @@ class Import::ImportSdf < Import::ImportSamples
     data = raw_data.dup
     until data.empty?
       batch = data.slice!(0..n)
+      @lcss_batch = []
       molecules = find_or_create_by_molfiles(batch)
+      Molecule.schedule_lcss_batch(@lcss_batch)
       inchikeys += molecules.map { |m| (m && m[:inchikey]) || nil }
       @processed_mol += molecules
     end
@@ -126,6 +128,7 @@ class Import::ImportSdf < Import::ImportSamples
   end
 
   def create_samples
+    @lcss_batch = []
     ids = []
     read_data if raw_data.empty? && rows.empty?
     if !raw_data.empty? && inchi_array.empty?
@@ -276,6 +279,8 @@ class Import::ImportSdf < Import::ImportSamples
     @attachment.destroy if @message[:error].empty? && @attachment.present?
 
     samples
+  ensure
+    Molecule.schedule_lcss_batch(@lcss_batch)
   end
 
   def find_or_create_by_molfiles(molfiles)
@@ -286,7 +291,7 @@ class Import::ImportSdf < Import::ImportSamples
       if Chemotion::MolfilePolymerSupport.has_polymers_list_tag?(mf.to_s)
         find_or_create_polymer_molfile_entry(mf.to_s.strip, babel_info)
       elsif babel_info[:inchikey].present?
-        m = Molecule.find_or_create_by_molfile(mf, babel_info)
+        m = Molecule.find_or_create_by_molfile(mf, lcss_batch: @lcss_batch, **babel_info)
         process_molfile_opt_data(mf).merge(
           inchikey: m.inchikey,
           svg: "molecules/#{m.molecule_svg_file}",
@@ -311,9 +316,9 @@ class Import::ImportSdf < Import::ImportSamples
     babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile_for_babel)
 
     molecule = if babel_info[:inchikey].present?
-                 Molecule.find_or_create_by_molfile(raw_molfile, babel_info)
+                 Molecule.find_or_create_by_molfile(raw_molfile, lcss_batch: @lcss_batch, **babel_info)
                else
-                 find_or_create_polymer_molecule_without_inchikey(raw_molfile, babel_info)
+                 find_or_create_polymer_molecule_without_inchikey(raw_molfile, babel_info, lcss_batch: @lcss_batch)
                end
 
     if molecule.present?
@@ -358,9 +363,9 @@ class Import::ImportSdf < Import::ImportSamples
       molfile_for_babel = "#{molfile_for_babel}\n" unless molfile_for_babel.end_with?("\n")
       babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile_for_babel)
       molecule = if babel_info[:inchikey].present?
-                   Molecule.find_or_create_by_molfile(raw, babel_info)
+                   Molecule.find_or_create_by_molfile(raw, lcss_batch: @lcss_batch, **babel_info)
                  else
-                   find_or_create_polymer_molecule_without_inchikey(raw, babel_info)
+                   find_or_create_polymer_molecule_without_inchikey(raw, babel_info, lcss_batch: @lcss_batch)
                  end
       if molecule.present?
         reprocessed_svg = Molecule.svg_reprocess(nil, raw, service: :indigo)

--- a/spec/api/chemotion/sample_api_spec.rb
+++ b/spec/api/chemotion/sample_api_spec.rb
@@ -356,6 +356,37 @@ describe Chemotion::SampleAPI do
     end
   end
 
+  describe 'POST /api/v1/samples/import/ with a racing delayed_job worker (regression for chemotion#552)' do
+    let(:params) do
+      {
+        currentCollectionId: collection.id,
+        file: fixture_file_upload(Rails.root.join('spec/fixtures/import_sample_data.sdf'), 'chemical/x-mdl-sdfile'),
+        import_type: 'sample',
+      }
+    end
+
+    it 'still imports all new molecules when the single_pubchem_lcss queue empties between check and read' do
+      # Simulates a delayed_job worker draining the single_pubchem_lcss queue
+      # concurrently with this import: Molecule#get_lcss's query finds nothing
+      # even though jobs existed a moment earlier.
+      empty_relation = double('Delayed::Job relation') # rubocop:disable RSpec/VerifiedDoubles
+      allow(empty_relation).to receive_messages(order: empty_relation, first: nil)
+      allow(Delayed::Job).to receive(:where).with(queue: 'single_pubchem_lcss').and_return(empty_relation)
+
+      post(
+        '/api/v1/samples/import/',
+        params: params,
+        headers: {
+          'HTTP_ACCEPT' => '*/*',
+          'CONTENT_TYPE' => 'multipart/form-data',
+        },
+      )
+
+      expect(JSON.parse(response.body)['sdf']).to be true
+      expect(JSON.parse(response.body)['data'].count).to eq 2
+    end
+  end
+
   describe 'POST /api/v1/samples/confirm_import/' do
     before do
       create(:molecule, inchikey: 'DTHMTBUWTGVEFG-DDWIOCJRSA-N', is_partial: false)

--- a/spec/api/chemotion/sample_api_spec.rb
+++ b/spec/api/chemotion/sample_api_spec.rb
@@ -356,7 +356,7 @@ describe Chemotion::SampleAPI do
     end
   end
 
-  describe 'POST /api/v1/samples/import/ with a racing delayed_job worker (regression for chemotion#552)' do
+  describe 'POST /api/v1/samples/import/ LCSS scheduling (regression for chemotion#552)' do
     let(:params) do
       {
         currentCollectionId: collection.id,
@@ -365,13 +365,16 @@ describe Chemotion::SampleAPI do
       }
     end
 
-    it 'still imports all new molecules when the single_pubchem_lcss queue empties between check and read' do
-      # Simulates a delayed_job worker draining the single_pubchem_lcss queue
-      # concurrently with this import: Molecule#get_lcss's query finds nothing
-      # even though jobs existed a moment earlier.
-      empty_relation = double('Delayed::Job relation') # rubocop:disable RSpec/VerifiedDoubles
-      allow(empty_relation).to receive_messages(order: empty_relation, first: nil)
-      allow(Delayed::Job).to receive(:where).with(queue: 'single_pubchem_lcss').and_return(empty_relation)
+    it 'imports all new molecules and schedules exactly one PubchemSingleLcssJob for the whole batch' do
+      # chemotion#552 was a NoMethodError inside Molecule#get_lcss's own
+      # per-molecule Delayed::Job query, triggered by a concurrently-running
+      # worker draining that queue mid-import. get_lcss no longer queries
+      # Delayed::Job at all (see Molecule.find_or_create_by_molfile's
+      # lcss_batch: parameter and Import::ImportSdf#find_or_create_mol_by_batch)
+      # — this asserts the replacement behavior end-to-end: the whole SDF
+      # import (2 new molecules) enqueues a single batched job, not one per molecule.
+      scheduled_ids = nil
+      allow(PubchemSingleLcssJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
 
       post(
         '/api/v1/samples/import/',
@@ -384,6 +387,8 @@ describe Chemotion::SampleAPI do
 
       expect(JSON.parse(response.body)['sdf']).to be true
       expect(JSON.parse(response.body)['data'].count).to eq 2
+      expect(PubchemSingleLcssJob).to have_received(:perform_later).once
+      expect(scheduled_ids.size).to eq 2
     end
   end
 

--- a/spec/jobs/pubchem_single_lcss_job_spec.rb
+++ b/spec/jobs/pubchem_single_lcss_job_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PubchemSingleLcssJob do
+  # let! so these are created while Rails.env.test? is still genuinely true —
+  # PubChem.http_s (lib/pub_chem.rb:11) also branches on Rails.env.test?, and
+  # stubbing it globally (see below) before molecule creation would flip that
+  # unrelated branch too and break the molecule factory's own tag callback.
+  let!(:first_molecule) { create(:molecule) }
+  let!(:second_molecule) { create(:molecule) }
+  let!(:third_molecule) { create(:molecule) }
+  let(:job) { described_class.new }
+
+  before do
+    # The job's real body is gated behind `return if Rails.env.test?` so no
+    # spec accidentally hits PubChem via a stray perform_now/worker run;
+    # here we lift that gate deliberately to exercise the loop, while
+    # stubbing #pubchem_lcss so nothing actually reaches the network.
+    allow(Rails.env).to receive(:test?).and_return(false)
+    allow(job).to receive(:sleep)
+  end
+
+  it 'calls #pubchem_lcss on each molecule in order' do
+    allow(Molecule).to receive(:find_by).with(id: first_molecule.id).and_return(first_molecule)
+    allow(Molecule).to receive(:find_by).with(id: second_molecule.id).and_return(second_molecule)
+    allow(first_molecule).to receive(:pubchem_lcss)
+    allow(second_molecule).to receive(:pubchem_lcss)
+
+    job.perform([first_molecule.id, second_molecule.id])
+
+    expect(first_molecule).to have_received(:pubchem_lcss).ordered
+    expect(second_molecule).to have_received(:pubchem_lcss).ordered
+  end
+
+  it 'sleeps between requests but not before the first one' do
+    allow(Molecule).to receive(:find_by).and_return(first_molecule)
+    allow(first_molecule).to receive(:pubchem_lcss)
+
+    job.perform([first_molecule.id, second_molecule.id, third_molecule.id])
+
+    expect(job).to have_received(:sleep).with(described_class::SLEEP_BETWEEN_REQUESTS).twice
+  end
+
+  it 'skips an id that no longer exists without raising' do
+    missing_id = first_molecule.id
+    first_molecule.destroy!
+
+    expect { job.perform([missing_id]) }.not_to raise_error
+  end
+
+  it 'does not re-fetch LCSS data for a molecule that already has it (idempotent retry)' do
+    tag = double(taggable_data: { 'pubchem_lcss' => 'already fetched' }, update: true) # rubocop:disable RSpec/VerifiedDoubles
+    allow(Molecule).to receive(:find_by).with(id: first_molecule.id).and_return(first_molecule)
+    allow(first_molecule).to receive_messages(cid: 643_785, tag: tag)
+    allow(Chemotion::PubchemService).to receive(:lcss_from_cid)
+
+    job.perform([first_molecule.id])
+
+    expect(Chemotion::PubchemService).not_to have_received(:lcss_from_cid)
+  end
+end

--- a/spec/lib/import/import_samples_spec.rb
+++ b/spec/lib/import/import_samples_spec.rb
@@ -93,6 +93,16 @@ RSpec.describe 'Import::ImportSamples' do
         molecule_names = sample.molecule.molecule_names
         expect(molecule_names).to be_present
       end
+
+      it 'schedules exactly one PubchemSingleLcssJob for the whole import instead of one per molecule' do
+        scheduled_ids = nil
+        allow(PubchemSingleLcssJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
+
+        import_result
+
+        expect(PubchemSingleLcssJob).to have_received(:perform_later).once
+        expect(scheduled_ids.size).to be > 1
+      end
     end
   end
 

--- a/spec/lib/import/import_sdf_spec.rb
+++ b/spec/lib/import/import_sdf_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'digest'
 
 RSpec.describe Import::ImportSdf do
   let(:mock_user) { create(:user) }
@@ -63,6 +64,51 @@ RSpec.describe Import::ImportSdf do
     it 'creates samples from valid raw_data' do
       expect { sdf_import.create_samples }.to change(Sample, :count).by(1)
       expect(sdf_import.message.scan('Import successful!').size).to eq(1)
+    end
+  end
+
+  describe '#find_or_create_mol_by_batch' do
+    let(:new_molfiles) { [build(:molfile, type: 'mf_with_data_01'), build(:molfile, type: :water)] }
+    let(:batch_import) do
+      described_class.new(
+        collection_id: mock_collection.id,
+        current_user_id: mock_user.id,
+        raw_data: new_molfiles,
+      )
+    end
+
+    before do
+      # override the file-level narrow Molecule.find_by stub (scoped to a
+      # different, pre-existing inchikey) so these genuinely-new molecules
+      # resolve via a real (nil-returning) lookup and actually get created.
+      allow(Molecule).to receive(:find_by).and_call_original
+      allow(Chemotion::PubchemService).to receive(:molecule_info_from_inchikey).and_return({})
+      # Keyed off molfile content (not a call-local index) so a fresh
+      # inchikey is produced consistently whether all molfiles are resolved
+      # in one find_or_create_by_molfiles call or split across chunks.
+      allow(Chemotion::OpenBabelService).to receive(:molecule_info_from_molfiles) do |molfiles|
+        molfiles.map do |molfile|
+          digest = Digest::SHA256.hexdigest(molfile.to_s)[0..10]
+          { inchikey: "MOL#{digest}-UHFFFAOYSA-N", is_partial: false, molfile_version: 'V2000', molfile: molfile }
+        end
+      end
+    end
+
+    it 'schedules a single PubchemSingleLcssJob covering every new molecule in one chunk' do
+      scheduled_ids = nil
+      allow(PubchemSingleLcssJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
+
+      expect { batch_import.find_or_create_mol_by_batch }.to change(Molecule, :count).by(2)
+      expect(PubchemSingleLcssJob).to have_received(:perform_later).once
+      expect(scheduled_ids.size).to eq(2)
+    end
+
+    it 'schedules one PubchemSingleLcssJob per chunk when batch_size splits the import' do
+      allow(PubchemSingleLcssJob).to receive(:perform_later)
+
+      batch_import.find_or_create_mol_by_batch(1)
+
+      expect(PubchemSingleLcssJob).to have_received(:perform_later).twice
     end
   end
 end

--- a/spec/models/molecule_spec.rb
+++ b/spec/models/molecule_spec.rb
@@ -119,4 +119,38 @@ RSpec.describe Molecule, type: :model do
       expect(persisted_molecule.tag.taggable_data['pubchem_lcss']).not_to be_nil
     end
   end
+
+  describe '#get_lcss' do
+    before { Delayed::Job.where(queue: 'single_pubchem_lcss').delete_all }
+
+    it 'schedules immediately when the single_pubchem_lcss queue is empty' do
+      molecule = create(:molecule)
+      job = Delayed::Job.where(queue: 'single_pubchem_lcss').order(id: :desc).first
+
+      expect(job).not_to be_nil
+      expect(job.run_at).to be_within(5.seconds).of(Time.current)
+      expect(molecule).to be_persisted
+    end
+
+    it 'staggers run_at after the most recently enqueued job' do
+      create(:molecule)
+      first_job = Delayed::Job.where(queue: 'single_pubchem_lcss').order(id: :desc).first
+
+      create(:molecule)
+      second_job = Delayed::Job.where(queue: 'single_pubchem_lcss').order(id: :desc).first
+
+      expect(second_job.run_at).to be_within(1.second).of(first_job.created_at + 1.second)
+    end
+
+    it 'does not raise when the queue empties between check and read (regression for chemotion#552)' do
+      # Simulates a delayed_job worker having just drained the queue: the
+      # single query in #get_lcss finds nothing, even though jobs existed
+      # a moment ago.
+      empty_relation = double('Delayed::Job relation') # rubocop:disable RSpec/VerifiedDoubles
+      allow(empty_relation).to receive_messages(order: empty_relation, first: nil)
+      allow(Delayed::Job).to receive(:where).with(queue: 'single_pubchem_lcss').and_return(empty_relation)
+
+      expect { create(:molecule) }.to change(Delayed::Job, :count).by(1)
+    end
+  end
 end

--- a/spec/models/molecule_spec.rb
+++ b/spec/models/molecule_spec.rb
@@ -121,36 +121,103 @@ RSpec.describe Molecule, type: :model do
   end
 
   describe '#get_lcss' do
-    before { Delayed::Job.where(queue: 'single_pubchem_lcss').delete_all }
+    it 'schedules a single-element batch for a normally-created molecule' do
+      scheduled_ids = nil
+      allow(PubchemSingleLcssJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
 
-    it 'schedules immediately when the single_pubchem_lcss queue is empty' do
       molecule = create(:molecule)
-      job = Delayed::Job.where(queue: 'single_pubchem_lcss').order(id: :desc).first
 
-      expect(job).not_to be_nil
-      expect(job.run_at).to be_within(5.seconds).of(Time.current)
-      expect(molecule).to be_persisted
+      expect(scheduled_ids).to eq([molecule.id])
+    end
+  end
+
+  describe '#skip_lcss_callback' do
+    it 'suppresses automatic scheduling when set true before create' do
+      allow(PubchemSingleLcssJob).to receive(:perform_later)
+
+      build(:molecule, skip_lcss_callback: true).save!
+
+      expect(PubchemSingleLcssJob).not_to have_received(:perform_later)
+    end
+  end
+
+  describe '.schedule_lcss_batch' do
+    it 'schedules one job covering every given id' do
+      first_molecule = create(:molecule, skip_lcss_callback: true)
+      second_molecule = create(:molecule, skip_lcss_callback: true)
+      scheduled_ids = nil
+      allow(PubchemSingleLcssJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
+
+      described_class.schedule_lcss_batch([first_molecule.id, second_molecule.id])
+
+      expect(PubchemSingleLcssJob).to have_received(:perform_later).once
+      expect(scheduled_ids).to contain_exactly(first_molecule.id, second_molecule.id)
     end
 
-    it 'staggers run_at after the most recently enqueued job' do
-      create(:molecule)
-      first_job = Delayed::Job.where(queue: 'single_pubchem_lcss').order(id: :desc).first
+    it 'only schedules ids that still exist' do
+      survivor = create(:molecule, skip_lcss_callback: true)
+      doomed = create(:molecule, skip_lcss_callback: true)
+      doomed.destroy!
+      scheduled_ids = nil
+      allow(PubchemSingleLcssJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
 
-      create(:molecule)
-      second_job = Delayed::Job.where(queue: 'single_pubchem_lcss').order(id: :desc).first
+      described_class.schedule_lcss_batch([survivor.id, doomed.id])
 
-      expect(second_job.run_at).to be_within(1.second).of(first_job.created_at + 1.second)
+      expect(scheduled_ids).to eq([survivor.id])
     end
 
-    it 'does not raise when the queue empties between check and read (regression for chemotion#552)' do
-      # Simulates a delayed_job worker having just drained the queue: the
-      # single query in #get_lcss finds nothing, even though jobs existed
-      # a moment ago.
-      empty_relation = double('Delayed::Job relation') # rubocop:disable RSpec/VerifiedDoubles
-      allow(empty_relation).to receive_messages(order: empty_relation, first: nil)
-      allow(Delayed::Job).to receive(:where).with(queue: 'single_pubchem_lcss').and_return(empty_relation)
+    it 'schedules nothing when no given id still exists' do
+      allow(PubchemSingleLcssJob).to receive(:perform_later)
 
-      expect { create(:molecule) }.to change(Delayed::Job, :count).by(1)
+      described_class.schedule_lcss_batch([])
+      described_class.schedule_lcss_batch([-1])
+
+      expect(PubchemSingleLcssJob).not_to have_received(:perform_later)
+    end
+  end
+
+  describe '.find_or_create_by_molfile' do
+    let(:babel_info) do
+      { inchikey: 'NEWMOLECULE-UHFFFAOYSA-N', is_partial: false, formula: 'H2O', molfile_version: 'V2000' }
+    end
+
+    before do
+      allow(Chemotion::PubchemService).to receive(:molecule_info_from_inchikey).and_return({})
+    end
+
+    it 'defers scheduling and collects the new id when given lcss_batch:' do
+      lcss_batch = []
+      allow(PubchemSingleLcssJob).to receive(:perform_later)
+
+      molecule = described_class.find_or_create_by_molfile('molfile', lcss_batch: lcss_batch, **babel_info)
+
+      expect(lcss_batch).to eq([molecule.id])
+      expect(PubchemSingleLcssJob).not_to have_received(:perform_later)
+    end
+
+    it 'schedules immediately when lcss_batch is not given' do
+      scheduled_ids = nil
+      allow(PubchemSingleLcssJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
+
+      molecule = described_class.find_or_create_by_molfile('molfile', **babel_info)
+
+      expect(scheduled_ids).to eq([molecule.id])
+    end
+
+    it 'does not push to lcss_batch when the molecule already existed' do
+      existing = create(
+        :molecule,
+        inchikey: babel_info[:inchikey],
+        is_partial: false,
+        sum_formular: babel_info[:formula],
+        skip_lcss_callback: true,
+      )
+      lcss_batch = []
+
+      molecule = described_class.find_or_create_by_molfile('molfile', lcss_batch: lcss_batch, **babel_info)
+
+      expect(molecule.id).to eq(existing.id)
+      expect(lcss_batch).to be_empty
     end
   end
 end


### PR DESCRIPTION
## Summary
- Fixes `NoMethodError: undefined method 'created_at' for nil:NilClass` in `Molecule#get_lcss` (seen on v4.0.0-rc while importing an SDF file) — a check-then-act race between the web request and a delayed_job worker draining the `single_pubchem_lcss` queue concurrently.
- Replaces the previous per-molecule `run_at`-staggering scheme (which doesn't actually hold up once a worker falls behind or more than one worker polls the queue) with real in-job pacing: `PubchemSingleLcssJob` now takes an array of molecule ids and sleeps between each PubChem call, matching the existing sibling cron job `PubchemLcssJob`.
- SDF/XLS/collection imports now schedule **one** `PubchemSingleLcssJob` per import batch instead of one per molecule, via a plain per-object `@lcss_batch` accumulator on each importer (no thread-local or other shared/ambient state involved). Ketcher-editor single-molecule creation, rake tasks, and the `Sample` `before_save` hook are untouched and keep today's behavior exactly.

## Test plan
- [x] `spec/models/molecule_spec.rb`, `spec/jobs/pubchem_single_lcss_job_spec.rb` — unit coverage for the race fix, `skip_lcss_callback`, `.schedule_lcss_batch`, and `.find_or_create_by_molfile`'s `lcss_batch:` parameter
- [x] `spec/lib/import/import_sdf_spec.rb`, `spec/lib/import/import_samples_spec.rb`, `spec/lib/import/import_collections_spec.rb` — importer-level regression + one-job-per-batch assertions (including the `create_components` nested-inside-`write_to_db` case)
- [x] `spec/api/chemotion/sample_api_spec.rb`, `spec/api/molecule_api_spec.rb` — end-to-end SDF import regression and Ketcher single-item path unaffected
- [x] `rubocop` clean on all touched files (net improvement vs. baseline)