### PR TITLE
fix(samples): run SDF import asynchronously in ImportSamplesJob

### DIFF
--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -144,26 +144,8 @@ module Chemotion
         end
 
         post do
-          ## 2-step SDF Import
-          if /\.(sdf?|mol)/i.match?(@att.extname)
-            sdf_import = Import::ImportSdf.new(
-              attachment: @att,
-              collection_id: params[:currentCollectionId],
-              current_user_id: current_user.id,
-            )
-
-            sdf_import.find_or_create_mol_by_batch
-            @att.really_destroy!
-            return {
-              sdf: true, message: sdf_import.message,
-              data: sdf_import.processed_mol, status: sdf_import.status,
-              custom_data_keys: sdf_import.custom_data_keys.keys,
-              mapped_keys: sdf_import.mapped_keys,
-              collection_id: sdf_import.collection_id
-            }
-          end
-
-          ## async CSV/xlx Import
+          ## async Import (SDF/mol, CSV, xlsx) — all heavy parsing/record creation
+          ## runs in ImportSamplesJob so the web worker is never blocked.
           ImportSamplesJob.perform_later(
             collection_id: params[:currentCollectionId],
             user_id: current_user.id,
@@ -171,49 +153,6 @@ module Chemotion
             import_type: params[:import_type],
           )
           { status: 'in progress', message: 'Importing samples in the background' }
-        end
-      end
-
-      namespace :confirm_import do
-        desc 'Create Samples from an Array of inchikeys'
-        params do
-          requires :rows, type: Array, desc: 'Selected Molecule from the UI'
-          requires :currentCollectionId, type: Integer
-          requires :mapped_keys, type: Hash
-        end
-
-        before do
-          error!('401 Unauthorized', 401) unless current_user.collections.find(params[:currentCollectionId])
-        end
-
-        post do
-          rows = params[:rows]
-          if rows.length < 25
-            sdf_import = Import::ImportSdf.new(
-              collection_id: params[:currentCollectionId],
-              current_user_id: current_user.id,
-              rows: rows,
-              mapped_keys: params[:mapped_keys],
-            )
-            sdf_import.create_samples
-            return {
-              sdf: true, message: sdf_import.message,
-              status: sdf_import.status,
-              error_messages: sdf_import.error_messages
-            }
-          else
-            parameters = {
-              collection_id: params[:currentCollectionId],
-              user_id: current_user.id,
-              file_name: 'dummy.sdf',
-              sdf_rows: rows,
-              mapped_keys: params[:mapped_keys],
-            }
-            ImportSamplesJob.perform_later(parameters)
-            return {
-              message: 'importing samples in background',
-            }
-          end
         end
       end
 

--- a/app/javascript/src/fetchers/SamplesFetcher.js
+++ b/app/javascript/src/fetchers/SamplesFetcher.js
@@ -108,34 +108,6 @@ export default class SamplesFetcher {
       });
   }
 
-  static importSamplesFromFileConfirm(params) {
-    const body = {
-      currentCollectionId: params.currentCollectionId,
-      rows: params.rows,
-      mapped_keys: params.mapped_keys,
-    };
-
-    return ApiClient.postJson('/api/v1/samples/confirm_import', { body })
-      .then((json) => {
-        if (Array.isArray(json.error_messages)) {
-          json.error_messages.forEach((message) => {
-            rootStore.notificationsStore.add({
-              message,
-              level: 'error',
-              autoDismiss: 10
-            });
-          });
-        } else {
-          rootStore.notificationsStore.add({
-            message: json.error_messages || json.message,
-            level: json.message ? 'success' : 'error',
-            autoDismiss: 10
-          });
-        }
-        return json;
-      });
-  }
-
   static batchRefreshSvg(svgs) {
     const body = {
       svgs: svgs.map((svg) => ({

--- a/app/javascript/src/stores/alt/actions/ElementActions.js
+++ b/app/javascript/src/stores/alt/actions/ElementActions.js
@@ -618,21 +618,6 @@ class ElementActions {
     };
   }
 
-  importSamplesFromFileDecline() {
-    return null;
-  }
-
-  importSamplesFromFileConfirm(params) {
-    return (dispatch) => {
-      SamplesFetcher.importSamplesFromFileConfirm(params)
-        .then((result) => {
-          dispatch(result);
-        }).catch((errorMessage) => {
-          console.log(errorMessage);
-        });
-    };
-  }
-
   // -- Molecules --
 
   fetchMoleculeByMolfile(molfile, svg_file = null) {

--- a/app/javascript/src/stores/alt/stores/ElementStore.js
+++ b/app/javascript/src/stores/alt/stores/ElementStore.js
@@ -198,8 +198,6 @@ class ElementStore {
       handleAddSampleToMaterialGroup: ElementActions.addSampleToMaterialGroup,
       handleShowReactionMaterial: ElementActions.showReactionMaterial,
       handleImportSamplesFromFile: ElementActions.importSamplesFromFile,
-      handleImportSamplesFromFileDecline: ElementActions.importSamplesFromFileDecline,
-      handleImportSamplesFromFileConfirm: ElementActions.importSamplesFromFileConfirm,
 
       handleSetCurrentElement: ElementActions.setCurrentElement,
       handleDeselectCurrentElement: ElementActions.deselectCurrentElement,
@@ -960,21 +958,11 @@ class ElementStore {
     this.changeCurrentElement(sample);
   }
 
-  handleImportSamplesFromFile(data) {
-    if (data.sdf) {
-      this.setState({ sdfUploadData: data });
-    } else {
-      this.handleRefreshElements('sample');
-    }
-  }
-
-  handleImportSamplesFromFileConfirm() {
-    this.setState({ sdfUploadData: null });
+  handleImportSamplesFromFile() {
+    // Import now runs asynchronously in ImportSamplesJob; completion is surfaced
+    // through the polling notification channel. Refresh so any already-created
+    // samples show up when the user revisits the collection.
     this.handleRefreshElements('sample');
-  }
-
-  handleImportSamplesFromFileDecline() {
-    this.setState({ sdfUploadData: null });
   }
 
   // -- Wellplates --

--- a/app/javascript/src/stores/mobx/NotificationsStore.js
+++ b/app/javascript/src/stores/mobx/NotificationsStore.js
@@ -64,10 +64,12 @@ export const NotificationsStore = types
     },
 
     notifyImportSamplesFromFile(result) {
-      const num = result.data?.length ?? 0;
-      const { status, sdf, message } = result;
+      const { status, message } = result;
       self.removeByUid('import_samples_upload');
 
+      // All imports (SDF/mol, CSV, xlsx) now run asynchronously in ImportSamplesJob
+      // and return { status: 'in progress' }. The real success/error outcome is
+      // surfaced later through the polling notification channel.
       let notification = {
         title: 'Oops!',
         message: `${message}\n Please check the file and try again.`,
@@ -76,32 +78,12 @@ export const NotificationsStore = types
         autoDismiss: 0,
       };
 
-      if (sdf) {
-        if (status === 'ok') {
-          notification = { title: 'Success', message, level: 'success', position: 'bl', autoDismiss: 10 };
-        } else if (status === 'invalid') {
-          notification.message = message;
-        }
-      } else if (status === 'ok') {
+      if (status === 'in progress') {
         notification = {
-          title: 'Success',
-          message: `The ${num} samples have been imported successfully`,
-          level: 'success',
-          position: 'bl',
-          autoDismiss: 10,
+          title: 'Status', message, level: 'success', position: 'bl', autoDismiss: 10
         };
       } else if (status === 'invalid') {
         notification.message = message;
-      } else if (status === 'in progress') {
-        notification = { title: 'Status', message, level: 'success', position: 'bl', autoDismiss: 10 };
-      } else if (status === 'warning') {
-        notification = {
-          title: 'Status',
-          message: `The ${num} samples have been imported successfully but ${message}`,
-          level: 'success',
-          position: 'bl',
-          autoDismiss: 10,
-        };
       }
 
       self.add(notification);

--- a/app/jobs/import_samples_job.rb
+++ b/app/jobs/import_samples_job.rb
@@ -10,7 +10,7 @@ class ImportSamplesJob < ApplicationJob
   def perform(params)
     @user_id = params[:user_id]
     @collection_id = params[:collection_id]
-    file_format = File.extname(params[:attachment]&.filename)
+    file_format = File.extname(params[:attachment]&.filename).downcase
 
     case file_format
     when '.xlsx', '.csv'

--- a/app/jobs/import_samples_job.rb
+++ b/app/jobs/import_samples_job.rb
@@ -21,15 +21,13 @@ class ImportSamplesJob < ApplicationJob
         params[:attachment].filename,
         params[:import_type],
       ).process
-    when '.sdf'
+    when '.sdf', '.mol'
       sdf_import = Import::ImportSdf.new(
         collection_id: @collection_id,
         current_user_id: @user_id,
-        rows: params[:sdf_rows],
-        mapped_keys: params[:mapped_keys],
         attachment: params[:attachment],
       )
-      sdf_import.create_samples
+      sdf_import.import_from_file
       @result = { message: sdf_import.message }
     else
       @result = { message: "Unsupported format: #{file_format}" }

--- a/lib/import/import_sdf.rb
+++ b/lib/import/import_sdf.rb
@@ -121,6 +121,45 @@ class Import::ImportSdf < Import::ImportSamples
     @inchi_array += inchikeys.compact
   end
 
+  # Runs the whole raw-SDF/mol import in one pass, off the web request (worker context):
+  #   1. find/create a Molecule for every record (populates {#processed_mol} + inchi_array)
+  #   2. turn the processed molecules into rows via the default {#keys_to_map}
+  #   3. reuse {#create_samples}' rows path to create the Sample records
+  #
+  # @return [ActiveRecord::Relation] the created samples (see {#create_samples})
+  def import_from_file
+    find_or_create_mol_by_batch
+    @rows = rows_from_processed_mol
+    create_samples
+  end
+
+  # Maps {#processed_mol} (whose SDF property tags are upcased/underscored keys, e.g.
+  # +"MOLECULE_NAME"+) onto the lowercase Sample field names declared in {#keys_to_map}.
+  # This replaces the former interactive frontend column-mapping step: any SDF tag whose
+  # name matches a known field is imported, everything else is ignored.
+  #
+  # @return [Array<Hash>] row hashes consumable by {#create_samples}' rows branch
+  def rows_from_processed_mol
+    field_by_upcase = mapped_keys.values.each_with_object({}) do |cfg, memo|
+      field = cfg[:field].to_s
+      memo[field.upcase] = field
+    end
+
+    processed_mol.filter_map do |mol|
+      next if mol.nil? || mol[:inchikey].blank?
+
+      row = { 'molfile' => mol[:molfile] }
+      mol.each do |key, value|
+        # SDF property tags are String keys; skip the merged :inchikey/:svg/:name/:molfile symbols
+        next unless key.is_a?(String) && value.present?
+
+        field = field_by_upcase[key.upcase]
+        row[field] = value if field
+      end
+      row
+    end
+  end
+
   def is_number?(string)
     true if Float(string)
   rescue StandardError

--- a/spec/api/chemotion/sample_api_spec.rb
+++ b/spec/api/chemotion/sample_api_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 # rubocop:disable RSpec/MultipleMemoizedHelpers, RSpec/IndexedLet, RSpec/MultipleExpectations, RSpec/NestedGroups, RSpec/ContextWording, RSpec/AnyInstance
-# rubocop:disable Layout/LineLength
 require 'rails_helper'
 
 describe Chemotion::SampleAPI do
@@ -172,14 +171,17 @@ describe Chemotion::SampleAPI do
         }
       end
 
-      it 'is able to import new samples' do
-        expect(
-          JSON.parse(response.body)['message'],
-        ).to eq "This file contains 2 Molecules.\n2 Molecules processed. "
+      it 'enqueues an async import and creates samples when the job runs' do
+        # Endpoint now returns async job status instead of a synchronous preview
+        response_data = JSON.parse(response.body)
+        expect(response_data['status']).to eq 'in progress'
+        expect(response_data['message']).to eq 'Importing samples in the background'
 
-        expect(JSON.parse(response.body)['sdf']).to be true
+        # Execute the enqueued job
+        perform_enqueued_jobs
 
-        expect(JSON.parse(response.body)['data'].count).to eq 2
+        # Verify molecules and samples were created end-to-end
+        expect(Sample.count).to eq 2
       end
     end
 
@@ -385,161 +387,13 @@ describe Chemotion::SampleAPI do
         },
       )
 
-      expect(JSON.parse(response.body)['sdf']).to be true
-      expect(JSON.parse(response.body)['data'].count).to eq 2
+      expect(JSON.parse(response.body)['status']).to eq 'in progress'
+
+      # LCSS scheduling now happens inside ImportSamplesJob (find_or_create_mol_by_batch)
+      perform_enqueued_jobs
+
       expect(PubchemSingleLcssJob).to have_received(:perform_later).once
       expect(scheduled_ids.size).to eq 2
-    end
-  end
-
-  describe 'POST /api/v1/samples/confirm_import/' do
-    before do
-      create(:molecule, inchikey: 'DTHMTBUWTGVEFG-DDWIOCJRSA-N', is_partial: false)
-      create(:molecule, inchikey: 'UGSFIVDHFJJCBJ-UHFFFAOYSA-M', is_partial: false)
-
-      post '/api/v1/samples/confirm_import', params: params, as: :json
-    end
-
-    context 'when parameters are valid' do
-      let(:params) do
-        {
-          currentCollectionId: collection.id,
-          mapped_keys: {
-            description: %w[
-              MOLECULE_NAME
-              SAFETY_R_S
-              SMILES_STEREO
-            ],
-            short_label: 'EMP_FORMULA_SHORT',
-            target_amount: 'AMOUNT',
-            real_amount: 'REAL_AMOUNT',
-            density: 'DENSITY_20',
-            decoupled: 'MOLECULE-LESS',
-            molarity: 'MOLARITY',
-            melting_point: 'melting_point',
-            boiling_point: 'boiling_point',
-            location: 'location',
-            external_label: 'external_label',
-            name: 'name',
-          },
-          rows: [{
-            inchikey: 'DTHMTBUWTGVEFG-DDWIOCJRSA-N',
-            molfile: build(:molfile, type: 'mf_with_data_01'),
-            description: "MOLECULE_NAME\n(R)-Methyl-2-amino-2-phenylacetate hydrochloride ?96%; (R)-(?)-2-Phenylglycine methyl ester hydrochloride\n\nSAFETY_R_S\nH: 319; P: 305+351+338\n\nSMILES_STEREO\n[Cl-].COC(=O)[C@H](N)c1ccccc1.[H+]\n",
-            short_label: 'C9H12ClNO2',
-            target_amount: '10 g /  g',
-            real_amount: '15mg/mg',
-            density: '30 g/mL',
-            decoupled: 'f',
-            molarity: '900',
-            melting_point: '900.0',
-            boiling_point: '900.0-1500.0',
-            location: 'location',
-            external_label: 'external_label',
-            name: 'name',
-          }],
-        }
-      end
-
-      it 'is able to create samples from an array of inchikeys' do
-        expect(
-          JSON.parse(response.body)['message'],
-        ).to eq "This file contains 1 Molecules.\nCreated 1 sample. \nImport successful! "
-
-        expect(
-          JSON.parse(response.body)['sdf'],
-        ).to be true
-
-        expect(
-          JSON.parse(response.body)['status'],
-        ).to eq 'ok'
-
-        molecule = Molecule.find_by(inchikey: 'DTHMTBUWTGVEFG-DDWIOCJRSA-N')
-        sample = Sample.find_by(molecule_id: molecule.id)
-
-        expect(sample['target_amount_value']).to eq 10
-        expect(sample['target_amount_unit']).to eq 'g'
-        expect(sample['real_amount_value']).to eq 15
-        expect(sample['real_amount_unit']).to eq 'mg'
-        expect(sample['short_label']).to eq 'C9H12ClNO2'
-        expect(sample['density']).to eq 30
-        expect(sample['description']).to eq "MOLECULE_NAME\n(R)-Methyl-2-amino-2-phenylacetate hydrochloride ?96%; (R)-(?)-2-Phenylglycine methyl ester hydrochloride\n\nSAFETY_R_S\nH: 319; P: 305+351+338\n\nSMILES_STEREO\n[Cl-].COC(=O)[C@H](N)c1ccccc1.[H+]\n"
-        expect(sample['location']).to eq 'location'
-        expect(sample['external_label']).to eq 'external_label'
-        expect(sample['name']).to eq 'name'
-        expect(sample['molarity_value']).to eq 0.0
-
-        expect(sample['boiling_point']).to eq 900.0..1500.0
-        expect(sample['melting_point']).to eq 900.0...Float::INFINITY
-      end
-    end
-
-    context 'when data type mapping is wrong' do
-      let(:params) do
-        {
-          currentCollectionId: collection.id,
-          mapped_keys: {
-            description: %w[
-              MOLECULE_NAME
-              SAFETY_R_S
-              SMILES_STEREO
-            ],
-            short_label: 'EMP_FORMULA_SHORT',
-            target_amount: 'AMOUNT',
-            real_amount: 'REAL_AMOUNT',
-            density: 'DENSITY_20',
-            decoupled: 'MOLECULE-LESS',
-          },
-          rows: [{
-            inchikey: 'DTHMTBUWTGVEFG-DDWIOCJRSA-N',
-            molfile: build(:molfile, type: 'mf_with_data_01'),
-            description: "MOLECULE_NAME\n(R)-Methyl-2-amino-2-phenylacetate hydrochloride ?96%; (R)-(?)-2-Phenylglycine methyl ester hydrochloride\n\nSAFETY_R_S\nH: 319; P: 305+351+338\n\nSMILES_STEREO\n[Cl-].COC(=O)[C@H](N)c1ccccc1.[H+]\n",
-            short_label: 'C9H12ClNO2',
-            target_amount: 'Test data',
-            real_amount: 'Test',
-            density: 'Test',
-            decoupled: 'f',
-            molarity: '900sdadsad',
-            melting_point: '900',
-            boiling_point: '1000',
-            location: 'location',
-            external_label: 'external_label',
-            name: 'name',
-          }],
-        }
-      end
-
-      it 'is able to import new samples' do
-        expect(
-          JSON.parse(response.body)['message'],
-        ).to eq "This file contains 1 Molecules.\nCreated 1 sample. \nImport successful! "
-
-        expect(
-          JSON.parse(response.body)['sdf'],
-        ).to be true
-
-        expect(
-          JSON.parse(response.body)['status'],
-        ).to eq 'ok'
-
-        molecule = Molecule.find_by(inchikey: 'DTHMTBUWTGVEFG-DDWIOCJRSA-N')
-        sample = Sample.find_by(molecule_id: molecule.id)
-
-        expect(sample['target_amount_value']).to eq 0
-        expect(sample['target_amount_unit']).to eq 'g'
-        expect(sample['real_amount_value']).to eq 0
-        expect(sample['real_amount_unit']).to eq 'g'
-        expect(sample['short_label']).to eq 'C9H12ClNO2'
-        expect(sample['density']).to eq 0
-        expect(sample['description']).to eq "MOLECULE_NAME\n(R)-Methyl-2-amino-2-phenylacetate hydrochloride ?96%; (R)-(?)-2-Phenylglycine methyl ester hydrochloride\n\nSAFETY_R_S\nH: 319; P: 305+351+338\n\nSMILES_STEREO\n[Cl-].COC(=O)[C@H](N)c1ccccc1.[H+]\n"
-        expect(sample['location']).to eq 'location'
-        expect(sample['external_label']).to eq 'external_label'
-        expect(sample['name']).to eq 'name'
-        expect(sample['molarity_value']).to eq 0.0
-
-        expect(sample['boiling_point']).to eq 1000.0...Float::INFINITY
-        expect(sample['melting_point']).to eq 900.0...Float::INFINITY
-      end
     end
   end
 
@@ -1360,5 +1214,4 @@ describe Chemotion::SampleAPI do
     end
   end
 end
-# rubocop:enable Layout/LineLength
 # rubocop:enable RSpec/MultipleMemoizedHelpers, RSpec/IndexedLet, RSpec/MultipleExpectations, RSpec/NestedGroups, RSpec/ContextWording, RSpec/AnyInstance

--- a/spec/jobs/import_samples_job_spec.rb
+++ b/spec/jobs/import_samples_job_spec.rb
@@ -85,15 +85,13 @@ describe ImportSamplesJob, active_job: true do
         collection_id: create(:collection).id,
         user_id: create(:user).id,
         attachment: attachment,
-        sdf_rows: [],
-        mapped_keys: {},
       }
     end
     let(:import_job) { described_class.perform_later(parameters) }
 
     before do
       allow(Import::ImportSdf).to receive(:new).and_return(import_samples_instance)
-      allow(import_samples_instance).to receive(:create_samples)
+      allow(import_samples_instance).to receive(:import_from_file)
       allow(import_samples_instance).to receive(:message).and_return(result_message)
     end
 

--- a/spec/jobs/import_samples_job_spec.rb
+++ b/spec/jobs/import_samples_job_spec.rb
@@ -77,9 +77,9 @@ describe ImportSamplesJob, active_job: true do
              file_path: 'spec/fixtures/import_sample_data.sdf')
     end
     let(:import_samples_instance) { instance_double(Import::ImportSdf) }
-    let(:result_message) do
-      { message: 'no rows to import' }
-    end
+    # Import::ImportSdf#message returns a String in production (not a Hash) -- stub it
+    # as such so this spec can't hide a type error in how ImportSamplesJob handles it.
+    let(:result_message) { 'no rows to import' }
     let(:parameters) do
       {
         collection_id: create(:collection).id,
@@ -114,6 +114,44 @@ describe ImportSamplesJob, active_job: true do
           expect(Message).to have_received(:create_msg_notification)
           expect { described_class.perform_now(parameters) }.not_to raise_error
         end
+      end
+    end
+  end
+
+  context 'when the attachment filename extension is upper/mixed case' do
+    let(:import_samples_instance) do
+      instance_double(Import::ImportSamples, process: { status: 'ok', message: '', data: [] })
+    end
+    let(:import_sdf_instance) { instance_double(Import::ImportSdf, import_from_file: nil, message: '') }
+    let(:parameters) do
+      {
+        collection_id: create(:collection).id, user_id: create(:user).id,
+        attachment: attachment, import_type: 'sample'
+      }
+    end
+
+    before do
+      allow(Import::ImportSamples).to receive(:new).and_return(import_samples_instance)
+      allow(Import::ImportSdf).to receive(:new).and_return(import_sdf_instance)
+    end
+
+    context 'with a .XLSX extension' do
+      let(:attachment) { instance_double(Attachment, filename: 'Sample.XLSX') }
+
+      it 'still routes to Import::ImportSamples instead of "Unsupported format"' do
+        described_class.new.perform(parameters)
+
+        expect(Import::ImportSamples).to have_received(:new)
+      end
+    end
+
+    context 'with a .SDF extension' do
+      let(:attachment) { instance_double(Attachment, filename: 'Structures.SDF') }
+
+      it 'still routes to Import::ImportSdf instead of "Unsupported format"' do
+        described_class.new.perform(parameters)
+
+        expect(Import::ImportSdf).to have_received(:new)
       end
     end
   end

--- a/spec/lib/import/import_sdf_spec.rb
+++ b/spec/lib/import/import_sdf_spec.rb
@@ -67,6 +67,45 @@ RSpec.describe Import::ImportSdf do
     end
   end
 
+  describe '#rows_from_processed_mol' do
+    let(:mapper) do
+      described_class.new(collection_id: mock_collection.id, current_user_id: mock_user.id)
+    end
+
+    it 'maps SDF property tags onto field names, keeps molfile, and drops unmatched tags / failed mols' do
+      mapper.instance_variable_set(:@processed_mol, [
+                                     { 'NAME' => 'Acetone', 'DESCRIPTION' => 'a ketone', 'UNKNOWN_TAG' => 'x',
+                                       inchikey: 'CSCPPACGZOOCGX-UHFFFAOYSA-N', molfile: 'molfile-1',
+                                       name: 'iupac', svg: 'molecules/x.svg' },
+                                     { name: nil, inchikey: nil, svg: 'no_image_180.svg' }, # failed record
+                                   ])
+
+      rows = mapper.rows_from_processed_mol
+
+      expect(rows).to eq([
+                           { 'molfile' => 'molfile-1', 'name' => 'Acetone', 'description' => 'a ketone' },
+                         ])
+    end
+  end
+
+  describe '#import_from_file' do
+    let(:one_shot) do
+      described_class.new(collection_id: mock_collection.id, current_user_id: mock_user.id)
+    end
+
+    it 'runs the molecule pass, builds rows from processed mols, then creates samples' do
+      allow(one_shot).to receive(:find_or_create_mol_by_batch)
+      allow(one_shot).to receive(:create_samples)
+      allow(one_shot).to receive(:rows_from_processed_mol).and_return([{ 'molfile' => 'm' }])
+
+      one_shot.import_from_file
+
+      expect(one_shot).to have_received(:find_or_create_mol_by_batch).ordered
+      expect(one_shot).to have_received(:create_samples).ordered
+      expect(one_shot.rows).to eq([{ 'molfile' => 'm' }])
+    end
+  end
+
   describe '#find_or_create_mol_by_batch' do
     let(:new_molfiles) { [build(:molfile, type: 'mf_with_data_01'), build(:molfile, type: :water)] }
     let(:batch_import) do


### PR DESCRIPTION
## Problem

Importing a large SDF sample file into a collection crashes the ELN (the request exhausts the web worker). The root cause is architectural, not just a slow query:

- The raw `.sdf` upload path ran **synchronously in the Puma web worker**. `POST /api/v1/samples/import` called `Import::ImportSdf#find_or_create_mol_by_batch` inline — reading the whole file into memory, then shelling out to OpenBabel to create `Molecule` rows + SVGs for every record. For a large SDF (hundreds/thousands of records) this ties up / OOMs the worker.
- **CSV/XLSX imports were already async** via `ImportSamplesJob`; SDF was the lone outlier that ran inline.
- The two-step confirm UI it fed (`sdfUploadData`, `/confirm_import`, `importSamplesFromFileConfirm`) was **dead code** — set/defined but reachable from no component — so the raw path created molecules but **never samples**.

## Fix

Route `.sdf`/`.mol` uploads through `ImportSamplesJob.perform_later`, exactly like CSV/XLSX. The job runs a one-shot `Import::ImportSdf#import_from_file`:

1. find/create a `Molecule` for every record (`find_or_create_mol_by_batch`, unchanged — preserves the batched LCSS scheduling);
2. map each record's SDF property tags onto the known sample fields (`rows_from_processed_mol`, replacing the removed interactive column-mapping step);
3. create the `Sample` records via the existing rows path of `create_samples`.

All heavy parsing/record creation now happens off the request thread, and samples are created **end-to-end** in the worker. Completion is reported through the existing `IMPORT_SAMPLES_NOTIFICATION` polling channel — no new infrastructure.

The unreachable `confirm_import` endpoint and its orphaned frontend counterparts (`sdfUploadData` store state, confirm/decline actions + handlers, the confirm fetcher) are removed.

## Testing

Run inside the app container.

- `spec/lib/import/import_sdf_spec.rb`, `spec/jobs/import_samples_job_spec.rb` — new unit coverage for `import_from_file` wiring and `rows_from_processed_mol` mapping.
- `spec/api/chemotion/sample_api_spec.rb` — the SDF import example now asserts the async response (`status: 'in progress'`) and that the enqueued job creates the samples end-to-end (`perform_enqueued_jobs` → `Sample.count == 2`); the LCSS-scheduling regression now runs the job before asserting.

```
RAILS_ENV=test bundle exec rspec spec/lib/import/import_sdf_spec.rb spec/jobs/import_samples_job_spec.rb spec/api/chemotion/sample_api_spec.rb
# 78 examples, 0 failures
```

`rubocop` (changed files) and `eslint` (changed JS) are clean.

> Note: not tested against very large SDFs in CI (they may exhaust resources); the automated coverage uses a small 2-molecule fixture. A manual dev-stack import of a moderate SDF confirms the request returns immediately, a `delayed_jobs` row is created, samples appear after the worker runs, and the completion notification fires.