### PR TITLE
fix(admin): correct payload-shape regressions from the fetcher refactor + usersDefault validation

### DIFF
--- a/app/api/chemotion/admin_api.rb
+++ b/app/api/chemotion/admin_api.rb
@@ -25,10 +25,11 @@ module Chemotion
           default = User.default_disk_space / 1024 / 1024
           { allocated_user_space: default }
         end
+        desc 'set users default allocated space'
+        params do
+          requires :allocatedUserSpace, type: Integer, desc: 'users default allocated space'
+        end
         put do
-          params do
-            require :allocatedUserSpace, type: Integer, desc: 'users default allocated space'
-          end
           User.default_disk_space = params[:allocatedUserSpace]
         end
       end

--- a/app/javascript/src/apps/admin/DelayedJobs.js
+++ b/app/javascript/src/apps/admin/DelayedJobs.js
@@ -27,7 +27,7 @@ export default class DelayedJobs extends Component {
   }
 
   handleRestartFetch(id) {
-    AdminFetcher.restartJob({ id })
+    AdminFetcher.restartJob(id)
       .then(() => this.handleFetchJob());
   }
 

--- a/app/javascript/src/fetchers/AdminFetcher.js
+++ b/app/javascript/src/fetchers/AdminFetcher.js
@@ -14,7 +14,7 @@ export default class AdminFetcher {
   }
 
   static setAllocatedUserSpace(allocatedUserSpace) {
-    return ApiClient.putJson('/api/v1/admin/usersDefault', { body: allocatedUserSpace });
+    return ApiClient.putJson('/api/v1/admin/usersDefault', { body: { allocatedUserSpace } });
   }
 
   static resetUserPassword(params) {


### PR DESCRIPTION
Fixes two admin payload-shape regressions introduced by the fetcher refactor #3294, plus the endpoint validation gap that let one of them fail silently. In both regressions the caller was left unchanged while the fetcher's wrap semantics changed, so the wire payload no longer matches the Grape endpoint.

`putJson`/`postJson` in `ChemotionApiClient` do `JSON.stringify(options.body)`, so the new wire payload is exactly the `body` argument serialized.

## 1. Delayed job restart — 400

```
PUT /api/v1/admin/jobs/restart/
payload:  {"id": {"id": 1224731}}
response: {"error":"id is invalid"}
```

`restartJob(id)` already wraps its argument in `{ id }`, but the caller passed `{ id }` too → body `{ id: { id: <n> } }`. Endpoint declares `requires :id, type: Integer` → coercion fails.

- Before #3294: `body: JSON.stringify(id)` → `{"id":<n>}` ✅
- After #3294: `{ body: { id } }` re-wraps → `{"id":{"id":<n>}}` ❌

**Fix** (`DelayedJobs.js`): pass the plain id.

```diff
-    AdminFetcher.restartJob({ id })
+    AdminFetcher.restartJob(id)
```

## 2. Default allocated user space — silently broken

`AdminDashboard` sets the default disk space with a scalar:
`setAllocatedUserSpace(Math.round(x) * 1024 * 1024)`.

- Before #3294: `body: JSON.stringify({ allocatedUserSpace })` → `{"allocatedUserSpace":<n>}` ✅
- After #3294: `{ body: allocatedUserSpace }` → bare integer `<n>` ❌

`PUT /api/v1/admin/usersDefault` reads `params[:allocatedUserSpace]` → nil for a bare-integer body → `User.default_disk_space` set to nil. No 400 — silent.

**Fix** (`AdminFetcher.js`): restore the wrapper.

```diff
-    return ApiClient.putJson('/api/v1/admin/usersDefault', { body: allocatedUserSpace });
+    return ApiClient.putJson('/api/v1/admin/usersDefault', { body: { allocatedUserSpace } });
```

## 3. usersDefault endpoint validation (why #2 was silent)

The endpoint's `params` block was nested *inside* the `put do` route body and used `require` (Kernel#require) instead of Grape's `requires`, so it never validated — a malformed body set `default_disk_space` to nil instead of returning 400.

**Fix** (`admin_api.rb`): move the `params`/`requires` block out of the route body, matching the other admin endpoints. Malformed payloads now 422.

## Audit

Reviewed every mutating `AdminFetcher` method migrated in #3294 (pre-refactor `JSON.stringify(...)` payload vs new `{ body: ... }` shape). Only #1 and #2 changed shape; the rest (`resetUserPassword`, `createUserAccount`, `enableDisableOtp`, `updateUser`, `restoreAccount`, `updateAccount`, `olsTermDisableEnable`, `updateGroup`, `deleteGroupRelation`, `createGroupDevice`, `updateMatrice`) are identical before and after.

## Verification

- Restart issues `{"id": <integer>}`; job rescheduled (`run_at` bumped, `failed_at` cleared).
- Setting default space issues `{"allocatedUserSpace": <integer>}`; `User.default_disk_space` updated; malformed body now 422s.

refs: #3294
