### PR TITLE
fix(collections): support generic elements in bulk collection actions

### DIFF
--- a/app/javascript/src/utilities/collectionUtilities.js
+++ b/app/javascript/src/utilities/collectionUtilities.js
@@ -1,4 +1,4 @@
-import { elementNames, allElnElements } from 'src/apps/generic/Utils';
+import { allElnElements } from 'src/apps/generic/Utils';
 import { PermissionConst } from 'src/utilities/PermissionConst';
 
 const isElementSelectionEmpty = (element) => !element.checkedAll
@@ -13,7 +13,14 @@ const filterParamsFromUIState = (uiState) => {
     currentCollection: { id: collectionId },
   };
 
-  allElnElements.map((element) => {
+  // Built-in ELN element types plus the generic (labimotion) klass names, which UIStore keeps in
+  // `klasses`. Both are collected synchronously here: the previous version added the generic keys
+  // inside an un-awaited `elementNames(false).then(...)` callback that resolved *after* this
+  // function had already returned, so generic-element selections were silently dropped from every
+  // consumer (Move / Assign / Remove / Share).
+  const elementTypes = [...allElnElements, ...(uiState.klasses || [])];
+
+  elementTypes.forEach((element) => {
     if (uiState[element] === undefined || isElementSelectionEmpty(uiState[element])) { return; }
 
     filterParams[element] = {
@@ -22,19 +29,6 @@ const filterParamsFromUIState = (uiState) => {
       excluded_ids: uiState[element].uncheckedIds,
       collection_id: collectionId,
     };
-  });
-
-  elementNames(false).then((klassArray) => {
-    klassArray.forEach((klass) => {
-      if (isElementSelectionEmpty(uiState[`${klass}`])) { return; }
-
-      filterParams[`${klass}`] = {
-        all: uiState[`${klass}`].checkedAll,
-        included_ids: uiState[`${klass}`].checkedIds,
-        excluded_ids: uiState[`${klass}`].uncheckedIds,
-        collection_id: collectionId
-      };
-    });
   });
 
   return filterParams;

--- a/app/usecases/collections/add_elements.rb
+++ b/app/usecases/collections/add_elements.rb
@@ -3,6 +3,8 @@
 module Usecases
   module Collections
     class AddElements
+      include ElementClassResolution
+
       attr_reader :current_user, :collection
 
       def initialize(current_user)
@@ -46,8 +48,7 @@ module Usecases
 
       def check_access_to_elements(ui_state)
         ui_state.each do |class_string, ui_selections|
-          element_class =
-            API::ELEMENT_CLASS[class_string] || Labimotion::ElementKlass.find_by(name: class_string).elements
+          element_class = element_scope_for(class_string)
           next unless element_class
 
           scope = element_class.by_ui_state(ui_selections)
@@ -64,24 +65,16 @@ module Usecases
 
       def add_elements_to_collection(ui_state)
         ui_state.each do |class_string, ui_selections|
-          element_class = API::ELEMENT_CLASS[class_string] || Labimotion::ElementKlass.find(name: class_string).elements
+          element_class = element_scope_for(class_string)
+          next unless element_class
+
           element_ids = element_class.by_ui_state(ui_selections).ids
 
           if element_class == DeviceDescription
             element_ids = Usecases::DeviceDescriptions::ByUIState.new(element_ids).with_joined_ids
           end
 
-          join_table = API::ELEMENT_CLASS[class_string].collections_element_class || Labimotion::CollectionsElement
-
-          join_table.create_in_collection(element_ids, collection.id)
-        end
-      end
-
-      def elements_scope(element_class, element_ids)
-        if element_class.in?(API::ELEMENT_CLASS.values)
-          element_class.where(id: element_ids)
-        else # Labimotion::ElementKlass
-          element_class.elements
+          join_table_for(class_string).create_in_collection(element_ids, collection.id)
         end
       end
     end

--- a/app/usecases/collections/element_class_resolution.rb
+++ b/app/usecases/collections/element_class_resolution.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Usecases
+  module Collections
+    # Resolves a UI element-type key to the ActiveRecord scope and collection join table it maps to,
+    # transparently handling both built-in ELN element types (via {API::ELEMENT_CLASS}) and generic
+    # labimotion elements (via {Labimotion::ElementKlass}). Shared by {AddElements} and
+    # {RemoveElements} so generic elements are treated identically to built-in ones — the two
+    # previously duplicated this resolution and each carried the same defects (a stray +find+ where
+    # +find_by+ was meant, and a nil dereference on the join-table lookup for generic keys).
+    module ElementClassResolution
+      # A +by_ui_state+-capable scope for the given UI element-type key.
+      #
+      # @param class_string [String] UI element-type key (e.g. +"sample"+, +"reaction"+, or a
+      #   generic {Labimotion::ElementKlass} name)
+      # @return [Class] the ActiveRecord model for a built-in element type
+      # @return [ActiveRecord::Relation] the generic elements of a matching klass
+      # @return [nil] when the key matches no known element type
+      def element_scope_for(class_string)
+        API::ELEMENT_CLASS[class_string] ||
+          Labimotion::ElementKlass.find_by(name: class_string)&.elements
+      end
+
+      # The collection join-table model for the given UI element-type key.
+      #
+      # @param class_string [String] UI element-type key
+      # @return [Class] a built-in +collections_*+ join model, or {Labimotion::CollectionsElement}
+      #   for generic elements
+      def join_table_for(class_string)
+        API::ELEMENT_CLASS[class_string]&.collections_element_class ||
+          Labimotion::CollectionsElement
+      end
+    end
+  end
+end

--- a/app/usecases/collections/remove_elements.rb
+++ b/app/usecases/collections/remove_elements.rb
@@ -3,6 +3,8 @@
 module Usecases
   module Collections
     class RemoveElements
+      include ElementClassResolution
+
       attr_reader :current_user, :collection
 
       def initialize(current_user)
@@ -38,22 +40,12 @@ module Usecases
 
       def remove_elements_from_collection(ui_state)
         ui_state.each do |class_string, ui_selections|
-          element_class =
-            API::ELEMENT_CLASS[class_string] || Labimotion::ElementKlass.find(name: class_string)&.elements
+          element_class = element_scope_for(class_string)
           next unless element_class
 
           element_ids = element_class.by_ui_state(ui_selections).ids
-          join_table = API::ELEMENT_CLASS[class_string].collections_element_class || Labimotion::CollectionsElement
 
-          join_table.remove_in_collection(element_ids, collection.id)
-        end
-      end
-
-      def elements_scope(element_class, element_ids)
-        if element_class.in?(API::ELEMENT_CLASS.values)
-          element_class.where(id: element_ids)
-        else # Labimotion::ElementKlass
-          element_class.elements
+          join_table_for(class_string).remove_in_collection(element_ids, collection.id)
         end
       end
     end

--- a/spec/api/chemotion/collection_elements_api_spec.rb
+++ b/spec/api/chemotion/collection_elements_api_spec.rb
@@ -176,5 +176,54 @@ describe Chemotion::CollectionElementsAPI do
       expect(response.body).to be_blank
     end
   end
+
+  # Regression: generic (labimotion) elements are keyed in ui_state by their ElementKlass name.
+  # They must be resolved and (un)linked exactly like built-in elements; the resolution previously
+  # used `find` instead of `find_by` and dereferenced a nil built-in class, so a generic-only
+  # selection either no-op'd (payload dropped upstream) or raised.
+  context 'with a generic (labimotion) element' do
+    let(:source_collection_user) { user }
+    let(:target_collection_user) { user }
+    let(:element_klass) { create(:element_klass, name: 'my_generic') }
+    let(:generic_element) do
+      create(:element, element_klass: element_klass, creator: user, collections: [source_collection])
+    end
+
+    let(:generic_input) do
+      {
+        collection_id: target_collection.id,
+        ui_state: {
+          currentCollection: { id: 0 },
+          'my_generic' => {
+            checkedAll: false,
+            checkedIds: [generic_element.id],
+            uncheckedIds: [],
+          },
+        },
+      }
+    end
+
+    it 'assigns the generic element to the target collection' do
+      expect(generic_element.collections).not_to include(target_collection)
+
+      post '/api/v1/collection_elements', params: generic_input
+      generic_element.reload
+
+      expect(response.status).to eq 201
+      expect(generic_element.collections).to include(target_collection)
+    end
+
+    it 'removes the generic element from the source collection' do
+      generic_element.collections << target_collection
+
+      delete "/api/v1/collection_elements/#{source_collection.id}",
+             params: generic_input.except(:collection_id)
+      generic_element.reload
+
+      expect(response).to have_http_status(:no_content)
+      expect(generic_element.collections).not_to include(source_collection)
+      expect(generic_element.collections).to include(target_collection)
+    end
+  end
 end
 # rubocop:enable RSpec/IndexedLet, RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations

--- a/spec/javascripts/packs/src/utilities/collectionUtilities.spec.js
+++ b/spec/javascripts/packs/src/utilities/collectionUtilities.spec.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/no-unresolved
-import { collectionHasPermission } from 'src/utilities/collectionUtilities';
+import { collectionHasPermission, filterParamsFromUIState } from 'src/utilities/collectionUtilities';
+import { List } from 'immutable';
 import expect from 'expect';
 function createCollectionDummy(collectionShareId = undefined, permissionLevel = 0) {
   const currentCollection = {};
@@ -21,6 +22,56 @@ describe('collectionUtilities', () => {
       it('has no permissions', () => {
         expect(collectionHasPermission(createCollectionDummy(2, 0), 1)).toBe(false);
       });
+    });
+  });
+
+  describe('.filterParamsFromUIState', () => {
+    const selection = (checkedIds) => ({
+      checkedAll: false,
+      checkedIds: List(checkedIds),
+      uncheckedIds: List(),
+    });
+
+    it('includes built-in element selections', () => {
+      const uiState = {
+        currentCollection: { id: 1 },
+        sample: selection([7]),
+      };
+
+      const params = filterParamsFromUIState(uiState);
+
+      expect(params.sample).toEqual({
+        all: false, included_ids: List([7]), excluded_ids: List(), collection_id: 1,
+      });
+    });
+
+    // Regression: generic (labimotion) klass selections must be collected synchronously from
+    // uiState.klasses. They were previously added inside an un-awaited promise callback that
+    // resolved after the function returned, so they were silently dropped from the payload.
+    it('includes generic element selections synchronously', () => {
+      const uiState = {
+        currentCollection: { id: 1 },
+        klasses: ['my_generic'],
+        my_generic: selection([42]),
+      };
+
+      const params = filterParamsFromUIState(uiState);
+
+      expect(params.my_generic).toEqual({
+        all: false, included_ids: List([42]), excluded_ids: List(), collection_id: 1,
+      });
+    });
+
+    it('omits generic types with an empty selection', () => {
+      const uiState = {
+        currentCollection: { id: 1 },
+        klasses: ['my_generic'],
+        my_generic: selection([]),
+      };
+
+      const params = filterParamsFromUIState(uiState);
+
+      expect(params.my_generic).toBe(undefined);
     });
   });
 });


### PR DESCRIPTION
## Problem

Selecting **only generic (labimotion) elements** and running a bulk collection action — **Move to Collection**, **Assign to Collection**, **Remove from Collection**, or **Share** — did nothing: no element was moved/assigned/removed and no error was shown. Built-in ELN elements (sample, reaction, wellplate, …) worked as expected.

## Root cause

Two independent defects, both introduced in #2783, that compounded:

1. **Frontend — generic selections dropped from the payload.** `filterParamsFromUIState` (`app/javascript/src/utilities/collectionUtilities.js`) added built-in element selections synchronously but added the generic klass keys inside an un-awaited `elementNames(false).then(...)` callback, which resolves on a later microtask — *after* the function has already `return`ed. So the request payload never carried generic elements, and the API accepted the empty selection as a no-op.

2. **Backend — latent generic-element handling bugs.** `AddElements` and `RemoveElements` each duplicated the element-type resolution and both mishandled generic keys: resolving the klass with `find(name:)` (an id lookup) instead of `find_by(name:)`, and dereferencing the nil built-in class when picking the join table (`API::ELEMENT_CLASS[key].collections_element_class`). These only stayed hidden because the frontend never sent generic keys; fixing the frontend alone would have surfaced a 500.

## Changes

- **Frontend:** collect generic klass keys **synchronously** from `uiState.klasses` alongside the built-in element types — one loop, no async gap. Fixes all four bulk actions in a single place with no caller changes.
- **Backend (DRY):** extract the shared element-type resolution into a new `Usecases::Collections::ElementClassResolution` concern (`element_scope_for` / `join_table_for`), used by both `AddElements` and `RemoveElements`. Resolution now uses `find_by(name:)` and safe-navigates the built-in class lookup. Added the missing empty-scope guard on the add path and removed the dead `elements_scope` method from both usecases.

## Tests

- `spec/api/chemotion/collection_elements_api_spec.rb` — new contexts assigning and removing a generic element between owned collections (asserting the join rows), alongside the existing built-in coverage.
- `spec/javascripts/packs/src/utilities/collectionUtilities.spec.js` — `filterParamsFromUIState` now includes generic selections synchronously and omits empty ones.

refs: #2783