### PR TITLE
fix(collections): notify users about locked samples during removal actions

### DIFF
--- a/app/api/chemotion/collection_elements_api.rb
+++ b/app/api/chemotion/collection_elements_api.rb
@@ -37,8 +37,8 @@ module Chemotion
         )
 
         # Some samples cannot be unshared on their own because they belong to a
-        # reaction that is still in the collection. Report them so the UI can
-        # explain why nothing happened; otherwise reply 204 No Content.
+        # reaction or wellplate that is still in the collection. Report them so the
+        # UI can explain why nothing happened; otherwise reply 204 No Content.
         if result[:locked_sample_ids].present?
           status 200
           { locked_sample_ids: result[:locked_sample_ids] }

--- a/app/api/chemotion/collection_elements_api.rb
+++ b/app/api/chemotion/collection_elements_api.rb
@@ -31,12 +31,21 @@ module Chemotion
 
       desc 'Removes elements from a collection'
       delete '/:collection_id' do
-        Usecases::Collections::RemoveElements.new(current_user).perform!(
+        result = Usecases::Collections::RemoveElements.new(current_user).perform!(
           collection_id: params[:collection_id],
           ui_state: params[:ui_state].except(:currentCollection),
         )
-        status 204
-        body false
+
+        # Some samples cannot be unshared on their own because they belong to a
+        # reaction that is still in the collection. Report them so the UI can
+        # explain why nothing happened; otherwise reply 204 No Content.
+        if result[:locked_sample_ids].present?
+          status 200
+          { locked_sample_ids: result[:locked_sample_ids] }
+        else
+          status 204
+          body false
+        end
       end
     end
   end

--- a/app/api/chemotion/element_api.rb
+++ b/app/api/chemotion/element_api.rb
@@ -82,13 +82,18 @@ module Chemotion
 
       desc 'Withdraw the ui-state selection from all of the user\'s collections (destroying orphans)'
       delete do
-        removed = Usecases::Collections::WithdrawElements.new(current_user).perform!(
+        usecase = Usecases::Collections::WithdrawElements.new(current_user)
+        removed = usecase.perform!(
           source_collection: @collection,
           ui_state: params,
           options: params[:options] || {},
         )
 
-        { selecteds: params[:selecteds].reject { |sel| removed.fetch(sel['type'], []).include?(sel['id']) } }
+        result = { selecteds: params[:selecteds].reject { |sel| removed.fetch(sel['type'], []).include?(sel['id']) } }
+        # Samples kept back because they belong to a reaction still in the user's
+        # collections: report them so the UI can explain why nothing was deleted.
+        result[:locked_sample_ids] = usecase.locked_sample_ids if usecase.locked_sample_ids.present?
+        result
       end
 
       namespace :load_report do

--- a/app/api/chemotion/element_api.rb
+++ b/app/api/chemotion/element_api.rb
@@ -90,8 +90,8 @@ module Chemotion
         )
 
         result = { selecteds: params[:selecteds].reject { |sel| removed.fetch(sel['type'], []).include?(sel['id']) } }
-        # Samples kept back because they belong to a reaction still in the user's
-        # collections: report them so the UI can explain why nothing was deleted.
+        # Samples kept back because they belong to a reaction or wellplate still in
+        # the user's collections: report them so the UI can explain why nothing was deleted.
         result[:locked_sample_ids] = usecase.locked_sample_ids if usecase.locked_sample_ids.present?
         result
       end

--- a/app/javascript/src/fetchers/CollectionElementsFetcher.js
+++ b/app/javascript/src/fetchers/CollectionElementsFetcher.js
@@ -7,15 +7,17 @@ export default class CollectionElementsFetcher {
 
   /**
    * Removes the ui_state-selected elements from the collection. The endpoint
-   * replies 204 No Content, so success is read from the HTTP status.
+   * replies 204 No Content when everything was removed, or 200 with
+   * `{ locked_sample_ids: [...] }` for samples that could not be unshared
+   * because they belong to a reaction still in the collection.
    *
    * @param {object} params - { collection_id, ui_state }
-   * @returns {Promise<boolean>} true on success (see ChemotionApiClient.apiRequest)
+   * @returns {Promise<object|null>} the parsed JSON body, or null on 204
+   *   (see ChemotionApiClient.apiRequest)
    */
   static deleteElementsFromCollection(params) {
     return ApiClient.deleteRequest(`/api/v1/collection_elements/${params.collection_id}`, {
       body: JSON.stringify(params),
-      handleResponseSuccess: (response) => response.ok,
     });
   }
 }

--- a/app/javascript/src/fetchers/CollectionElementsFetcher.js
+++ b/app/javascript/src/fetchers/CollectionElementsFetcher.js
@@ -12,8 +12,10 @@ export default class CollectionElementsFetcher {
    * because they belong to a reaction or wellplate still in the collection.
    *
    * @param {object} params - { collection_id, ui_state }
-   * @returns {Promise<object|null>} the parsed JSON body, or null on 204
-   *   (see ChemotionApiClient.apiRequest)
+   * @returns {Promise<object|null|undefined>} the parsed JSON body, null on 204,
+   *   or undefined on a network/parse failure (see ChemotionApiClient.apiRequest).
+   *   Callers must distinguish undefined (request failed) from null (success, no
+   *   body): CollectionsStore.removeElementsFromCollection depends on this.
    */
   static deleteElementsFromCollection(params) {
     return ApiClient.deleteRequest(`/api/v1/collection_elements/${params.collection_id}`, {

--- a/app/javascript/src/fetchers/CollectionElementsFetcher.js
+++ b/app/javascript/src/fetchers/CollectionElementsFetcher.js
@@ -9,7 +9,7 @@ export default class CollectionElementsFetcher {
    * Removes the ui_state-selected elements from the collection. The endpoint
    * replies 204 No Content when everything was removed, or 200 with
    * `{ locked_sample_ids: [...] }` for samples that could not be unshared
-   * because they belong to a reaction still in the collection.
+   * because they belong to a reaction or wellplate still in the collection.
    *
    * @param {object} params - { collection_id, ui_state }
    * @returns {Promise<object|null>} the parsed JSON body, or null on 204

--- a/app/javascript/src/stores/alt/actions/ElementActions.js
+++ b/app/javascript/src/stores/alt/actions/ElementActions.js
@@ -48,7 +48,7 @@ import ReactionSvgFetcher from 'src/fetchers/ReactionSvgFetcher';
 import Metadata from 'src/models/Metadata';
 import UserStore from 'src/stores/alt/stores/UserStore';
 import { generateNextShortLabel } from 'src/utilities/VesselUtilities';
-import { SAMPLE_REACTION_LOCK_NOTIFICATION } from 'src/utilities/collectionUtilities';
+import { sampleAssociationLockNotification } from 'src/utilities/collectionUtilities';
 
 import _ from 'lodash';
 
@@ -1340,7 +1340,9 @@ class ElementActions {
       UIFetcher.deleteElementsByUIState(params)
         .then((result) => {
           if (result && result.locked_sample_ids && result.locked_sample_ids.length > 0) {
-            rootStore.notificationsStore.add({ ...SAMPLE_REACTION_LOCK_NOTIFICATION, position: 'tr' });
+            rootStore.notificationsStore.add(
+              sampleAssociationLockNotification(result.locked_sample_ids.length)
+            );
           }
           dispatch(result);
         })

--- a/app/javascript/src/stores/alt/actions/ElementActions.js
+++ b/app/javascript/src/stores/alt/actions/ElementActions.js
@@ -48,7 +48,7 @@ import ReactionSvgFetcher from 'src/fetchers/ReactionSvgFetcher';
 import Metadata from 'src/models/Metadata';
 import UserStore from 'src/stores/alt/stores/UserStore';
 import { generateNextShortLabel } from 'src/utilities/VesselUtilities';
-import { sampleAssociationLockNotification } from 'src/utilities/collectionUtilities';
+import { sampleAssociationLockNotification } from 'src/utilities/notificationMessages';
 
 import _ from 'lodash';
 

--- a/app/javascript/src/stores/alt/actions/ElementActions.js
+++ b/app/javascript/src/stores/alt/actions/ElementActions.js
@@ -48,6 +48,7 @@ import ReactionSvgFetcher from 'src/fetchers/ReactionSvgFetcher';
 import Metadata from 'src/models/Metadata';
 import UserStore from 'src/stores/alt/stores/UserStore';
 import { generateNextShortLabel } from 'src/utilities/VesselUtilities';
+import { SAMPLE_REACTION_LOCK_NOTIFICATION } from 'src/utilities/collectionUtilities';
 
 import _ from 'lodash';
 
@@ -1337,7 +1338,12 @@ class ElementActions {
   deleteElementsByUIState(params) {
     return (dispatch) => {
       UIFetcher.deleteElementsByUIState(params)
-        .then((result) => { dispatch(result); })
+        .then((result) => {
+          if (result && result.locked_sample_ids && result.locked_sample_ids.length > 0) {
+            rootStore.notificationsStore.add({ ...SAMPLE_REACTION_LOCK_NOTIFICATION, position: 'tr' });
+          }
+          dispatch(result);
+        })
         .catch((errorMessage) => { console.log(errorMessage); });
     };
   }

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -9,7 +9,10 @@ import MessagesFetcher from 'src/fetchers/MessagesFetcher';
 
 import UIActions from 'src/stores/alt/actions/UIActions';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
-import { sampleAssociationLockNotification } from 'src/utilities/collectionUtilities';
+import {
+  sampleAssociationLockNotification,
+  sampleAssociationMoveNotification
+} from 'src/utilities/notificationMessages';
 
 export const Collection = types.model({
   ancestry: types.string,
@@ -265,8 +268,16 @@ export const CollectionsStore = types
     removeElementsFromCollection: flow(function* removeElementsFromCollection(params, { notifyLock = true } = {}) {
       const response = yield CollectionElementsFetcher.deleteElementsFromCollection(params);
 
-      // A network/parse failure resolves to undefined; a 204 resolves to null.
+      // A network/parse failure resolves to undefined; a 204 resolves to null. Surface the failure:
+      // otherwise a dropped DELETE is completely silent — and in a move the selection has already
+      // been copied into the target, so silence would strand the samples in both collections.
       if (response === undefined) {
+        getRoot(self).notificationsStore.add({
+          title: 'Remove from Collection',
+          message: 'The request failed, so the selection was not removed. Please try again.',
+          level: 'error',
+          autoDismiss: 10,
+        });
         return { success: false, lockedSampleIds: [] };
       }
 
@@ -319,15 +330,7 @@ export const CollectionsStore = types
           // Samples bound to a reaction/wellplate cannot leave that collection, so they were copied
           // to the target but stayed in the source: warn that the move was only partial.
           if (success && lockedSampleIds.length > 0) {
-            getRoot(self).notificationsStore.add({
-              title: 'Move incomplete',
-              message: 'Some samples stayed here - they belong to a reaction or wellplate. '
-                + 'Move the reaction or wellplate to move '
-                + 'its associated samples.',
-              level: 'warning',
-              autoDismiss: 10,
-              position: 'tr',
-            });
+            getRoot(self).notificationsStore.add(sampleAssociationMoveNotification());
           }
 
           if (success && isNewCollection) {

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -9,7 +9,7 @@ import MessagesFetcher from 'src/fetchers/MessagesFetcher';
 
 import UIActions from 'src/stores/alt/actions/UIActions';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
-import { SAMPLE_REACTION_LOCK_NOTIFICATION } from 'src/utilities/collectionUtilities';
+import { sampleAssociationLockNotification } from 'src/utilities/collectionUtilities';
 
 export const Collection = types.model({
   ancestry: types.string,
@@ -259,9 +259,9 @@ export const CollectionsStore = types
       }
     }),
     // Returns { success, lockedSampleIds }: success is false only on request failure; lockedSampleIds
-    // lists samples the backend kept because they belong to a reaction still in the collection. Callers
-    // that give their own feedback (e.g. move) can pass { notifyLock: false } to suppress the
-    // built-in "linked to a reaction" toast and react to lockedSampleIds themselves.
+    // lists samples the backend kept because they belong to a reaction or wellplate still in the
+    // collection. Callers that give their own feedback (e.g. move) can pass { notifyLock: false } to
+    // suppress the built-in association-lock toast and react to lockedSampleIds themselves.
     removeElementsFromCollection: flow(function* removeElementsFromCollection(params, { notifyLock = true } = {}) {
       const response = yield CollectionElementsFetcher.deleteElementsFromCollection(params);
 
@@ -279,7 +279,7 @@ export const CollectionsStore = types
 
       const lockedSampleIds = (response && response.locked_sample_ids) || [];
       if (notifyLock && lockedSampleIds.length > 0) {
-        getRoot(self).notificationsStore.add({ ...SAMPLE_REACTION_LOCK_NOTIFICATION });
+        getRoot(self).notificationsStore.add(sampleAssociationLockNotification(lockedSampleIds.length));
       }
 
       // refresh elements
@@ -316,13 +316,14 @@ export const CollectionsStore = types
             { notifyLock: false }
           );
 
-          // Reaction-linked samples cannot leave their reaction's collection, so they were copied
+          // Samples bound to a reaction/wellplate cannot leave that collection, so they were copied
           // to the target but stayed in the source: warn that the move was only partial.
           if (success && lockedSampleIds.length > 0) {
             getRoot(self).notificationsStore.add({
               title: 'Move to Collection',
-              message: 'Samples that are part of a reaction were copied to the target but not removed '
-                + 'from the current collection. Move the reaction to move its associated samples.',
+              message: 'Samples that belong to a reaction or wellplate were copied to the target but '
+                + 'not removed from the current collection. Move the reaction or wellplate to move '
+                + 'its associated samples.',
               level: 'warning',
               autoDismiss: 10,
             });

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -9,6 +9,7 @@ import MessagesFetcher from 'src/fetchers/MessagesFetcher';
 
 import UIActions from 'src/stores/alt/actions/UIActions';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
+import { SAMPLE_REACTION_LOCK_NOTIFICATION } from 'src/utilities/collectionUtilities';
 
 export const Collection = types.model({
   ancestry: types.string,
@@ -258,13 +259,25 @@ export const CollectionsStore = types
       }
     }),
     removeElementsFromCollection: flow(function* removeElementsFromCollection(params) {
-      const success = yield CollectionElementsFetcher.deleteElementsFromCollection(params)
+      const response = yield CollectionElementsFetcher.deleteElementsFromCollection(params);
 
-      if (success) {
-        // refresh elements
-        ElementActions.refreshElementsAfterCollectionChanges(params.ui_state.currentCollection.id)
-        return true
+      // A network/parse failure resolves to undefined; a 204 resolves to null.
+      if (response === undefined) { return false; }
+
+      if (response && response.error) {
+        getRoot(self).notificationsStore.add({
+          title: 'Remove from Collection', message: response.error, level: 'error', autoDismiss: 10
+        });
+        return false;
       }
+
+      if (response && response.locked_sample_ids && response.locked_sample_ids.length > 0) {
+        getRoot(self).notificationsStore.add({ ...SAMPLE_REACTION_LOCK_NOTIFICATION });
+      }
+
+      // refresh elements
+      ElementActions.refreshElementsAfterCollectionChanges(params.ui_state.currentCollection.id);
+      return true;
     }),
     assignElementsToCollection: flow(function* assignElementsToCollection(collectionParams, uiState) {
       const { collectionId, isNewCollection, newCollection } = yield self.useOrCreateCollection(collectionParams)
@@ -364,7 +377,7 @@ export const CollectionsStore = types
             (self.chemotion_repository_collection && collectionItem.ancestorIds.includes(self.chemotion_repository_collection.id))
               ? self.chemotion_repository_collection.children
               : self.own_collections
-          
+
           self.addCollectionToTree(collectionItem, collectionTree)
         }
       });

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -320,12 +320,13 @@ export const CollectionsStore = types
           // to the target but stayed in the source: warn that the move was only partial.
           if (success && lockedSampleIds.length > 0) {
             getRoot(self).notificationsStore.add({
-              title: 'Move to Collection',
-              message: 'Samples that belong to a reaction or wellplate were copied to the target but '
-                + 'not removed from the current collection. Move the reaction or wellplate to move '
+              title: 'Move incomplete',
+              message: 'Some samples stayed here - they belong to a reaction or wellplate. '
+                + 'Move the reaction or wellplate to move '
                 + 'its associated samples.',
               level: 'warning',
               autoDismiss: 10,
+              position: 'tr',
             });
           }
 

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -258,26 +258,33 @@ export const CollectionsStore = types
         return true
       }
     }),
-    removeElementsFromCollection: flow(function* removeElementsFromCollection(params) {
+    // Returns { success, lockedSampleIds }: success is false only on request failure; lockedSampleIds
+    // lists samples the backend kept because they belong to a reaction still in the collection. Callers
+    // that give their own feedback (e.g. move) can pass { notifyLock: false } to suppress the
+    // built-in "linked to a reaction" toast and react to lockedSampleIds themselves.
+    removeElementsFromCollection: flow(function* removeElementsFromCollection(params, { notifyLock = true } = {}) {
       const response = yield CollectionElementsFetcher.deleteElementsFromCollection(params);
 
       // A network/parse failure resolves to undefined; a 204 resolves to null.
-      if (response === undefined) { return false; }
+      if (response === undefined) {
+        return { success: false, lockedSampleIds: [] };
+      }
 
       if (response && response.error) {
         getRoot(self).notificationsStore.add({
           title: 'Remove from Collection', message: response.error, level: 'error', autoDismiss: 10
         });
-        return false;
+        return { success: false, lockedSampleIds: [] };
       }
 
-      if (response && response.locked_sample_ids && response.locked_sample_ids.length > 0) {
+      const lockedSampleIds = (response && response.locked_sample_ids) || [];
+      if (notifyLock && lockedSampleIds.length > 0) {
         getRoot(self).notificationsStore.add({ ...SAMPLE_REACTION_LOCK_NOTIFICATION });
       }
 
       // refresh elements
       ElementActions.refreshElementsAfterCollectionChanges(params.ui_state.currentCollection.id);
-      return true;
+      return { success: true, lockedSampleIds };
     }),
     assignElementsToCollection: flow(function* assignElementsToCollection(collectionParams, uiState) {
       const { collectionId, isNewCollection, newCollection } = yield self.useOrCreateCollection(collectionParams)
@@ -293,16 +300,36 @@ export const CollectionsStore = types
       }
     }),
     moveElementsToCollection: flow(function* moveElementsToCollection(collectionParams, uiState) {
-      const { collectionId, isNewCollection, newCollection } = yield self.useOrCreateCollection(collectionParams)
+      const { collectionId, isNewCollection, newCollection } = yield self.useOrCreateCollection(collectionParams);
 
       if (collectionId) {
-        const response = yield self.addElementsToCollection(collectionId, uiState, 'Move to Collection', isNewCollection)
+        const response = yield self.addElementsToCollection(
+          collectionId,
+          uiState,
+          'Move to Collection',
+          isNewCollection
+        );
 
         if (response) {
-          const elementsRemoved = yield self.removeElementsFromCollection({ collection_id: uiState.currentCollection.id, ui_state: uiState })
+          const { success, lockedSampleIds } = yield self.removeElementsFromCollection(
+            { collection_id: uiState.currentCollection.id, ui_state: uiState },
+            { notifyLock: false }
+          );
 
-          if (elementsRemoved && isNewCollection) {
-            self.addNewCollectionToOwnCollection(newCollection)
+          // Reaction-linked samples cannot leave their reaction's collection, so they were copied
+          // to the target but stayed in the source: warn that the move was only partial.
+          if (success && lockedSampleIds.length > 0) {
+            getRoot(self).notificationsStore.add({
+              title: 'Move to Collection',
+              message: 'Samples that are part of a reaction were copied to the target but not removed '
+                + 'from the current collection. Move the reaction to move its associated samples.',
+              level: 'warning',
+              autoDismiss: 10,
+            });
+          }
+
+          if (success && isNewCollection) {
+            self.addNewCollectionToOwnCollection(newCollection);
           }
         }
       }

--- a/app/javascript/src/utilities/collectionUtilities.js
+++ b/app/javascript/src/utilities/collectionUtilities.js
@@ -1,6 +1,18 @@
 import { allElnElements } from 'src/apps/generic/Utils';
 import { PermissionConst } from 'src/utilities/PermissionConst';
 
+// Shown when a sample cannot be removed from a collection or deleted on its own
+// because it belongs to a reaction that is also in the collection. Used for both
+// the "Remove from current Collection" (unshare) and "Remove from all Collections"
+// (delete) actions so the wording stays identical for both scenarios.
+const SAMPLE_REACTION_LOCK_NOTIFICATION = {
+  title: 'Sample linked to a reaction',
+  message: 'This sample is part of a reaction and cannot be removed on its own. '
+    + 'Remove the reaction to remove its associated samples.',
+  level: 'warning',
+  autoDismiss: 10,
+};
+
 const isElementSelectionEmpty = (element) => !element.checkedAll
     && element.checkedIds.size === 0
     && element.uncheckedIds.size === 0;
@@ -72,5 +84,6 @@ const collectionHasPermission = (collection, permissionLevel) => {
 };
 
 export {
-  isElementSelectionEmpty, filterParamsFromUIState, collectionOptions, collectionHasPermission
+  isElementSelectionEmpty, filterParamsFromUIState, collectionOptions, collectionHasPermission,
+  SAMPLE_REACTION_LOCK_NOTIFICATION
 };

--- a/app/javascript/src/utilities/collectionUtilities.js
+++ b/app/javascript/src/utilities/collectionUtilities.js
@@ -8,14 +8,10 @@ import { PermissionConst } from 'src/utilities/PermissionConst';
 const sampleAssociationLockNotification = (lockedCount = 1) => {
   const plural = lockedCount > 1;
   return {
-    title: plural
-      ? 'Samples linked to a reaction or wellplate'
-      : 'Sample linked to a reaction or wellplate',
+    title: plural ? 'Samples not removed' : 'Sample not removed',
     message: plural
-      ? 'These samples belong to a reaction or wellplate in this collection, so they cannot be '
-        + 'removed on their own. Remove the reaction or wellplate to remove its associated samples.'
-      : 'This sample belongs to a reaction or wellplate in this collection, so it cannot be '
-        + 'removed on its own. Remove the reaction or wellplate to remove its associated samples.',
+      ? 'They belong to a reaction or wellplate. Remove the reaction or wellplate to remove its associated samples.'
+      : 'It belongs to a reaction or wellplate. Remove the reaction or wellplate to remove its associated samples.',
     level: 'warning',
     autoDismiss: 10,
     position: 'tr',

--- a/app/javascript/src/utilities/collectionUtilities.js
+++ b/app/javascript/src/utilities/collectionUtilities.js
@@ -1,16 +1,25 @@
 import { allElnElements } from 'src/apps/generic/Utils';
 import { PermissionConst } from 'src/utilities/PermissionConst';
 
-// Shown when a sample cannot be removed from a collection or deleted on its own
-// because it belongs to a reaction that is also in the collection. Used for both
-// the "Remove from current Collection" (unshare) and "Remove from all Collections"
-// (delete) actions so the wording stays identical for both scenarios.
-const SAMPLE_REACTION_LOCK_NOTIFICATION = {
-  title: 'Sample linked to a reaction',
-  message: 'This sample is part of a reaction and cannot be removed on its own. '
-    + 'Remove the reaction to remove its associated samples.',
-  level: 'warning',
-  autoDismiss: 10,
+// Shown when a sample cannot be removed from a collection or deleted on its own because it belongs
+// to a reaction or wellplate that is also in the collection. Used for both the "Remove from current
+// Collection" (unshare) and "Remove from all Collections" (delete) actions so the wording stays
+// identical for both scenarios. Pass the locked-id count so singular/plural copy matches.
+const sampleAssociationLockNotification = (lockedCount = 1) => {
+  const plural = lockedCount > 1;
+  return {
+    title: plural
+      ? 'Samples linked to a reaction or wellplate'
+      : 'Sample linked to a reaction or wellplate',
+    message: plural
+      ? 'These samples belong to a reaction or wellplate in this collection, so they cannot be '
+        + 'removed on their own. Remove the reaction or wellplate to remove its associated samples.'
+      : 'This sample belongs to a reaction or wellplate in this collection, so it cannot be '
+        + 'removed on its own. Remove the reaction or wellplate to remove its associated samples.',
+    level: 'warning',
+    autoDismiss: 10,
+    position: 'tr',
+  };
 };
 
 const isElementSelectionEmpty = (element) => !element.checkedAll
@@ -85,5 +94,5 @@ const collectionHasPermission = (collection, permissionLevel) => {
 
 export {
   isElementSelectionEmpty, filterParamsFromUIState, collectionOptions, collectionHasPermission,
-  SAMPLE_REACTION_LOCK_NOTIFICATION
+  sampleAssociationLockNotification
 };

--- a/app/javascript/src/utilities/collectionUtilities.js
+++ b/app/javascript/src/utilities/collectionUtilities.js
@@ -1,23 +1,6 @@
 import { allElnElements } from 'src/apps/generic/Utils';
 import { PermissionConst } from 'src/utilities/PermissionConst';
 
-// Shown when a sample cannot be removed from a collection or deleted on its own because it belongs
-// to a reaction or wellplate that is also in the collection. Used for both the "Remove from current
-// Collection" (unshare) and "Remove from all Collections" (delete) actions so the wording stays
-// identical for both scenarios. Pass the locked-id count so singular/plural copy matches.
-const sampleAssociationLockNotification = (lockedCount = 1) => {
-  const plural = lockedCount > 1;
-  return {
-    title: plural ? 'Samples not removed' : 'Sample not removed',
-    message: plural
-      ? 'They belong to a reaction or wellplate. Remove the reaction or wellplate to remove its associated samples.'
-      : 'It belongs to a reaction or wellplate. Remove the reaction or wellplate to remove its associated samples.',
-    level: 'warning',
-    autoDismiss: 10,
-    position: 'tr',
-  };
-};
-
 const isElementSelectionEmpty = (element) => !element.checkedAll
     && element.checkedIds.size === 0
     && element.uncheckedIds.size === 0;
@@ -89,6 +72,5 @@ const collectionHasPermission = (collection, permissionLevel) => {
 };
 
 export {
-  isElementSelectionEmpty, filterParamsFromUIState, collectionOptions, collectionHasPermission,
-  sampleAssociationLockNotification
+  isElementSelectionEmpty, filterParamsFromUIState, collectionOptions, collectionHasPermission
 };

--- a/app/javascript/src/utilities/notificationMessages.js
+++ b/app/javascript/src/utilities/notificationMessages.js
@@ -1,0 +1,37 @@
+// Notification payloads for the "sample locked by a reaction/wellplate" cases. Kept in a
+// dependency-free module (no imports) so the stores/actions that display them — CollectionsStore
+// (MobX) and ElementActions (alt) — can import without creating an import cycle: collectionUtilities
+// transitively pulls in the MobX root store, which imports CollectionsStore back.
+
+// Shown when a sample cannot be removed/deleted on its own because it belongs to a reaction or
+// wellplate. Used for both "Remove from current Collection" (unshare) and "Remove from all
+// Collections" (delete). The copy is deliberately scope-neutral — it does NOT say "this collection"
+// — because the two paths evaluate the lock against different scopes: the remove path against the
+// current collection, the withdraw path across all of the user's collections. Pass the locked-id
+// count so singular/plural copy matches.
+const sampleAssociationLockNotification = (lockedCount = 1) => {
+  const plural = lockedCount > 1;
+  return {
+    title: plural ? 'Samples not removed' : 'Sample not removed',
+    message: plural
+      ? 'They belong to a reaction or wellplate. Remove the reaction or wellplate to remove its associated samples.'
+      : 'It belongs to a reaction or wellplate. Remove the reaction or wellplate to remove its associated samples.',
+    level: 'warning',
+    autoDismiss: 10,
+    position: 'tr',
+  };
+};
+
+// Move-path variant of the above: samples locked by a reaction/wellplate are copied to the target
+// but cannot leave the source, so the move is only partial. Kept beside the remove/delete copy so
+// the two related warnings stay presentationally consistent (both warning, top-right).
+const sampleAssociationMoveNotification = () => ({
+  title: 'Move incomplete',
+  message: 'Some samples stayed here - they belong to a reaction or wellplate. '
+    + 'Move the reaction or wellplate to move its associated samples.',
+  level: 'warning',
+  autoDismiss: 10,
+  position: 'tr',
+});
+
+export { sampleAssociationLockNotification, sampleAssociationMoveNotification };

--- a/app/models/collections_sample.rb
+++ b/app/models/collections_sample.rb
@@ -55,6 +55,26 @@ class CollectionsSample < ApplicationRecord
     end
   end
 
+  # Of the given samples, returns the ids that remain in (one of) the given
+  # collection(s) because they are still linked to a reaction that is also in
+  # the same collection. Such samples cannot be unshared/removed/deleted on
+  # their own (see +delete_in_collection_with_filter+); the reaction has to be
+  # removed instead. +collection_ids+ accepts a single id or an array.
+  def self.locked_by_reaction(sample_ids, collection_ids)
+    cids = Array(collection_ids).grep(Integer)
+    return [] if sample_ids.blank? || cids.blank?
+
+    joins(
+      <<~SQL
+        inner join reactions_samples rs
+        on rs.sample_id = collections_samples.sample_id and rs.deleted_at isnull
+        inner join collections_reactions cr
+        on cr.reaction_id = rs.reaction_id and cr.collection_id = collections_samples.collection_id
+        and cr.deleted_at is null
+      SQL
+    ).where(collection_id: cids, sample_id: sample_ids).distinct.pluck(:sample_id)
+  end
+
   def self.create_in_collection(element_ids, collection_ids)
     # upsert in target collection
     # update sample tag with collection info

--- a/app/models/collections_sample.rb
+++ b/app/models/collections_sample.rb
@@ -24,19 +24,25 @@ class CollectionsSample < ApplicationRecord
   include Collecting
 
   def self.remove_in_collection(element_ids, collection_ids)
-    # Remove from collections
-    delete_in_collection_with_filter(element_ids, collection_ids)
+    # Remove from collections; returns the ids kept back because they are still linked to a
+    # reaction or wellplate in the collection (see delete_in_collection_with_filter).
+    locked_ids = delete_in_collection_with_filter(element_ids, collection_ids)
     # update sample tag with collection info
     update_tag_by_element_ids(element_ids)
+    locked_ids
   end
 
-  # prevent removing sample from a collection if associated wellplate or reaction is present
+  # Removes each sample from the collection unless it is still linked to a reaction or wellplate
+  # that is also in that collection. Returns the ids of the samples that were kept for that reason:
+  # they cannot be removed/deleted on their own, the reaction or wellplate has to be removed instead.
   def self.delete_in_collection_with_filter(sample_ids, collection_ids)
+    locked_sample_ids = []
     [collection_ids].flatten.each do |cid|
       next unless cid.is_a?(Integer)
+
+      # from a collection, join each requested sample to any reaction/wellplate it belongs to there
       # TODO: sql function
-      # from a collection, select sample_ids with neither wellplate nor reaction associated
-      ids = CollectionsSample.joins(
+      associated = CollectionsSample.joins(
         <<~SQL
           left join reactions_samples rs
           on rs.sample_id = collections_samples.sample_id and rs.deleted_at isnull
@@ -47,32 +53,16 @@ class CollectionsSample < ApplicationRecord
           left join collections_wellplates cw
           on cw.collection_id = #{cid} and cw.wellplate_id = w.wellplate_id and cw.deleted_at is null
         SQL
-      ).where(
-        "collections_samples.collection_id = #{cid} and collections_samples.sample_id in (?) and cw.id isnull and cr.id isnull",
-        sample_ids
-      ).pluck(:sample_id)
-      delete_in_collection(ids, cid)
+      ).where('collections_samples.collection_id = ? and collections_samples.sample_id in (?)', cid, sample_ids)
+
+      # samples with neither wellplate nor reaction are removable; the rest (present but not
+      # removable) are kept -> reported as locked so the UI can explain why nothing happened
+      present_ids = associated.distinct.pluck(:sample_id)
+      deletable_ids = associated.where('cw.id isnull and cr.id isnull').distinct.pluck(:sample_id)
+      delete_in_collection(deletable_ids, cid)
+      locked_sample_ids |= (present_ids - deletable_ids)
     end
-  end
-
-  # Of the given samples, returns the ids that remain in (one of) the given
-  # collection(s) because they are still linked to a reaction that is also in
-  # the same collection. Such samples cannot be unshared/removed/deleted on
-  # their own (see +delete_in_collection_with_filter+); the reaction has to be
-  # removed instead. +collection_ids+ accepts a single id or an array.
-  def self.locked_by_reaction(sample_ids, collection_ids)
-    cids = Array(collection_ids).grep(Integer)
-    return [] if sample_ids.blank? || cids.blank?
-
-    joins(
-      <<~SQL.squish,
-        inner join reactions_samples rs
-        on rs.sample_id = collections_samples.sample_id and rs.deleted_at isnull
-        inner join collections_reactions cr
-        on cr.reaction_id = rs.reaction_id and cr.collection_id = collections_samples.collection_id
-        and cr.deleted_at is null
-      SQL
-    ).where(collection_id: cids, sample_id: sample_ids).distinct.pluck(:sample_id)
+    locked_sample_ids
   end
 
   def self.create_in_collection(element_ids, collection_ids)

--- a/app/models/collections_sample.rb
+++ b/app/models/collections_sample.rb
@@ -55,8 +55,14 @@ class CollectionsSample < ApplicationRecord
         SQL
       ).where('collections_samples.collection_id = ? and collections_samples.sample_id in (?)', cid, sample_ids)
 
-      # samples with neither wellplate nor reaction are removable; the rest (present but not
-      # removable) are kept -> reported as locked so the UI can explain why nothing happened
+      # A sample is removable when it has no wellplate/reaction in this collection; the rest
+      # (present but not removable) are kept -> reported as locked so the UI can explain why
+      # nothing happened.
+      # TODO: this predicate is evaluated per JOIN row, not per sample. A sample linked to
+      # reaction A (in this collection) and reaction B (not in it) yields a both-null row for B
+      # and is treated as free -> removed and never reported as locked. The check should be
+      # set-wise (a sample is deletable only if *no* row locks it). Kept row-wise for now to
+      # preserve existing behaviour; see the specs in collection_elements_api_spec.rb.
       present_ids = associated.distinct.pluck(:sample_id)
       deletable_ids = associated.where('cw.id isnull and cr.id isnull').distinct.pluck(:sample_id)
       delete_in_collection(deletable_ids, cid)

--- a/app/models/collections_sample.rb
+++ b/app/models/collections_sample.rb
@@ -65,7 +65,7 @@ class CollectionsSample < ApplicationRecord
     return [] if sample_ids.blank? || cids.blank?
 
     joins(
-      <<~SQL
+      <<~SQL.squish,
         inner join reactions_samples rs
         on rs.sample_id = collections_samples.sample_id and rs.deleted_at isnull
         inner join collections_reactions cr

--- a/app/usecases/collections/remove_elements.rb
+++ b/app/usecases/collections/remove_elements.rb
@@ -46,10 +46,9 @@ module Usecases
       def remove_elements_from_collection(ui_state)
         @locked_sample_ids = []
         ui_state.each do |class_string, ui_selections|
-          element_class = element_scope_for(class_string)
-          next unless element_class
+          element_ids = resolve_element_ids(class_string, ui_selections)
+          next if element_ids.blank?
 
-          element_ids = resolve_element_ids(element_class, ui_selections)
           join_table = join_table_for(class_string)
 
           kept = join_table.remove_in_collection(element_ids, collection.id)
@@ -58,12 +57,24 @@ module Usecases
         end
       end
 
-      # Resolves the selected element ids. Samples are scoped to the collection so a checkedAll
-      # selection does not resolve to every sample in the database (by_ui_state has no collection
-      # filter of its own).
-      def resolve_element_ids(element_class, ui_selections)
-        scope = element_class == Sample ? collection.samples : element_class
+      # Resolves selected element ids within the current collection. Must scope before
+      # +by_ui_state+: with +checkedAll+, that scope expands to +where.not(id: ...)+ on its
+      # receiver, so an unscoped class would load every record of that type (full-table scan /
+      # huge id lists). Same approach as {WithdrawElements}.
+      def resolve_element_ids(class_string, ui_selections)
+        scope = collection_scoped_elements(class_string)
+        return [] unless scope
+
         scope.by_ui_state(ui_selections).ids
+      end
+
+      # Collection association for a UI element-type key (built-in or Labimotion generic).
+      def collection_scoped_elements(class_string)
+        if (klass = API::ELEMENT_CLASS[class_string])
+          collection.send(klass.model_name.route_key)
+        elsif (element_klass = Labimotion::ElementKlass.find_by(name: class_string))
+          collection.elements.merge(element_klass.elements)
+        end
       end
     end
   end

--- a/app/usecases/collections/remove_elements.rb
+++ b/app/usecases/collections/remove_elements.rb
@@ -5,6 +5,17 @@ module Usecases
     class RemoveElements
       include ElementClassResolution
 
+      # Join tables whose remove_in_collection cascades down to CollectionsSample and therefore
+      # returns the sample ids kept back by the association guard — either directly
+      # (CollectionsSample) or via their child samples (removing a reaction/wellplate/screen
+      # cascades to its samples, which may still be locked by another association).
+      SAMPLE_LOCKING_JOIN_TABLES = [
+        CollectionsSample,
+        CollectionsReaction,
+        CollectionsWellplate,
+        CollectionsScreen,
+      ].freeze
+
       attr_reader :current_user, :collection
 
       def initialize(current_user)
@@ -52,9 +63,26 @@ module Usecases
           join_table = join_table_for(class_string)
 
           kept = join_table.remove_in_collection(element_ids, collection.id)
-          # only the samples join table reports kept-by-reaction/wellplate sample ids
-          @locked_sample_ids |= Array(kept) if join_table == CollectionsSample
+          # capture kept sample ids, whether the sample was selected directly or reached through a
+          # selected reaction/wellplate/screen cascade (which can leave a sample locked by another
+          # association)
+          @locked_sample_ids |= Array(kept) if SAMPLE_LOCKING_JOIN_TABLES.include?(join_table)
         end
+
+        reconcile_locked_sample_ids
+      end
+
+      # ui_state is processed in the client's key order (sample before reaction/wellplate), so a
+      # sample flagged as kept during the sample pass can still be removed later in the same request
+      # when a selected reaction/wellplate pass cascades to it
+      # (CollectionsReaction/CollectionsWellplate#remove_in_collection). Reconcile against final
+      # membership so only samples that truly remain in the collection are reported as locked.
+      def reconcile_locked_sample_ids
+        return if @locked_sample_ids.empty?
+
+        @locked_sample_ids = CollectionsSample
+                             .where(collection_id: collection.id, sample_id: @locked_sample_ids)
+                             .pluck(:sample_id)
       end
 
       # Resolves selected element ids within the current collection. Must scope before

--- a/app/usecases/collections/remove_elements.rb
+++ b/app/usecases/collections/remove_elements.rb
@@ -49,10 +49,19 @@ module Usecases
           element_class = element_scope_for(class_string)
           next unless element_class
 
-          element_ids = element_class.by_ui_state(ui_selections).ids
-          @requested_sample_ids = element_ids if element_class == Sample
+          element_ids = resolve_element_ids(element_class, ui_selections)
           join_table_for(class_string).remove_in_collection(element_ids, collection.id)
         end
+      end
+
+      # Resolves the selected element ids. Samples are scoped to the collection so a checkedAll
+      # selection does not resolve to every sample in the database (by_ui_state has no collection
+      # filter of its own). Records the requested sample ids for #locked_sample_ids.
+      def resolve_element_ids(element_class, ui_selections)
+        scope = element_class == Sample ? collection.samples : element_class
+        ids = scope.by_ui_state(ui_selections).ids
+        @requested_sample_ids = ids if element_class == Sample
+        ids
       end
 
       # Samples the user asked to remove but which stayed in the collection

--- a/app/usecases/collections/remove_elements.rb
+++ b/app/usecases/collections/remove_elements.rb
@@ -16,6 +16,11 @@ module Usecases
         find_collection(collection_id)
         prevent_removal_from_all_collection!
         remove_elements_from_collection(ui_state)
+
+        # Samples linked to a reaction that is still in the collection are kept
+        # on purpose (they belong to the reaction). Report them so the UI can
+        # tell the user why the sample was not unshared.
+        { locked_sample_ids: locked_sample_ids }
       end
 
       # rubocop:disable Rails/FindByOrAssignmentMemoization
@@ -39,14 +44,21 @@ module Usecases
       end
 
       def remove_elements_from_collection(ui_state)
+        @requested_sample_ids = []
         ui_state.each do |class_string, ui_selections|
           element_class = element_scope_for(class_string)
           next unless element_class
 
           element_ids = element_class.by_ui_state(ui_selections).ids
-
+          @requested_sample_ids = element_ids if element_class == Sample
           join_table_for(class_string).remove_in_collection(element_ids, collection.id)
         end
+      end
+
+      # Samples the user asked to remove but which stayed in the collection
+      # because they are connected to a reaction that is also in the collection.
+      def locked_sample_ids
+        CollectionsSample.locked_by_reaction(@requested_sample_ids, collection.id)
       end
     end
   end

--- a/app/usecases/collections/remove_elements.rb
+++ b/app/usecases/collections/remove_elements.rb
@@ -17,10 +17,10 @@ module Usecases
         prevent_removal_from_all_collection!
         remove_elements_from_collection(ui_state)
 
-        # Samples linked to a reaction that is still in the collection are kept
-        # on purpose (they belong to the reaction). Report them so the UI can
-        # tell the user why the sample was not unshared.
-        { locked_sample_ids: locked_sample_ids }
+        # Samples linked to a reaction or wellplate still in the collection are kept on purpose
+        # (they belong to that reaction/wellplate). Report them so the UI can tell the user why
+        # the sample was not removed.
+        { locked_sample_ids: @locked_sample_ids }
       end
 
       # rubocop:disable Rails/FindByOrAssignmentMemoization
@@ -44,30 +44,26 @@ module Usecases
       end
 
       def remove_elements_from_collection(ui_state)
-        @requested_sample_ids = []
+        @locked_sample_ids = []
         ui_state.each do |class_string, ui_selections|
           element_class = element_scope_for(class_string)
           next unless element_class
 
           element_ids = resolve_element_ids(element_class, ui_selections)
-          join_table_for(class_string).remove_in_collection(element_ids, collection.id)
+          join_table = join_table_for(class_string)
+
+          kept = join_table.remove_in_collection(element_ids, collection.id)
+          # only the samples join table reports kept-by-reaction/wellplate sample ids
+          @locked_sample_ids |= Array(kept) if join_table == CollectionsSample
         end
       end
 
       # Resolves the selected element ids. Samples are scoped to the collection so a checkedAll
       # selection does not resolve to every sample in the database (by_ui_state has no collection
-      # filter of its own). Records the requested sample ids for #locked_sample_ids.
+      # filter of its own).
       def resolve_element_ids(element_class, ui_selections)
         scope = element_class == Sample ? collection.samples : element_class
-        ids = scope.by_ui_state(ui_selections).ids
-        @requested_sample_ids = ids if element_class == Sample
-        ids
-      end
-
-      # Samples the user asked to remove but which stayed in the collection
-      # because they are connected to a reaction that is also in the collection.
-      def locked_sample_ids
-        CollectionsSample.locked_by_reaction(@requested_sample_ids, collection.id)
+        scope.by_ui_state(ui_selections).ids
       end
     end
   end

--- a/app/usecases/collections/withdraw_elements.rb
+++ b/app/usecases/collections/withdraw_elements.rb
@@ -27,7 +27,6 @@ module Usecases
       def initialize(current_user)
         @current_user = current_user
         @owned_collection_ids = []
-        @selected_sample_ids = []
         @locked_sample_ids = []
       end
 
@@ -45,14 +44,11 @@ module Usecases
         @owned_collection_ids = Collection.where(user_id: [current_user.id, *current_user.group_ids]).pluck(:id)
         removed = Hash.new { |hash, key| hash[key] = [] }
 
+        # As a side effect, #withdraw records into @locked_sample_ids any samples kept back by the
+        # association guard (still bound to a reaction/wellplate in one of the user's collections).
         withdrawn_reaction_ids = withdraw_selected_elements(source_collection, ui_state, removed)
         removed['sample'] |= withdraw_reaction_subsamples(withdrawn_reaction_ids, options)
         withdraw_generic_elements(source_collection, ui_state, removed)
-
-        # Samples the user selected but which stayed in one of their collections
-        # because they belong to a reaction that is also there. Computed after
-        # all withdrawals so a sample removed via its reaction is not reported.
-        @locked_sample_ids = CollectionsSample.locked_by_reaction(@selected_sample_ids, @owned_collection_ids)
         removed
       end
 
@@ -66,7 +62,6 @@ module Usecases
           next unless selected?(selection)
 
           ids = source_collection.send(klass.model_name.route_key).by_ui_state(selection).ids
-          @selected_sample_ids = ids if klass == Sample
           left_view = withdraw(klass, klass.collections_element_class, ids)
           removed[klass.model_name.param_key] = left_view
           reaction_ids = left_view if klass == Reaction
@@ -104,8 +99,11 @@ module Usecases
         # reaction/wellplate in one of our collections), and that decision is only visible by asking
         # membership again — never derivable from `actionable`.
         still_ours = membership_ids(klass, actionable, @owned_collection_ids) # guard-kept ⇒ stay visible
+        # guard-kept samples (bound to a reaction or wellplate here) cannot leave on their own;
+        # surface them so the endpoint can tell the user why they were not removed
+        @locked_sample_ids |= still_ours if klass == Sample
         left_view = actionable - still_ours
-        orphaned = left_view - membership_ids(klass, left_view, nil)          # in no collection ⇒ sole owner
+        orphaned = left_view - membership_ids(klass, left_view, nil) # in no collection ⇒ sole owner
 
         klass.where(id: orphaned).find_each(&:destroy) # per-record destroy keeps paranoia/callbacks
         left_view

--- a/app/usecases/collections/withdraw_elements.rb
+++ b/app/usecases/collections/withdraw_elements.rb
@@ -50,6 +50,12 @@ module Usecases
         withdrawn_reaction_ids = withdraw_selected_elements(source_collection, ui_state, removed)
         removed['sample'] |= withdraw_reaction_subsamples(withdrawn_reaction_ids, options)
         withdraw_generic_elements(source_collection, ui_state, removed)
+
+        # A directly-selected sample can be flagged locked in an early pass and then removed by a
+        # later reaction/wellplate pass in the same request. This is order-safe today (samples come
+        # last in API::ELEMENT_CLASS), but rather than depend on that constant's ordering we
+        # reconcile against final membership: keep only samples that truly remain in an owned collection.
+        @locked_sample_ids = membership_ids(Sample, @locked_sample_ids, @owned_collection_ids)
         removed
       end
 

--- a/app/usecases/collections/withdraw_elements.rb
+++ b/app/usecases/collections/withdraw_elements.rb
@@ -42,6 +42,7 @@ module Usecases
         # already destroy group-collection elements, so withdrawal keeps that reach). Restricting
         # group-owned withdrawal to group-admins is a deliberate future refinement, not done here.
         @owned_collection_ids = Collection.where(user_id: [current_user.id, *current_user.group_ids]).pluck(:id)
+        @locked_sample_ids = []
         removed = Hash.new { |hash, key| hash[key] = [] }
 
         # As a side effect, #withdraw records into @locked_sample_ids any samples kept back by the

--- a/app/usecases/collections/withdraw_elements.rb
+++ b/app/usecases/collections/withdraw_elements.rb
@@ -22,11 +22,13 @@ module Usecases
         CollectionsSequenceBasedMacromoleculeSample,
       ].freeze
 
-      attr_reader :current_user
+      attr_reader :current_user, :locked_sample_ids
 
       def initialize(current_user)
         @current_user = current_user
         @owned_collection_ids = []
+        @selected_sample_ids = []
+        @locked_sample_ids = []
       end
 
       # @param source_collection [Collection] the collection the selection was made in; scopes the
@@ -46,6 +48,11 @@ module Usecases
         withdrawn_reaction_ids = withdraw_selected_elements(source_collection, ui_state, removed)
         removed['sample'] |= withdraw_reaction_subsamples(withdrawn_reaction_ids, options)
         withdraw_generic_elements(source_collection, ui_state, removed)
+
+        # Samples the user selected but which stayed in one of their collections
+        # because they belong to a reaction that is also there. Computed after
+        # all withdrawals so a sample removed via its reaction is not reported.
+        @locked_sample_ids = CollectionsSample.locked_by_reaction(@selected_sample_ids, @owned_collection_ids)
         removed
       end
 
@@ -59,6 +66,7 @@ module Usecases
           next unless selected?(selection)
 
           ids = source_collection.send(klass.model_name.route_key).by_ui_state(selection).ids
+          @selected_sample_ids = ids if klass == Sample
           left_view = withdraw(klass, klass.collections_element_class, ids)
           removed[klass.model_name.param_key] = left_view
           reaction_ids = left_view if klass == Reaction

--- a/spec/api/chemotion/collection_elements_api_spec.rb
+++ b/spec/api/chemotion/collection_elements_api_spec.rb
@@ -278,5 +278,35 @@ describe Chemotion::CollectionElementsAPI do
       end
     end
   end
+
+  context 'when removing a sample connected to a wellplate in the same collection' do
+    let(:source_collection_user) { user }
+    let(:wellplate) { create(:wellplate, samples: [sample1]) }
+    let(:remove_input) do
+      {
+        ui_state: {
+          currentCollection: { id: 0 },
+          sample: {
+            checkedAll: false,
+            checkedIds: [sample1.id],
+            uncheckedIds: [],
+          },
+        },
+      }
+    end
+
+    before do
+      CollectionsWellplate.create!(collection_id: source_collection.id, wellplate_id: wellplate.id)
+    end
+
+    # Not only reactions lock samples: a wellplate-linked sample must also be reported, not silently kept.
+    it 'keeps the sample and reports it as locked' do
+      delete "/api/v1/collection_elements/#{source_collection.id}", params: remove_input
+
+      expect(response).to have_http_status(:ok)
+      expect(parsed_json_response['locked_sample_ids']).to eq [sample1.id]
+      expect(sample1.reload.collections).to include(source_collection)
+    end
+  end
 end
 # rubocop:enable RSpec/IndexedLet, RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations

--- a/spec/api/chemotion/collection_elements_api_spec.rb
+++ b/spec/api/chemotion/collection_elements_api_spec.rb
@@ -253,6 +253,30 @@ describe Chemotion::CollectionElementsAPI do
       expect(parsed_json_response['locked_sample_ids']).to eq [sample1.id]
       expect(sample1.reload.collections).to include(source_collection)
     end
+
+    context 'with a checkedAll selection' do
+      let(:remove_input) do
+        {
+          ui_state: {
+            currentCollection: { id: 0 },
+            sample: { checkedAll: true, checkedIds: [], uncheckedIds: [] },
+          },
+        }
+      end
+
+      # Guards against the checkedAll id resolution falling back to every sample in the DB:
+      # only the collection's own samples are touched, the reaction-linked one is reported locked.
+      it 'removes the free samples but keeps and reports the reaction-linked one' do
+        # sample2/sample3 are free samples in the collection alongside the reaction-linked sample1
+        [sample2, sample3].each { |s| expect(source_collection.samples).to include(s) }
+
+        delete "/api/v1/collection_elements/#{source_collection.id}", params: remove_input, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(parsed_json_response['locked_sample_ids']).to eq [sample1.id]
+        expect(source_collection.reload.samples).to contain_exactly(sample1)
+      end
+    end
   end
 end
 # rubocop:enable RSpec/IndexedLet, RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations

--- a/spec/api/chemotion/collection_elements_api_spec.rb
+++ b/spec/api/chemotion/collection_elements_api_spec.rb
@@ -170,7 +170,7 @@ describe Chemotion::CollectionElementsAPI do
     end
 
     it 'responds 204 No Content with an empty body' do
-      delete "/api/v1/collection_elements/#{source_collection.id}", params: remove_input
+      delete "/api/v1/collection_elements/#{source_collection.id}", params: remove_input, as: :json
 
       expect(response).to have_http_status(:no_content)
       expect(response.body).to be_blank
@@ -217,7 +217,7 @@ describe Chemotion::CollectionElementsAPI do
       generic_element.collections << target_collection
 
       delete "/api/v1/collection_elements/#{source_collection.id}",
-             params: generic_input.except(:collection_id)
+             params: generic_input.except(:collection_id), as: :json
       generic_element.reload
 
       expect(response).to have_http_status(:no_content)
@@ -247,7 +247,7 @@ describe Chemotion::CollectionElementsAPI do
     end
 
     it 'keeps the sample and reports it as locked' do
-      delete "/api/v1/collection_elements/#{source_collection.id}", params: remove_input
+      delete "/api/v1/collection_elements/#{source_collection.id}", params: remove_input, as: :json
 
       expect(response).to have_http_status(:ok)
       expect(parsed_json_response['locked_sample_ids']).to contain_exactly(sample1.id)
@@ -301,11 +301,71 @@ describe Chemotion::CollectionElementsAPI do
 
     # Not only reactions lock samples: a wellplate-linked sample must also be reported, not silently kept.
     it 'keeps the sample and reports it as locked' do
-      delete "/api/v1/collection_elements/#{source_collection.id}", params: remove_input
+      delete "/api/v1/collection_elements/#{source_collection.id}", params: remove_input, as: :json
 
       expect(response).to have_http_status(:ok)
       expect(parsed_json_response['locked_sample_ids']).to contain_exactly(sample1.id)
       expect(sample1.reload.collections).to include(source_collection)
+    end
+  end
+
+  # Regression: ui_state is processed sample-first, so the sample pass flags sample1 as locked while
+  # reaction R is still present; the later reaction pass then removes R and cascades to sample1. The
+  # locked set must be reconciled against final membership, or the user is falsely told the sample
+  # could not be removed even though it was.
+  context 'when removing a reaction together with its associated sample' do
+    let(:source_collection_user) { user }
+    let(:reaction) { create(:reaction, samples: [sample1]) }
+    let(:remove_input) do
+      {
+        ui_state: {
+          currentCollection: { id: 0 },
+          sample: { checkedAll: false, checkedIds: [sample1.id], uncheckedIds: [] },
+          reaction: { checkedAll: false, checkedIds: [reaction.id], uncheckedIds: [] },
+        },
+      }
+    end
+
+    before do
+      CollectionsReaction.create!(collection_id: source_collection.id, reaction_id: reaction.id)
+    end
+
+    it 'removes both and does not falsely report the sample as locked' do
+      delete "/api/v1/collection_elements/#{source_collection.id}", params: remove_input, as: :json
+
+      expect(response).to have_http_status(:no_content)
+      expect(source_collection.reload.samples).to be_empty
+      expect(source_collection.reactions).to be_empty
+    end
+  end
+
+  # Regression: removing only the wellplate cascades to its sample, which is still blocked by the
+  # reaction. That kept id comes back from CollectionsWellplate#remove_in_collection (not the sample
+  # pass), so it must not be discarded — otherwise the sample stays with no explanation.
+  context 'when removing a wellplate whose sample is also locked by a reaction' do
+    let(:source_collection_user) { user }
+    let(:wellplate) { create(:wellplate, samples: [sample1]) }
+    let(:reaction) { create(:reaction, samples: [sample1]) }
+    let(:remove_input) do
+      {
+        ui_state: {
+          currentCollection: { id: 0 },
+          wellplate: { checkedAll: false, checkedIds: [wellplate.id], uncheckedIds: [] },
+        },
+      }
+    end
+
+    before do
+      CollectionsWellplate.create!(collection_id: source_collection.id, wellplate_id: wellplate.id)
+      CollectionsReaction.create!(collection_id: source_collection.id, reaction_id: reaction.id)
+    end
+
+    it 'reports the cascade-discovered locked sample instead of silently keeping it' do
+      delete "/api/v1/collection_elements/#{source_collection.id}", params: remove_input, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(parsed_json_response['locked_sample_ids']).to contain_exactly(sample1.id)
+      expect(source_collection.reload.samples).to contain_exactly(sample1)
     end
   end
 end

--- a/spec/api/chemotion/collection_elements_api_spec.rb
+++ b/spec/api/chemotion/collection_elements_api_spec.rb
@@ -225,5 +225,34 @@ describe Chemotion::CollectionElementsAPI do
       expect(generic_element.collections).to include(target_collection)
     end
   end
+
+  context 'when removing a sample connected to a reaction in the same collection' do
+    let(:source_collection_user) { user }
+    let(:reaction) { create(:reaction, samples: [sample1]) }
+    let(:remove_input) do
+      {
+        ui_state: {
+          currentCollection: { id: 0 },
+          sample: {
+            checkedAll: false,
+            checkedIds: [sample1.id],
+            uncheckedIds: [],
+          },
+        },
+      }
+    end
+
+    before do
+      CollectionsReaction.create!(collection_id: source_collection.id, reaction_id: reaction.id)
+    end
+
+    it 'keeps the sample and reports it as locked' do
+      delete "/api/v1/collection_elements/#{source_collection.id}", params: remove_input
+
+      expect(response).to have_http_status(:ok)
+      expect(parsed_json_response['locked_sample_ids']).to eq [sample1.id]
+      expect(sample1.reload.collections).to include(source_collection)
+    end
+  end
 end
 # rubocop:enable RSpec/IndexedLet, RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations

--- a/spec/api/chemotion/collection_elements_api_spec.rb
+++ b/spec/api/chemotion/collection_elements_api_spec.rb
@@ -250,7 +250,7 @@ describe Chemotion::CollectionElementsAPI do
       delete "/api/v1/collection_elements/#{source_collection.id}", params: remove_input
 
       expect(response).to have_http_status(:ok)
-      expect(parsed_json_response['locked_sample_ids']).to eq [sample1.id]
+      expect(parsed_json_response['locked_sample_ids']).to contain_exactly(sample1.id)
       expect(sample1.reload.collections).to include(source_collection)
     end
 
@@ -273,7 +273,7 @@ describe Chemotion::CollectionElementsAPI do
         delete "/api/v1/collection_elements/#{source_collection.id}", params: remove_input, as: :json
 
         expect(response).to have_http_status(:ok)
-        expect(parsed_json_response['locked_sample_ids']).to eq [sample1.id]
+        expect(parsed_json_response['locked_sample_ids']).to contain_exactly(sample1.id)
         expect(source_collection.reload.samples).to contain_exactly(sample1)
       end
     end
@@ -304,7 +304,7 @@ describe Chemotion::CollectionElementsAPI do
       delete "/api/v1/collection_elements/#{source_collection.id}", params: remove_input
 
       expect(response).to have_http_status(:ok)
-      expect(parsed_json_response['locked_sample_ids']).to eq [sample1.id]
+      expect(parsed_json_response['locked_sample_ids']).to contain_exactly(sample1.id)
       expect(sample1.reload.collections).to include(source_collection)
     end
   end

--- a/spec/api/chemotion/element_api_spec.rb
+++ b/spec/api/chemotion/element_api_spec.rb
@@ -52,7 +52,7 @@ describe Chemotion::ElementAPI do
           .not_to change(Sample, :count)
 
         expect(response).to have_http_status(:ok)
-        expect(parsed_json_response['locked_sample_ids']).to eq [sample.id]
+        expect(parsed_json_response['locked_sample_ids']).to contain_exactly(sample.id)
       end
     end
 

--- a/spec/api/chemotion/element_api_spec.rb
+++ b/spec/api/chemotion/element_api_spec.rb
@@ -24,9 +24,12 @@ describe Chemotion::ElementAPI do
     context 'when the collection belongs to the user' do
       let(:collection) { create(:collection, user: user) }
 
-      it 'deletes the selected element' do
+      it 'deletes the selected element and omits locked_sample_ids when nothing is locked' do
         expect { delete '/api/v1/ui_state/', params: params, as: :json }
           .to change(Sample, :count).by(-1)
+
+        expect(response).to have_http_status(:ok)
+        expect(parsed_json_response).not_to have_key('locked_sample_ids')
       end
     end
 
@@ -53,6 +56,47 @@ describe Chemotion::ElementAPI do
 
         expect(response).to have_http_status(:ok)
         expect(parsed_json_response['locked_sample_ids']).to contain_exactly(sample.id)
+      end
+    end
+
+    # Pins the partition in WithdrawElements: the locked sample goes to locked_sample_ids while the
+    # free one goes to `removed`, which drives the `selecteds` filter. If a locked id leaked into
+    # `removed`, the still-existing sample's detail tab would be closed.
+    context 'with a mix of a locked sample and a free sample' do
+      let(:collection) { create(:collection, user: user) }
+      let(:free_sample) { create(:sample, collections: [collection]) }
+      let(:reaction) { create(:reaction, creator: user, collections: [collection]) }
+      let(:params) do
+        {
+          currentCollection: { id: collection.id },
+          options: { deleteSubsamples: false },
+          sample: { checkedAll: false, checkedIds: [sample.id, free_sample.id], uncheckedIds: [] },
+          selecteds: [
+            { type: 'sample', id: sample.id },
+            { type: 'sample', id: free_sample.id },
+          ],
+        }
+      end
+
+      before do
+        free_sample
+        ReactionsReactantSample.create!(reaction: reaction, sample: sample, reference: false)
+      end
+
+      it 'removes only the free sample, reports the locked one, and keeps its tab open' do
+        expect { delete '/api/v1/ui_state/', params: params, as: :json }
+          .to change(Sample, :count).by(-1)
+
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(parsed_json_response['locked_sample_ids']).to contain_exactly(sample.id)
+          expect(collection.reload.samples).to contain_exactly(sample)
+          # only the removed (free) sample's tab is closed; the locked sample, which still exists,
+          # stays in `selecteds`
+          # rubocop:disable Rails/Pluck -- selecteds is parsed JSON (Array of Hash), not an AR relation
+          expect(parsed_json_response['selecteds'].map { |s| s['id'] }).to contain_exactly(sample.id)
+          # rubocop:enable Rails/Pluck
+        end
       end
     end
 

--- a/spec/api/chemotion/element_api_spec.rb
+++ b/spec/api/chemotion/element_api_spec.rb
@@ -41,6 +41,21 @@ describe Chemotion::ElementAPI do
       end
     end
 
+    context 'when the sample is connected to a reaction in the same collection' do
+      let(:collection) { create(:collection, user: user) }
+      let(:reaction) { create(:reaction, creator: user, collections: [collection]) }
+
+      before { ReactionsReactantSample.create!(reaction: reaction, sample: sample, reference: false) }
+
+      it 'keeps the sample and reports it as locked by its reaction' do
+        expect { delete '/api/v1/ui_state/', params: params, as: :json }
+          .not_to change(Sample, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(parsed_json_response['locked_sample_ids']).to eq [sample.id]
+      end
+    end
+
     # Destroying the element records themselves is owner-only: a sharee unlinks them from the
     # collection instead (Usecases::Collections::RemoveElements). No rung on the ladder grants this.
     CollectionShare::PERMISSION_LEVELS.each_key do |level_key|

--- a/spec/javascripts/packs/src/utilities/notificationMessages.spec.js
+++ b/spec/javascripts/packs/src/utilities/notificationMessages.spec.js
@@ -1,0 +1,43 @@
+// eslint-disable-next-line import/no-unresolved
+import {
+  sampleAssociationLockNotification,
+  sampleAssociationMoveNotification,
+} from 'src/utilities/notificationMessages';
+import expect from 'expect';
+
+describe('notificationMessages', () => {
+  describe('.sampleAssociationLockNotification', () => {
+    it('uses singular copy for a single locked sample', () => {
+      const notification = sampleAssociationLockNotification(1);
+
+      expect(notification.title).toBe('Sample not removed');
+      expect(notification.message).toMatch(/^It belongs to a reaction or wellplate/);
+      expect(notification.level).toBe('warning');
+      expect(notification.position).toBe('tr');
+    });
+
+    it('uses plural copy for more than one locked sample', () => {
+      const notification = sampleAssociationLockNotification(3);
+
+      expect(notification.title).toBe('Samples not removed');
+      expect(notification.message).toMatch(/^They belong to a reaction or wellplate/);
+    });
+
+    it('defaults to singular copy', () => {
+      expect(sampleAssociationLockNotification().title).toBe('Sample not removed');
+    });
+  });
+
+  describe('.sampleAssociationMoveNotification', () => {
+    // Guards against the move-path toast drifting from the shared presentation: it must stay a
+    // top-right warning like the remove/delete toast so related warnings appear in the same corner.
+    it('is a top-right warning titled for the move', () => {
+      const notification = sampleAssociationMoveNotification();
+
+      expect(notification.title).toBe('Move incomplete');
+      expect(notification.message).toMatch(/reaction or wellplate/);
+      expect(notification.level).toBe('warning');
+      expect(notification.position).toBe('tr');
+    });
+  });
+});

--- a/spec/javascripts/stores/mobx/CollectionsStore.spec.js
+++ b/spec/javascripts/stores/mobx/CollectionsStore.spec.js
@@ -1,0 +1,65 @@
+/* eslint-disable import/no-unresolved */
+import expect from 'expect';
+import sinon from 'sinon';
+import { RootStore } from 'src/stores/mobx/RootStore';
+import ElementActions from 'src/stores/alt/actions/ElementActions';
+import CollectionElementsFetcher from 'src/fetchers/CollectionElementsFetcher';
+
+// Pins removeElementsFromCollection's return contract { success, lockedSampleIds }. moveElementsToCollection
+// and the lock toast both branch on it, and the fetcher's return-shape change (boolean -> object|null|
+// undefined) is otherwise untested: restoring `handleResponseSuccess: (r) => r.ok` on the fetcher would
+// make lockedSampleIds empty and the "sample locked" toast silently never fire — these cases catch that.
+describe('CollectionsStore', () => {
+  const params = { collection_id: 1, ui_state: { currentCollection: { id: 1 } } };
+  let deleteStub;
+  let refreshStub;
+  let store;
+
+  beforeEach(() => {
+    // Stub at the fetcher boundary: the store maps deleteElementsFromCollection's
+    // null / body / undefined into { success, lockedSampleIds }.
+    deleteStub = sinon.stub(CollectionElementsFetcher, 'deleteElementsFromCollection');
+    // isolate from the alt dispatcher / element refetch
+    refreshStub = sinon.stub(ElementActions, 'refreshElementsAfterCollectionChanges');
+    store = RootStore.create({}).collectionsStore;
+  });
+
+  afterEach(() => {
+    deleteStub.restore();
+    refreshStub.restore();
+  });
+
+  describe('.removeElementsFromCollection', () => {
+    it('maps a 204 No Content to success with no locked samples', async () => {
+      deleteStub.resolves(null);
+
+      const result = await store.removeElementsFromCollection(params);
+
+      expect(result).toEqual({ success: true, lockedSampleIds: [] });
+    });
+
+    it('maps a 200 body to the reported locked sample ids', async () => {
+      deleteStub.resolves({ locked_sample_ids: [7, 9] });
+
+      const result = await store.removeElementsFromCollection(params);
+
+      expect(result).toEqual({ success: true, lockedSampleIds: [7, 9] });
+    });
+
+    it('still returns the locked ids when notifyLock is false (the move path relies on this)', async () => {
+      deleteStub.resolves({ locked_sample_ids: [3] });
+
+      const result = await store.removeElementsFromCollection(params, { notifyLock: false });
+
+      expect(result).toEqual({ success: true, lockedSampleIds: [3] });
+    });
+
+    it('maps a request failure to success:false', async () => {
+      deleteStub.resolves(undefined);
+
+      const result = await store.removeElementsFromCollection(params);
+
+      expect(result).toEqual({ success: false, lockedSampleIds: [] });
+    });
+  });
+});

--- a/spec/models/collections_sample_spec.rb
+++ b/spec/models/collections_sample_spec.rb
@@ -20,14 +20,12 @@ require 'rails_helper'
 RSpec.describe CollectionsSample, type: :model do
   let(:c1) { create(:collection) }
   let(:c2) { create(:collection) }
-  let(:c3) { create(:collection) }
   let(:s1) { create(:sample) }
   let(:s2) { create(:sample) }
   let(:s3) { create(:sample) }
   let(:s4) { create(:sample) }
   let(:s5) { create(:sample) }
   let(:s6) { create(:sample) }
-
   let(:wp) { create(:wellplate, samples: [s5]) }
   let(:r) { create(:reaction, samples: [s6]) }
 
@@ -88,7 +86,7 @@ RSpec.describe CollectionsSample, type: :model do
     end
   end
 
-  describe 'locked_by_reaction, ' do
+  describe 'locked_by_reaction,' do
     before do
       described_class.create!(collection_id: c1.id, sample_id: s1.id)
       described_class.create!(collection_id: c1.id, sample_id: s6.id)
@@ -96,7 +94,7 @@ RSpec.describe CollectionsSample, type: :model do
     end
 
     it 'returns samples that are connected to a reaction in the collection' do
-      expect(described_class.locked_by_reaction([s1.id, s6.id], c1.id)).to match_array [s6.id]
+      expect(described_class.locked_by_reaction([s1.id, s6.id], c1.id)).to contain_exactly(s6.id)
     end
 
     it 'returns nothing when the reaction is not in the collection' do

--- a/spec/models/collections_sample_spec.rb
+++ b/spec/models/collections_sample_spec.rb
@@ -88,6 +88,26 @@ RSpec.describe CollectionsSample, type: :model do
     end
   end
 
+  describe 'locked_by_reaction, ' do
+    before do
+      described_class.create!(collection_id: c1.id, sample_id: s1.id)
+      described_class.create!(collection_id: c1.id, sample_id: s6.id)
+      CollectionsReaction.create!(collection_id: c1.id, reaction_id: r.id)
+    end
+
+    it 'returns samples that are connected to a reaction in the collection' do
+      expect(described_class.locked_by_reaction([s1.id, s6.id], c1.id)).to match_array [s6.id]
+    end
+
+    it 'returns nothing when the reaction is not in the collection' do
+      expect(described_class.locked_by_reaction([s1.id, s6.id], c2.id)).to be_empty
+    end
+
+    it 'returns nothing for blank sample ids' do
+      expect(described_class.locked_by_reaction([], c1.id)).to be_empty
+    end
+  end
+
   describe 'insert_in_collection, ' do
     before do
       described_class.create!(collection_id: c1.id, sample_id: s2.id)

--- a/spec/models/collections_sample_spec.rb
+++ b/spec/models/collections_sample_spec.rb
@@ -84,25 +84,11 @@ RSpec.describe CollectionsSample, type: :model do
       expect(c1.samples).to match_array [s5, s6]
       expect(c2.samples).to match_array [s1]
     end
-  end
 
-  describe 'locked_by_reaction,' do
-    before do
-      described_class.create!(collection_id: c1.id, sample_id: s1.id)
-      described_class.create!(collection_id: c1.id, sample_id: s6.id)
-      CollectionsReaction.create!(collection_id: c1.id, reaction_id: r.id)
-    end
-
-    it 'returns samples that are connected to a reaction in the collection' do
-      expect(described_class.locked_by_reaction([s1.id, s6.id], c1.id)).to contain_exactly(s6.id)
-    end
-
-    it 'returns nothing when the reaction is not in the collection' do
-      expect(described_class.locked_by_reaction([s1.id, s6.id], c2.id)).to be_empty
-    end
-
-    it 'returns nothing for blank sample ids' do
-      expect(described_class.locked_by_reaction([], c1.id)).to be_empty
+    it 'returns the kept ids, covering both the wellplate- and reaction-linked samples' do
+      # s5 is kept by its wellplate, s6 by its reaction; s1 is free and removed
+      locked = described_class.delete_in_collection_with_filter([s1.id, s5.id, s6.id], [c1.id])
+      expect(locked).to contain_exactly(s5.id, s6.id)
     end
   end
 

--- a/spec/usecases/collections/withdraw_elements_spec.rb
+++ b/spec/usecases/collections/withdraw_elements_spec.rb
@@ -88,6 +88,24 @@ RSpec.describe Usecases::Collections::WithdrawElements do
     end
   end
 
+  describe 'a sample kept by the wellplate association guard' do
+    let(:sample) { create(:sample, creator: user, collections: [user_all, user_sub]) }
+    let(:wellplate) { create(:wellplate, samples: [sample]) }
+
+    before do
+      # sample sits in a well of a wellplate living in the same collection
+      CollectionsWellplate.create!(collection_id: user_sub.id, wellplate_id: wellplate.id)
+    end
+
+    it 'is not unlinked, and is reported as locked (not only reactions lock samples)' do
+      usecase = described_class.new(user)
+      expect { usecase.perform!(source_collection: user_sub, ui_state: selection_for(sample), options: {}) }
+        .not_to change(Sample, :count)
+      expect(sample.reload.collections.where(id: user_sub.id)).to be_present
+      expect(usecase.locked_sample_ids).to contain_exactly(sample.id)
+    end
+  end
+
   describe 'a sole-owned reaction with associated subsamples' do
     let(:reaction) { create(:reaction, creator: user, collections: [user_all, user_sub]) }
     let(:solvent) { create(:sample, creator: user, collections: [user_all, user_sub]) }

--- a/spec/usecases/collections/withdraw_elements_spec.rb
+++ b/spec/usecases/collections/withdraw_elements_spec.rb
@@ -80,6 +80,12 @@ RSpec.describe Usecases::Collections::WithdrawElements do
       expect { withdraw_from(user_sub, sample) }.not_to change(Sample, :count)
       expect(sample.reload.collections.where(id: user_sub.id)).to be_present
     end
+
+    it 'reports the sample as locked by its reaction' do
+      usecase = described_class.new(user)
+      usecase.perform!(source_collection: user_sub, ui_state: selection_for(sample), options: {})
+      expect(usecase.locked_sample_ids).to contain_exactly(sample.id)
+    end
   end
 
   describe 'a sole-owned reaction with associated subsamples' do

--- a/spec/usecases/collections/withdraw_elements_spec.rb
+++ b/spec/usecases/collections/withdraw_elements_spec.rb
@@ -86,6 +86,21 @@ RSpec.describe Usecases::Collections::WithdrawElements do
       usecase.perform!(source_collection: user_sub, ui_state: selection_for(sample), options: {})
       expect(usecase.locked_sample_ids).to contain_exactly(sample.id)
     end
+
+    # Order-independence: selecting the reaction together with its sample must remove both and NOT
+    # report the sample as locked, regardless of the order the element types are processed in.
+    it 'does not report the sample as locked when its reaction is removed in the same request' do
+      selection = {
+        sample: { all: false, included_ids: [sample.id] },
+        reaction: { all: false, included_ids: [reaction.id] },
+      }.with_indifferent_access
+
+      usecase = described_class.new(user)
+      usecase.perform!(source_collection: user_sub, ui_state: selection, options: {})
+
+      expect(usecase.locked_sample_ids).to be_empty
+      expect(sample.reload.collections.where(id: user_sub.id)).to be_empty
+    end
   end
 
   describe 'a sample kept by the wellplate association guard' do


### PR DESCRIPTION
Resolves the following,

- https://github.com/ComPlat/chemotion_ELN/issues/462
- https://github.com/ComPlat/chemotion_ELN/issues/2442
- https://github.com/ComPlat/chemotion_ELN/issues/1033