### PR TITLE
refactor(groups): extract dedicated REST API for group management

### DIFF
--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -187,6 +187,7 @@ class API < Grape::API
   mount Chemotion::ResearchPlanMetadataAPI
   mount Chemotion::ScreenAPI
   mount Chemotion::UserAPI
+  mount Chemotion::GroupAPI
   mount Chemotion::UserLabelAPI
   mount Chemotion::ReactionSvgAPI
   mount Chemotion::PermissionAPI

--- a/app/api/chemotion/group_api.rb
+++ b/app/api/chemotion/group_api.rb
@@ -7,7 +7,7 @@ module Chemotion
         message = error.record.errors.messages.map do |attr, msg|
           format('%<attr>s %<msg>s', attr: attr, msg: msg.first)
         end
-        error!(message.join(', '), 404)
+        error!(message.join(', '), 422)
       end
 
       desc 'create a group of persons'
@@ -72,8 +72,10 @@ module Chemotion
             desc 'remove a member from a group, or leave it'
             delete do
               error!('401 Unauthorized', 401) unless @policy.manage? || @policy.leave?(params[:user_id])
+              error!('Cannot remove the last admin', 422) if @policy.last_admin?(params[:user_id])
 
               @group.users.delete(User.where(id: params[:user_id]))
+              @group.users_admins.where(admin_id: params[:user_id]).destroy_all
               User.gen_matrix([params[:user_id]])
               present @group, with: Entities::GroupEntity, root: 'group'
             end

--- a/app/api/chemotion/group_api.rb
+++ b/app/api/chemotion/group_api.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Chemotion
+  class GroupAPI < Grape::API
+    resource :groups do
+      rescue_from ActiveRecord::RecordInvalid do |error|
+        message = error.record.errors.messages.map do |attr, msg|
+          format('%<attr>s %<msg>s', attr: attr, msg: msg.first)
+        end
+        error!(message.join(', '), 404)
+      end
+
+      desc 'create a group of persons'
+      params do
+        requires :first_name, type: String
+        requires :last_name, type: String
+        optional :email, type: String, regexp: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i
+        requires :name_abbreviation, type: String
+        optional :users, type: [Integer]
+      end
+      post do
+        users = params[:users] || []
+        group_params = declared(params, include_missing: false)
+        group_params[:email] ||= format('%<time>i@eln.edu', time: Time.now.getutc.to_i)
+        group_params[:password] = Devise.friendly_token.first(8)
+        group_params[:password_confirmation] = group_params[:password]
+        group_params[:users] = User.where(id: [current_user.id] + users)
+        group_params[:admins] = User.where(id: current_user.id)
+
+        new_group = Group.new(group_params)
+        present new_group, with: Entities::GroupEntity, root: 'group' if new_group.save!
+      end
+
+      desc 'fetch groups of current user'
+      get do
+        data = current_user.groups | current_user.administrated_accounts.where(type: 'Group').distinct
+        present data, with: Entities::GroupEntity, root: 'currentGroups'
+      end
+
+      route_param :id, type: Integer do
+        rescue_from ActiveRecord::RecordNotFound do
+          error!('404 Group not found', 404)
+        end
+
+        after_validation do
+          @group = Group.find(params[:id])
+          @policy = GroupPolicy.new(current_user, @group)
+        end
+
+        desc 'destroy a group'
+        delete do
+          error!('401 Unauthorized', 401) unless @policy.manage?
+
+          @group.destroy!
+          { destroyed_id: params[:id] }
+        end
+
+        resource :members do
+          desc 'add members to a group'
+          params do
+            requires :user_ids, type: [Integer], desc: 'ids of users to add'
+          end
+          post do
+            error!('401 Unauthorized', 401) unless @policy.manage?
+
+            new_user_ids = params[:user_ids] - @group.users.pluck(:id)
+            @group.users << Person.where(id: new_user_ids)
+            present @group, with: Entities::GroupEntity, root: 'group'
+          end
+
+          route_param :user_id, type: Integer do
+            desc 'remove a member from a group, or leave it'
+            delete do
+              error!('401 Unauthorized', 401) unless @policy.manage? || @policy.leave?(params[:user_id])
+
+              @group.users.delete(User.where(id: params[:user_id]))
+              User.gen_matrix([params[:user_id]])
+              present @group, with: Entities::GroupEntity, root: 'group'
+            end
+          end
+        end
+
+        resource :admins do
+          route_param :user_id, type: Integer do
+            desc 'promote a member to group admin'
+            post do
+              error!('401 Unauthorized', 401) unless @policy.manage?
+
+              @group.admins << User.where(id: params[:user_id]) unless @group.admins.exists?(id: params[:user_id])
+              present @group, with: Entities::GroupEntity, root: 'group'
+            end
+
+            desc 'demote a group admin'
+            delete do
+              error!('401 Unauthorized', 401) unless @policy.manage?
+              error!('Cannot remove the last admin', 422) if @policy.last_admin?(params[:user_id])
+
+              @group.users_admins.where(admin_id: params[:user_id]).destroy_all
+              present @group, with: Entities::GroupEntity, root: 'group'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/api/chemotion/user_api.rb
+++ b/app/api/chemotion/user_api.rb
@@ -73,6 +73,12 @@ module Chemotion
         end
       end
 
+      desc "fetch current user's own devices and those of their groups"
+      get 'devices' do
+        data = [current_user.devices + current_user.groups.map(&:devices)].flatten.uniq
+        present data, with: Entities::DeviceEntity, root: 'currentDevices'
+      end
+
       namespace :update_counter do
         desc 'create or update user labels'
         params do
@@ -181,119 +187,6 @@ module Chemotion
       end
     end
 
-    resource :groups do
-      rescue_from ActiveRecord::RecordInvalid do |error|
-        message = error.record.errors.messages.map do |attr, msg|
-          format('%<attr>s %<msg>s', attr: attr, msg: msg.first)
-        end
-        error!(message.join(', '), 404)
-      end
-
-      namespace :create do
-        desc 'create a group of persons'
-        params do
-          requires :group_param, type: Hash do
-            requires :first_name, type: String
-            requires :last_name, type: String
-            optional :email, type: String, regexp: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i
-            requires :name_abbreviation, type: String
-            optional :users, type: [Integer]
-          end
-        end
-
-        after_validation do
-          users = params[:group_param][:users] || []
-          @group_params = declared(params, include_missing: false).deep_symbolize_keys[:group_param]
-          @group_params[:email] ||= format('%i@eln.edu', Time.now.getutc.to_i)
-          @group_params[:password] = Devise.friendly_token.first(8)
-          @group_params[:password_confirmation] = @group_params[:password]
-          @group_params[:users] = User.where(id: [current_user.id] + users)
-          @group_params[:admins] = User.where(id: current_user.id)
-        end
-
-        post do
-          new_group = Group.new(@group_params)
-          present new_group, with: Entities::GroupEntity, root: 'group' if new_group.save!
-        end
-      end
-
-      namespace :qrycurrent do
-        desc 'fetch groups of current user'
-        get do
-          data = current_user.groups | current_user.administrated_accounts.where(type: 'Group').distinct
-          present data, with: Entities::GroupEntity, root: 'currentGroups'
-        end
-      end
-
-      namespace :queryCurrentDevices do
-        desc 'fetch devices of current user'
-        get do
-          data = [current_user.devices + current_user.groups.map(&:devices)].flatten.uniq
-          present data, with: Entities::DeviceEntity, root: 'currentDevices'
-        end
-      end
-
-      namespace :deviceMetadata do
-        desc 'Get deviceMetadata by device id'
-        params do
-          requires :device_id, type: Integer, desc: 'device id'
-        end
-        route_param :device_id do
-          get do
-            device_metadata = DeviceMetadata.find_by(device_id: params[:device_id])
-            present device_metadata,
-                    with: Entities::DeviceMetadataEntity,
-                    root: 'device_metadata'
-          end
-        end
-      end
-
-      namespace :upd do
-        desc 'update a group of persons'
-        params do
-          requires :id, type: Integer
-          optional :rm_users, type: [Integer], desc: 'remove users from group', default: []
-          optional :add_users, type: [Integer], desc: 'add users to group', default: []
-          optional :add_admin, type: [Integer], desc: 'add admin to group', default: []
-          optional :rm_admin, type: [Integer], desc: 'remove admin from group', default: []
-          optional :destroy_group, type: Boolean, default: false
-        end
-
-        after_validation do
-          @group = Group.find_by(id: params[:id])
-          @as_admin = @group.administrated_by?(current_user)
-          @rm_current_user_id = !@as_admin && params[:rm_users].delete(current_user.id)
-          error!('401 Unauthorized', 401) unless @group.administrated_by?(current_user) || @rm_current_user_id
-        end
-
-        put ':id' do
-          if @rm_current_user_id
-            @group.users.delete(User.where(id: @rm_current_user_id))
-            User.gen_matrix([@rm_current_user_id])
-            present @group, with: Entities::GroupEntity, root: 'group'
-          elsif params[:destroy_group]
-            @group.destroy! && { destroyed_id: params[:id] }
-          else
-            # add new admins
-            params[:add_admin].delete(@group.admins.pluck(:id)) # ensure that admins are not added twice
-            @group.admins << User.where(id: params[:add_admin])
-            # remove admins
-            # ensure that current_user is not removed from admins when being last admin
-            params[:rm_admin].delete(current_user.id) if Group.last.admins.count == 1
-            @group.users_admins.where(admin_id: params[:rm_admin]).destroy_all
-            # add new users
-            params[:add_users].delete(@group.users.pluck(:id))
-            @group.users << Person.where(id: params[:add_users])
-            # remove users
-            @group.users.delete(User.where(id: params[:rm_users]))
-            User.gen_matrix(params[:rm_users]) if params[:rm_users].length.positive?
-
-            present @group, with: Entities::GroupEntity, root: 'group'
-          end
-        end
-      end
-    end
-
     resource :devices do
       params do
         optional :id, type: String, regexp: /\d+/, default: '0'
@@ -336,6 +229,19 @@ module Chemotion
       rescue SystemCallError => e
         Rails.logger.error("current_connection: #{e.class} – #{e.message}")
         error!('Internal server error', 500)
+      end
+
+      desc 'Get deviceMetadata for a device accessible to the current user'
+      params do
+        requires :device_id, type: Integer, desc: 'device id'
+      end
+      route_param :device_id do
+        get 'metadata' do
+          device = Device.by_user_ids(user_ids).find_by(id: params[:device_id])
+          error!('404 Device not found', 404) unless device
+
+          present device.device_metadata, with: Entities::DeviceMetadataEntity, root: 'device_metadata'
+        end
       end
     end
   end

--- a/app/javascript/src/components/navigation/GroupElement.js
+++ b/app/javascript/src/components/navigation/GroupElement.js
@@ -38,13 +38,11 @@ export default class GroupElement extends React.Component {
       return;
     }
 
-    const params = {
-      id: groupRec.id,
-      add_admin: setAdmin ? [userRec.id] : [],
-      rm_admin: !setAdmin ? [userRec.id] : [],
-    };
+    const request = setAdmin
+      ? UsersFetcher.promoteAdmin(groupRec.id, userRec.id)
+      : UsersFetcher.demoteAdmin(groupRec.id, userRec.id);
 
-    UsersFetcher.updateGroup(params).then((group) => {
+    request.then((group) => {
       if (setAdmin) {
         const usrIdx = _.findIndex(
           group.group.admins,
@@ -139,11 +137,7 @@ export default class GroupElement extends React.Component {
       if (!isUserInGroup) { userIds.push(g.value); }
     });
 
-    UsersFetcher.updateGroup({
-      id: groupRec.id,
-      destroy_group: false,
-      add_users: userIds,
-    }).then((group) => {
+    UsersFetcher.addMembers(groupRec.id, userIds).then((group) => {
       const idx = _.findIndex(
         this.props.currentGroup,
         (o) => o.id == group.group.id

--- a/app/javascript/src/components/navigation/UserAuth.js
+++ b/app/javascript/src/components/navigation/UserAuth.js
@@ -216,7 +216,6 @@ export default class UserAuth extends Component {
   }
 
   // create new group
-  // need to use the wording 'group_param' because of the definition of current api
   createGroup() {
     const {
       groupFirstName,
@@ -225,14 +224,14 @@ export default class UserAuth extends Component {
       currentUser,
       currentGroups,
     } = this.state;
-    const group_param = {
+    const groupParams = {
       first_name: groupFirstName,
       last_name: groupLastName,
       name_abbreviation: groupAbbreviation,
       users: [currentUser.id],
     };
 
-    UsersFetcher.createGroup({ group_param }).then((result) => {
+    UsersFetcher.createGroup(groupParams).then((result) => {
       if (result.error) {
         alert(result.error);
       } else {
@@ -252,17 +251,13 @@ export default class UserAuth extends Component {
     const currentGroups = this.state.currentGroups.filter(
       (cg) => cg.id !== currentGroupId
     );
-    UsersFetcher.updateGroup({ id: currentGroupId, destroy_group: true });
+    UsersFetcher.destroyGroup(currentGroupId);
     this.setState({ currentGroups });
   };
 
   handleDeleteUser = (groupRec, userRec) => {
     let { currentGroups, currentUser } = this.state;
-    UsersFetcher.updateGroup({
-      id: groupRec.id,
-      destroy_group: false,
-      rm_users: [userRec.id],
-    }).then((result) => {
+    UsersFetcher.removeMember(groupRec.id, userRec.id).then((result) => {
       const findIdx = _.findIndex(
         result.group.users,
         (o) => o.id == currentUser.id

--- a/app/javascript/src/fetchers/UsersFetcher.js
+++ b/app/javascript/src/fetchers/UsersFetcher.js
@@ -59,35 +59,43 @@ export default class UsersFetcher {
   }
 
   static createGroup(params = {}) {
-    return ApiClient.postJson('/api/v1/groups/create', { body: params });
+    return ApiClient.postJson('/api/v1/groups', { body: params });
   }
 
   static fetchCurrentGroup() {
-    return ApiClient.getJson('/api/v1/groups/qrycurrent');
+    return ApiClient.getJson('/api/v1/groups');
   }
 
   static fetchCurrentDevices() {
-    return ApiClient.getJson('/api/v1/groups/queryCurrentDevices');
+    return ApiClient.getJson('/api/v1/users/devices');
   }
 
   static fetchDeviceMetadataByDeviceId(deviceId) {
-    return ApiClient.getJson(`/api/v1/groups/deviceMetadata/${deviceId}`);
+    return ApiClient.getJson(`/api/v1/devices/${deviceId}/metadata`);
   }
 
   static fetchUserOmniauthProviders() {
     return ApiClient.getJson('/api/v1/users/omniauth_providers');
   }
 
-  static updateGroup(params = {}) {
-    const body = {
-      id: params.id,
-      destroy_group: params.destroy_group,
-      rm_users: params.rm_users,
-      add_users: params.add_users,
-      add_admin: params.add_admin,
-      rm_admin: params.rm_admin,
-    };
-    return ApiClient.putJson(`/api/v1/groups/upd/${params.id}`, { body });
+  static addMembers(groupId, userIds) {
+    return ApiClient.postJson(`/api/v1/groups/${groupId}/members`, { body: { user_ids: userIds } });
+  }
+
+  static removeMember(groupId, userId) {
+    return ApiClient.deleteRequest(`/api/v1/groups/${groupId}/members/${userId}`);
+  }
+
+  static promoteAdmin(groupId, userId) {
+    return ApiClient.postJson(`/api/v1/groups/${groupId}/admins/${userId}`);
+  }
+
+  static demoteAdmin(groupId, userId) {
+    return ApiClient.deleteRequest(`/api/v1/groups/${groupId}/admins/${userId}`);
+  }
+
+  static destroyGroup(groupId) {
+    return ApiClient.deleteRequest(`/api/v1/groups/${groupId}`);
   }
 
   static fetchOls(name, edited = true) {

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class GroupPolicy
+  attr_reader :user, :group
+
+  def initialize(user, group)
+    @user = user
+    @group = group
+  end
+
+  def system_admin?
+    user.present? && user.is_a?(Admin)
+  end
+
+  def group_admin?
+    user.present? && group.present? && group.administrated_by?(user)
+  end
+
+  def member?
+    user.present? && group.present? && group.users.exists?(id: user.id)
+  end
+
+  # System Admin or this group's own admin may manage membership/admins/destroy.
+  def manage?
+    system_admin? || group_admin?
+  end
+
+  # A member may remove themself ("leave").
+  def leave?(target_user_id)
+    member? && user.id == target_user_id
+  end
+
+  def last_admin?(target_user_id)
+    group.admins.one? && group.admins.first.id == target_user_id
+  end
+end

--- a/spec/api/chemotion/group_api_spec.rb
+++ b/spec/api/chemotion/group_api_spec.rb
@@ -180,6 +180,33 @@ describe Chemotion::GroupAPI do
       end
     end
 
+    context 'when the removed member is also an admin (not the last one)' do
+      let!(:group) do
+        create(:group, admins: [group_admin, second_admin], users: [group_admin, second_admin, member])
+      end
+      let(:second_admin) { create(:person) }
+      let(:user) { group_admin }
+      let(:target) { second_admin }
+
+      it 'also revokes the admin relationship so no orphaned admin remains' do
+        execute_request
+        expect(group.reload.users.pluck(:id)).not_to include(second_admin.id)
+        expect(group.reload.admins.pluck(:id)).not_to include(second_admin.id)
+      end
+    end
+
+    context 'when removing the sole remaining admin via the members endpoint' do
+      let(:user) { group_admin }
+      let(:target) { group_admin }
+
+      it 'refuses with 422 and keeps the member and admin' do
+        execute_request
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(group.reload.users.pluck(:id)).to include(group_admin.id)
+        expect(group.reload.admins.pluck(:id)).to include(group_admin.id)
+      end
+    end
+
     context 'when a plain member tries to remove someone else' do
       let(:user) { member }
       let(:target) { group_admin }

--- a/spec/api/chemotion/group_api_spec.rb
+++ b/spec/api/chemotion/group_api_spec.rb
@@ -1,0 +1,275 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Chemotion::GroupAPI do
+  include_context 'api request authorization context'
+
+  let(:group_admin) { create(:person) }
+  let(:member) { create(:person) }
+  let(:non_member) { create(:person) }
+  let(:admin_user) { create(:admin) }
+  let!(:group) do
+    create(
+      :group, admins: [group_admin], users: [group_admin, member],
+              first_name: 'Doe', last_name: 'Group Test'
+    )
+  end
+
+  describe 'POST /api/v1/groups' do
+    let(:params) do
+      {
+        first_name: 'My', last_name: 'Fanclub', email: 'jane.s@fan.club',
+        name_abbreviation: 'JFC', users: [group_admin.id]
+      }
+    end
+    let(:new_group) { Group.find_by(name_abbreviation: 'JFC') }
+
+    before { post '/api/v1/groups', params: params }
+
+    it 'creates a group of persons' do
+      expect(new_group).to be_present
+    end
+
+    it 'adds the current user and the given users as members' do
+      expect(new_group.users.pluck(:id)).to contain_exactly(user.id, group_admin.id)
+    end
+
+    it 'makes the creator the sole admin' do
+      expect(new_group.admins.first).to eq(user)
+      expect(user.administrated_accounts.where(name_abbreviation: 'JFC')).not_to be_empty
+    end
+  end
+
+  describe 'GET /api/v1/groups' do
+    let!(:own_group) { create(:group, admins: [user], users: [user], first_name: 'Own', last_name: 'Group') }
+
+    before { get '/api/v1/groups' }
+
+    it "returns only the current user's groups" do
+      ids = parsed_json_response['currentGroups'].pluck('id')
+      expect(ids).to include(own_group.id)
+      expect(ids).not_to include(group.id)
+    end
+  end
+
+  describe 'DELETE /api/v1/groups/:id' do
+    subject(:execute_request) { delete "/api/v1/groups/#{group.id}" }
+
+    context 'when called by the group admin' do
+      let(:user) { group_admin }
+
+      it 'destroys the group' do
+        execute_request
+        expect(Group.where(id: group.id)).to be_empty
+        expect(parsed_json_response['destroyed_id']).to eq(group.id)
+      end
+    end
+
+    context 'when called by a system Admin' do
+      let(:user) { admin_user }
+
+      it 'destroys the group' do
+        execute_request
+        expect(Group.where(id: group.id)).to be_empty
+      end
+    end
+
+    context 'when called by a plain member' do
+      let(:user) { member }
+
+      it 'is unauthorized and does not destroy the group' do
+        execute_request
+        expect(response).to have_http_status(:unauthorized)
+        expect(Group.where(id: group.id)).not_to be_empty
+      end
+    end
+
+    context 'when called by a non-member' do
+      let(:user) { non_member }
+
+      it 'is unauthorized' do
+        execute_request
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when the group does not exist' do
+      let(:user) { group_admin }
+
+      it 'returns 404' do
+        delete '/api/v1/groups/0'
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'POST /api/v1/groups/:id/members' do
+    subject(:execute_request) { post "/api/v1/groups/#{group.id}/members", params: params, as: :json }
+
+    let(:params) { { user_ids: [non_member.id] } }
+
+    context 'when called by the group admin' do
+      let(:user) { group_admin }
+
+      it 'adds the members' do
+        execute_request
+        expect(group.reload.users.pluck(:id)).to include(non_member.id)
+      end
+    end
+
+    context 'when called by a system Admin' do
+      let(:user) { admin_user }
+
+      it 'adds the members' do
+        execute_request
+        expect(group.reload.users.pluck(:id)).to include(non_member.id)
+      end
+    end
+
+    context 'when called by a plain member' do
+      let(:user) { member }
+
+      it 'is unauthorized and does not add the members' do
+        execute_request
+        expect(response).to have_http_status(:unauthorized)
+        expect(group.reload.users.pluck(:id)).not_to include(non_member.id)
+      end
+    end
+
+    context 'when called by a non-member' do
+      let(:user) { non_member }
+
+      it 'is unauthorized' do
+        execute_request
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/groups/:id/members/:user_id' do
+    subject(:execute_request) { delete "/api/v1/groups/#{group.id}/members/#{target.id}" }
+
+    context 'when the group admin removes another member' do
+      let(:user) { group_admin }
+      let(:target) { member }
+
+      it 'removes the member' do
+        execute_request
+        expect(group.reload.users.pluck(:id)).not_to include(member.id)
+      end
+    end
+
+    context 'when called by a system Admin' do
+      let(:user) { admin_user }
+      let(:target) { member }
+
+      it 'removes the member' do
+        execute_request
+        expect(group.reload.users.pluck(:id)).not_to include(member.id)
+      end
+    end
+
+    context 'when a member removes themself (leave)' do
+      let(:user) { member }
+      let(:target) { member }
+
+      it 'removes self from the group' do
+        execute_request
+        expect(group.reload.users.pluck(:id)).not_to include(member.id)
+      end
+    end
+
+    context 'when a plain member tries to remove someone else' do
+      let(:user) { member }
+      let(:target) { group_admin }
+
+      it 'is unauthorized and does not remove the target' do
+        execute_request
+        expect(response).to have_http_status(:unauthorized)
+        expect(group.reload.users.pluck(:id)).to include(group_admin.id)
+      end
+    end
+
+    context 'when called by a non-member' do
+      let(:user) { non_member }
+      let(:target) { member }
+
+      it 'is unauthorized' do
+        execute_request
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'POST /api/v1/groups/:id/admins/:user_id' do
+    subject(:execute_request) { post "/api/v1/groups/#{group.id}/admins/#{member.id}" }
+
+    context 'when called by the group admin' do
+      let(:user) { group_admin }
+
+      it 'promotes the member to admin' do
+        execute_request
+        expect(group.reload.admins.pluck(:id)).to include(member.id)
+      end
+    end
+
+    context 'when called by a system Admin' do
+      let(:user) { admin_user }
+
+      it 'promotes the member to admin' do
+        execute_request
+        expect(group.reload.admins.pluck(:id)).to include(member.id)
+      end
+    end
+
+    context 'when called by a plain member' do
+      let(:user) { member }
+
+      it 'is unauthorized and does not promote' do
+        execute_request
+        expect(response).to have_http_status(:unauthorized)
+        expect(group.reload.admins.pluck(:id)).not_to include(member.id)
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/groups/:id/admins/:user_id' do
+    subject(:execute_request) { delete "/api/v1/groups/#{group.id}/admins/#{target.id}" }
+
+    context 'when the group has more than one admin' do
+      let!(:group) do
+        create(:group, admins: [group_admin, second_admin], users: [group_admin, second_admin, member])
+      end
+      let(:second_admin) { create(:person) }
+      let(:user) { group_admin }
+      let(:target) { second_admin }
+
+      it 'demotes the target admin' do
+        execute_request
+        expect(group.reload.admins.pluck(:id)).not_to include(second_admin.id)
+      end
+    end
+
+    context 'when the target is the sole remaining admin' do
+      let(:user) { group_admin }
+      let(:target) { group_admin }
+
+      it 'refuses with 422 and keeps the admin' do
+        execute_request
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(group.reload.admins.pluck(:id)).to include(group_admin.id)
+      end
+    end
+
+    context 'when called by a plain member' do
+      let(:user) { member }
+      let(:target) { group_admin }
+
+      it 'is unauthorized' do
+        execute_request
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/api/chemotion/user_api_spec.rb
+++ b/spec/api/chemotion/user_api_spec.rb
@@ -5,9 +5,6 @@ require 'rails_helper'
 describe Chemotion::UserAPI do
   include_context 'api request authorization context'
 
-  let(:other_user) { create(:person) }
-  let(:alternative_user) { create(:person) }
-
   describe 'GET /api/v1/users/name' do
     let(:query_param) { "name=#{name_param}&type=Group,Person" }
 
@@ -110,131 +107,59 @@ describe Chemotion::UserAPI do
     pending 'TODO: Add missing spec'
   end
 
-  describe 'POST /api/v1/groups/create' do
-    let(:params) do
-      {
-        'group_param' => {
-          'first_name' => 'My', 'last_name' => 'Fanclub',
-          'email' => 'jane.s@fan.club',
-          'name_abbreviation' => 'JFC', 'users' => [other_user.id]
-        },
-      }
-    end
+  describe 'GET /api/v1/users/devices' do
+    let(:own_device) { create(:device) }
+    let(:group_device) { create(:device) }
+    let(:unrelated_device) { create(:device) }
+    let!(:group) { create(:group, admins: [user], users: [user]) }
 
     before do
-      post '/api/v1/groups/create', params: params
+      own_device.people << user
+      group_device.groups << group
+      get '/api/v1/users/devices'
     end
 
-    it 'Creates a group of persons' do
-      expect(
-        Group.where(
-          last_name: 'Fanclub',
-          first_name: 'My', name_abbreviation: 'JFC'
-        ),
-      ).not_to be_empty
-      expect(
-        Group.find_by(name_abbreviation: 'JFC').users.pluck(:id),
-      ).to contain_exactly(user.id, other_user.id)
-      expect(
-        Group.find_by(name_abbreviation: 'JFC').admins,
-      ).not_to be_empty
-      expect(
-        Group.find_by(name_abbreviation: 'JFC').admins.first,
-      ).to eq user
-      expect(
-        user.administrated_accounts.where(name_abbreviation: 'JFC'),
-      ).not_to be_empty
+    it "returns the user's own devices and their groups' devices" do
+      ids = parsed_json_response['currentDevices'].pluck('id')
+      expect(ids).to include(own_device.id, group_device.id)
+      expect(ids).not_to include(unrelated_device.id)
     end
   end
 
-  describe 'GET /api/v1/groups/qrycurrent' do
-    pending 'TODO: Add missing spec'
-  end
+  describe 'GET /api/v1/devices/{device_id}/metadata' do
+    let(:device) { create(:device) }
+    let!(:device_metadata) { create(:device_metadata, device: device) }
 
-  describe 'GET /api/v1/groups/queryCurrentDevices' do
-    pending 'TODO: Add missing spec'
-  end
-
-  describe 'GET /api/v1/groups/deviceMetadata/{device_id}' do
-    pending 'TODO: Add missing spec'
-  end
-
-  describe 'PUT /api/v1/groups/upd/{id}' do
-    let(:execute_put_request) { put "/api/v1/groups/upd/#{group.id}", params: params, as: :json }
-
-    context 'when update group as a group admin' do
-      let(:group) do
-        create(:group, admins: [user], users: [user, other_user], first_name: 'Doe', last_name: 'Group Test')
+    context 'when the device belongs to the current user' do
+      before do
+        device.people << user
+        get "/api/v1/devices/#{device.id}/metadata"
       end
-      let(:params) do
-        {
-          rm_users: [user.id, other_user.id],
-          add_users: [alternative_user.id],
-        }
+
+      it 'returns the device metadata' do
+        expect(response).to have_http_status(:ok)
+        expect(parsed_json_response['device_metadata']['id']).to eq(device_metadata.id)
       end
+    end
+
+    context 'when the device belongs to one of the current user\'s groups' do
+      let!(:group) { create(:group, admins: [user], users: [user]) }
 
       before do
-        execute_put_request
-        group.reload
+        device.groups << group
+        get "/api/v1/devices/#{device.id}/metadata"
       end
 
-      it 'updates a group of persons' do
-        expect(group.users.pluck(:id)).to contain_exactly(alternative_user.id)
-      end
-
-      it 'returns an updated group' do
-        expect(parsed_json_response['group']['users'].first['id']).to eq(alternative_user.id)
+      it 'returns the device metadata' do
+        expect(response).to have_http_status(:ok)
       end
     end
 
-    context 'when destroy a group as a group admin' do
-      let(:group) do
-        create(:group, admins: [user], first_name: 'Doe', last_name: 'Group Test')
-      end
-      let(:params) { { destroy_group: true } }
+    context 'when the current user has no relation to the device' do
+      before { get "/api/v1/devices/#{device.id}/metadata" }
 
-      before do
-        execute_put_request
-      end
-
-      it 'deletes a group of persons' do
-        expect(Group.where(id: [group.id])).to be_empty
-        expect(Group.count).to eq(0)
-      end
-
-      it 'returns the id of destroyed group' do
-        expect(parsed_json_response['destroyed_id']).to eq(group.id)
-      end
-    end
-
-    context 'when try to update a group as a non group admin' do
-      let(:group) do
-        create(:group, admins: [other_user], users: [other_user, alternative_user],
-                       first_name: 'Doe', last_name: 'Group Test')
-      end
-      let(:params) do
-        {
-          rm_users: [other_user.id, alternative_user.id],
-          add_users: [user.id],
-        }
-      end
-
-      before do
-        execute_put_request
-      end
-
-      it 'does not update a group of persons' do
-        expect(
-          Group.find(group.id).users.pluck(:id),
-        ).to contain_exactly(other_user.id, alternative_user.id)
-      end
-
-      it 'returns with unauthorized status' do
-        expect(response).to have_http_status(:unauthorized)
-      end
-
-      it 'returns with unauthorized message' do
-        expect(parsed_json_response['error']).to eq('401 Unauthorized')
+      it 'returns 404' do
+        expect(response).to have_http_status(:not_found)
       end
     end
   end


### PR DESCRIPTION
## Summary

The self-service group endpoints lived as RPC-style routes under `resource :groups` in `user_api.rb` (`groups/create`, `groups/upd/:id` with a `destroy_group`/`add_users`/`rm_users`/`add_admin`/`rm_admin` flag soup, `groups/qrycurrent`, `groups/queryCurrentDevices`, `groups/deviceMetadata`). This extracts them into a dedicated `GroupAPI` with clean REST verbs/paths and a `GroupPolicy` authorization model covering the four contexts a `current_user` can have with respect to a group: system Admin, non-member, plain member, and that group's own admin.

**New routes** (mounted via `Chemotion::GroupAPI`):
- `POST /api/v1/groups`, `GET /api/v1/groups`
- `DELETE /api/v1/groups/:id`
- `POST/DELETE /api/v1/groups/:id/members(/:user_id)`
- `POST/DELETE /api/v1/groups/:id/admins/:user_id`

**Relocations** — two endpoints that were never group-scoped operations:
- `GET .../queryCurrentDevices` → `GET /api/v1/users/devices`
- `GET .../deviceMetadata/:id` → `GET /api/v1/devices/:id/metadata` — this previously had **no authorization check at all**; it now requires the device be accessible to the current user via `Device.by_user_ids`.

**Bug fixes found while tracing this**:
- The "can't remove the last admin" guard checked `Group.last` instead of the group actually being updated — broken for every group except the most-recently-created one.
- A missing group id crashed with an uncaught 500 instead of a clean 404 (`route_param :id` + `rescue_from ActiveRecord::RecordNotFound`).

**Behavior addition, not a pure refactor**: system Admins can now manage any group through this API (previously only possible via the separate `admin_api.rb` `group_device` panel, which is untouched by this PR).

Frontend fetchers/call sites (`UsersFetcher.js`, `GroupElement.js`, `UserAuth.js`) updated to match; the `group_param` body-wrapper workaround and its explanatory comment in `UserAuth.js` are gone now that the API takes flat params.

## Test plan
- [x] `bundle exec rspec spec/api/chemotion/group_api_spec.rb spec/api/chemotion/user_api_spec.rb` — 40 examples, 0 failures
- [x] `bundle exec rspec spec/api/chemotion/admin_api_spec.rb` — confirms the separate admin `group_device` panel is unaffected
- [x] `bundle exec rubocop` on all new/changed backend files — clean
- [x] `yarn eslint` on changed frontend files — no new issues vs `main` baseline
- [ ] Manual smoke test of the "My Groups & Devices" modal (add/remove members, promote/demote admins, leave, destroy group) and the admin panel's Groups & Devices screen