### PR TITLE
fix(users): point UsersFetcher.updateGroup at the groups/upd endpoint

### DIFF
--- a/app/javascript/src/fetchers/UsersFetcher.js
+++ b/app/javascript/src/fetchers/UsersFetcher.js
@@ -87,7 +87,7 @@ export default class UsersFetcher {
       add_admin: params.add_admin,
       rm_admin: params.rm_admin,
     };
-    return ApiClient.putJson('/api/v1/users/omniauth_providers', { body });
+    return ApiClient.putJson(`/api/v1/groups/upd/${params.id}`, { body });
   }
 
   static fetchOls(name, edited = true) {


### PR DESCRIPTION
## Summary
- `UsersFetcher.updateGroup` PUT'd to `/api/v1/users/omniauth_providers`, which only defines a `GET` — adding/removing a group member 405'd, then crashed the UI when the caller dereferenced the missing response shape.
- Regression from the ChemotionApiClient fetcher unification (#3294), which replaced the original `fetch('/api/v1/groups/upd/${id}', { method: 'PUT', ... })` call with the wrong URL.
- Restores the PUT target to `/api/v1/groups/upd/${params.id}`, matching the existing Grape route (`app/api/chemotion/user_api.rb`, `resource :groups / namespace :upd / put ':id'`) and the body shape already built by the fetcher.

## Test plan
- [ ] Manually verify adding/removing a user from a group in the group management UI no longer 405s
- [ ] `yarn eslint app/javascript/src/fetchers/UsersFetcher.js`