### PR TITLE
fix: batch per-sample collection-membership check

### DIFF
--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -267,11 +267,20 @@ module Chemotion
                            .order(Arel.sql("LENGTH(SUBSTRING(sum_formular, 'C\\d+'))"))
                            .order(:sum_formular)
           reset_pagination_page(molecule_scope)
-          paginate(molecule_scope).each do |molecule|
+          paginated_molecules = paginate(molecule_scope)
+          samples_by_molecule = paginated_molecules.map do |molecule|
             samples_group = sample_scope.select { |v| v.molecule_id == molecule.id }
-            samples_group = samples_group.sort { |x, y| y.updated_at <=> x.updated_at }
+            samples_group.sort { |x, y| y.updated_at <=> x.updated_at }
+          end
+          page_samples = samples_by_molecule.flatten
+          owned_element_ids = ElementDetailLevelCalculator.owned_element_ids(elements: page_samples, user: current_user)
+          samples_by_molecule.each do |samples_group|
             samples_group.each do |sample|
-              detail_levels = ElementDetailLevelCalculator.new(user: current_user, element: sample).detail_levels
+              detail_levels = ElementDetailLevelCalculator.new(
+                user: current_user,
+                element: sample,
+                owns_collection_with_element: owned_element_ids.include?(sample.id),
+              ).detail_levels
               sample_list.push(
                 Entities::SampleEntity.represent(sample, detail_levels: detail_levels, displayed_in_list: true),
               )
@@ -280,8 +289,14 @@ module Chemotion
         else
           reset_pagination_page(sample_scope)
           sample_scope = sample_scope.order('samples.updated_at DESC')
-          paginate(sample_scope).each do |sample|
-            detail_levels = ElementDetailLevelCalculator.new(user: current_user, element: sample).detail_levels
+          page_samples = paginate(sample_scope).to_a
+          owned_element_ids = ElementDetailLevelCalculator.owned_element_ids(elements: page_samples, user: current_user)
+          page_samples.each do |sample|
+            detail_levels = ElementDetailLevelCalculator.new(
+              user: current_user,
+              element: sample,
+              owns_collection_with_element: owned_element_ids.include?(sample.id),
+            ).detail_levels
             sample_list.push(
               Entities::SampleEntity.represent(sample, detail_levels: detail_levels, displayed_in_list: true),
             )

--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -261,46 +261,33 @@ module Chemotion
 
         sample_list = []
 
-        if params[:molecule_sort] == 1
-          molecule_scope = Molecule
-                           .where(id: (sample_scope.pluck :molecule_id))
-                           .order(Arel.sql("LENGTH(SUBSTRING(sum_formular, 'C\\d+'))"))
-                           .order(:sum_formular)
-          reset_pagination_page(molecule_scope)
-          paginated_molecules = paginate(molecule_scope)
-          samples_by_molecule = paginated_molecules.map do |molecule|
-            samples_group = sample_scope.select { |v| v.molecule_id == molecule.id }
-            samples_group.sort { |x, y| y.updated_at <=> x.updated_at }
-          end
-          page_samples = samples_by_molecule.flatten
-          owned_element_ids = ElementDetailLevelCalculator.owned_element_ids(elements: page_samples, user: current_user)
-          samples_by_molecule.each do |samples_group|
-            samples_group.each do |sample|
-              detail_levels = ElementDetailLevelCalculator.new(
-                user: current_user,
-                element: sample,
-                owns_collection_with_element: owned_element_ids.include?(sample.id),
-              ).detail_levels
-              sample_list.push(
-                Entities::SampleEntity.represent(sample, detail_levels: detail_levels, displayed_in_list: true),
-              )
-            end
-          end
-        else
-          reset_pagination_page(sample_scope)
-          sample_scope = sample_scope.order('samples.updated_at DESC')
-          page_samples = paginate(sample_scope).to_a
-          owned_element_ids = ElementDetailLevelCalculator.owned_element_ids(elements: page_samples, user: current_user)
-          page_samples.each do |sample|
-            detail_levels = ElementDetailLevelCalculator.new(
-              user: current_user,
-              element: sample,
-              owns_collection_with_element: owned_element_ids.include?(sample.id),
-            ).detail_levels
-            sample_list.push(
-              Entities::SampleEntity.represent(sample, detail_levels: detail_levels, displayed_in_list: true),
-            )
-          end
+        page_samples = if params[:molecule_sort] == 1
+                         molecule_scope = Molecule
+                                          .where(id: (sample_scope.pluck :molecule_id))
+                                          .order(Arel.sql("LENGTH(SUBSTRING(sum_formular, 'C\\d+'))"))
+                                          .order(:sum_formular)
+                         reset_pagination_page(molecule_scope)
+                         paginated_molecules = paginate(molecule_scope)
+                         paginated_molecules.flat_map do |molecule|
+                           samples_group = sample_scope.select { |v| v.molecule_id == molecule.id }
+                           samples_group.sort { |x, y| y.updated_at <=> x.updated_at }
+                         end
+                       else
+                         reset_pagination_page(sample_scope)
+                         sample_scope = sample_scope.order('samples.updated_at DESC')
+                         paginate(sample_scope).to_a
+                       end
+
+        owned_element_ids = ElementDetailLevelCalculator.owned_element_ids(elements: page_samples, user: current_user)
+        page_samples.each do |sample|
+          detail_levels = ElementDetailLevelCalculator.new(
+            user: current_user,
+            element: sample,
+            owns_collection_with_element: owned_element_ids.include?(sample.id),
+          ).detail_levels
+          sample_list.push(
+            Entities::SampleEntity.represent(sample, detail_levels: detail_levels, displayed_in_list: true),
+          )
         end
 
         return {

--- a/app/services/element_detail_level_calculator.rb
+++ b/app/services/element_detail_level_calculator.rb
@@ -4,10 +4,37 @@
 class ElementDetailLevelCalculator
   attr_reader :user, :element, :detail_levels
 
-  def initialize(user:, element:)
+  # owns_collection_with_element: optional pre-computed boolean (from
+  # .owned_element_ids) to avoid a per-element existence query when the
+  # caller already knows, for a batch of elements, whether each one
+  # belongs to a collection owned by the user.
+  def initialize(user:, element:, owns_collection_with_element: nil)
     @user = user
     @element = element
+    @owns_collection_with_element = owns_collection_with_element
     @detail_levels = calculate_detail_levels
+  end
+
+  # Batch-computes, in a single query, which of the given elements belong to a
+  # collection owned by the user (or one of the user's groups). Intended to
+  # replace the per-element `user_collections_with_element.any?` check when
+  # calculating detail levels for a whole page of elements.
+  #
+  # Returns a Set of element ids.
+  def self.owned_element_ids(elements:, user:)
+    elements = elements.to_a
+    return Set.new if elements.empty?
+
+    klass = elements.first.class
+    user_ids = user.group_ids + [user.id]
+
+    klass
+      .joins(:collections)
+      .where(collections: { user_id: user_ids })
+      .where(id: elements.map(&:id))
+      .distinct
+      .pluck(:id)
+      .to_set
   end
 
   private
@@ -36,13 +63,19 @@ class ElementDetailLevelCalculator
   end
 
   def detail_level_for(key)
-    if user_collections_with_element.any?
+    if owns_collection_with_element?
       10 # full access for all elements within own collections
     elsif shared_collections_with_element.any?
       shared_collections_with_element.maximum(key) || 0
     else
       0
     end
+  end
+
+  def owns_collection_with_element?
+    return @owns_collection_with_element unless @owns_collection_with_element.nil?
+
+    @owns_collection_with_element = user_collections_with_element.any?
   end
 
   # All collections containing the element that belong to the user

--- a/app/services/element_detail_level_calculator.rb
+++ b/app/services/element_detail_level_calculator.rb
@@ -20,19 +20,23 @@ class ElementDetailLevelCalculator
   # replace the per-element `user_collections_with_element.any?` check when
   # calculating detail levels for a whole page of elements.
   #
+  # All elements must be the same class (the query is scoped to one table) —
+  # a mixed-class array would otherwise silently understate detail levels for
+  # every class but the first.
+  #
   # Returns a Set of element ids.
   def self.owned_element_ids(elements:, user:)
     elements = elements.to_a
     return Set.new if elements.empty?
 
     klass = elements.first.class
+    raise ArgumentError, 'elements must all be the same class' unless elements.all?(klass)
+
     user_ids = user.group_ids + [user.id]
 
     klass
-      .joins(:collections)
-      .where(collections: { user_id: user_ids })
+      .for_user_n_groups(user_ids)
       .where(id: elements.map(&:id))
-      .distinct
       .pluck(:id)
       .to_set
   end

--- a/spec/api/chemotion/sample_api_spec.rb
+++ b/spec/api/chemotion/sample_api_spec.rb
@@ -559,6 +559,25 @@ describe Chemotion::SampleAPI do
       end
     end
 
+    context 'when a page mixes an owned sample and a merely-shared sample' do
+      let(:shared_collection) do
+        create(:collection, user: other_user).tap do |collection|
+          create(:collection_share, collection: collection, shared_with: user, sample_detail_level: 2)
+        end
+      end
+      let!(:owned_sample) { create(:sample, collections: [shared_collection, personal_collection]) }
+      let!(:shared_only_sample) { create(:sample, collections: [shared_collection]) }
+
+      it 'reports full access for the owned sample and restricted access for the shared-only one' do
+        get '/api/v1/samples', params: { collection_id: shared_collection.id }
+
+        samples = JSON.parse(response.body)['samples'].index_by { |s| s['id'] }
+        expect(samples.keys).to contain_exactly(owned_sample.id, shared_only_sample.id)
+        expect(samples[owned_sample.id]['is_restricted']).to be false
+        expect(samples[shared_only_sample.id]['is_restricted']).to be true
+      end
+    end
+
     context 'when collection_id is given and no samples found' do
       let(:empty_collection) { create(:collection, label: 'empty collection', user: user) }
 

--- a/spec/services/element_detail_level_calculator_spec.rb
+++ b/spec/services/element_detail_level_calculator_spec.rb
@@ -86,6 +86,17 @@ describe ElementDetailLevelCalculator do
       end
     end
 
+    context 'when elements are not all the same class' do
+      let(:sample) { create(:sample, collections: [owned_collection]) }
+      let(:reaction) { create(:reaction, collections: [owned_collection]) }
+
+      it 'raises instead of silently scoping to only the first class' do
+        expect do
+          described_class.owned_element_ids(elements: [sample, reaction], user: user)
+        end.to raise_error(ArgumentError, /same class/)
+      end
+    end
+
     context 'with a mixed page of owned, shared, and unowned elements' do
       let(:page) do
         [

--- a/spec/services/element_detail_level_calculator_spec.rb
+++ b/spec/services/element_detail_level_calculator_spec.rb
@@ -52,5 +52,74 @@ describe ElementDetailLevelCalculator do
         expect(calculator.detail_levels.values.max).to eq 2
       end
     end
+
+    context 'when owns_collection_with_element is pre-computed' do
+      let(:element_collections) { [owned_collection] }
+
+      it 'trusts the pre-computed value over actual ownership' do
+        calc = described_class.new(user: user, element: element, owns_collection_with_element: false)
+        expect(calc.detail_levels.values.max).to eq 0
+      end
+
+      it 'matches the result of the per-element check when true' do
+        precomputed = described_class.new(user: user, element: element, owns_collection_with_element: true)
+        computed = described_class.new(user: user, element: element)
+        expect(precomputed.detail_levels).to eq computed.detail_levels
+      end
+    end
+
+    context 'when owns_collection_with_element is false but element is shared' do
+      let(:element_collections) { [other_users_shared_collection] }
+
+      it 'matches the result of the per-element check' do
+        precomputed = described_class.new(user: user, element: element, owns_collection_with_element: false)
+        computed = described_class.new(user: user, element: element)
+        expect(precomputed.detail_levels).to eq computed.detail_levels
+      end
+    end
+  end
+
+  describe '.owned_element_ids' do
+    context 'when elements is empty' do
+      it 'returns an empty set without querying' do
+        expect(described_class.owned_element_ids(elements: [], user: user)).to eq Set.new
+      end
+    end
+
+    context 'with a mixed page of owned, shared, and unowned elements' do
+      let(:page) do
+        [
+          create(:sample, collections: [owned_collection]),
+          create(:sample, collections: [other_users_shared_collection]),
+          create(:sample, collections: [other_users_unshared_collection]),
+        ]
+      end
+
+      it 'returns only the ids of elements owned by the user' do
+        result = described_class.owned_element_ids(elements: page, user: user)
+        expect(result).to eq Set[page.first.id]
+      end
+
+      it 'matches the per-element user_collections_with_element.any? check for each element' do
+        owned_ids = described_class.owned_element_ids(elements: page, user: user)
+
+        page.each do |sample|
+          per_element_result = sample.collections.where(user_id: user.group_ids + [user.id]).any?
+          expect(owned_ids.include?(sample.id)).to eq per_element_result
+        end
+      end
+    end
+
+    context 'when an element belongs to a collection owned by the user via a group' do
+      let(:group_sample) do
+        group = create(:group, users: [user])
+        create(:sample, collections: [create(:collection, user: group)])
+      end
+
+      it 'includes the element id' do
+        result = described_class.owned_element_ids(elements: [group_sample], user: user)
+        expect(result).to eq Set[group_sample.id]
+      end
+    end
   end
 end


### PR DESCRIPTION
GET /api/v1/samples ran a per-key, per-sample EXISTS-style query
(ElementDetailLevelCalculator#user_collections_with_element.any?) to check
whether each sample belongs to a collection owned by the current user,
since an unloaded relation re-executes on every #any? call. Batch it into
a single query per page via ElementDetailLevelCalculator.owned_element_ids.