### PR TITLE
fix(report): emit <sup> for Quill script:super in report Delta→HTML

### DIFF
--- a/lib/reporter/delta.rb
+++ b/lib/reporter/delta.rb
@@ -141,7 +141,11 @@ module Reporter
         when "italic"
           tags += ["i"] if value == "true"
         when "script"
-          tags += [value]
+          # Quill encodes superscript as script: "super", but "super" is not a
+          # valid HTML tag; the correct element is <sup>. sablon >= 0.4.3 rejects
+          # unregistered tags (ArgumentError "Don't know how to handle HTML tag:
+          # super"), so map "super" to "sup" while "sub" is already valid.
+          tags += [value == "super" ? "sup" : value]
         when "color"
           styles << "color: #{value}"
         when "background"

--- a/spec/lib/reporter/delta_spec.rb
+++ b/spec/lib/reporter/delta_spec.rb
@@ -15,5 +15,20 @@ RSpec.describe Reporter::Delta do
       delta = { 'ops' => [{ 'insert' => "hello\n" }] }
       expect(described_class.new(delta).getHTML).to eq('<p>hello</p>')
     end
+
+    # Quill superscript is script: "super", but "super" is not a valid HTML tag;
+    # sablon >= 0.4.3 raises ArgumentError on it. The converter must emit <sup>.
+    it 'renders script: "super" as a <sup> tag, not an invalid <super> tag' do
+      delta = { 'ops' => [{ 'attributes' => { 'script' => 'super' }, 'insert' => '2+' }] }
+      html = described_class.new(delta).getHTML
+      expect(html).to include('<sup>').and include('</sup>')
+      expect(html).not_to include('<super>')
+    end
+
+    it 'renders script: "sub" as a <sub> tag' do
+      delta = { 'ops' => [{ 'attributes' => { 'script' => 'sub' }, 'insert' => '2' }] }
+      html = described_class.new(delta).getHTML
+      expect(html).to include('<sub>').and include('</sub>')
+    end
   end
 end


### PR DESCRIPTION
## Problem

DOCX report generation crashes in the `delayed_job` report worker with:

```
ArgumentError: Don't know how to handle HTML tag: super
  sablon/html/ast_builder.rb:24:in `fetch_tag'
  ... lib/reporter/worker.rb:28:in `process'
  ... app/models/report.rb:94:in `create_docx'
```

The report is never produced. This is a regression introduced by the sablon bump
`v0.0.19 → v0.4.3-1` (#3342, 7b9653d54), which ships in `v4.0.0-rc`.

## Root cause

`lib/reporter/delta.rb` (the report's Quill-delta → HTML converter) mapped a Quill
`script` attribute value directly to a tag name:

```ruby
when "script"
  tags += [value]        # value ∈ {"super", "sub"}
```

Quill encodes superscript as `{"script":"super"}`, so this emitted a literal
**`<super>…</super>`** element. `<super>` is **not** valid HTML — the correct element is
`<sup>`. (The `sub` branch was accidentally fine because `<sub>` is a real tag.)

The old sablon (0.0.19) silently tolerated the unknown tag. sablon 0.4.3
(`ast_builder.rb` `fetch_tag`) strictly validates tag names and registers only `sub`/`sup`
(not `super`), so it now raises — turning a latent invalid-HTML bug into a hard crash.

`script: "super"` deltas are produced by `sum_formular_delta` in
`lib/reporter/docx/detail_reaction.rb`: a material's molecular sum formula is tokenised and
every non-word run (`\W+`) is emitted as superscript. So **any material whose sum formula
contains a non-alphanumeric character** (charge, brackets, `·` hydrate dot) crashes the report.

## Fix

Map Quill `script: "super"` to `<sup>` (valid HTML that sablon renders as superscript;
`sub` stays valid):

```ruby
when "script"
  tags += [value == "super" ? "sup" : value]
```

`delta.rb` is the single choke point, so this fixes every `script: super` site at once.

## Verification

- Added regression specs asserting `script: "super"` → `<sup>` (never `<super>`) and
  `script: "sub"` → `<sub>` — `spec/lib/reporter/delta_spec.rb`.
- `bundle exec rspec spec/lib/reporter/delta_spec.rb` → 7 examples, 0 failures.
- Confirmed the emitted `<p><sup>…</sup></p>` now parses through sablon's AST builder without
  the `ArgumentError`.
