### PR TITLE
fix(spectra): route same-type multi-curve archives through bagit grouping

### DIFF
--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -326,10 +326,12 @@ module AttachmentJcampProcess
     # archives - so `== 'bagit'` alone missed same-type multi-curve archives
     # (CV, multi-run NMR). Those need read_bagit_data's "N_bagit" filenames,
     # which ContainerDatasetModalContent#classifyAttachments groups into one
-    # series; otherwise they land as ungrouped standalone attachments.
+    # series; otherwise they land as ungrouped standalone attachments. A bagit
+    # archive can itself hold just one curve, so keep routing spc_type ==
+    # 'bagit' there regardless of arr_jcamp.length.
     if spc_type == 'lcms'
       read_processed_data(arr_jcamp, arr_img, spc_type, is_regen)
-    elsif arr_jcamp.length > 1
+    elsif spc_type == 'bagit' || arr_jcamp.length > 1
       read_bagit_data(arr_jcamp, arr_img, arr_csv, spc_type, is_regen, params)
     else
       img_att = generate_img_att(tmp_img, 'peak')

--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -321,10 +321,16 @@ module AttachmentJcampProcess
 
     check_invalid_molfile(invalid_molfile)
 
-    if spc_type == 'bagit'
-      read_bagit_data(arr_jcamp, arr_img, arr_csv, spc_type, is_regen, params)
-    elsif arr_jcamp.length > 1
+    # spc_type is the archive's specific spectrum type (e.g. "CYCLIC VOLTAMMETRY")
+    # whenever every curve shares one, only falling back to "bagit" for mixed
+    # archives - so `== 'bagit'` alone missed same-type multi-curve archives
+    # (CV, multi-run NMR). Those need read_bagit_data's "N_bagit" filenames,
+    # which ContainerDatasetModalContent#classifyAttachments groups into one
+    # series; otherwise they land as ungrouped standalone attachments.
+    if spc_type == 'lcms'
       read_processed_data(arr_jcamp, arr_img, spc_type, is_regen)
+    elsif arr_jcamp.length > 1
+      read_bagit_data(arr_jcamp, arr_img, arr_csv, spc_type, is_regen, params)
     else
       img_att = generate_img_att(tmp_img, 'peak')
       jcamp_att = generate_jcamp_att(tmp_jcamp, 'peak')


### PR DESCRIPTION
spc_type carries the archive's specific spectrum type (e.g. "CYCLIC VOLTAMMETRY"), only falling back to "bagit" for mixed-type archives, so checking `spc_type == 'bagit'` alone missed same-type multi-curve archives (CV, multi-run NMR). Those need read_bagit_data's "N_bagit" filenames, which ContainerDatasetModalContent#classifyAttachments groups into one series; otherwise they landed as ungrouped standalone attachments.
