### PR TITLE
fix(collections): honor can_update for read-only shared research plans, screens, and wellplates

### DIFF
--- a/app/api/chemotion/research_plan_api.rb
+++ b/app/api/chemotion/research_plan_api.rb
@@ -100,7 +100,8 @@ module Chemotion
         research_plan.collections << all_coll if all_coll && research_plan.collections.exclude?(all_coll)
 
         update_element_labels(research_plan, params[:user_labels], current_user.id)
-        present research_plan.reload, with: Entities::ResearchPlanEntity, root: :research_plan
+        @element_policy = ElementPolicy.new(current_user, research_plan)
+        present research_plan.reload, with: Entities::ResearchPlanEntity, root: :research_plan, policy: @element_policy
       end
 
       namespace :table_schemas do
@@ -158,8 +159,8 @@ module Chemotion
       route_param :id do
         get do
           research_plan = ResearchPlan.find(params[:id])
-          policy = ElementPolicy.new(current_user, research_plan)
-          error!('401 Unauthorized', 401) unless policy.read?
+          @element_policy = ElementPolicy.new(current_user, research_plan)
+          error!('401 Unauthorized', 401) unless @element_policy.read?
           # TODO: Refactor this massively ugly fallback to be in a more convenient place
           # (i.e. the entity or maybe return a null element from the model)
           if research_plan.research_plan_metadata.nil?
@@ -198,7 +199,8 @@ module Chemotion
       end
       route_param :id do
         before do
-          error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, ResearchPlan.find(params[:id])).update?
+          @element_policy = ElementPolicy.new(current_user, ResearchPlan.find(params[:id]))
+          error!('401 Unauthorized', 401) unless @element_policy.update?
         end
 
         put do
@@ -216,7 +218,11 @@ module Chemotion
           research_plan.reload
           detail_levels = ElementDetailLevelCalculator.new(user: current_user, element: research_plan).detail_levels
           {
-            research_plan: Entities::ResearchPlanEntity.represent(research_plan, detail_levels: detail_levels),
+            research_plan: Entities::ResearchPlanEntity.represent(
+              research_plan,
+              detail_levels: detail_levels,
+              policy: @element_policy,
+            ),
             attachments: Entities::AttachmentEntity.represent(research_plan.attachments),
             literatures: Entities::LiteratureEntity.represent(
               citation_for_elements(research_plan.id, 'ResearchPlan'),
@@ -339,7 +345,8 @@ module Chemotion
       end
       route_param :id do
         before do
-          error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, ResearchPlan.find(params[:id])).update?
+          @element_policy = ElementPolicy.new(current_user, ResearchPlan.find(params[:id]))
+          error!('401 Unauthorized', 401) unless @element_policy.update?
           error!('401 Unauthorized', 401) unless ElementPolicy.new(
             current_user, Wellplate.find(params[:wellplate_id])
           ).read?
@@ -358,6 +365,7 @@ module Chemotion
                 detail_levels: ElementDetailLevelCalculator.new(
                   user: current_user, element: research_plan,
                 ).detail_levels,
+                policy: @element_policy,
               ),
               attachments: Entities::AttachmentEntity.represent(research_plan.attachments),
             }
@@ -375,7 +383,8 @@ module Chemotion
       route_param :id do
         before do
           research_plan = ResearchPlan.find(params[:id])
-          error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, research_plan).update?
+          @element_policy = ElementPolicy.new(current_user, research_plan)
+          error!('401 Unauthorized', 401) unless @element_policy.update?
         end
 
         post 'import_table/:attachment_id' do
@@ -391,6 +400,7 @@ module Chemotion
                 detail_levels: ElementDetailLevelCalculator.new(
                   user: current_user, element: research_plan,
                 ).detail_levels,
+                policy: @element_policy,
               ),
               attachments: Entities::AttachmentEntity.represent(research_plan.attachments),
             }

--- a/app/api/chemotion/research_plan_api.rb
+++ b/app/api/chemotion/research_plan_api.rb
@@ -52,6 +52,7 @@ module Chemotion
             research_plan,
             displayed_in_list: true,
             detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: research_plan).detail_levels,
+            policy: ElementPolicy.new(current_user, research_plan),
           )
         end
 

--- a/app/api/chemotion/research_plan_api.rb
+++ b/app/api/chemotion/research_plan_api.rb
@@ -96,7 +96,8 @@ module Chemotion
         research_plan.collections << all_coll if all_coll && research_plan.collections.exclude?(all_coll)
 
         update_element_labels(research_plan, params[:user_labels], current_user.id)
-        present research_plan.reload, with: Entities::ResearchPlanEntity, root: :research_plan
+        @element_policy = ElementPolicy.new(current_user, research_plan)
+        present research_plan.reload, with: Entities::ResearchPlanEntity, root: :research_plan, policy: @element_policy
       end
 
       namespace :table_schemas do
@@ -154,8 +155,8 @@ module Chemotion
       route_param :id do
         get do
           research_plan = ResearchPlan.find(params[:id])
-          policy = ElementPolicy.new(current_user, research_plan)
-          error!('401 Unauthorized', 401) unless policy.read?
+          @element_policy = ElementPolicy.new(current_user, research_plan)
+          error!('401 Unauthorized', 401) unless @element_policy.read?
           # TODO: Refactor this massively ugly fallback to be in a more convenient place
           # (i.e. the entity or maybe return a null element from the model)
           if research_plan.research_plan_metadata.nil?
@@ -194,7 +195,8 @@ module Chemotion
       end
       route_param :id do
         before do
-          error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, ResearchPlan.find(params[:id])).update?
+          @element_policy = ElementPolicy.new(current_user, ResearchPlan.find(params[:id]))
+          error!('401 Unauthorized', 401) unless @element_policy.update?
         end
 
         put do
@@ -212,7 +214,11 @@ module Chemotion
           research_plan.reload
           detail_levels = ElementDetailLevelCalculator.new(user: current_user, element: research_plan).detail_levels
           {
-            research_plan: Entities::ResearchPlanEntity.represent(research_plan, detail_levels: detail_levels),
+            research_plan: Entities::ResearchPlanEntity.represent(
+              research_plan,
+              detail_levels: detail_levels,
+              policy: @element_policy,
+            ),
             attachments: Entities::AttachmentEntity.represent(research_plan.attachments),
             literatures: Entities::LiteratureEntity.represent(
               citation_for_elements(research_plan.id, 'ResearchPlan'),
@@ -335,7 +341,8 @@ module Chemotion
       end
       route_param :id do
         before do
-          error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, ResearchPlan.find(params[:id])).update?
+          @element_policy = ElementPolicy.new(current_user, ResearchPlan.find(params[:id]))
+          error!('401 Unauthorized', 401) unless @element_policy.update?
           error!('401 Unauthorized', 401) unless ElementPolicy.new(
             current_user, Wellplate.find(params[:wellplate_id])
           ).read?
@@ -354,6 +361,7 @@ module Chemotion
                 detail_levels: ElementDetailLevelCalculator.new(
                   user: current_user, element: research_plan,
                 ).detail_levels,
+                policy: @element_policy,
               ),
               attachments: Entities::AttachmentEntity.represent(research_plan.attachments),
             }
@@ -371,7 +379,8 @@ module Chemotion
       route_param :id do
         before do
           research_plan = ResearchPlan.find(params[:id])
-          error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, research_plan).update?
+          @element_policy = ElementPolicy.new(current_user, research_plan)
+          error!('401 Unauthorized', 401) unless @element_policy.update?
         end
 
         post 'import_table/:attachment_id' do
@@ -387,6 +396,7 @@ module Chemotion
                 detail_levels: ElementDetailLevelCalculator.new(
                   user: current_user, element: research_plan,
                 ).detail_levels,
+                policy: @element_policy,
               ),
               attachments: Entities::AttachmentEntity.represent(research_plan.attachments),
             }

--- a/app/api/chemotion/research_plan_api.rb
+++ b/app/api/chemotion/research_plan_api.rb
@@ -48,7 +48,6 @@ module Chemotion
             research_plan,
             displayed_in_list: true,
             detail_levels: detail_levels,
-            policy: ElementPolicy.new(current_user, research_plan),
           )
         end
 

--- a/app/api/chemotion/research_plan_api.rb
+++ b/app/api/chemotion/research_plan_api.rb
@@ -48,6 +48,7 @@ module Chemotion
             research_plan,
             displayed_in_list: true,
             detail_levels: detail_levels,
+            policy: ElementPolicy.new(current_user, research_plan),
           )
         end
 

--- a/app/api/chemotion/research_plan_metadata_api.rb
+++ b/app/api/chemotion/research_plan_metadata_api.rb
@@ -1,6 +1,16 @@
+# frozen_string_literal: true
+
 module Chemotion
   class ResearchPlanMetadataAPI < Grape::API
     include Grape::Kaminari
+
+    helpers do
+      def load_research_plan!
+        ResearchPlan.find(params[:research_plan_id])
+      rescue ActiveRecord::RecordNotFound
+        error!('404 Not Found', 404)
+      end
+    end
 
     namespace :research_plan_metadata do
       desc 'Get researchPlanMetadata by researchPlan id'
@@ -9,7 +19,14 @@ module Chemotion
       end
       route_param :research_plan_id do
         get do
-          present ResearchPlanMetadata.find_by(research_plan_id: params[:research_plan_id]), with: Entities::ResearchPlanMetadataEntity, root: 'research_plan_metadata'
+          research_plan = load_research_plan!
+          error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, research_plan).read?
+
+          present(
+            ResearchPlanMetadata.find_by(research_plan_id: research_plan.id),
+            with: Entities::ResearchPlanMetadataEntity,
+            root: 'research_plan_metadata',
+          )
         end
       end
 
@@ -33,9 +50,11 @@ module Chemotion
         optional :type, type: String, desc: 'research plan type'
       end
       post do
+        research_plan = load_research_plan!
+        error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, research_plan).update?
+
         attributes = declared(params, include_missing: false)
-        metadata = ResearchPlanMetadata.find_or_initialize_by(research_plan_id: attributes[:research_plan_id])
-        new_record = metadata.new_record?
+        metadata = ResearchPlanMetadata.find_or_initialize_by(research_plan_id: research_plan.id)
         metadata.update!(attributes)
         # DataCite.find_and_create_at_chemotion!(metadata.research_plan) if new_record
         present metadata.reload, with: Entities::ResearchPlanMetadataEntity, root: 'research_plan_metadata'

--- a/app/api/chemotion/research_plan_metadata_api.rb
+++ b/app/api/chemotion/research_plan_metadata_api.rb
@@ -56,7 +56,6 @@ module Chemotion
         attributes = declared(params, include_missing: false)
         metadata = ResearchPlanMetadata.find_or_initialize_by(research_plan_id: research_plan.id)
         metadata.update!(attributes)
-        # DataCite.find_and_create_at_chemotion!(metadata.research_plan) if new_record
         present metadata.reload, with: Entities::ResearchPlanMetadataEntity, root: 'research_plan_metadata'
       rescue ActiveRecord::RecordInvalid => e
         { error: e.message }

--- a/app/api/chemotion/screen_api.rb
+++ b/app/api/chemotion/screen_api.rb
@@ -88,6 +88,7 @@ module Chemotion
 
           post do
             screen = Screen.find(params[:id])
+            error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, screen).update?
             collection = current_user.collections.find(params[:collection_id])
             number = screen.research_plans.size + 1
             screen.research_plans << ResearchPlan.new(
@@ -98,6 +99,8 @@ module Chemotion
             )
 
             present screen, with: Entities::ScreenEntity, root: :screen, policy: ElementPolicy.new(current_user, screen)
+          rescue ActiveRecord::RecordNotFound
+            error!('404 Not Found', 404)
           end
         end
       end

--- a/app/api/chemotion/screen_api.rb
+++ b/app/api/chemotion/screen_api.rb
@@ -122,7 +122,8 @@ module Chemotion
       end
       route_param :id do
         before do
-          error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, Screen.find(params[:id])).update?
+          @element_policy = ElementPolicy.new(current_user, Screen.find(params[:id]))
+          error!('401 Unauthorized', 401) unless @element_policy.update?
         end
 
         put do
@@ -152,7 +153,7 @@ module Chemotion
             with: Entities::ScreenEntity,
             detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: screen).detail_levels,
             root: :screen,
-            policy: ElementPolicy.new(current_user, screen),
+            policy: @element_policy,
           )
         end
       end

--- a/app/api/chemotion/screen_api.rb
+++ b/app/api/chemotion/screen_api.rb
@@ -53,6 +53,7 @@ module Chemotion
             screen,
             detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: screen).detail_levels,
             displayed_in_list: true,
+            policy: ElementPolicy.new(current_user, screen),
           )
         end
 

--- a/app/api/chemotion/screen_api.rb
+++ b/app/api/chemotion/screen_api.rb
@@ -74,6 +74,7 @@ module Chemotion
             with: Entities::ScreenEntity,
             detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: screen).detail_levels,
             root: :screen,
+            policy: policy,
           )
         rescue ActiveRecord::RecordNotFound
           error!('404 Not Found', 404)
@@ -95,7 +96,7 @@ module Chemotion
               name: "New Research Plan #{number} for #{screen.name}",
             )
 
-            present screen, with: Entities::ScreenEntity, root: :screen
+            present screen, with: Entities::ScreenEntity, root: :screen, policy: ElementPolicy.new(current_user, screen)
           end
         end
       end
@@ -151,6 +152,7 @@ module Chemotion
             with: Entities::ScreenEntity,
             detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: screen).detail_levels,
             root: :screen,
+            policy: ElementPolicy.new(current_user, screen),
           )
         end
       end
@@ -208,7 +210,7 @@ module Chemotion
           ScreensWellplate.find_or_create_by(wellplate_id: id, screen_id: screen.id)
         end
 
-        present screen, with: Entities::ScreenEntity, root: :screen
+        present screen, with: Entities::ScreenEntity, root: :screen, policy: ElementPolicy.new(current_user, screen)
       end
     end
   end

--- a/app/api/chemotion/screen_api.rb
+++ b/app/api/chemotion/screen_api.rb
@@ -68,6 +68,7 @@ module Chemotion
             with: Entities::ScreenEntity,
             detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: screen).detail_levels,
             root: :screen,
+            policy: policy,
           )
         rescue ActiveRecord::RecordNotFound
           error!('404 Not Found', 404)
@@ -89,7 +90,7 @@ module Chemotion
               name: "New Research Plan #{number} for #{screen.name}",
             )
 
-            present screen, with: Entities::ScreenEntity, root: :screen
+            present screen, with: Entities::ScreenEntity, root: :screen, policy: ElementPolicy.new(current_user, screen)
           end
         end
       end
@@ -145,6 +146,7 @@ module Chemotion
             with: Entities::ScreenEntity,
             detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: screen).detail_levels,
             root: :screen,
+            policy: ElementPolicy.new(current_user, screen),
           )
         end
       end
@@ -202,7 +204,7 @@ module Chemotion
           ScreensWellplate.find_or_create_by(wellplate_id: id, screen_id: screen.id)
         end
 
-        present screen, with: Entities::ScreenEntity, root: :screen
+        present screen, with: Entities::ScreenEntity, root: :screen, policy: ElementPolicy.new(current_user, screen)
       end
     end
   end

--- a/app/api/chemotion/screen_api.rb
+++ b/app/api/chemotion/screen_api.rb
@@ -47,6 +47,7 @@ module Chemotion
             screen,
             detail_levels: detail_levels,
             displayed_in_list: true,
+            policy: ElementPolicy.new(current_user, screen),
           )
         end
 

--- a/app/api/chemotion/screen_api.rb
+++ b/app/api/chemotion/screen_api.rb
@@ -82,6 +82,7 @@ module Chemotion
 
           post do
             screen = Screen.find(params[:id])
+            error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, screen).update?
             collection = current_user.collections.find(params[:collection_id])
             number = screen.research_plans.size + 1
             screen.research_plans << ResearchPlan.new(
@@ -92,6 +93,8 @@ module Chemotion
             )
 
             present screen, with: Entities::ScreenEntity, root: :screen, policy: ElementPolicy.new(current_user, screen)
+          rescue ActiveRecord::RecordNotFound
+            error!('404 Not Found', 404)
           end
         end
       end

--- a/app/api/chemotion/screen_api.rb
+++ b/app/api/chemotion/screen_api.rb
@@ -47,7 +47,6 @@ module Chemotion
             screen,
             detail_levels: detail_levels,
             displayed_in_list: true,
-            policy: ElementPolicy.new(current_user, screen),
           )
         end
 

--- a/app/api/chemotion/screen_api.rb
+++ b/app/api/chemotion/screen_api.rb
@@ -116,7 +116,8 @@ module Chemotion
       end
       route_param :id do
         before do
-          error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, Screen.find(params[:id])).update?
+          @element_policy = ElementPolicy.new(current_user, Screen.find(params[:id]))
+          error!('401 Unauthorized', 401) unless @element_policy.update?
         end
 
         put do
@@ -146,7 +147,7 @@ module Chemotion
             with: Entities::ScreenEntity,
             detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: screen).detail_levels,
             root: :screen,
-            policy: ElementPolicy.new(current_user, screen),
+            policy: @element_policy,
           )
         end
       end

--- a/app/api/chemotion/search_api.rb
+++ b/app/api/chemotion/search_api.rb
@@ -207,12 +207,20 @@ module Chemotion
 
         paginated_wellplate_ids = Kaminari.paginate_array(wellplate_ids).page(page).per(page_size)
         serialized_wellplates = Wellplate.find(paginated_wellplate_ids).map do |wellplate|
-          Entities::WellplateEntity.represent(wellplate, displayed_in_list: true).serializable_hash
+          Entities::WellplateEntity.represent(
+            wellplate,
+            displayed_in_list: true,
+            policy: ElementPolicy.new(current_user, wellplate),
+          ).serializable_hash
         end
 
         paginated_screen_ids = Kaminari.paginate_array(screen_ids).page(page).per(page_size)
         serialized_screens = Screen.find(paginated_screen_ids).map do |screen|
-          Entities::ScreenEntity.represent(screen, displayed_in_list: true).serializable_hash
+          Entities::ScreenEntity.represent(
+            screen,
+            displayed_in_list: true,
+            policy: ElementPolicy.new(current_user, screen),
+          ).serializable_hash
         end
 
         paginated_cell_line_ids = Kaminari.paginate_array(cell_line_ids).page(page).per(page_size)
@@ -222,7 +230,11 @@ module Chemotion
 
         paginated_research_plan_ids = Kaminari.paginate_array(research_plan_ids).page(page).per(page_size)
         serialized_research_plans = ResearchPlan.find(paginated_research_plan_ids).map do |research_plan|
-          Entities::ResearchPlanEntity.represent(research_plan, displayed_in_list: true).serializable_hash
+          Entities::ResearchPlanEntity.represent(
+            research_plan,
+            displayed_in_list: true,
+            policy: ElementPolicy.new(current_user, research_plan),
+          ).serializable_hash
         end
 
         paginated_sequence_based_macromolecule_sample_ids =

--- a/app/api/chemotion/search_api.rb
+++ b/app/api/chemotion/search_api.rb
@@ -207,20 +207,12 @@ module Chemotion
 
         paginated_wellplate_ids = Kaminari.paginate_array(wellplate_ids).page(page).per(page_size)
         serialized_wellplates = Wellplate.find(paginated_wellplate_ids).map do |wellplate|
-          Entities::WellplateEntity.represent(
-            wellplate,
-            displayed_in_list: true,
-            policy: ElementPolicy.new(current_user, wellplate),
-          ).serializable_hash
+          Entities::WellplateEntity.represent(wellplate, displayed_in_list: true).serializable_hash
         end
 
         paginated_screen_ids = Kaminari.paginate_array(screen_ids).page(page).per(page_size)
         serialized_screens = Screen.find(paginated_screen_ids).map do |screen|
-          Entities::ScreenEntity.represent(
-            screen,
-            displayed_in_list: true,
-            policy: ElementPolicy.new(current_user, screen),
-          ).serializable_hash
+          Entities::ScreenEntity.represent(screen, displayed_in_list: true).serializable_hash
         end
 
         paginated_cell_line_ids = Kaminari.paginate_array(cell_line_ids).page(page).per(page_size)
@@ -230,11 +222,7 @@ module Chemotion
 
         paginated_research_plan_ids = Kaminari.paginate_array(research_plan_ids).page(page).per(page_size)
         serialized_research_plans = ResearchPlan.find(paginated_research_plan_ids).map do |research_plan|
-          Entities::ResearchPlanEntity.represent(
-            research_plan,
-            displayed_in_list: true,
-            policy: ElementPolicy.new(current_user, research_plan),
-          ).serializable_hash
+          Entities::ResearchPlanEntity.represent(research_plan, displayed_in_list: true).serializable_hash
         end
 
         paginated_sequence_based_macromolecule_sample_ids =

--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -112,7 +112,7 @@ module Chemotion
           error!('401 Unauthorized', 401) unless policy.read?
 
           {
-            wellplate: Entities::WellplateEntity.represent(wellplate, detail_levels: detail_levels),
+            wellplate: Entities::WellplateEntity.represent(wellplate, detail_levels: detail_levels, policy: policy),
             attachments: Entities::AttachmentEntity.represent(wellplate.attachments),
           }
         rescue ActiveRecord::RecordNotFound
@@ -147,7 +147,8 @@ module Chemotion
       end
       route_param :id do
         before do
-          error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, Wellplate.find(params[:id])).update?
+          @element_policy = ElementPolicy.new(current_user, Wellplate.find(params[:id]))
+          error!('401 Unauthorized', 401) unless @element_policy.update?
         end
 
         put do
@@ -166,6 +167,7 @@ module Chemotion
             with: Entities::WellplateEntity,
             detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: wellplate).detail_levels,
             root: :wellplate,
+            policy: @element_policy,
           )
           present wellplate.attachments, with: Entities::AttachmentEntity, root: :attachments
         end
@@ -202,6 +204,7 @@ module Chemotion
           with: Entities::WellplateEntity,
           detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: wellplate).detail_levels,
           root: :wellplate,
+          policy: ElementPolicy.new(current_user, wellplate),
         )
         present wellplate.attachments, with: Entities::AttachmentEntity, root: :attachments
       end
@@ -241,8 +244,8 @@ module Chemotion
         end
         route_param :wellplate_id do
           before do
-            error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user,
-                                                                     Wellplate.find(params[:wellplate_id])).update?
+            @element_policy = ElementPolicy.new(current_user, Wellplate.find(params[:wellplate_id]))
+            error!('401 Unauthorized', 401) unless @element_policy.update?
           end
 
           put do
@@ -258,6 +261,7 @@ module Chemotion
                   wellplate,
                   detail_levels: ElementDetailLevelCalculator.new(user: current_user,
                                                                   element: wellplate).detail_levels,
+                  policy: @element_policy,
                 ),
                 attachments: Entities::AttachmentEntity.represent(wellplate.attachments),
                 molarity_discarded: import.molarity_discarded,

--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -46,7 +46,15 @@ module Chemotion
                        .for_user(current_user.id)
           error!('401 Unauthorized', 401) unless ElementsPolicy.new(current_user, wellplates).read_all?
 
-          present wellplates, with: Entities::WellplateEntity, root: :wellplates, displayed_in_list: true
+          {
+            wellplates: wellplates.map do |wellplate|
+              Entities::WellplateEntity.represent(
+                wellplate,
+                displayed_in_list: true,
+                policy: ElementPolicy.new(current_user, wellplate),
+              )
+            end,
+          }
         end
       end
 
@@ -94,6 +102,7 @@ module Chemotion
             wellplate,
             displayed_in_list: true,
             detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: wellplate).detail_levels,
+            policy: ElementPolicy.new(current_user, wellplate),
           )
         end
 

--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -107,7 +107,7 @@ module Chemotion
           error!('401 Unauthorized', 401) unless policy.read?
 
           {
-            wellplate: Entities::WellplateEntity.represent(wellplate, detail_levels: detail_levels),
+            wellplate: Entities::WellplateEntity.represent(wellplate, detail_levels: detail_levels, policy: policy),
             attachments: Entities::AttachmentEntity.represent(wellplate.attachments),
           }
         rescue ActiveRecord::RecordNotFound
@@ -142,7 +142,8 @@ module Chemotion
       end
       route_param :id do
         before do
-          error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, Wellplate.find(params[:id])).update?
+          @element_policy = ElementPolicy.new(current_user, Wellplate.find(params[:id]))
+          error!('401 Unauthorized', 401) unless @element_policy.update?
         end
 
         put do
@@ -161,6 +162,7 @@ module Chemotion
             with: Entities::WellplateEntity,
             detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: wellplate).detail_levels,
             root: :wellplate,
+            policy: @element_policy,
           )
           present wellplate.attachments, with: Entities::AttachmentEntity, root: :attachments
         end
@@ -197,6 +199,7 @@ module Chemotion
           with: Entities::WellplateEntity,
           detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: wellplate).detail_levels,
           root: :wellplate,
+          policy: ElementPolicy.new(current_user, wellplate),
         )
         present wellplate.attachments, with: Entities::AttachmentEntity, root: :attachments
       end
@@ -236,8 +239,8 @@ module Chemotion
         end
         route_param :wellplate_id do
           before do
-            error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user,
-                                                                     Wellplate.find(params[:wellplate_id])).update?
+            @element_policy = ElementPolicy.new(current_user, Wellplate.find(params[:wellplate_id]))
+            error!('401 Unauthorized', 401) unless @element_policy.update?
           end
 
           put do
@@ -253,6 +256,7 @@ module Chemotion
                   wellplate,
                   detail_levels: ElementDetailLevelCalculator.new(user: current_user,
                                                                   element: wellplate).detail_levels,
+                  policy: @element_policy,
                 ),
                 attachments: Entities::AttachmentEntity.represent(wellplate.attachments),
                 molarity_discarded: import.molarity_discarded,

--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -46,7 +46,15 @@ module Chemotion
                        .for_user(current_user.id)
           error!('401 Unauthorized', 401) unless ElementsPolicy.new(current_user, wellplates).read_all?
 
-          present wellplates, with: Entities::WellplateEntity, root: :wellplates, displayed_in_list: true
+          {
+            wellplates: wellplates.map do |wellplate|
+              Entities::WellplateEntity.represent(
+                wellplate,
+                displayed_in_list: true,
+                policy: ElementPolicy.new(current_user, wellplate),
+              )
+            end,
+          }
         end
       end
 
@@ -89,6 +97,7 @@ module Chemotion
             wellplate,
             displayed_in_list: true,
             detail_levels: detail_levels,
+            policy: ElementPolicy.new(current_user, wellplate),
           )
         end
 

--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -46,15 +46,7 @@ module Chemotion
                        .for_user(current_user.id)
           error!('401 Unauthorized', 401) unless ElementsPolicy.new(current_user, wellplates).read_all?
 
-          {
-            wellplates: wellplates.map do |wellplate|
-              Entities::WellplateEntity.represent(
-                wellplate,
-                displayed_in_list: true,
-                policy: ElementPolicy.new(current_user, wellplate),
-              )
-            end,
-          }
+          present wellplates, with: Entities::WellplateEntity, root: :wellplates, displayed_in_list: true
         end
       end
 
@@ -97,7 +89,6 @@ module Chemotion
             wellplate,
             displayed_in_list: true,
             detail_levels: detail_levels,
-            policy: ElementPolicy.new(current_user, wellplate),
           )
         end
 

--- a/app/api/entities/application_entity.rb
+++ b/app/api/entities/application_entity.rb
@@ -82,8 +82,23 @@ module Entities
       minimal_default_levels.merge(options[:detail_levels])
     end
 
+    # Prefer the provided policy when it already targets this object. Nested grape-entity
+    # representations inherit the parent options hash, so a Screen ElementPolicy would otherwise
+    # incorrectly answer can_update/can_copy for nested research plans and wellplates.
+    def element_policy
+      policy = options[:policy]
+      return policy unless policy.is_a?(ElementPolicy)
+      return policy if policy.record == object
+
+      ElementPolicy.new(policy.user, object)
+    end
+
+    def can_update
+      element_policy.try(:update?) || false
+    end
+
     def can_copy
-      options[:policy].try(:copy?) || false
+      element_policy.try(:copy?) || false
     end
 
     class MissingCurrentUserError < StandardError

--- a/app/api/entities/application_entity.rb
+++ b/app/api/entities/application_entity.rb
@@ -82,15 +82,8 @@ module Entities
       minimal_default_levels.merge(options[:detail_levels])
     end
 
-    # Prefer the provided policy when it already targets this object. Nested grape-entity
-    # representations inherit the parent options hash, so a Screen ElementPolicy would otherwise
-    # incorrectly answer can_update/can_copy for nested research plans and wellplates.
     def element_policy
-      policy = options[:policy]
-      return policy unless policy.is_a?(ElementPolicy)
-      return policy if policy.record == object
-
-      ElementPolicy.new(policy.user, object)
+      options[:policy]
     end
 
     def can_update

--- a/app/api/entities/nested_element_policy.rb
+++ b/app/api/entities/nested_element_policy.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Entities
+  # Nested grape-entity representations inherit the parent options hash, including
+  # +policy+. For research plans, screens, and wellplates this PR needs each nested
+  # element to answer +can_update+/+can_copy+ from its own ElementPolicy rather than
+  # the parent's. Other ApplicationEntity subclasses (e.g. SampleEntity nested under
+  # Reaction/Wellplate) keep the pre-existing parent-policy inheritance.
+  module NestedElementPolicy
+    extend ActiveSupport::Concern
+
+    private
+
+    def element_policy
+      policy = options[:policy]
+      return policy unless policy.is_a?(ElementPolicy)
+      return policy if policy.record == object
+
+      ElementPolicy.new(policy.user, object)
+    end
+  end
+end

--- a/app/api/entities/reaction_entity.rb
+++ b/app/api/entities/reaction_entity.rb
@@ -65,10 +65,6 @@ module Entities
 
     private
 
-    def can_update
-      options[:policy].try(:update?) || false
-    end
-
     def code_log
       displayed_in_list? ? nil : object.code_log
     end

--- a/app/api/entities/research_plan_entity.rb
+++ b/app/api/entities/research_plan_entity.rb
@@ -31,10 +31,6 @@ module Entities
 
     private
 
-    def can_update
-      options[:policy].try(:update?) || false
-    end
-
     def attachment_count
       object.attachments.size
     end

--- a/app/api/entities/research_plan_entity.rb
+++ b/app/api/entities/research_plan_entity.rb
@@ -5,6 +5,7 @@ module Entities
     # rubocop:disable Layout/ExtraSpacing
     with_options(anonymize_below: 0) do
       expose! :can_copy,                                     unless: :displayed_in_list
+      expose! :can_update,                                   unless: :displayed_in_list
       expose! :body
       expose! :container,                                    using: 'Entities::ContainerEntity'
       expose! :id
@@ -29,6 +30,10 @@ module Entities
     expose_timestamps
 
     private
+
+    def can_update
+      options[:policy].try(:update?) || false
+    end
 
     def attachment_count
       object.attachments.size

--- a/app/api/entities/research_plan_entity.rb
+++ b/app/api/entities/research_plan_entity.rb
@@ -2,10 +2,12 @@
 
 module Entities
   class ResearchPlanEntity < ApplicationEntity
+    include NestedElementPolicy
+
     # rubocop:disable Layout/ExtraSpacing
     with_options(anonymize_below: 0) do
       expose! :can_copy,                                     unless: :displayed_in_list
-      expose! :can_update,                                   unless: :displayed_in_list
+      expose! :can_update
       expose! :body
       expose! :container,                                    using: 'Entities::ContainerEntity'
       expose! :id

--- a/app/api/entities/research_plan_entity.rb
+++ b/app/api/entities/research_plan_entity.rb
@@ -7,7 +7,7 @@ module Entities
     # rubocop:disable Layout/ExtraSpacing
     with_options(anonymize_below: 0) do
       expose! :can_copy,                                     unless: :displayed_in_list
-      expose! :can_update
+      expose! :can_update,                                   unless: :displayed_in_list
       expose! :body
       expose! :container,                                    using: 'Entities::ContainerEntity'
       expose! :id

--- a/app/api/entities/sample_entity.rb
+++ b/app/api/entities/sample_entity.rb
@@ -88,12 +88,8 @@ module Entities
       object.residues.any?
     end
 
-    def can_update
-      options[:policy].try(:update?) || false
-    end
-
     def can_publish
-      options[:policy].try(:destroy?) || false
+      element_policy.try(:destroy?) || false
     end
 
     def children_count

--- a/app/api/entities/screen_entity.rb
+++ b/app/api/entities/screen_entity.rb
@@ -4,6 +4,7 @@ module Entities
   class ScreenEntity < ApplicationEntity
     # rubocop:disable Layout/ExtraSpacing
     with_options(anonymize_below: 0) do
+      expose! :can_update, unless: :displayed_in_list
       expose! :id
       expose! :type
       expose! :name
@@ -31,6 +32,10 @@ module Entities
     expose_timestamps
 
     private
+
+    def can_update
+      options[:policy].try(:update?) || false
+    end
 
     def code_log
       displayed_in_list? ? nil : object.code_log

--- a/app/api/entities/screen_entity.rb
+++ b/app/api/entities/screen_entity.rb
@@ -33,10 +33,6 @@ module Entities
 
     private
 
-    def can_update
-      options[:policy].try(:update?) || false
-    end
-
     def code_log
       displayed_in_list? ? nil : object.code_log
     end

--- a/app/api/entities/screen_entity.rb
+++ b/app/api/entities/screen_entity.rb
@@ -2,9 +2,11 @@
 
 module Entities
   class ScreenEntity < ApplicationEntity
+    include NestedElementPolicy
+
     # rubocop:disable Layout/ExtraSpacing
     with_options(anonymize_below: 0) do
-      expose! :can_update, unless: :displayed_in_list
+      expose! :can_update
       expose! :id
       expose! :type
       expose! :name

--- a/app/api/entities/screen_entity.rb
+++ b/app/api/entities/screen_entity.rb
@@ -6,7 +6,7 @@ module Entities
 
     # rubocop:disable Layout/ExtraSpacing
     with_options(anonymize_below: 0) do
-      expose! :can_update
+      expose! :can_update,                          unless: :displayed_in_list
       expose! :id
       expose! :type
       expose! :name

--- a/app/api/entities/sequence_based_macromolecule_sample_entity.rb
+++ b/app/api/entities/sequence_based_macromolecule_sample_entity.rb
@@ -71,12 +71,8 @@ module Entities
     end
     # rubocop:enable Naming/PredicateMethod
 
-    def can_update
-      options[:policy].try(:update?) || false
-    end
-
     def can_publish
-      options[:policy].try(:destroy?) || false
+      element_policy.try(:destroy?) || false
     end
 
     def errors

--- a/app/api/entities/wellplate_entity.rb
+++ b/app/api/entities/wellplate_entity.rb
@@ -2,10 +2,12 @@
 
 module Entities
   class WellplateEntity < ApplicationEntity
+    include NestedElementPolicy
+
     # rubocop:disable Layout/ExtraSpacing
     # Level 0 attributes and relations
     with_options(anonymize_below: 0) do
-      expose! :can_update,                           unless: :displayed_in_list
+      expose! :can_update
       expose! :id
       expose! :is_restricted
       expose! :height

--- a/app/api/entities/wellplate_entity.rb
+++ b/app/api/entities/wellplate_entity.rb
@@ -5,6 +5,7 @@ module Entities
     # rubocop:disable Layout/ExtraSpacing
     # Level 0 attributes and relations
     with_options(anonymize_below: 0) do
+      expose! :can_update,                           unless: :displayed_in_list
       expose! :id
       expose! :is_restricted
       expose! :height
@@ -30,6 +31,10 @@ module Entities
     expose_timestamps
 
     private
+
+    def can_update
+      options[:policy].try(:update?) || false
+    end
 
     def is_restricted # rubocop:disable Naming/PredicateName
       detail_levels[Wellplate] < 10

--- a/app/api/entities/wellplate_entity.rb
+++ b/app/api/entities/wellplate_entity.rb
@@ -32,10 +32,6 @@ module Entities
 
     private
 
-    def can_update
-      options[:policy].try(:update?) || false
-    end
-
     def is_restricted # rubocop:disable Naming/PredicateName
       detail_levels[Wellplate] < 10
     end

--- a/app/api/entities/wellplate_entity.rb
+++ b/app/api/entities/wellplate_entity.rb
@@ -7,7 +7,7 @@ module Entities
     # rubocop:disable Layout/ExtraSpacing
     # Level 0 attributes and relations
     with_options(anonymize_below: 0) do
-      expose! :can_update
+      expose! :can_update,                            unless: :displayed_in_list
       expose! :id
       expose! :is_restricted
       expose! :height

--- a/app/javascript/src/apps/mydb/elements/details/ElementDetailCard.js
+++ b/app/javascript/src/apps/mydb/elements/details/ElementDetailCard.js
@@ -127,13 +127,15 @@ export default function ElementDetailCard({
     <ConfirmationOverlay
       overlayTarget={closeOverlayTarget}
       placement={closeOverlayPlacement}
-      warningText="You have unsaved changes. Save before closing?"
+      warningText={saveDisabled
+        ? 'You have unsaved changes that cannot be saved. Discard before closing?'
+        : 'You have unsaved changes. Save before closing?'}
       destructiveAction={() => handleClose(true)}
       destructiveActionLabel="Discard"
       hideAction={() => setCloseOverlayTarget(null)}
       hideActionLabel="Cancel"
-      primaryAction={handleSaveClose}
-      primaryActionLabel="Save and Close"
+      primaryAction={saveDisabled ? undefined : handleSaveClose}
+      primaryActionLabel={saveDisabled ? undefined : 'Save and Close'}
     />
   );
 

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
@@ -173,7 +173,7 @@ export default class ResearchPlanDetails extends Component {
 
   // handle attachment actions
   handleAttachmentDrop(files) {
-    if (!this.state.researchPlan.can_update) { return; }
+    if (this.state.researchPlan.isReadOnly) { return; }
     this.setState((prevState) => {
       const { researchPlan } = prevState;
       const newAttachments = files.map((file) => Attachment.fromFile(file));
@@ -186,7 +186,7 @@ export default class ResearchPlanDetails extends Component {
 
   handleAttachmentDelete(attachment) {
     const { researchPlan } = this.state;
-    if (!researchPlan.can_update) { return; }
+    if (researchPlan.isReadOnly) { return; }
     const index = researchPlan.attachments.indexOf(attachment);
     researchPlan.changed = true;
     researchPlan.attachments[index].is_deleted = true;
@@ -195,7 +195,7 @@ export default class ResearchPlanDetails extends Component {
 
   handleAttachmentUndoDelete(attachment) {
     const { researchPlan } = this.state;
-    if (!researchPlan.can_update) { return; }
+    if (researchPlan.isReadOnly) { return; }
     const index = researchPlan.attachments.indexOf(attachment);
     researchPlan.attachments[index].is_deleted = false;
     this.setState({ researchPlan });
@@ -203,7 +203,7 @@ export default class ResearchPlanDetails extends Component {
 
   handleAttachmentEdit(attachment) {
     const { researchPlan } = this.state;
-    if (!researchPlan.can_update) { return; }
+    if (researchPlan.isReadOnly) { return; }
     researchPlan.changed = true;
     // update only this attachment
     researchPlan.attachments.map((currentAttachment) => {
@@ -350,7 +350,7 @@ export default class ResearchPlanDetails extends Component {
     const {
       name, body, changed, attachments
     } = researchPlan;
-    const canUpdate = researchPlan.can_update;
+    const canUpdate = !researchPlan.isReadOnly;
     const edit = researchPlan.mode === 'edit' && canUpdate;
 
     const editTooltip = (<Tooltip id="edit-tooltip">Switch to edit mode</Tooltip>);
@@ -428,7 +428,7 @@ export default class ResearchPlanDetails extends Component {
         handleSubmit={this.handleSubmit}
         handleResearchPlanChange={this.handleResearchPlanChange}
         researchPlan={researchPlan}
-        readOnly={!researchPlan.can_update}
+        readOnly={researchPlan.isReadOnly}
       />
     );
   }
@@ -443,7 +443,7 @@ export default class ResearchPlanDetails extends Component {
         onUndoDelete={this.handleAttachmentUndoDelete.bind(this)}
         onAttachmentImportComplete={this.handleAttachmentImportComplete.bind(this)}
         onEdit={this.handleAttachmentEdit.bind(this)}
-        readOnly={!researchPlan.can_update}
+        readOnly={researchPlan.isReadOnly}
       />
     );
   } /* eslint-enable */
@@ -463,7 +463,7 @@ export default class ResearchPlanDetails extends Component {
             element={researchPlan}
             fnCb={this.handleResearchPlanChange}
           />
-          <PrivateNoteElement element={researchPlan} disabled={!researchPlan.can_update} />
+          <PrivateNoteElement element={researchPlan} disabled={researchPlan.isReadOnly} />
         </Tab>
       ),
       analyses: (
@@ -501,7 +501,7 @@ export default class ResearchPlanDetails extends Component {
             dropWellplate={(wellplate) => this.dropWellplate(wellplate)}
             deleteWellplate={(wellplate) => this.deleteWellplate(wellplate)}
             importWellplate={(wellplate) => this.importWellplate(wellplate)}
-            readOnly={!researchPlan.can_update}
+            readOnly={researchPlan.isReadOnly}
           />
         </Tab>
       ),
@@ -512,7 +512,7 @@ export default class ResearchPlanDetails extends Component {
           }
           <ResearchPlanMetadata
             researchPlan={researchPlan}
-            readOnly={!researchPlan.can_update}
+            readOnly={researchPlan.isReadOnly}
           />
         </Tab>
       ),
@@ -547,7 +547,7 @@ export default class ResearchPlanDetails extends Component {
       <ElementDetailCard
         element={researchPlan}
         isPendingToSave={researchPlan.isPendingToSave}
-        saveDisabled={!researchPlan.can_update}
+        saveDisabled={researchPlan.isReadOnly}
         title={researchPlan.name}
         titleTooltip={formatTimeStampsOfElement(researchPlan || {})}
         onSave={() => this.handleSubmit()}

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
@@ -349,7 +349,8 @@ export default class ResearchPlanDetails extends Component {
     const {
       name, body, changed, attachments
     } = researchPlan;
-    const edit = researchPlan.mode === 'edit';
+    const canUpdate = researchPlan.can_update;
+    const edit = researchPlan.mode === 'edit' && canUpdate;
 
     const editTooltip = (<Tooltip id="edit-tooltip">Switch to edit mode</Tooltip>);
     const viewTooltip = (<Tooltip id="view-tooltip">Switch to view mode</Tooltip>);
@@ -359,6 +360,7 @@ export default class ResearchPlanDetails extends Component {
         <OverlayTrigger placement="top" overlay={editTooltip}>
           <ButtonGroupToggleButton
             active={researchPlan.mode === 'edit'}
+            disabled={!canUpdate}
             onClick={() => this.handleSwitchMode('edit')}
           >
             <i className="fa fa-pencil" />
@@ -425,7 +427,7 @@ export default class ResearchPlanDetails extends Component {
         handleSubmit={this.handleSubmit}
         handleResearchPlanChange={this.handleResearchPlanChange}
         researchPlan={researchPlan}
-        readOnly={false}
+        readOnly={!researchPlan.can_update}
       />
     );
   }
@@ -440,7 +442,7 @@ export default class ResearchPlanDetails extends Component {
         onUndoDelete={this.handleAttachmentUndoDelete.bind(this)}
         onAttachmentImportComplete={this.handleAttachmentImportComplete.bind(this)}
         onEdit={this.handleAttachmentEdit.bind(this)}
-        readOnly={false}
+        readOnly={!researchPlan.can_update}
       />
     );
   } /* eslint-enable */
@@ -460,7 +462,7 @@ export default class ResearchPlanDetails extends Component {
             element={researchPlan}
             fnCb={this.handleResearchPlanChange}
           />
-          <PrivateNoteElement element={researchPlan} disabled={researchPlan.can_update} />
+          <PrivateNoteElement element={researchPlan} disabled={!researchPlan.can_update} />
         </Tab>
       ),
       analyses: (
@@ -540,6 +542,7 @@ export default class ResearchPlanDetails extends Component {
       <ElementDetailCard
         element={researchPlan}
         isPendingToSave={researchPlan.isPendingToSave}
+        saveDisabled={!researchPlan.can_update}
         title={researchPlan.name}
         titleTooltip={formatTimeStampsOfElement(researchPlan || {})}
         onSave={() => this.handleSubmit()}

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/ResearchPlanDetails.js
@@ -173,21 +173,20 @@ export default class ResearchPlanDetails extends Component {
 
   // handle attachment actions
   handleAttachmentDrop(files) {
+    if (!this.state.researchPlan.can_update) { return; }
     this.setState((prevState) => {
+      const { researchPlan } = prevState;
       const newAttachments = files.map((file) => Attachment.fromFile(file));
-      const updatedAttachments = prevState.researchPlan.attachments.concat(newAttachments);
-      const updatedResearchPlan = new ResearchPlan({
-        ...prevState.researchPlan,
-        attachments: updatedAttachments,
-        changed: true
-      });
+      researchPlan.attachments = researchPlan.attachments.concat(newAttachments);
+      researchPlan.changed = true;
 
-      return { researchPlan: updatedResearchPlan };
+      return { researchPlan };
     });
   }
 
   handleAttachmentDelete(attachment) {
     const { researchPlan } = this.state;
+    if (!researchPlan.can_update) { return; }
     const index = researchPlan.attachments.indexOf(attachment);
     researchPlan.changed = true;
     researchPlan.attachments[index].is_deleted = true;
@@ -196,6 +195,7 @@ export default class ResearchPlanDetails extends Component {
 
   handleAttachmentUndoDelete(attachment) {
     const { researchPlan } = this.state;
+    if (!researchPlan.can_update) { return; }
     const index = researchPlan.attachments.indexOf(attachment);
     researchPlan.attachments[index].is_deleted = false;
     this.setState({ researchPlan });
@@ -203,6 +203,7 @@ export default class ResearchPlanDetails extends Component {
 
   handleAttachmentEdit(attachment) {
     const { researchPlan } = this.state;
+    if (!researchPlan.can_update) { return; }
     researchPlan.changed = true;
     // update only this attachment
     researchPlan.attachments.map((currentAttachment) => {
@@ -500,6 +501,7 @@ export default class ResearchPlanDetails extends Component {
             dropWellplate={(wellplate) => this.dropWellplate(wellplate)}
             deleteWellplate={(wellplate) => this.deleteWellplate(wellplate)}
             importWellplate={(wellplate) => this.importWellplate(wellplate)}
+            readOnly={!researchPlan.can_update}
           />
         </Tab>
       ),
@@ -508,7 +510,10 @@ export default class ResearchPlanDetails extends Component {
           {
             !researchPlan.isNew && <CommentSection section="research_plan_metadata" element={researchPlan} />
           }
-          <ResearchPlanMetadata researchPlan={researchPlan} />
+          <ResearchPlanMetadata
+            researchPlan={researchPlan}
+            readOnly={!researchPlan.can_update}
+          />
         </Tab>
       ),
       history: (

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/ResearchPlanMetadata.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/ResearchPlanMetadata.js
@@ -41,6 +41,8 @@ export default class ResearchPlanMetadata extends Component {
   }
 
   handleFieldChange(key, value) {
+    if (this.props.readOnly) { return; }
+
     const { researchPlanMetadata } = this.state;
 
     this.setState({
@@ -52,6 +54,8 @@ export default class ResearchPlanMetadata extends Component {
   }
 
   saveResearchPlanMetadata() {
+    if (this.props.readOnly) { return; }
+
     const { researchPlan } = this.props;
     const { researchPlanMetadata } = this.state;
 
@@ -82,6 +86,8 @@ export default class ResearchPlanMetadata extends Component {
   }
 
   updateResearchPlanMetadataDataCiteState(value) {
+    if (this.props.readOnly) { return; }
+
     this.setState(state => {
       const researchPlanMetadata = state.researchPlanMetadata;
       researchPlanMetadata.data_cite_state = value;
@@ -108,6 +114,8 @@ export default class ResearchPlanMetadata extends Component {
   }
 
   addResearchPlanMetadataArrayItem(type) {
+    if (this.props.readOnly) { return; }
+
     this.setState(state => {
       const newItem = this.newItemByType(type);
 
@@ -124,6 +132,8 @@ export default class ResearchPlanMetadata extends Component {
   }
 
   removeResearchPlanMetadataArrayItem(type, index) {
+    if (this.props.readOnly) { return; }
+
     this.setState(state => {
       const researchPlanMetadata = state.researchPlanMetadata;
       const newCollection = [...researchPlanMetadata[type]];
@@ -138,6 +148,8 @@ export default class ResearchPlanMetadata extends Component {
   }
 
   updateResearchPlanMetadataArrayItem(type, index, fieldname, value) {
+    if (this.props.readOnly) { return; }
+
     this.setState(state => {
       const researchPlanMetadata = state.researchPlanMetadata;
       researchPlanMetadata[type][index][fieldname] = value;
@@ -146,6 +158,8 @@ export default class ResearchPlanMetadata extends Component {
   }
 
   updateResearchPlanMetadataGeoLocation(index, fieldname, value) {
+    if (this.props.readOnly) { return; }
+
     this.setState(state => {
       const researchPlanMetadata = state.researchPlanMetadata;
       researchPlanMetadata.geo_location[index]['geoLocationPoint'][fieldname] = value;
@@ -155,8 +169,10 @@ export default class ResearchPlanMetadata extends Component {
 
   render() {
     const { researchPlanMetadata } = this.state;
+    const { readOnly } = this.props;
     return (
       <div className="px-1 py-2">
+        <fieldset disabled={readOnly}>
         <Form>
           <Form.Group className="mb-2" controlId="title">
             <Form.Label>Title</Form.Label>
@@ -494,11 +510,14 @@ export default class ResearchPlanMetadata extends Component {
           ))}
 
           <div className="d-flex align-items-center mt-5 mb-0">
-          <Button className="ms-auto" variant="success" size="md" onClick={() => this.saveResearchPlanMetadata()}>
-            Save Metadata
-          </Button>
+          {!readOnly && (
+            <Button className="ms-auto" variant="success" size="md" onClick={() => this.saveResearchPlanMetadata()}>
+              Save Metadata
+            </Button>
+          )}
           </div>
         </Form>
+        </fieldset>
       </div>
     );
   }
@@ -506,5 +525,10 @@ export default class ResearchPlanMetadata extends Component {
 
 ResearchPlanMetadata.propTypes = {
   researchPlan: PropTypes.object.isRequired,
+  readOnly: PropTypes.bool,
+};
+
+ResearchPlanMetadata.defaultProps = {
+  readOnly: false,
 };
 

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
@@ -201,7 +201,7 @@ class ResearchPlanDetailsAttachments extends Component {
     const {
       filteredAttachments, sortDirection,
     } = this.state;
-    const { researchPlan, onEdit } = this.props;
+    const { researchPlan, onEdit, readOnly } = this.props;
     const { currentUser } = UserStore.getState();
 
     let combinedAttachments = filteredAttachments;
@@ -213,26 +213,30 @@ class ResearchPlanDetailsAttachments extends Component {
     const { onUndoDelete, attachments } = this.props;
     const { thirdPartyApps } = this;
 
+    const showToolbar = !readOnly || attachments.length > 0;
+
     return (
-      <div className="p-3 border-rounded">
+      <div className={showToolbar ? 'p-3 border-rounded' : 'm-4'}>
         {this.renderImageEditModal()}
-        <div className="d-flex justify-content-between align-items-center gap-4 mb-4">
-          <div className="flex-grow-1">
-            {customDropzone(this.props.onDrop)}
-          </div>
-          {attachments.length > 0
-            && sortingAndFilteringUI(
-              sortDirection,
-              this.handleSortChange,
-              this.toggleSortDirection,
-              this.handleFilterChange,
-              true
+        {showToolbar && (
+          <div className="d-flex justify-content-between align-items-center gap-4 mb-4">
+            {!readOnly && (
+              <div className="flex-grow-1">
+                {customDropzone(this.props.onDrop)}
+              </div>
             )}
-        </div>
-        {combinedAttachments.length === 0 ? (
-          <div className="text-center text-gray-500 fs-5">
-            There are currently no attachments.
+            {attachments.length > 0
+              && sortingAndFilteringUI(
+                sortDirection,
+                this.handleSortChange,
+                this.toggleSortDirection,
+                this.handleFilterChange,
+                true
+              )}
           </div>
+        )}
+        {combinedAttachments.length === 0 ? (
+          <span>There are currently no attachments.</span>
         ) : (
           <>
             {combinedAttachments.map((attachment) => (
@@ -262,43 +266,51 @@ class ResearchPlanDetailsAttachments extends Component {
                 </div>
                 <div className="attachment-row-actions d-flex justify-content-end align-items-center gap-1">
                   {attachment.is_deleted ? (
-                    <Button
-                      size="sm"
-                      variant="danger"
-                      className="attachment-button-size"
-                      onClick={() => onUndoDelete(attachment)}
-                    >
-                      <i className="fa fa-undo" aria-hidden="true" />
-                    </Button>
+                    !readOnly && (
+                      <Button
+                        size="sm"
+                        variant="danger"
+                        className="attachment-button-size"
+                        onClick={() => onUndoDelete(attachment)}
+                      >
+                        <i className="fa fa-undo" aria-hidden="true" />
+                      </Button>
+                    )
                   ) : (
                     <>
                       <ButtonToolbar>
                         {downloadButton(attachment)}
                         <ThirdPartyAppButton attachment={attachment} options={thirdPartyApps} />
-                        <EditButton attachment={attachment} onChange={onEdit} />
-                        {annotateButton(attachment, () => {
-                          this.setState({
-                            imageEditModalShown: true,
-                            chosenAttachment: attachment,
-                          });
-                        })}
-                        {importButton(
-                          attachment,
-                          this.state.showImportConfirm,
-                          this.props.researchPlan.changed,
-                          this.showImportConfirm,
-                          this.hideImportConfirm,
-                          this.confirmAttachmentImport
+                        {!readOnly && (
+                          <>
+                            <EditButton attachment={attachment} onChange={onEdit} />
+                            {annotateButton(attachment, () => {
+                              this.setState({
+                                imageEditModalShown: true,
+                                chosenAttachment: attachment,
+                              });
+                            })}
+                            {importButton(
+                              attachment,
+                              this.state.showImportConfirm,
+                              this.props.researchPlan.changed,
+                              this.showImportConfirm,
+                              this.hideImportConfirm,
+                              this.confirmAttachmentImport
+                            )}
+                          </>
                         )}
                       </ButtonToolbar>
-                      <div className="ms-2">
-                        {removeButton(
-                          attachment,
-                          this.props.onDelete,
-                          this.props.readOnly || this.isAttachmentInBody(attachment),
-                          this.getDeleteButtonTooltip(attachment)
-                        )}
-                      </div>
+                      {!readOnly && (
+                        <div className="ms-2">
+                          {removeButton(
+                            attachment,
+                            this.props.onDelete,
+                            this.isAttachmentInBody(attachment),
+                            this.getDeleteButtonTooltip(attachment)
+                          )}
+                        </div>
+                      )}
                     </>
                   )}
                 </div>
@@ -312,11 +324,13 @@ class ResearchPlanDetailsAttachments extends Component {
                 )}
               </div>
             ))}
-            <Alert variant="warning" show={UserStore.isUserQuotaExceeded(filteredAttachments)}>
-              Uploading attachments will fail; User quota
-              {currentUser !== null ? ` (${currentUser.allocated_space / 1024 / 1024} MB) ` : ' '}
-              will be exceeded.
-            </Alert>
+            {!readOnly && (
+              <Alert variant="warning" show={UserStore.isUserQuotaExceeded(filteredAttachments)}>
+                Uploading attachments will fail; User quota
+                {currentUser !== null ? ` (${currentUser.allocated_space / 1024 / 1024} MB) ` : ' '}
+                will be exceeded.
+              </Alert>
+            )}
           </>
         )}
       </div>

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/attachmentsTab/ResearchPlanDetailsAttachments.js
@@ -236,7 +236,7 @@ class ResearchPlanDetailsAttachments extends Component {
           </div>
         )}
         {combinedAttachments.length === 0 ? (
-          <span>There are currently no attachments.</span>
+          <p className="m-0">There are currently no attachments.</p>
         ) : (
           <>
             {combinedAttachments.map((attachment) => (

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsField.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/researchPlanTab/ResearchPlanDetailsField.js
@@ -129,7 +129,7 @@ export default class ResearchPlanDetailsField extends Component {
         </Col>
       );
 
-      if (field.type === 'richtext') {
+      if (field.type === 'richtext' && copyableFields) {
         copyToMetadataButton = (
           <ButtonGroup>
             <Dropdown as={ButtonGroup}>

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/wellplatesTab/EmbeddedWellplate.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/wellplatesTab/EmbeddedWellplate.js
@@ -44,6 +44,8 @@ export default class EmbeddedWellplate extends Component {
   }
 
   renderImportWellplateButton() {
+    if (this.props.readOnly) { return null; }
+
     const importDisabled = this.props.researchPlan.changed;
     const show = this.state.showImportConfirm;
     const tooltipText = importDisabled
@@ -203,7 +205,7 @@ export default class EmbeddedWellplate extends Component {
       </Tooltip>
     );
 
-    const removeButton = (
+    const removeButton = this.props.readOnly ? null : (
       <OverlayTrigger
         placement="bottom"
         overlay={<Tooltip id="remove_wellplate">Remove Wellplate from Research Plan</Tooltip>}
@@ -219,7 +221,7 @@ export default class EmbeddedWellplate extends Component {
       </OverlayTrigger>
     );
 
-    const removeConfirmationOverlay = (
+    const removeConfirmationOverlay = this.props.readOnly ? null : (
       <Overlay
         rootClose
         target={this.target}
@@ -255,6 +257,8 @@ export default class EmbeddedWellplate extends Component {
         <div className="d-flex align-items-center gap-1">
           {this.renderImportWellplateButton()}
           {openInTabButton}
+          {removeButton}
+          {removeConfirmationOverlay}
         </div>
       </div>
     );
@@ -286,4 +290,9 @@ EmbeddedWellplate.propTypes = {
   wellplateIndex: PropTypes.number.isRequired,
   importWellplate: PropTypes.func.isRequired,
   deleteWellplate: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
+};
+
+EmbeddedWellplate.defaultProps = {
+  readOnly: false,
 };

--- a/app/javascript/src/apps/mydb/elements/details/researchPlans/wellplatesTab/ResearchPlanWellplates.js
+++ b/app/javascript/src/apps/mydb/elements/details/researchPlans/wellplatesTab/ResearchPlanWellplates.js
@@ -7,6 +7,8 @@ import EmbeddedWellplate from 'src/apps/mydb/elements/details/researchPlans/well
 
 const target = {
   drop(props, monitor) {
+    if (props.readOnly) { return; }
+
     const { dropWellplate } = props;
     const item = monitor.getItem();
     const itemType = monitor.getItemType();
@@ -15,6 +17,8 @@ const target = {
     }
   },
   canDrop(props, monitor) {
+    if (props.readOnly) { return false; }
+
     const itemType = monitor.getItemType();
     return (itemType === 'wellplate');
   }
@@ -28,30 +32,45 @@ const collect = (connect, monitor) => ({
 
 class ResearchPlanWellplates extends Component {
   renderDropZone() {
-    const { isOver, connectDropTarget } = this.props;
+    const { isOver, connectDropTarget, readOnly } = this.props;
+    if (readOnly) { return null; }
+
     let className = 'mb-3 dnd-zone';
     if (isOver) { className += ' dnd-zone-over'; }
     return connectDropTarget(<div className={className}>Drop Wellplate here to add.</div>);
   }
 
   render() {
-    const { wellplates, deleteWellplate, importWellplate, researchPlan } = this.props;
+    const {
+      wellplates, deleteWellplate, importWellplate, researchPlan, readOnly
+    } = this.props;
+    const hasWellplates = wellplates && wellplates.length > 0;
+
     return (
       <div>
         {this.renderDropZone()}
 
-        <Accordion className="border rounded overflow-hidden">
-          {wellplates && wellplates.map((wellplate, wellplateIndex) => (
-            <EmbeddedWellplate
-              key={`${wellplate.short_label}-${wellplate.id}`}
-              researchPlan={researchPlan}
-              wellplate={wellplate}
-              wellplateIndex={wellplateIndex}
-              deleteWellplate={deleteWellplate}
-              importWellplate={importWellplate}
-            />
-          ))}
-        </Accordion>
+        {readOnly && !hasWellplates && (
+          <div className="m-4">
+            <span>There are currently no Wellplates.</span>
+          </div>
+        )}
+
+        {hasWellplates && (
+          <Accordion className="border rounded overflow-hidden">
+            {wellplates.map((wellplate, wellplateIndex) => (
+              <EmbeddedWellplate
+                key={`${wellplate.short_label}-${wellplate.id}`}
+                researchPlan={researchPlan}
+                wellplate={wellplate}
+                wellplateIndex={wellplateIndex}
+                deleteWellplate={deleteWellplate}
+                importWellplate={importWellplate}
+                readOnly={readOnly}
+              />
+            ))}
+          </Accordion>
+        )}
       </div>
     );
   }
@@ -65,7 +84,12 @@ ResearchPlanWellplates.propTypes = { /* eslint-disable react/no-unused-prop-type
   deleteWellplate: PropTypes.func.isRequired,
   importWellplate: PropTypes.func.isRequired,
   dropWellplate: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
   isOver: PropTypes.bool.isRequired,
   canDrop: PropTypes.bool.isRequired,
   connectDropTarget: PropTypes.func.isRequired
 }; /* eslint-enable */
+
+ResearchPlanWellplates.defaultProps = {
+  readOnly: false,
+};

--- a/app/javascript/src/apps/mydb/elements/details/screens/ResearchplanFlowDisplay.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/ResearchplanFlowDisplay.js
@@ -63,9 +63,11 @@ const ResearchplanFlowDisplay = (props) => {
       >
         <Background />
         <Controls showInteractive={false}>
-          <ControlButton onClick={() => toggleModal(true)}>
-            <div>Edit</div>
-          </ControlButton>
+          {!props.readOnly && (
+            <ControlButton onClick={() => toggleModal(true)}>
+              <div>Edit</div>
+            </ControlButton>
+          )}
         </Controls>
       </ReactFlow>
       <ResearchplanFlowEditorWithProvider

--- a/app/javascript/src/apps/mydb/elements/details/screens/ScreenDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/ScreenDetails.js
@@ -87,6 +87,8 @@ export default class ScreenDetails extends Component {
 
   handleSubmit() {
     const { screen } = this.state;
+    if (screen.isReadOnly) { return; }
+
     LoadingActions.start();
 
     if (screen.isNew) {
@@ -101,9 +103,11 @@ export default class ScreenDetails extends Component {
   }
 
   handleInputChange(type, event) {
+    const { screen } = this.state;
+    if (screen.isReadOnly) { return; }
+
     const types = ['name', 'requirements', 'collaborator', 'conditions', 'result', 'description'];
     if (types.indexOf(type) !== -1) {
-      const { screen } = this.state;
       const { value } = event.target;
 
       screen[type] = value;
@@ -113,6 +117,8 @@ export default class ScreenDetails extends Component {
 
   handleSegmentsChange(se) {
     const { screen } = this.state;
+    if (screen.isReadOnly) { return; }
+
     const { segments } = screen;
     const idx = findIndex(segments, (o) => o.segment_klass_id === se.segment_klass_id);
     if (idx >= 0) { segments.splice(idx, 1, se); } else { segments.push(se); }
@@ -127,12 +133,16 @@ export default class ScreenDetails extends Component {
 
   dropResearchPlan(researchPlan) {
     const { screen } = this.state;
+    if (screen.isReadOnly) { return; }
+
     screen.research_plans = unionBy(screen.research_plans, [researchPlan], 'id');
     this.forceUpdate();
   }
 
   deleteResearchPlan(researchPlanID) {
     const { screen } = this.state;
+    if (screen.isReadOnly) { return; }
+
     const researchPlanIndex = screen.research_plans.findIndex((rp) => rp.id === researchPlanID);
     screen.research_plans.splice(researchPlanIndex, 1);
 
@@ -161,12 +171,16 @@ export default class ScreenDetails extends Component {
 
   dropWellplate(wellplate) {
     const { screen } = this.state;
+    if (screen.isReadOnly) { return; }
+
     screen.wellplates = unionBy(screen.wellplates, [wellplate], 'id');
     this.forceUpdate();
   }
 
   deleteWellplate(wellplate) {
     const { screen } = this.state;
+    if (screen.isReadOnly) { return; }
+
     const wellplateIndex = screen.wellplates.indexOf(wellplate);
     screen.wellplates.splice(wellplateIndex, 1);
 
@@ -180,88 +194,90 @@ export default class ScreenDetails extends Component {
 
     return (
       <Form>
-        <Row className="mb-4">
-          <Col>
-            <Form.Group>
-              <Form.Label>Name</Form.Label>
-              <Form.Control
-                type="text"
-                value={name || ''}
-                onChange={(event) => this.handleInputChange('name', event)}
-                disabled={screen.isReadOnly || screen.isMethodDisabled('name')}
+        <fieldset disabled={screen.isReadOnly}>
+          <Row className="mb-4">
+            <Col>
+              <Form.Group>
+                <Form.Label>Name</Form.Label>
+                <Form.Control
+                  type="text"
+                  value={name || ''}
+                  onChange={(event) => this.handleInputChange('name', event)}
+                  disabled={screen.isReadOnly || screen.isMethodDisabled('name')}
+                />
+              </Form.Group>
+            </Col>
+            <Col>
+              <Form.Group>
+                <Form.Label>Collaborator</Form.Label>
+                <Form.Control
+                  type="text"
+                  value={collaborator || ''}
+                  onChange={(event) => this.handleInputChange('collaborator', event)}
+                  disabled={screen.isReadOnly || screen.isMethodDisabled('collaborator')}
+                />
+              </Form.Group>
+            </Col>
+          </Row>
+          <Row className="mb-4">
+            <Col>
+              <Form.Group>
+                <Form.Label>Requirements</Form.Label>
+                <Form.Control
+                  type="text"
+                  value={requirements || ''}
+                  onChange={(event) => this.handleInputChange('requirements', event)}
+                  disabled={screen.isReadOnly || screen.isMethodDisabled('requirements')}
+                />
+              </Form.Group>
+            </Col>
+            <Col>
+              <Form.Group>
+                <Form.Label>Conditions</Form.Label>
+                <Form.Control
+                  type="text"
+                  value={conditions || ''}
+                  onChange={(event) => this.handleInputChange('conditions', event)}
+                  disabled={screen.isReadOnly || screen.isMethodDisabled('conditions')}
+                />
+              </Form.Group>
+            </Col>
+          </Row>
+          <Row className="mb-4">
+            <Col>
+              <Form.Group>
+                <Form.Label>Result</Form.Label>
+                <Form.Control
+                  type="text"
+                  value={result || ''}
+                  onChange={(event) => this.handleInputChange('result', event)}
+                  disabled={screen.isReadOnly || screen.isMethodDisabled('result')}
+                />
+              </Form.Group>
+            </Col>
+          </Row>
+          <Row className="mb-4">
+            <Col>
+              <Form.Group>
+                <Form.Label>Description</Form.Label>
+                <QuillEditor
+                  value={description}
+                  onChange={(event) => this.handleInputChange('description', { target: { value: event } })}
+                  disabled={screen.isReadOnly || screen.isMethodDisabled('description')}
+                />
+              </Form.Group>
+            </Col>
+          </Row>
+          <Row className="mb-4">
+            <Col>
+              <EditUserLabels
+                element={screen}
+                fnCb={this.handleScreenChanged}
               />
-            </Form.Group>
-          </Col>
-          <Col>
-            <Form.Group>
-              <Form.Label>Collaborator</Form.Label>
-              <Form.Control
-                type="text"
-                value={collaborator || ''}
-                onChange={(event) => this.handleInputChange('collaborator', event)}
-                disabled={screen.isReadOnly || screen.isMethodDisabled('collaborator')}
-              />
-            </Form.Group>
-          </Col>
-        </Row>
-        <Row className="mb-4">
-          <Col>
-            <Form.Group>
-              <Form.Label>Requirements</Form.Label>
-              <Form.Control
-                type="text"
-                value={requirements || ''}
-                onChange={(event) => this.handleInputChange('requirements', event)}
-                disabled={screen.isReadOnly || screen.isMethodDisabled('requirements')}
-              />
-            </Form.Group>
-          </Col>
-          <Col>
-            <Form.Group>
-              <Form.Label>Conditions</Form.Label>
-              <Form.Control
-                type="text"
-                value={conditions || ''}
-                onChange={(event) => this.handleInputChange('conditions', event)}
-                disabled={screen.isReadOnly || screen.isMethodDisabled('conditions')}
-              />
-            </Form.Group>
-          </Col>
-        </Row>
-        <Row className="mb-4">
-          <Col>
-            <Form.Group>
-              <Form.Label>Result</Form.Label>
-              <Form.Control
-                type="text"
-                value={result || ''}
-                onChange={(event) => this.handleInputChange('result', event)}
-                disabled={screen.isReadOnly || screen.isMethodDisabled('result')}
-              />
-            </Form.Group>
-          </Col>
-        </Row>
-        <Row className="mb-4">
-          <Col>
-            <Form.Group>
-              <Form.Label>Description</Form.Label>
-              <QuillEditor
-                value={description}
-                onChange={(event) => this.handleInputChange('description', { target: { value: event } })}
-                disabled={screen.isReadOnly || screen.isMethodDisabled('description')}
-              />
-            </Form.Group>
-          </Col>
-        </Row>
-        <Row className="mb-4">
-          <Col>
-            <EditUserLabels
-              element={screen}
-              fnCb={this.handleScreenChanged}
-            />
-            <PrivateNoteElement element={screen} disabled={screen.isReadOnly} />
-          </Col>
-        </Row>
+              <PrivateNoteElement element={screen} disabled={screen.isReadOnly} />
+            </Col>
+          </Row>
+        </fieldset>
         <hr />
         <h4 className="list-group-item-heading">Wellplates</h4>
         <ScreenWellplates
@@ -283,6 +299,8 @@ export default class ScreenDetails extends Component {
 
   updateComponentGraphData(data) {
     const { screen } = this.state;
+    if (screen.isReadOnly) { return; }
+
     screen.componentGraphData = data;
     this.setState({ screen });
   }

--- a/app/javascript/src/apps/mydb/elements/details/screens/ScreenDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/ScreenDetails.js
@@ -188,7 +188,7 @@ export default class ScreenDetails extends Component {
                 type="text"
                 value={name || ''}
                 onChange={(event) => this.handleInputChange('name', event)}
-                disabled={screen.isMethodDisabled('name')}
+                disabled={!screen.can_update || screen.isMethodDisabled('name')}
               />
             </Form.Group>
           </Col>
@@ -199,7 +199,7 @@ export default class ScreenDetails extends Component {
                 type="text"
                 value={collaborator || ''}
                 onChange={(event) => this.handleInputChange('collaborator', event)}
-                disabled={screen.isMethodDisabled('collaborator')}
+                disabled={!screen.can_update || screen.isMethodDisabled('collaborator')}
               />
             </Form.Group>
           </Col>
@@ -212,7 +212,7 @@ export default class ScreenDetails extends Component {
                 type="text"
                 value={requirements || ''}
                 onChange={(event) => this.handleInputChange('requirements', event)}
-                disabled={screen.isMethodDisabled('requirements')}
+                disabled={!screen.can_update || screen.isMethodDisabled('requirements')}
               />
             </Form.Group>
           </Col>
@@ -223,7 +223,7 @@ export default class ScreenDetails extends Component {
                 type="text"
                 value={conditions || ''}
                 onChange={(event) => this.handleInputChange('conditions', event)}
-                disabled={screen.isMethodDisabled('conditions')}
+                disabled={!screen.can_update || screen.isMethodDisabled('conditions')}
               />
             </Form.Group>
           </Col>
@@ -236,7 +236,7 @@ export default class ScreenDetails extends Component {
                 type="text"
                 value={result || ''}
                 onChange={(event) => this.handleInputChange('result', event)}
-                disabled={screen.isMethodDisabled('result')}
+                disabled={!screen.can_update || screen.isMethodDisabled('result')}
               />
             </Form.Group>
           </Col>
@@ -248,7 +248,7 @@ export default class ScreenDetails extends Component {
               <QuillEditor
                 value={description}
                 onChange={(event) => this.handleInputChange('description', { target: { value: event } })}
-                disabled={screen.isMethodDisabled('description')}
+                disabled={!screen.can_update || screen.isMethodDisabled('description')}
               />
             </Form.Group>
           </Col>
@@ -259,7 +259,7 @@ export default class ScreenDetails extends Component {
               element={screen}
               fnCb={this.handleScreenChanged}
             />
-            <PrivateNoteElement element={screen} disabled={screen.can_update} />
+            <PrivateNoteElement element={screen} disabled={!screen.can_update} />
           </Col>
         </Row>
         <hr />
@@ -268,6 +268,7 @@ export default class ScreenDetails extends Component {
           wellplates={wellplates}
           dropWellplate={(wellplate) => this.dropWellplate(wellplate)}
           deleteWellplate={(wellplate) => this.deleteWellplate(wellplate)}
+          readOnly={!screen.can_update}
         />
       </Form>
     );
@@ -320,6 +321,7 @@ export default class ScreenDetails extends Component {
           <ScreenDetailsContainers
             screen={screen}
             handleScreenChanged={this.handleScreenChanged}
+            readOnly={!screen.can_update}
           />
         </Tab>
       ),
@@ -332,6 +334,7 @@ export default class ScreenDetails extends Component {
             deleteResearchPlan={(researchPlan) => this.deleteResearchPlan(researchPlan)}
             updateResearchPlan={(researchPlan) => this.updateResearchPlan(researchPlan)}
             saveResearchPlan={(researchPlan) => this.saveResearchPlan(researchPlan)}
+            readOnly={!screen.can_update}
           />
         </Tab>
       ),
@@ -380,6 +383,7 @@ export default class ScreenDetails extends Component {
       <ElementDetailCard
         element={screen}
         isPendingToSave={screen.isPendingToSave}
+        saveDisabled={!screen.can_update}
         title={screen.name}
         titleTooltip={formatTimeStampsOfElement(screen || {})}
         onSave={() => this.handleSubmit()}
@@ -389,6 +393,7 @@ export default class ScreenDetails extends Component {
           initialData={screen.componentGraphData}
           researchplans={screen.research_plans}
           flowConfiguration={flowConfiguration}
+          readOnly={!screen.can_update}
         />
         <div className="tabs-container--with-borders">
           <ElementDetailSortTab

--- a/app/javascript/src/apps/mydb/elements/details/screens/ScreenDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/ScreenDetails.js
@@ -188,7 +188,7 @@ export default class ScreenDetails extends Component {
                 type="text"
                 value={name || ''}
                 onChange={(event) => this.handleInputChange('name', event)}
-                disabled={!screen.can_update || screen.isMethodDisabled('name')}
+                disabled={screen.isReadOnly || screen.isMethodDisabled('name')}
               />
             </Form.Group>
           </Col>
@@ -199,7 +199,7 @@ export default class ScreenDetails extends Component {
                 type="text"
                 value={collaborator || ''}
                 onChange={(event) => this.handleInputChange('collaborator', event)}
-                disabled={!screen.can_update || screen.isMethodDisabled('collaborator')}
+                disabled={screen.isReadOnly || screen.isMethodDisabled('collaborator')}
               />
             </Form.Group>
           </Col>
@@ -212,7 +212,7 @@ export default class ScreenDetails extends Component {
                 type="text"
                 value={requirements || ''}
                 onChange={(event) => this.handleInputChange('requirements', event)}
-                disabled={!screen.can_update || screen.isMethodDisabled('requirements')}
+                disabled={screen.isReadOnly || screen.isMethodDisabled('requirements')}
               />
             </Form.Group>
           </Col>
@@ -223,7 +223,7 @@ export default class ScreenDetails extends Component {
                 type="text"
                 value={conditions || ''}
                 onChange={(event) => this.handleInputChange('conditions', event)}
-                disabled={!screen.can_update || screen.isMethodDisabled('conditions')}
+                disabled={screen.isReadOnly || screen.isMethodDisabled('conditions')}
               />
             </Form.Group>
           </Col>
@@ -236,7 +236,7 @@ export default class ScreenDetails extends Component {
                 type="text"
                 value={result || ''}
                 onChange={(event) => this.handleInputChange('result', event)}
-                disabled={!screen.can_update || screen.isMethodDisabled('result')}
+                disabled={screen.isReadOnly || screen.isMethodDisabled('result')}
               />
             </Form.Group>
           </Col>
@@ -248,7 +248,7 @@ export default class ScreenDetails extends Component {
               <QuillEditor
                 value={description}
                 onChange={(event) => this.handleInputChange('description', { target: { value: event } })}
-                disabled={!screen.can_update || screen.isMethodDisabled('description')}
+                disabled={screen.isReadOnly || screen.isMethodDisabled('description')}
               />
             </Form.Group>
           </Col>
@@ -259,7 +259,7 @@ export default class ScreenDetails extends Component {
               element={screen}
               fnCb={this.handleScreenChanged}
             />
-            <PrivateNoteElement element={screen} disabled={!screen.can_update} />
+            <PrivateNoteElement element={screen} disabled={screen.isReadOnly} />
           </Col>
         </Row>
         <hr />
@@ -268,7 +268,7 @@ export default class ScreenDetails extends Component {
           wellplates={wellplates}
           dropWellplate={(wellplate) => this.dropWellplate(wellplate)}
           deleteWellplate={(wellplate) => this.deleteWellplate(wellplate)}
-          readOnly={!screen.can_update}
+          readOnly={screen.isReadOnly}
         />
       </Form>
     );
@@ -321,7 +321,7 @@ export default class ScreenDetails extends Component {
           <ScreenDetailsContainers
             screen={screen}
             handleScreenChanged={this.handleScreenChanged}
-            readOnly={!screen.can_update}
+            readOnly={screen.isReadOnly}
           />
         </Tab>
       ),
@@ -334,7 +334,7 @@ export default class ScreenDetails extends Component {
             deleteResearchPlan={(researchPlan) => this.deleteResearchPlan(researchPlan)}
             updateResearchPlan={(researchPlan) => this.updateResearchPlan(researchPlan)}
             saveResearchPlan={(researchPlan) => this.saveResearchPlan(researchPlan)}
-            readOnly={!screen.can_update}
+            readOnly={screen.isReadOnly}
           />
         </Tab>
       ),
@@ -383,7 +383,7 @@ export default class ScreenDetails extends Component {
       <ElementDetailCard
         element={screen}
         isPendingToSave={screen.isPendingToSave}
-        saveDisabled={!screen.can_update}
+        saveDisabled={screen.isReadOnly}
         title={screen.name}
         titleTooltip={formatTimeStampsOfElement(screen || {})}
         onSave={() => this.handleSubmit()}
@@ -393,7 +393,7 @@ export default class ScreenDetails extends Component {
           initialData={screen.componentGraphData}
           researchplans={screen.research_plans}
           flowConfiguration={flowConfiguration}
-          readOnly={!screen.can_update}
+          readOnly={screen.isReadOnly}
         />
         <div className="tabs-container--with-borders">
           <ElementDetailSortTab

--- a/app/javascript/src/apps/mydb/elements/details/screens/ScreenWellplates.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/ScreenWellplates.js
@@ -8,6 +8,8 @@ import { aviatorNavigation } from 'src/utilities/routesUtils';
 
 const target = {
   drop(props, monitor) {
+    if (props.readOnly) { return; }
+
     const { dropWellplate } = props;
     const item = monitor.getItem();
     const itemType = monitor.getItemType();
@@ -16,6 +18,8 @@ const target = {
     }
   },
   canDrop(props, monitor) {
+    if (props.readOnly) { return false; }
+
     const itemType = monitor.getItemType();
     return (itemType === 'wellplate');
   }
@@ -30,7 +34,11 @@ const collect = (connect, monitor) => ({
 class ScreenWellplates extends Component {
   // eslint-disable-next-line class-methods-use-this
   renderDropZone() {
-    const { isOver, canDrop, connectDropTarget } = this.props;
+    const {
+      isOver, canDrop, connectDropTarget, readOnly
+    } = this.props;
+    if (readOnly) { return null; }
+
     const borderColor = isOver && canDrop ? 'dnd-zone-over' : '';
 
     return connectDropTarget( // eslint-disable-line function-paren-newline
@@ -40,8 +48,8 @@ class ScreenWellplates extends Component {
   }
 
   render() {
-    const { wellplates, deleteWellplate } = this.props;
-  
+    const { wellplates, deleteWellplate, readOnly } = this.props;
+
     return (
       <div>
         {this.renderDropZone()}
@@ -68,13 +76,15 @@ class ScreenWellplates extends Component {
               />
             </Col>
             <Col>
-              <Button
-                variant="danger"
-                className="float-end mt-3"
-                onClick={() => deleteWellplate(wellplate)}
-              >
-                <i className="fa fa-trash-o" />
-              </Button>
+              {!readOnly && (
+                <Button
+                  variant="danger"
+                  className="float-end mt-3"
+                  onClick={() => deleteWellplate(wellplate)}
+                >
+                  <i className="fa fa-trash-o" />
+                </Button>
+              )}
             </Col>
           </Row>
         ))}
@@ -89,7 +99,12 @@ ScreenWellplates.propTypes = {
   wellplates: PropTypes.arrayOf(PropTypes.object).isRequired,
   deleteWellplate: PropTypes.func.isRequired,
   dropWellplate: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
   isOver: PropTypes.bool.isRequired,
   canDrop: PropTypes.bool.isRequired,
   connectDropTarget: PropTypes.func.isRequired
+};
+
+ScreenWellplates.defaultProps = {
+  readOnly: false,
 };

--- a/app/javascript/src/apps/mydb/elements/details/screens/researchPlansTab/EmbeddedResearchPlanDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/researchPlansTab/EmbeddedResearchPlanDetails.js
@@ -182,7 +182,7 @@ export default class EmbeddedResearchPlanDetails extends Component {
 
   renderResearchPlanMain(researchPlan, update) { /* eslint-disable react/jsx-no-bind */
     const { name, body, changed } = researchPlan;
-    const edit = researchPlan.mode === 'edit';
+    const edit = researchPlan.mode === 'edit' && researchPlan.can_update;
     return (
       <Container>
         <Row>
@@ -289,16 +289,18 @@ export default class EmbeddedResearchPlanDetails extends Component {
               <i className="fa fa-window-maximize" aria-hidden="true" />
             </Button>
           </OverlayTrigger>
-          <OverlayTrigger placement="bottom" overlay={<Tooltip id="save_research_plan">Save Research Plan</Tooltip>}>
-            <Button
-              variant="warning"
-              size="xxsm"
-              onClick={() => saveResearchPlan(researchPlan)}
-              style={{ display: (researchPlan.changed || false) ? 'block' : 'none' }}
-            >
-              <i className="fa fa-floppy-o" aria-hidden="true" />
-            </Button>
-          </OverlayTrigger>
+          {researchPlan.can_update && (
+            <OverlayTrigger placement="bottom" overlay={<Tooltip id="save_research_plan">Save Research Plan</Tooltip>}>
+              <Button
+                variant="warning"
+                size="xxsm"
+                onClick={() => saveResearchPlan(researchPlan)}
+                style={{ display: (researchPlan.changed || false) ? 'block' : 'none' }}
+              >
+                <i className="fa fa-floppy-o" aria-hidden="true" />
+              </Button>
+            </OverlayTrigger>
+          )}
           <ConfirmationOverlay
             overlayTarget={confirmRemoveTarget}
             placement="bottom"
@@ -329,18 +331,9 @@ export default class EmbeddedResearchPlanDetails extends Component {
 
   render() {
     const { researchPlan, update } = this.state;
-    let btnMode = (
-      <Button
-        size="sm"
-        variant="success"
-        className="mb-4"
-        onClick={() => this.handleSwitchMode('edit')}
-      >
-        click to edit
-      </Button>
-    );
-    if (researchPlan.mode !== 'view') {
-      btnMode = (
+    let btnMode = null;
+    if (researchPlan.can_update) {
+      btnMode = researchPlan.mode !== 'view' ? (
         <Button
           size="sm"
           variant="info"
@@ -348,6 +341,15 @@ export default class EmbeddedResearchPlanDetails extends Component {
           onClick={() => this.handleSwitchMode('view')}
         >
           click to view
+        </Button>
+      ) : (
+        <Button
+          size="sm"
+          variant="success"
+          className="mb-4"
+          onClick={() => this.handleSwitchMode('edit')}
+        >
+          click to edit
         </Button>
       );
     }

--- a/app/javascript/src/apps/mydb/elements/details/screens/researchPlansTab/EmbeddedResearchPlanDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/researchPlansTab/EmbeddedResearchPlanDetails.js
@@ -301,29 +301,36 @@ export default class EmbeddedResearchPlanDetails extends Component {
               </Button>
             </OverlayTrigger>
           )}
-          <ConfirmationOverlay
-            overlayTarget={confirmRemoveTarget}
-            placement="bottom"
-            warningText={`Remove ${researchPlan.name} from Screen?`}
-            destructiveAction={() => deleteResearchPlan(researchPlan.id)}
-            destructiveActionLabel="Yes"
-            hideAction={() => this.setState({ confirmRemoveTarget: null })}
-            hideActionLabel="No"
-          />
-          <OverlayTrigger
-            placement="bottom"
-            overlay={<Tooltip id="remove_esearch_plan">Remove Research Plan from Screen</Tooltip>}
-          >
-            <Button
-              variant="danger"
-              size="xxsm"
-              onClick={(event) => this.setState((prevState) => ({
-                confirmRemoveTarget: prevState.confirmRemoveTarget ? null : event.currentTarget,
-              }))}
-            >
-              <i className="fa fa-trash-o" aria-hidden="true" />
-            </Button>
-          </OverlayTrigger>
+          {researchPlan.can_update && (
+            <>
+              <ConfirmationOverlay
+                overlayTarget={confirmRemoveTarget}
+                placement="bottom"
+                warningText={`Remove ${researchPlan.name} from Screen?`}
+                destructiveAction={() => deleteResearchPlan(researchPlan.id)}
+                destructiveActionLabel="Yes"
+                hideAction={() => this.setState({ confirmRemoveTarget: null })}
+                hideActionLabel="No"
+              />
+              <OverlayTrigger
+                placement="bottom"
+                overlay={<Tooltip id="remove_esearch_plan">Remove Research Plan from Screen</Tooltip>}
+              >
+                <Button
+                  variant="danger"
+                  size="xxsm"
+                  onClick={(event) => {
+                    const { currentTarget } = event;
+                    this.setState((prevState) => ({
+                      confirmRemoveTarget: prevState.confirmRemoveTarget ? null : currentTarget,
+                    }));
+                  }}
+                >
+                  <i className="fa fa-trash-o" aria-hidden="true" />
+                </Button>
+              </OverlayTrigger>
+            </>
+          )}
         </div>
       </div>
     );

--- a/app/javascript/src/apps/mydb/elements/details/screens/researchPlansTab/EmbeddedResearchPlanDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/researchPlansTab/EmbeddedResearchPlanDetails.js
@@ -182,7 +182,7 @@ export default class EmbeddedResearchPlanDetails extends Component {
 
   renderResearchPlanMain(researchPlan, update) { /* eslint-disable react/jsx-no-bind */
     const { name, body, changed } = researchPlan;
-    const edit = researchPlan.mode === 'edit' && researchPlan.can_update;
+    const edit = researchPlan.mode === 'edit' && !researchPlan.isReadOnly;
     return (
       <Container>
         <Row>
@@ -247,7 +247,7 @@ export default class EmbeddedResearchPlanDetails extends Component {
   }
 
   renderCardHeader(researchPlan) {
-    const { deleteResearchPlan, saveResearchPlan } = this.props;
+    const { deleteResearchPlan, saveResearchPlan, readOnly } = this.props;
     const titleTooltip = formatTimeStampsOfElement(researchPlan || {});
     const expandIconClass = this.state.expanded ? 'fa fa-compress' : 'fa fa-expand';
     const { confirmRemoveTarget } = this.state;
@@ -289,7 +289,7 @@ export default class EmbeddedResearchPlanDetails extends Component {
               <i className="fa fa-window-maximize" aria-hidden="true" />
             </Button>
           </OverlayTrigger>
-          {researchPlan.can_update && (
+          {!researchPlan.isReadOnly && (
             <OverlayTrigger placement="bottom" overlay={<Tooltip id="save_research_plan">Save Research Plan</Tooltip>}>
               <Button
                 variant="warning"
@@ -301,7 +301,7 @@ export default class EmbeddedResearchPlanDetails extends Component {
               </Button>
             </OverlayTrigger>
           )}
-          {researchPlan.can_update && (
+          {!readOnly && (
             <>
               <ConfirmationOverlay
                 overlayTarget={confirmRemoveTarget}
@@ -339,7 +339,7 @@ export default class EmbeddedResearchPlanDetails extends Component {
   render() {
     const { researchPlan, update } = this.state;
     let btnMode = null;
-    if (researchPlan.can_update) {
+    if (!researchPlan.isReadOnly) {
       btnMode = researchPlan.mode !== 'view' ? (
         <Button
           size="sm"
@@ -383,4 +383,9 @@ EmbeddedResearchPlanDetails.propTypes = {
   updateResearchPlan: PropTypes.func.isRequired,
   saveResearchPlan: PropTypes.func.isRequired,
   deleteResearchPlan: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
+};
+
+EmbeddedResearchPlanDetails.defaultProps = {
+  readOnly: false,
 };

--- a/app/javascript/src/apps/mydb/elements/details/screens/researchPlansTab/ScreenResearchPlans.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/researchPlansTab/ScreenResearchPlans.js
@@ -12,6 +12,8 @@ import { DropTarget } from 'react-dnd';
 
 const target = {
   drop(props, monitor) {
+    if (props.readOnly) { return; }
+
     const { dropResearchPlan } = props;
     const item = monitor.getItem();
     const itemType = monitor.getItemType();
@@ -20,6 +22,8 @@ const target = {
     }
   },
   canDrop(props, monitor) {
+    if (props.readOnly) { return false; }
+
     const itemType = monitor.getItemType();
     return (itemType === 'research_plan');
   }
@@ -33,7 +37,9 @@ const collect = (connect, monitor) => ({
 
 class ScreenResearchPlans extends Component {
   renderDropZone() {
-    const { isOver, connectDropTarget } = this.props;
+    const { isOver, connectDropTarget, readOnly } = this.props;
+    if (readOnly) { return null; }
+
     const borderColor = isOver ? 'dnd-zone-over' : '';
 
     return connectDropTarget( // eslint-disable-line function-paren-newline
@@ -69,12 +75,19 @@ class ScreenResearchPlans extends Component {
 
   render() {
     const {
-      researchPlans, deleteResearchPlan, updateResearchPlan, saveResearchPlan
+      researchPlans, deleteResearchPlan, updateResearchPlan, saveResearchPlan, readOnly
     } = this.props;
+    const hasResearchPlans = researchPlans && researchPlans.length > 0;
 
     return (
       <div>
         {this.renderDropZone()}
+
+        {readOnly && !hasResearchPlans && (
+          <div className="m-4">
+            <span>There are currently no Research Plans.</span>
+          </div>
+        )}
 
         {researchPlans.map(researchPlan => (
           <EmbeddedResearchPlanDetails
@@ -86,14 +99,16 @@ class ScreenResearchPlans extends Component {
             saveResearchPlan={saveResearchPlan}
           />
         ))}
-        <Button
-          size="sm"
-          variant="success"
-          onClick={this.handleAddResearchPlan.bind(this)}
-          type="button"
-        >
-          Add new research plan
-        </Button>
+        {!readOnly && (
+          <Button
+            size="sm"
+            variant="success"
+            onClick={this.handleAddResearchPlan.bind(this)}
+            type="button"
+          >
+            Add new research plan
+          </Button>
+        )}
       </div>);
   }
 }
@@ -107,7 +122,12 @@ ScreenResearchPlans.propTypes = { /* eslint-disable react/no-unused-prop-types *
   updateResearchPlan: PropTypes.func.isRequired,
   saveResearchPlan: PropTypes.func.isRequired,
   dropResearchPlan: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
   isOver: PropTypes.bool.isRequired,
   canDrop: PropTypes.bool.isRequired,
   connectDropTarget: PropTypes.func.isRequired
 }; /* eslint-enable */
+
+ScreenResearchPlans.defaultProps = {
+  readOnly: false,
+};

--- a/app/javascript/src/apps/mydb/elements/details/screens/researchPlansTab/ScreenResearchPlans.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/researchPlansTab/ScreenResearchPlans.js
@@ -97,6 +97,7 @@ class ScreenResearchPlans extends Component {
             deleteResearchPlan={deleteResearchPlan}
             updateResearchPlan={updateResearchPlan}
             saveResearchPlan={saveResearchPlan}
+            readOnly={readOnly}
           />
         ))}
         {!readOnly && (

--- a/app/javascript/src/apps/mydb/elements/details/screens/researchPlansTab/ScreenResearchPlans.js
+++ b/app/javascript/src/apps/mydb/elements/details/screens/researchPlansTab/ScreenResearchPlans.js
@@ -84,7 +84,7 @@ class ScreenResearchPlans extends Component {
         {this.renderDropZone()}
 
         {readOnly && !hasResearchPlans && (
-          <div className="m-4">
+          <div className="d-flex align-items-center justify-content-between my-2">
             <span>There are currently no Research Plans.</span>
           </div>
         )}

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
@@ -89,6 +89,8 @@ export default class WellplateDetails extends Component {
 
   handleSegmentsChange(se) {
     const { wellplate } = this.state;
+    if (wellplate.isReadOnly) { return; }
+
     const { segments } = wellplate;
     const idx = findIndex(segments, (o) => o.segment_klass_id === se.segment_klass_id);
     if (idx >= 0) { segments.splice(idx, 1, se); } else { segments.push(se); }
@@ -99,6 +101,8 @@ export default class WellplateDetails extends Component {
 
   handleSubmit() {
     const { wellplate } = this.state;
+    if (wellplate.isReadOnly) { return; }
+
     this.context.attachmentNotificationStore.clearMessages();
     LoadingActions.start();
     if (wellplate.isNew) {
@@ -129,12 +133,16 @@ export default class WellplateDetails extends Component {
 
   handleWellsChange(wells) {
     const { wellplate } = this.state;
+    if (wellplate.isReadOnly) { return; }
+
     wellplate.wells = wells;
     this.setState({ wellplate });
   }
 
   handleAddReadout() {
     const { wellplate } = this.state;
+    if (wellplate.isReadOnly) { return; }
+
     wellplate.wells.forEach((well) => {
       well.readouts.push({ value: '', unit: '' });
     });
@@ -143,6 +151,8 @@ export default class WellplateDetails extends Component {
 
   handleRemoveReadout(index) {
     const { wellplate } = this.state;
+    if (wellplate.isReadOnly) { return; }
+
     wellplate.wells.forEach((well) => {
       well.readouts.splice(index, 1);
     });
@@ -151,6 +161,8 @@ export default class WellplateDetails extends Component {
 
   handleChangeProperties(change = {}) {
     const { wellplate } = this.state;
+    if (wellplate.isReadOnly) { return; }
+
     const { type, value } = change;
 
     if (type == 'name') wellplate.name = value === '' ? 'New Wellplate' : value;
@@ -195,9 +207,10 @@ export default class WellplateDetails extends Component {
   }
 
   handleAttachmentImport(attachment) {
-    if (this.state.wellplate.isReadOnly) { return; }
-    LoadingActions.start();
     const { wellplate } = this.state;
+    if (wellplate.isReadOnly) { return; }
+
+    LoadingActions.start();
     const wellplateId = wellplate.id;
     const attachmentId = attachment.id;
 

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
@@ -169,7 +169,7 @@ export default class WellplateDetails extends Component {
 
   // handle attachment actions
   handleAttachmentDrop(files) {
-    if (!this.state.wellplate.can_update) { return; }
+    if (this.state.wellplate.isReadOnly) { return; }
     this.setState((prevState) => {
       const newAttachments = files.map((file) => Attachment.fromFile(file));
       const { wellplate } = prevState;
@@ -187,7 +187,7 @@ export default class WellplateDetails extends Component {
 
   handleAttachmentDelete(attachment) {
     const { wellplate } = this.state;
-    if (!wellplate.can_update) { return; }
+    if (wellplate.isReadOnly) { return; }
     const index = wellplate.attachments.indexOf(attachment);
     wellplate.changed = true;
     wellplate.attachments[index].is_deleted = true;
@@ -195,7 +195,7 @@ export default class WellplateDetails extends Component {
   }
 
   handleAttachmentImport(attachment) {
-    if (!this.state.wellplate.can_update) { return; }
+    if (this.state.wellplate.isReadOnly) { return; }
     LoadingActions.start();
     const { wellplate } = this.state;
     const wellplateId = wellplate.id;
@@ -206,7 +206,7 @@ export default class WellplateDetails extends Component {
 
   handleAttachmentUndoDelete(attachment) {
     const { wellplate } = this.state;
-    if (!wellplate.can_update) { return; }
+    if (wellplate.isReadOnly) { return; }
     const index = wellplate.attachments.indexOf(attachment);
     wellplate.attachments[index].is_deleted = false;
     this.setState({ wellplate });
@@ -218,7 +218,7 @@ export default class WellplateDetails extends Component {
 
   handleAttachmentEdit(attachment) {
     const { wellplate } = this.state;
-    if (!wellplate.can_update) { return; }
+    if (wellplate.isReadOnly) { return; }
     wellplate.changed = true;
     // update only this attachment
     wellplate.attachments.map((currentAttachment) => {
@@ -275,7 +275,7 @@ export default class WellplateDetails extends Component {
               <Wellplate
                 wellplate={wellplate}
                 handleWellsChange={(wells) => this.handleWellsChange(wells)}
-                readOnly={!wellplate.can_update}
+                readOnly={wellplate.isReadOnly}
               />
             </Card.Body>
           </Card>
@@ -291,7 +291,7 @@ export default class WellplateDetails extends Component {
               wells={wellplate.wells}
               readoutTitles={readoutTitles}
               handleWellsChange={(w) => this.handleWellsChange(w)}
-              readOnly={!wellplate.can_update}
+              readOnly={wellplate.isReadOnly}
             />
           </div>
         </Tab>
@@ -312,7 +312,7 @@ export default class WellplateDetails extends Component {
             element={wellplate}
             fnCb={this.handleWellplateChanged}
           />
-          <PrivateNoteElement element={wellplate} disabled={!wellplate.can_update} />
+          <PrivateNoteElement element={wellplate} disabled={wellplate.isReadOnly} />
           {' '}
           {/* For samples and reactions (<element>): disabled={!<element>.can_update} */}
         </Tab>
@@ -327,7 +327,7 @@ export default class WellplateDetails extends Component {
               wellplate={wellplate}
               setWellplate={(w) => this.setState({ wellplate: w })}
               handleWellplateChanged={this.handleWellplateChanged}
-              readOnly={!wellplate.can_update}
+              readOnly={wellplate.isReadOnly}
             />
           </ListGroupItem>
         </Tab>
@@ -345,7 +345,7 @@ export default class WellplateDetails extends Component {
                 onDownload={this.handleAttachmentDownload.bind(this)}
                 onImport={this.handleAttachmentImport.bind(this)}
                 onEdit={this.handleAttachmentEdit.bind(this)}
-                readOnly={!wellplate.can_update}
+                readOnly={wellplate.isReadOnly}
               />
             </ListGroupItem>
           </ListGroup>
@@ -383,7 +383,7 @@ export default class WellplateDetails extends Component {
       <ElementDetailCard
         element={wellplate}
         isPendingToSave={wellplate.isPendingToSave}
-        saveDisabled={!wellplate.can_update}
+        saveDisabled={wellplate.isReadOnly}
         title={wellplate.name}
         titleTooltip={formatTimeStampsOfElement(wellplate || {})}
         footerToolbar={this.wellplateFooter()}

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/WellplateDetails.js
@@ -169,6 +169,7 @@ export default class WellplateDetails extends Component {
 
   // handle attachment actions
   handleAttachmentDrop(files) {
+    if (!this.state.wellplate.can_update) { return; }
     this.setState((prevState) => {
       const newAttachments = files.map((file) => Attachment.fromFile(file));
       const { wellplate } = prevState;
@@ -186,6 +187,7 @@ export default class WellplateDetails extends Component {
 
   handleAttachmentDelete(attachment) {
     const { wellplate } = this.state;
+    if (!wellplate.can_update) { return; }
     const index = wellplate.attachments.indexOf(attachment);
     wellplate.changed = true;
     wellplate.attachments[index].is_deleted = true;
@@ -193,6 +195,7 @@ export default class WellplateDetails extends Component {
   }
 
   handleAttachmentImport(attachment) {
+    if (!this.state.wellplate.can_update) { return; }
     LoadingActions.start();
     const { wellplate } = this.state;
     const wellplateId = wellplate.id;
@@ -203,6 +206,7 @@ export default class WellplateDetails extends Component {
 
   handleAttachmentUndoDelete(attachment) {
     const { wellplate } = this.state;
+    if (!wellplate.can_update) { return; }
     const index = wellplate.attachments.indexOf(attachment);
     wellplate.attachments[index].is_deleted = false;
     this.setState({ wellplate });
@@ -214,6 +218,7 @@ export default class WellplateDetails extends Component {
 
   handleAttachmentEdit(attachment) {
     const { wellplate } = this.state;
+    if (!wellplate.can_update) { return; }
     wellplate.changed = true;
     // update only this attachment
     wellplate.attachments.map((currentAttachment) => {
@@ -270,6 +275,7 @@ export default class WellplateDetails extends Component {
               <Wellplate
                 wellplate={wellplate}
                 handleWellsChange={(wells) => this.handleWellsChange(wells)}
+                readOnly={!wellplate.can_update}
               />
             </Card.Body>
           </Card>
@@ -285,6 +291,7 @@ export default class WellplateDetails extends Component {
               wells={wellplate.wells}
               readoutTitles={readoutTitles}
               handleWellsChange={(w) => this.handleWellsChange(w)}
+              readOnly={!wellplate.can_update}
             />
           </div>
         </Tab>
@@ -305,7 +312,7 @@ export default class WellplateDetails extends Component {
             element={wellplate}
             fnCb={this.handleWellplateChanged}
           />
-          <PrivateNoteElement element={wellplate} disabled={wellplate.can_update || false} />
+          <PrivateNoteElement element={wellplate} disabled={!wellplate.can_update} />
           {' '}
           {/* For samples and reactions (<element>): disabled={!<element>.can_update} */}
         </Tab>
@@ -320,6 +327,7 @@ export default class WellplateDetails extends Component {
               wellplate={wellplate}
               setWellplate={(w) => this.setState({ wellplate: w })}
               handleWellplateChanged={this.handleWellplateChanged}
+              readOnly={!wellplate.can_update}
             />
           </ListGroupItem>
         </Tab>
@@ -337,7 +345,7 @@ export default class WellplateDetails extends Component {
                 onDownload={this.handleAttachmentDownload.bind(this)}
                 onImport={this.handleAttachmentImport.bind(this)}
                 onEdit={this.handleAttachmentEdit.bind(this)}
-                readOnly={false}
+                readOnly={!wellplate.can_update}
               />
             </ListGroupItem>
           </ListGroup>
@@ -375,6 +383,7 @@ export default class WellplateDetails extends Component {
       <ElementDetailCard
         element={wellplate}
         isPendingToSave={wellplate.isPendingToSave}
+        saveDisabled={!wellplate.can_update}
         title={wellplate.name}
         titleTooltip={formatTimeStampsOfElement(wellplate || {})}
         footerToolbar={this.wellplateFooter()}

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/attachmentsTab/WellplateDetailsAttachments.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/attachmentsTab/WellplateDetailsAttachments.js
@@ -231,7 +231,9 @@ export class WellplateDetailsAttachments extends Component {
     const {
       filteredAttachments, sortDirection
     } = this.state;
-    const { onUndoDelete, attachments, wellplate } = this.props;
+    const {
+      onUndoDelete, attachments, wellplate, readOnly, onEdit, onDelete, onDrop
+    } = this.props;
     const { currentUser } = UserStore.getState();
 
     let combinedAttachments = filteredAttachments;
@@ -239,30 +241,36 @@ export class WellplateDetailsAttachments extends Component {
       combinedAttachments = this.context.attachmentNotificationStore.getCombinedAttachments(filteredAttachments, 'Wellplate', wellplate);
     }
 
+    const showToolbar = !readOnly || attachments.length > 0;
+
     return (
       <div className="attachment-main-container">
-        {this.renderTemplateDownload()}
+        {!readOnly && this.renderTemplateDownload()}
         {this.renderImageEditModal()}
-        <div className="d-flex justify-content-between align-items-center">
-          <div className="flex-grow-1 align-self-center">
-            {customDropzone(this.props.onDrop)}
+        {showToolbar && (
+          <div className="d-flex justify-content-between align-items-center">
+            {!readOnly && (
+              <div className="flex-grow-1 align-self-center">
+                {customDropzone(onDrop)}
+              </div>
+            )}
+            <div className="ms-3 align-self-center">
+              {
+                attachments.length > 0
+                && sortingAndFilteringUI(
+                  sortDirection,
+                  this.handleSortChange,
+                  this.toggleSortDirection,
+                  this.handleFilterChange,
+                  true
+                )
+              }
+            </div>
           </div>
-          <div className="ms-3 align-self-center">
-            {
-              attachments.length > 0
-              && sortingAndFilteringUI(
-                sortDirection,
-                this.handleSortChange,
-                this.toggleSortDirection,
-                this.handleFilterChange,
-                true
-              )
-            }
-          </div>
-        </div>
+        )}
         {combinedAttachments.length === 0 ? (
-          <div className="no-attachments-text">
-            There are currently no attachments.
+          <div className={readOnly ? 'm-4' : 'no-attachments-text'}>
+            <span>There are currently no attachments.</span>
           </div>
         ) : (
           <>
@@ -292,46 +300,54 @@ export class WellplateDetailsAttachments extends Component {
                 </div>
                 <div className="attachment-row-actions d-flex align-items-center gap-1">
                   {attachment.is_deleted ? (
-                    <Button
-                      size="sm"
-                      variant="danger"
-                      className="attachment-button-size"
-                      onClick={() => onUndoDelete(attachment)}
-                    >
-                      <i className="fa fa-undo" aria-hidden="true" />
-                    </Button>
+                    !readOnly && (
+                      <Button
+                        size="sm"
+                        variant="danger"
+                        className="attachment-button-size"
+                        onClick={() => onUndoDelete(attachment)}
+                      >
+                        <i className="fa fa-undo" aria-hidden="true" />
+                      </Button>
+                    )
                   ) : (
                     <>
                       {downloadButton(attachment)}
                       <ThirdPartyAppButton attachment={attachment} options={this.thirdPartyApps} />
-                      <EditButton attachment={attachment} onChange={this.props.onEdit} />
-                      {annotateButton(attachment, () => {
-                        this.setState({
-                          imageEditModalShown: true,
-                          chosenAttachment: attachment,
-                        });
-                      })}
-                      {importButton(
-                        attachment,
-                        this.state.showImportConfirm,
-                        this.props.wellplate.changed,
-                        this.showImportConfirm,
-                        this.hideImportConfirm,
-                        this.confirmAttachmentImport
+                      {!readOnly && (
+                        <>
+                          <EditButton attachment={attachment} onChange={onEdit} />
+                          {annotateButton(attachment, () => {
+                            this.setState({
+                              imageEditModalShown: true,
+                              chosenAttachment: attachment,
+                            });
+                          })}
+                          {importButton(
+                            attachment,
+                            this.state.showImportConfirm,
+                            wellplate.changed,
+                            this.showImportConfirm,
+                            this.hideImportConfirm,
+                            this.confirmAttachmentImport
+                          )}
+                          &nbsp;
+                          {removeButton(attachment, onDelete, false)}
+                        </>
                       )}
-                      &nbsp;
-                      {removeButton(attachment, this.props.onDelete, this.props.readOnly)}
                     </>
                   )}
                 </div>
                 {attachment.updatedAnnotation && <SaveEditedImageWarning visible />}
               </div>
             ))}
-            <Alert variant="warning" show={UserStore.isUserQuotaExceeded(filteredAttachments)}>
-              Uploading attachments will fail; User quota
-              {currentUser !== null ? ` (${currentUser.allocated_space / 1024 / 1024} MB) ` : ' '}
-              will be exceeded.
-            </Alert>
+            {!readOnly && (
+              <Alert variant="warning" show={UserStore.isUserQuotaExceeded(filteredAttachments)}>
+                Uploading attachments will fail; User quota
+                {currentUser !== null ? ` (${currentUser.allocated_space / 1024 / 1024} MB) ` : ' '}
+                will be exceeded.
+              </Alert>
+            )}
           </>
         )}
       </div>

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/attachmentsTab/WellplateDetailsAttachments.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/attachmentsTab/WellplateDetailsAttachments.js
@@ -269,7 +269,7 @@ export class WellplateDetailsAttachments extends Component {
           </div>
         )}
         {combinedAttachments.length === 0 ? (
-          <div className={readOnly ? 'm-4' : 'no-attachments-text'}>
+          <div className="d-flex align-items-center justify-content-between my-2">
             <span>There are currently no attachments.</span>
           </div>
         ) : (

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/designerTab/WellContainer.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/designerTab/WellContainer.js
@@ -5,6 +5,9 @@ import { DragDropItemTypes } from 'src/utilities/DndConst';
 import Well from 'src/apps/mydb/elements/details/wellplates/designerTab/Well';
 
 const wellSource = {
+  canDrag(props) {
+    return !props.readOnly;
+  },
   beginDrag(props) {
     return props;
   }
@@ -12,6 +15,8 @@ const wellSource = {
 
 const wellTarget = {
   canDrop(props, monitor) {
+    if (props.readOnly) { return false; }
+
     const item = monitor.getItem();
     const itemType = monitor.getItemType();
     let canDrop = true;
@@ -23,6 +28,8 @@ const wellTarget = {
     return canDrop;
   },
   drop(props, monitor) {
+    if (props.readOnly) { return; }
+
     const item = monitor.getItem();
     const itemType = monitor.getItemType();
     if (itemType == 'sample') {
@@ -80,5 +87,10 @@ WellContainer.propTypes = {
   canDrop: PropTypes.bool.isRequired,
   swapWells: PropTypes.func.isRequired,
   dropSample: PropTypes.func.isRequired,
-  well: PropTypes.object
+  well: PropTypes.object,
+  readOnly: PropTypes.bool,
+};
+
+WellContainer.defaultProps = {
+  readOnly: false,
 };

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/designerTab/WellDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/designerTab/WellDetails.js
@@ -34,7 +34,7 @@ const sampleName = (sample) => {
   );
 };
 
-const sampleVisualisation = (well, onChange) => {
+const sampleVisualisation = (well, onChange, readOnly) => {
   const { sample } = well;
   let svg = null;
   let removeButton = null;
@@ -45,11 +45,13 @@ const sampleVisualisation = (well, onChange) => {
 
   if (sample) {
     svg = <SVG key={sample.id} className="molecule-mid" src={sample.svgPath} />;
-    removeButton = (
-      <Button size="sm" variant="danger" onClick={removeSampleFromWell}>
-        Clear well
-      </Button>
-    );
+    if (!readOnly) {
+      removeButton = (
+        <Button size="sm" variant="danger" onClick={removeSampleFromWell}>
+          Clear well
+        </Button>
+      );
+    }
   }
   return (
     <>
@@ -89,7 +91,7 @@ const readoutSection = (readouts, readoutTitles) => {
   );
 };
 
-const labelSelection = (well, onChange) => {
+const labelSelection = (well, onChange, readOnly) => {
   const wellLabels = well.label ? well.label.split(',') : [];
   const labelsIncludesMolecularStructure = wellLabels.some((item) => item === 'Molecular structure');
   const labelsIncludeNonMolecularStructure = wellLabels.some((item) => item !== 'Molecular structure');
@@ -108,6 +110,7 @@ const labelSelection = (well, onChange) => {
         isMulti
         options={labelOptions}
         value={labelOptions.filter(({ value }) => wellLabels.includes(value))}
+        isDisabled={readOnly}
         isOptionDisabled={(option) => option.disabled}
         styles={{
           option: (provided, state) => {
@@ -128,13 +131,14 @@ const labelSelection = (well, onChange) => {
   );
 };
 
-const colorPicker = (well, onChange, activeColor, setActiveColor) => (
+const colorPicker = (well, onChange, activeColor, setActiveColor, readOnly) => (
   <Form.Group controlId="formColorSelectorDisplay" className="mt-3">
     <Form.Label as="h4">Select Color</Form.Label>
     <Select
       className="rounded-corners"
       name="colorPicker"
       isClearable
+      isDisabled={readOnly}
       options={colorOptions}
       value={colorOptions.find(({ value }) => value === activeColor) || null}
       onChange={(option) => {
@@ -152,7 +156,7 @@ const colorPicker = (well, onChange, activeColor, setActiveColor) => (
   </Form.Group>
 );
 
-function WellDetails({ well, readoutTitles, handleClose, onChange }) {
+function WellDetails({ well, readoutTitles, handleClose, onChange, readOnly }) {
   const [activeColor, setActiveColor] = useState(well.color_code || null);
   return (
     <AppModal
@@ -161,10 +165,10 @@ function WellDetails({ well, readoutTitles, handleClose, onChange }) {
       onHide={handleClose}
       showFooter={false}
     >
-      {sampleVisualisation(well, onChange)}
-      {labelSelection(well, onChange)}
+      {sampleVisualisation(well, onChange, readOnly)}
+      {labelSelection(well, onChange, readOnly)}
       {readoutSection(well.readouts, readoutTitles)}
-      {colorPicker(well, onChange, activeColor, setActiveColor)}
+      {colorPicker(well, onChange, activeColor, setActiveColor, readOnly)}
     </AppModal>
   );
 }
@@ -174,6 +178,11 @@ WellDetails.propTypes = {
   readoutTitles: PropTypes.array.isRequired,
   handleClose: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
+};
+
+WellDetails.defaultProps = {
+  readOnly: false,
 };
 
 export default WellDetails;

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/designerTab/Wellplate.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/designerTab/Wellplate.js
@@ -14,10 +14,12 @@ const VerticalHeaderField = ({ label }) => {
   );
 }
 
-const Wellplate = ({ wellplate, handleWellsChange }) => {
+const Wellplate = ({ wellplate, handleWellsChange, readOnly }) => {
   const [selectedWell, setSelectedWell] = useState(null)
 
   const swapWells = (firstWell, secondWell) => {
+    if (readOnly) { return; }
+
     const wells = wellplate.wells
     const firstWellId = wells.indexOf(firstWell);
     const secondWellId = wells.indexOf(secondWell);
@@ -28,6 +30,8 @@ const Wellplate = ({ wellplate, handleWellsChange }) => {
   }
 
   const dropSample = (droppedSample, well) => {
+    if (readOnly) { return; }
+
     const wells = wellplate.wells
     const wellId = wells.indexOf(well);
     const sample = droppedSample.buildChild();
@@ -49,6 +53,8 @@ const Wellplate = ({ wellplate, handleWellsChange }) => {
   }
 
   const updateSelectedWell = (updatedWell) => {
+    if (readOnly) { return; }
+
     const wells = wellplate.wells
     const wellIndex = wells.findIndex(well => well.id == updatedWell.id)
     if (wellIndex == -1) return;
@@ -82,6 +88,7 @@ const Wellplate = ({ wellplate, handleWellsChange }) => {
             swapWells={swapWells}
             dropSample={dropSample}
             active={isWellActive(well)}
+            readOnly={readOnly}
             key={`${well.id}-container`}
           />
         </div>
@@ -103,6 +110,7 @@ const Wellplate = ({ wellplate, handleWellsChange }) => {
           readoutTitles={wellplate.readout_titles}
           handleClose={hideDetails}
           onChange={updateSelectedWell}
+          readOnly={readOnly}
         />
       }
     </div>
@@ -111,7 +119,12 @@ const Wellplate = ({ wellplate, handleWellsChange }) => {
 
 Wellplate.propTypes = {
   wellplate: PropTypes.instanceOf(WellplateModel),
-  handleWellsChange: PropTypes.func.isRequired
+  handleWellsChange: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
+};
+
+Wellplate.defaultProps = {
+  readOnly: false,
 };
 
 export default Wellplate;

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/listTab/WellplateList.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/listTab/WellplateList.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import SVG from 'react-inlinesvg';
 import { AgGridReact } from 'ag-grid-react';
 
-const WellplateList = ({ wells, readoutTitles, handleWellsChange }) => {
+const WellplateList = ({ wells, readoutTitles, handleWellsChange, readOnly }) => {
   const gridRef = useRef();
   const [wellsList, setWellsList] = useState(wells);
 
@@ -61,6 +61,7 @@ const WellplateList = ({ wells, readoutTitles, handleWellsChange }) => {
   };
 
   const updateRow = useCallback(({ data: oldRow, colDef, newValue }) => {
+    if (readOnly) { return null; }
     const { field, cellRendererParams } = colDef;
     if (!oldRow.sample) { return null }
 
@@ -74,7 +75,9 @@ const WellplateList = ({ wells, readoutTitles, handleWellsChange }) => {
     
     setWellsList(wellsList);
     handleWellsChange(wellsList);
-  }, [wellsList, readoutTitles]);
+  }, [wellsList, readoutTitles, readOnly, handleWellsChange]);
+
+  const canEditCell = (params) => !readOnly && !!params.data.sample;
 
   const columnDefs = [
     {
@@ -121,7 +124,7 @@ const WellplateList = ({ wells, readoutTitles, handleWellsChange }) => {
     {
       headerName: 'Molarity (M)',
       field: 'molarity_value',
-      editable: (params) => params.data.sample,
+      editable: canEditCell,
       valueGetter: (params) => {
         if (params.data?.sample) {
           return params.data.sample.molarity_value;
@@ -133,7 +136,7 @@ const WellplateList = ({ wells, readoutTitles, handleWellsChange }) => {
       },
       cellRenderer: renderMolarity,
       wrapText: true,
-      cellClass: ['editable-cell', 'border-end', 'px-2'],
+      cellClass: ["editable-cell", "border-end", "px-2"],
     }
   ];
 
@@ -142,7 +145,7 @@ const WellplateList = ({ wells, readoutTitles, handleWellsChange }) => {
       {
         headerName: `${title} Value`,
         field: "value",
-        editable: (params) => params.data.sample,
+        editable: canEditCell,
         valueGetter: (params) => {
           if (params.data?.readouts) {
             return params.data.readouts[index]?.value;
@@ -163,7 +166,7 @@ const WellplateList = ({ wells, readoutTitles, handleWellsChange }) => {
       {
         headerName: `${title} Unit`,
         field: "unit",
-        editable: (params) => params.data.sample,
+        editable: canEditCell,
         valueGetter: (params) => {
           if (params.data?.readouts) {
             return params.data.readouts[index]?.unit;
@@ -209,7 +212,7 @@ const WellplateList = ({ wells, readoutTitles, handleWellsChange }) => {
         autoSizeStrategy={{ type: 'fitGridWidth' }}
         readOnlyEdit
         onCellEditRequest={updateRow}
-        singleClickEdit={true}
+        singleClickEdit={!readOnly}
         stopEditingWhenCellsLoseFocus={true}
       />
     </div>
@@ -221,5 +224,10 @@ export default WellplateList;
 WellplateList.propTypes = {
   wells: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   readoutTitles: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
-  handleWellsChange: PropTypes.func.isRequired
+  handleWellsChange: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
+};
+
+WellplateList.defaultProps = {
+  readOnly: false,
 };

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateProperties.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateProperties.js
@@ -76,7 +76,7 @@ export default class WellplateProperties extends Component {
                 type="text"
                 value={name || ''}
                 onChange={(event) => this.handleInputChange('name', event)}
-                disabled={!wellplate.can_update || name === '***'}
+                disabled={wellplate.isReadOnly || name === '***'}
               />
             </Form.Group>
           </Col>
@@ -100,12 +100,12 @@ export default class WellplateProperties extends Component {
                 type="text"
                 value={readoutTitle}
                 onChange={(event) => this.updateReadoutTitle(index, event.target.value)}
-                disabled={!wellplate.can_update}
+                disabled={wellplate.isReadOnly}
               />
               <Button
                 variant="danger"
                 onClick={() => this.setState({ selectedReadoutIndex: index })}
-                disabled={!wellplate.can_update}
+                disabled={wellplate.isReadOnly}
               >
                 <i className="fa fa-trash-o" />
               </Button>
@@ -115,7 +115,7 @@ export default class WellplateProperties extends Component {
             variant="success"
             className="mt-2 mx-3 w-auto"
             onClick={() => this.addReadoutTitle()}
-            disabled={!wellplate.can_update}
+            disabled={wellplate.isReadOnly}
           >
             Add Readouts
           </Button>
@@ -127,7 +127,7 @@ export default class WellplateProperties extends Component {
             <QuillEditor
               value={description}
               onChange={(event) => this.handleInputChange('description', { target: { value: event } })}
-              disabled={!wellplate.can_update || description === '***'}
+              disabled={wellplate.isReadOnly || description === '***'}
             />
           </Form.Group>
         </Row>

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateProperties.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateProperties.js
@@ -20,13 +20,17 @@ export default class WellplateProperties extends Component {
   }
 
   handleInputChange(type, event) {
-    const { changeProperties } = this.props;
+    const { wellplate, changeProperties } = this.props;
+    if (wellplate.isReadOnly) { return; }
+
     const { value } = event.target;
     changeProperties({ type, value });
   }
 
   addReadoutTitle() {
-    const { readoutTitles, changeProperties, handleAddReadout } = this.props;
+    const { wellplate, readoutTitles, changeProperties, handleAddReadout } = this.props;
+    if (wellplate.isReadOnly) { return; }
+
     const currentTitles = readoutTitles || [];
     const newTitles = currentTitles.concat(`Readout ${currentTitles.length + 1}`);
     changeProperties({ type: 'readoutTitles', value: newTitles });
@@ -34,7 +38,9 @@ export default class WellplateProperties extends Component {
   }
 
   deleteReadoutTitle(index) {
-    const { readoutTitles, changeProperties, handleRemoveReadout } = this.props;
+    const { wellplate, readoutTitles, changeProperties, handleRemoveReadout } = this.props;
+    if (wellplate.isReadOnly) { return; }
+
     const currentTitles = readoutTitles || [];
     currentTitles.splice(index, 1);
     changeProperties({ type: 'readoutTitles', value: currentTitles });
@@ -43,7 +49,9 @@ export default class WellplateProperties extends Component {
   }
 
   updateReadoutTitle(index, newValue) {
-    const { readoutTitles, changeProperties } = this.props;
+    const { wellplate, readoutTitles, changeProperties } = this.props;
+    if (wellplate.isReadOnly) { return; }
+
     const currentTitles = readoutTitles || [];
     currentTitles[index] = newValue;
     changeProperties({ type: 'readoutTitles', value: currentTitles });
@@ -68,69 +76,71 @@ export default class WellplateProperties extends Component {
             this.setState({ selectedReadoutIndex: null })
           }}
         />
-        <Row className="">
-          <Col xs="9">
+        <fieldset disabled={wellplate.isReadOnly}>
+          <Row className="">
+            <Col xs="9">
+              <Form.Group>
+                <Form.Label>Name</Form.Label>
+                <Form.Control
+                  type="text"
+                  value={name || ''}
+                  onChange={(event) => this.handleInputChange('name', event)}
+                  disabled={wellplate.isReadOnly || name === '***'}
+                />
+              </Form.Group>
+            </Col>
+            <Col xs="3">
+              <Form.Label>Size</Form.Label>
+              <div className="custom-size-dropdown">
+                <WellplateSizeDropdown
+                  updateWellplate={changeProperties}
+                  wellplate={wellplate}
+                  key={`${wellplate.id}-wellplate-size-dropdown`}
+                />
+              </div>
+            </Col>
+          </Row>
+
+          <Row className="gy-1 mt-3">
+            <Form.Label>Readouts</Form.Label>
+            {readoutTitles && readoutTitles.map((readoutTitle, index) => (
+              <InputGroup key={`wellplate-${wellplate.id}-readout-${index}`}>
+                <Form.Control
+                  type="text"
+                  value={readoutTitle}
+                  onChange={(event) => this.updateReadoutTitle(index, event.target.value)}
+                  disabled={wellplate.isReadOnly}
+                />
+                <Button
+                  variant="danger"
+                  onClick={() => this.setState({ selectedReadoutIndex: index })}
+                  disabled={wellplate.isReadOnly}
+                >
+                  <i className="fa fa-trash-o" />
+                </Button>
+              </InputGroup>
+            ))}
+            <Button
+              variant="success"
+              className="mt-2 mx-3 w-auto"
+              onClick={() => this.addReadoutTitle()}
+              disabled={wellplate.isReadOnly}
+            >
+              Add Readouts
+            </Button>
+          </Row>
+
+          <Row className="mt-3">
             <Form.Group>
-              <Form.Label>Name</Form.Label>
-              <Form.Control
-                type="text"
-                value={name || ''}
-                onChange={(event) => this.handleInputChange('name', event)}
-                disabled={wellplate.isReadOnly || name === '***'}
+              <Form.Label>Description</Form.Label>
+              <QuillEditor
+                value={description}
+                onChange={(event) => this.handleInputChange('description', { target: { value: event } })}
+                disabled={wellplate.isReadOnly || description === '***'}
               />
             </Form.Group>
-          </Col>
-          <Col xs="3">
-            <Form.Label>Size</Form.Label>
-            <div className="custom-size-dropdown">
-              <WellplateSizeDropdown
-                updateWellplate={changeProperties}
-                wellplate={wellplate}
-                key={`${wellplate.id}-wellplate-size-dropdown`}
-              />
-            </div>
-          </Col>
-        </Row>
-
-        <Row className="gy-1 mt-3">
-          <Form.Label>Readouts</Form.Label>
-          {readoutTitles && readoutTitles.map((readoutTitle, index) => (
-            <InputGroup key={`wellplate-${wellplate.id}-readout-${index}`}>
-              <Form.Control
-                type="text"
-                value={readoutTitle}
-                onChange={(event) => this.updateReadoutTitle(index, event.target.value)}
-                disabled={wellplate.isReadOnly}
-              />
-              <Button
-                variant="danger"
-                onClick={() => this.setState({ selectedReadoutIndex: index })}
-                disabled={wellplate.isReadOnly}
-              >
-                <i className="fa fa-trash-o" />
-              </Button>
-            </InputGroup>
-          ))}
-          <Button
-            variant="success"
-            className="mt-2 mx-3 w-auto"
-            onClick={() => this.addReadoutTitle()}
-            disabled={wellplate.isReadOnly}
-          >
-            Add Readouts
-          </Button>
-        </Row>
-
-        <Row className="mt-3">
-          <Form.Group>
-            <Form.Label>Description</Form.Label>
-            <QuillEditor
-              value={description}
-              onChange={(event) => this.handleInputChange('description', { target: { value: event } })}
-              disabled={wellplate.isReadOnly || description === '***'}
-            />
-          </Form.Group>
-        </Row>
+          </Row>
+        </fieldset>
       </div>
     );
   }

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateProperties.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateProperties.js
@@ -76,7 +76,7 @@ export default class WellplateProperties extends Component {
                 type="text"
                 value={name || ''}
                 onChange={(event) => this.handleInputChange('name', event)}
-                disabled={name === '***'}
+                disabled={!wellplate.can_update || name === '***'}
               />
             </Form.Group>
           </Col>
@@ -100,13 +100,23 @@ export default class WellplateProperties extends Component {
                 type="text"
                 value={readoutTitle}
                 onChange={(event) => this.updateReadoutTitle(index, event.target.value)}
+                disabled={!wellplate.can_update}
               />
-              <Button variant="danger" onClick={() => this.setState({ selectedReadoutIndex: index })}>
+              <Button
+                variant="danger"
+                onClick={() => this.setState({ selectedReadoutIndex: index })}
+                disabled={!wellplate.can_update}
+              >
                 <i className="fa fa-trash-o" />
               </Button>
             </InputGroup>
           ))}
-          <Button variant="success" className="mt-2 mx-3 w-auto" onClick={() => this.addReadoutTitle()}>
+          <Button
+            variant="success"
+            className="mt-2 mx-3 w-auto"
+            onClick={() => this.addReadoutTitle()}
+            disabled={!wellplate.can_update}
+          >
             Add Readouts
           </Button>
         </Row>
@@ -117,7 +127,7 @@ export default class WellplateProperties extends Component {
             <QuillEditor
               value={description}
               onChange={(event) => this.handleInputChange('description', { target: { value: event } })}
-              disabled={description === '***'}
+              disabled={!wellplate.can_update || description === '***'}
             />
           </Form.Group>
         </Row>

--- a/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
+++ b/app/javascript/src/apps/mydb/elements/details/wellplates/propertiesTab/WellplateSizeDropdown.js
@@ -17,6 +17,8 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
   const [showCustomSizeModal, setShowCustomSizeModal] = useState(false)
 
   const onChange = (event) => {
+    if (wellplate.isReadOnly) { return; }
+
     const values = event.target.value.split(" ").map(x => parseInt(x, 10))
     const width = values[0]
     const height = values[1]
@@ -45,13 +47,13 @@ const WellplateSizeDropdown = ({ wellplate, updateWellplate }) => {
           required={true}
           value={size}
           onChange={onChange}
-          disabled={!wellplate.is_new}
+          disabled={!wellplate.is_new || wellplate.isReadOnly}
         >
           {options}
         </Form.Select>
         <Button
           className="create-own-size-button"
-          disabled={!wellplate.is_new}
+          disabled={!wellplate.is_new || wellplate.isReadOnly}
           onClick={() => setShowCustomSizeModal(true)}
         >
           <i className="fa fa-braille" />

--- a/app/javascript/src/components/UserLabels.js
+++ b/app/javascript/src/components/UserLabels.js
@@ -370,7 +370,7 @@ function EditUserLabels({ element, fnCb }) {
       <Form.Label>My labels</Form.Label>
       <Select
         isMulti
-        isDisabled={!element?.can_update}
+        isDisabled={element.isReadOnly}
         options={options}
         getOptionValue={(currentLabel) => currentLabel.id}
         getOptionLabel={(currentLabel) => currentLabel.title}

--- a/app/javascript/src/models/Element.js
+++ b/app/javascript/src/models/Element.js
@@ -17,6 +17,14 @@ export default class Element {
     return this[m] == '***'
   }
 
+  // Editability derived from the backend `can_update` permission flag. The flag may be
+  // undefined when the backend omits it (e.g. list payloads); undefined/true means editable,
+  // only an explicit false makes the element read-only. Centralized here so call sites read
+  // intent (`element.isReadOnly`) instead of re-deriving `can_update === false` everywhere.
+  get isReadOnly() {
+    return this.can_update === false;
+  }
+
   static buildID() {
     return uuid.v1();
   }

--- a/app/javascript/src/models/ResearchPlan.js
+++ b/app/javascript/src/models/ResearchPlan.js
@@ -44,6 +44,9 @@ export default class ResearchPlan extends Element {
   constructor(args) {
     super(args);
     this.mode = args.mode ? args.mode : 'view';
+    // Default to editable when the backend did not send a permission flag (e.g. list
+    // payloads omit can_update). Genuinely read-only elements carry can_update: false.
+    if (this.can_update === undefined) { this.can_update = true; }
   }
 
   static buildEmpty(collectionId) {

--- a/app/javascript/src/models/ResearchPlan.js
+++ b/app/javascript/src/models/ResearchPlan.js
@@ -44,9 +44,6 @@ export default class ResearchPlan extends Element {
   constructor(args) {
     super(args);
     this.mode = args.mode ? args.mode : 'view';
-    // Default to editable when the backend did not send a permission flag (e.g. list
-    // payloads omit can_update). Genuinely read-only elements carry can_update: false.
-    if (this.can_update === undefined) { this.can_update = true; }
   }
 
   static buildEmpty(collectionId) {

--- a/app/javascript/src/models/Screen.js
+++ b/app/javascript/src/models/Screen.js
@@ -4,6 +4,13 @@ import Container from 'src/models/Container';
 import Segment from 'src/models/Segment';
 
 export default class Screen extends Element {
+  constructor(args) {
+    super(args);
+    // Default to editable when the backend did not send a permission flag (e.g. list
+    // payloads omit can_update). Genuinely read-only elements carry can_update: false.
+    if (this.can_update === undefined) { this.can_update = true; }
+  }
+
   static buildEmpty(collectionID) {
     const descriptionDefault = {
       ops: [{ insert: '' }]

--- a/app/javascript/src/models/Screen.js
+++ b/app/javascript/src/models/Screen.js
@@ -6,9 +6,6 @@ import Segment from 'src/models/Segment';
 export default class Screen extends Element {
   constructor(args) {
     super(args);
-    // Default to editable when the backend did not send a permission flag (e.g. list
-    // payloads omit can_update). Genuinely read-only elements carry can_update: false.
-    if (this.can_update === undefined) { this.can_update = true; }
   }
 
   static buildEmpty(collectionID) {
@@ -30,6 +27,7 @@ export default class Screen extends Element {
       research_plans: [],
       container: Container.init(),
       segments: [],
+      can_update: true,
       component_graph_data: {
         nodes: [],
         edges: []
@@ -43,7 +41,7 @@ export default class Screen extends Element {
     };
 
     return new Screen({
-      collection_id: collectionID,
+      collection_id: collection_id,
       type: 'screen',
       name: 'New Screen with Wellplates',
       collaborator: '',
@@ -56,6 +54,7 @@ export default class Screen extends Element {
       user_labels: [],
       container: Container.init(),
       segments: [],
+      can_update: true,
       component_graph_data: {
         nodes: [],
         edges: []

--- a/app/javascript/src/models/Wellplate.js
+++ b/app/javascript/src/models/Wellplate.js
@@ -8,9 +8,6 @@ export default class Wellplate extends Element {
   constructor(args) {
     super(args);
     this.#initEmptyWells();
-    // Default to editable when the backend did not send a permission flag (e.g. list
-    // payloads omit can_update). Genuinely read-only elements carry can_update: false.
-    if (this.can_update === undefined) { this.can_update = true; }
   }
 
   static buildEmpty(collectionId, width = 12, height = 8) {
@@ -27,7 +24,8 @@ export default class Wellplate extends Element {
         readout_titles: [],
         container: Container.init(),
         segments: [],
-        attachments: []
+        attachments: [],
+        can_update: true,
       }
     );
   }

--- a/app/javascript/src/models/Wellplate.js
+++ b/app/javascript/src/models/Wellplate.js
@@ -8,6 +8,9 @@ export default class Wellplate extends Element {
   constructor(args) {
     super(args);
     this.#initEmptyWells();
+    // Default to editable when the backend did not send a permission flag (e.g. list
+    // payloads omit can_update). Genuinely read-only elements carry can_update: false.
+    if (this.can_update === undefined) { this.can_update = true; }
   }
 
   static buildEmpty(collectionId, width = 12, height = 8) {

--- a/spec/api/chemotion/research_plan_api_spec.rb
+++ b/spec/api/chemotion/research_plan_api_spec.rb
@@ -16,6 +16,12 @@ describe Chemotion::ResearchPlanAPI do
         expect(response).to have_http_status :ok
         expect(parsed_json_response['research_plans'].pluck('id')).to contain_exactly(research_plan.id)
       end
+
+      it 'omits can_update for listed research plans' do
+        get '/api/v1/research_plans', params: { collection_id: collection.id }
+
+        expect(parsed_json_response['research_plans']).to all(satisfy { |rp| !rp.key?('can_update') })
+      end
     end
 
     context 'when no collection_id is given (All)' do

--- a/spec/api/chemotion/screen_api_spec.rb
+++ b/spec/api/chemotion/screen_api_spec.rb
@@ -46,6 +46,11 @@ describe Chemotion::ScreenAPI do
         get '/api/v1/screens', headers: request_headers
         expect(parsed_json_response['screens'].length).to eq(2)
       end
+
+      it 'includes can_update for listed screens' do
+        get '/api/v1/screens', headers: request_headers
+        expect(parsed_json_response['screens'].map { |s| s['can_update'] }).to all(be true)
+      end
     end
 
     context 'when collection_id is given' do

--- a/spec/api/chemotion/screen_api_spec.rb
+++ b/spec/api/chemotion/screen_api_spec.rb
@@ -141,26 +141,72 @@ describe Chemotion::ScreenAPI do
   describe 'POST /api/v1/screens/:id/add_research_plan' do
     let(:request_body) do
       {
-        collection_id: collection.id
+        collection_id: collection.id,
       }
     end
-    let(:expected_response) do
-      Entities::ScreenEntity.represent(screen, root: :screen)
-    end
 
-    it 'adds an empty research plan to the screen' do
-      expect do
+    context 'when the user can update the screen' do
+      it 'adds an empty research plan to the screen' do
+        expect do
+          post "/api/v1/screens/#{screen.id}/add_research_plan", params: request_body
+        end.to change(screen.research_plans, :count).by(1)
+      end
+
+      it 'returns the serialized screen with a policy-backed can_update' do
         post "/api/v1/screens/#{screen.id}/add_research_plan", params: request_body
-      end.to change(screen.research_plans, :count).by(1)
+
+        expect(response.status).to eq 201
+        screen_json = JSON.parse(response.body)['screen']
+        expect(screen_json['id']).to eq(screen.id)
+        expect(screen_json['can_update']).to be true
+      end
     end
 
-    it 'returns the serialized screen' do
-      post "/api/v1/screens/#{screen.id}/add_research_plan", params: request_body
+    context 'when the screen is in a read-only shared collection' do
+      let(:screen_collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(
+            :collection_share,
+            collection: c,
+            shared_with: user,
+            permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements],
+          )
+        end
+      end
+      let(:screen) { create(:screen, collections: [screen_collection]) }
 
-      expect(response.status).to eq 201
-      body_value = JSON.parse(response.body)
-      expected_response.instance_variables.each do |ivar_name|
-        expect(body_value[ivar_name]).to eq(expected_response.instance_variable_get ivar_name)
+      before do
+        post "/api/v1/screens/#{screen.id}/add_research_plan", params: request_body
+      end
+
+      it 'returns 401 unauthorized' do
+        expect(response).to have_http_status :unauthorized
+      end
+
+      it 'does not add a research plan' do
+        expect(screen.research_plans.reload.count).to eq(0)
+      end
+    end
+
+    context 'without update permissions' do
+      let(:screen) { create(:screen, collections: [other_user_collection]) }
+
+      before do
+        post "/api/v1/screens/#{screen.id}/add_research_plan", params: request_body
+      end
+
+      it 'returns 401 unauthorized' do
+        expect(response).to have_http_status :unauthorized
+      end
+    end
+
+    context 'when the screen does not exist' do
+      before do
+        post '/api/v1/screens/0/add_research_plan', params: request_body
+      end
+
+      it 'returns 404 not found' do
+        expect(response).to have_http_status :not_found
       end
     end
   end

--- a/spec/api/chemotion/screen_api_spec.rb
+++ b/spec/api/chemotion/screen_api_spec.rb
@@ -188,12 +188,14 @@ describe Chemotion::ScreenAPI do
 
       it 'is able to change a screen by id' do
         expect(parsed_json_response['screen']['name']).to eq('Another Testname')
+        # rubocop:disable Rails/Pluck -- wellplates/research_plans are parsed JSON (Array of Hash), not AR relations
         expect(
-          parsed_json_response['screen']['wellplates'].map { |w| w['id'] }
+          parsed_json_response['screen']['wellplates'].map { |w| w['id'] },
         ).to eq([wellplate.id])
         expect(
-          parsed_json_response['screen']['research_plans'].map { |r| r['id'] }
+          parsed_json_response['screen']['research_plans'].map { |r| r['id'] },
         ).to eq([research_plan.id])
+        # rubocop:enable Rails/Pluck
       end
 
       it 'updates the component_graph_data correctly' do

--- a/spec/api/chemotion/screen_api_spec.rb
+++ b/spec/api/chemotion/screen_api_spec.rb
@@ -49,7 +49,7 @@ describe Chemotion::ScreenAPI do
 
       it 'includes can_update for listed screens' do
         get '/api/v1/screens', headers: request_headers
-        expect(parsed_json_response['screens'].map { |s| s['can_update'] }).to all(be true)
+        expect(parsed_json_response['screens'].pluck('can_update')).to all(be true)
       end
     end
 

--- a/spec/api/chemotion/screen_api_spec.rb
+++ b/spec/api/chemotion/screen_api_spec.rb
@@ -86,6 +86,10 @@ describe Chemotion::ScreenAPI do
       expect(JSON.parse(response.body)['screen']['name']).to eq(screen.name)
     end
 
+    it 'returns can_update as true for the owner' do
+      expect(JSON.parse(response.body)['screen']['can_update']).to be true
+    end
+
     it 'returns the component_graph_data as json object' do
       expect(JSON.parse(response.body)['screen']['component_graph_data']).to eq(
         { some_dummy: 'data', with_nested: { but_cool: 'Stuff' } }.deep_stringify_keys,
@@ -97,6 +101,34 @@ describe Chemotion::ScreenAPI do
 
       it 'returns 401 unauthorized status code' do
         expect(response.status).to eq 401
+      end
+    end
+
+    context 'when the screen is in a read-only shared collection' do
+      let(:collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements])
+        end
+      end
+
+      it 'returns can_update as false' do
+        expect(response).to have_http_status :ok
+        expect(JSON.parse(response.body)['screen']['can_update']).to be false
+      end
+    end
+
+    context 'when the screen is in a writable shared collection' do
+      let(:collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare::PERMISSION_LEVELS[:edit_elements])
+        end
+      end
+
+      it 'returns can_update as true' do
+        expect(response).to have_http_status :ok
+        expect(JSON.parse(response.body)['screen']['can_update']).to be true
       end
     end
   end
@@ -148,28 +180,55 @@ describe Chemotion::ScreenAPI do
       }
     end
 
-    before do
-      ScreensWellplate.create!(wellplate: other_wellplate, screen: screen)
-      put "/api/v1/screens/#{screen.id}", params: params.to_json, headers: request_headers
+    context 'when the user can update the screen' do
+      before do
+        ScreensWellplate.create!(wellplate: other_wellplate, screen: screen)
+        put "/api/v1/screens/#{screen.id}", params: params.to_json, headers: request_headers
+      end
+
+      it 'is able to change a screen by id' do
+        expect(parsed_json_response['screen']['name']).to eq('Another Testname')
+        expect(
+          parsed_json_response['screen']['wellplates'].map { |w| w['id'] }
+        ).to eq([wellplate.id])
+        expect(
+          parsed_json_response['screen']['research_plans'].map { |r| r['id'] }
+        ).to eq([research_plan.id])
+      end
+
+      it 'updates the component_graph_data correctly' do
+        expect(parsed_json_response['screen']['component_graph_data']).to eq(
+          {
+            'nodes' => [{ 'id' => 1337 }],
+            'edges' => [],
+          },
+        )
+      end
+
+      it 'returns can_update as true after a successful update' do
+        expect(parsed_json_response['screen']['can_update']).to be true
+      end
     end
 
-    it 'is able to change a screen by id' do
-      expect(parsed_json_response['screen']['name']).to eq('Another Testname')
-      expect(
-        parsed_json_response['screen']['wellplates'].map { |w| w['id'] }
-      ).to eq([wellplate.id])
-      expect(
-        parsed_json_response['screen']['research_plans'].map { |r| r['id'] }
-      ).to eq([research_plan.id])
-    end
+    context 'when the screen is in a read-only shared collection' do
+      let(:collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements])
+        end
+      end
 
-    it 'updates the component_graph_data correctly' do
-      expect(parsed_json_response['screen']['component_graph_data']).to eq(
-        {
-          'nodes' => [{ 'id' => 1337 }],
-          'edges' => [],
-        },
-      )
+      before do
+        put "/api/v1/screens/#{screen.id}", params: params.to_json, headers: request_headers
+      end
+
+      it 'returns 401 unauthorized' do
+        expect(response).to have_http_status :unauthorized
+      end
+
+      it 'does not update the screen' do
+        expect(screen.reload.name).to eq('Testname')
+      end
     end
   end
 

--- a/spec/api/chemotion/screen_api_spec.rb
+++ b/spec/api/chemotion/screen_api_spec.rb
@@ -47,9 +47,9 @@ describe Chemotion::ScreenAPI do
         expect(parsed_json_response['screens'].length).to eq(2)
       end
 
-      it 'includes can_update for listed screens' do
+      it 'omits can_update for listed screens' do
         get '/api/v1/screens', headers: request_headers
-        expect(parsed_json_response['screens'].pluck('can_update')).to all(be true)
+        expect(parsed_json_response['screens']).to all(satisfy { |s| !s.key?('can_update') })
       end
     end
 

--- a/spec/api/chemotion/screen_api_spec.rb
+++ b/spec/api/chemotion/screen_api_spec.rb
@@ -95,6 +95,10 @@ describe Chemotion::ScreenAPI do
       expect(JSON.parse(response.body)['screen']['name']).to eq(screen.name)
     end
 
+    it 'returns can_update as true for the owner' do
+      expect(JSON.parse(response.body)['screen']['can_update']).to be true
+    end
+
     it 'returns the component_graph_data as json object' do
       expect(JSON.parse(response.body)['screen']['component_graph_data']).to eq(
         { some_dummy: 'data', with_nested: { but_cool: 'Stuff' } }.deep_stringify_keys,
@@ -106,6 +110,34 @@ describe Chemotion::ScreenAPI do
 
       it 'returns 401 unauthorized status code' do
         expect(response.status).to eq 401
+      end
+    end
+
+    context 'when the screen is in a read-only shared collection' do
+      let(:collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements])
+        end
+      end
+
+      it 'returns can_update as false' do
+        expect(response).to have_http_status :ok
+        expect(JSON.parse(response.body)['screen']['can_update']).to be false
+      end
+    end
+
+    context 'when the screen is in a writable shared collection' do
+      let(:collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare::PERMISSION_LEVELS[:edit_elements])
+        end
+      end
+
+      it 'returns can_update as true' do
+        expect(response).to have_http_status :ok
+        expect(JSON.parse(response.body)['screen']['can_update']).to be true
       end
     end
   end
@@ -157,28 +189,55 @@ describe Chemotion::ScreenAPI do
       }
     end
 
-    before do
-      ScreensWellplate.create!(wellplate: other_wellplate, screen: screen)
-      put "/api/v1/screens/#{screen.id}", params: params.to_json, headers: request_headers
+    context 'when the user can update the screen' do
+      before do
+        ScreensWellplate.create!(wellplate: other_wellplate, screen: screen)
+        put "/api/v1/screens/#{screen.id}", params: params.to_json, headers: request_headers
+      end
+
+      it 'is able to change a screen by id' do
+        expect(parsed_json_response['screen']['name']).to eq('Another Testname')
+        expect(
+          parsed_json_response['screen']['wellplates'].map { |w| w['id'] }
+        ).to eq([wellplate.id])
+        expect(
+          parsed_json_response['screen']['research_plans'].map { |r| r['id'] }
+        ).to eq([research_plan.id])
+      end
+
+      it 'updates the component_graph_data correctly' do
+        expect(parsed_json_response['screen']['component_graph_data']).to eq(
+          {
+            'nodes' => [{ 'id' => 1337 }],
+            'edges' => [],
+          },
+        )
+      end
+
+      it 'returns can_update as true after a successful update' do
+        expect(parsed_json_response['screen']['can_update']).to be true
+      end
     end
 
-    it 'is able to change a screen by id' do
-      expect(parsed_json_response['screen']['name']).to eq('Another Testname')
-      expect(
-        parsed_json_response['screen']['wellplates'].map { |w| w['id'] }
-      ).to eq([wellplate.id])
-      expect(
-        parsed_json_response['screen']['research_plans'].map { |r| r['id'] }
-      ).to eq([research_plan.id])
-    end
+    context 'when the screen is in a read-only shared collection' do
+      let(:collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements])
+        end
+      end
 
-    it 'updates the component_graph_data correctly' do
-      expect(parsed_json_response['screen']['component_graph_data']).to eq(
-        {
-          'nodes' => [{ 'id' => 1337 }],
-          'edges' => [],
-        },
-      )
+      before do
+        put "/api/v1/screens/#{screen.id}", params: params.to_json, headers: request_headers
+      end
+
+      it 'returns 401 unauthorized' do
+        expect(response).to have_http_status :unauthorized
+      end
+
+      it 'does not update the screen' do
+        expect(screen.reload.name).to eq('Testname')
+      end
     end
   end
 

--- a/spec/api/chemotion/screen_api_spec.rb
+++ b/spec/api/chemotion/screen_api_spec.rb
@@ -150,26 +150,72 @@ describe Chemotion::ScreenAPI do
   describe 'POST /api/v1/screens/:id/add_research_plan' do
     let(:request_body) do
       {
-        collection_id: collection.id
+        collection_id: collection.id,
       }
     end
-    let(:expected_response) do
-      Entities::ScreenEntity.represent(screen, root: :screen)
-    end
 
-    it 'adds an empty research plan to the screen' do
-      expect do
+    context 'when the user can update the screen' do
+      it 'adds an empty research plan to the screen' do
+        expect do
+          post "/api/v1/screens/#{screen.id}/add_research_plan", params: request_body
+        end.to change(screen.research_plans, :count).by(1)
+      end
+
+      it 'returns the serialized screen with a policy-backed can_update' do
         post "/api/v1/screens/#{screen.id}/add_research_plan", params: request_body
-      end.to change(screen.research_plans, :count).by(1)
+
+        expect(response.status).to eq 201
+        screen_json = JSON.parse(response.body)['screen']
+        expect(screen_json['id']).to eq(screen.id)
+        expect(screen_json['can_update']).to be true
+      end
     end
 
-    it 'returns the serialized screen' do
-      post "/api/v1/screens/#{screen.id}/add_research_plan", params: request_body
+    context 'when the screen is in a read-only shared collection' do
+      let(:screen_collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(
+            :collection_share,
+            collection: c,
+            shared_with: user,
+            permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements],
+          )
+        end
+      end
+      let(:screen) { create(:screen, collections: [screen_collection]) }
 
-      expect(response.status).to eq 201
-      body_value = JSON.parse(response.body)
-      expected_response.instance_variables.each do |ivar_name|
-        expect(body_value[ivar_name]).to eq(expected_response.instance_variable_get ivar_name)
+      before do
+        post "/api/v1/screens/#{screen.id}/add_research_plan", params: request_body
+      end
+
+      it 'returns 401 unauthorized' do
+        expect(response).to have_http_status :unauthorized
+      end
+
+      it 'does not add a research plan' do
+        expect(screen.research_plans.reload.count).to eq(0)
+      end
+    end
+
+    context 'without update permissions' do
+      let(:screen) { create(:screen, collections: [other_user_collection]) }
+
+      before do
+        post "/api/v1/screens/#{screen.id}/add_research_plan", params: request_body
+      end
+
+      it 'returns 401 unauthorized' do
+        expect(response).to have_http_status :unauthorized
+      end
+    end
+
+    context 'when the screen does not exist' do
+      before do
+        post '/api/v1/screens/0/add_research_plan', params: request_body
+      end
+
+      it 'returns 404 not found' do
+        expect(response).to have_http_status :not_found
       end
     end
   end

--- a/spec/api/chemotion/screen_api_spec.rb
+++ b/spec/api/chemotion/screen_api_spec.rb
@@ -197,12 +197,14 @@ describe Chemotion::ScreenAPI do
 
       it 'is able to change a screen by id' do
         expect(parsed_json_response['screen']['name']).to eq('Another Testname')
+        # rubocop:disable Rails/Pluck -- wellplates/research_plans are parsed JSON (Array of Hash), not AR relations
         expect(
-          parsed_json_response['screen']['wellplates'].map { |w| w['id'] }
+          parsed_json_response['screen']['wellplates'].map { |w| w['id'] },
         ).to eq([wellplate.id])
         expect(
-          parsed_json_response['screen']['research_plans'].map { |r| r['id'] }
+          parsed_json_response['screen']['research_plans'].map { |r| r['id'] },
         ).to eq([research_plan.id])
+        # rubocop:enable Rails/Pluck
       end
 
       it 'updates the component_graph_data correctly' do

--- a/spec/api/chemotion/wellplate_api_spec.rb
+++ b/spec/api/chemotion/wellplate_api_spec.rb
@@ -82,6 +82,11 @@ describe Chemotion::WellplateAPI do
         get '/api/v1/wellplates/'
         expect(JSON.parse(response.body)['wellplates'].size).to eq(1)
       end
+
+      it 'includes can_update for listed wellplates' do
+        get '/api/v1/wellplates/'
+        expect(JSON.parse(response.body)['wellplates'].map { |w| w['can_update'] }).to all(be true)
+      end
     end
 
     context 'when collection_id is given' do

--- a/spec/api/chemotion/wellplate_api_spec.rb
+++ b/spec/api/chemotion/wellplate_api_spec.rb
@@ -118,11 +118,45 @@ describe Chemotion::WellplateAPI do
       expect(JSON.parse(response.body)['wellplate']['name']).to eq(wellplate.name)
     end
 
+    it 'returns can_update as true for the owner' do
+      expect(JSON.parse(response.body)['wellplate']['can_update']).to be true
+    end
+
     context 'when permissions are inappropriate' do
       let(:collection) { other_user_collection }
 
       it 'returns 401 unauthorized status code' do
         expect(response).to have_http_status :unauthorized
+      end
+    end
+
+    context 'when the wellplate is in a read-only shared collection' do
+      let(:collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements],
+                                    wellplate_detail_level: 10)
+        end
+      end
+
+      it 'returns can_update as false' do
+        expect(response).to have_http_status :ok
+        expect(JSON.parse(response.body)['wellplate']['can_update']).to be false
+      end
+    end
+
+    context 'when the wellplate is in a writable shared collection' do
+      let(:collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare::PERMISSION_LEVELS[:edit_elements],
+                                    wellplate_detail_level: 10)
+        end
+      end
+
+      it 'returns can_update as true' do
+        expect(response).to have_http_status :ok
+        expect(JSON.parse(response.body)['wellplate']['can_update']).to be true
       end
     end
   end
@@ -168,17 +202,46 @@ describe Chemotion::WellplateAPI do
       }
     end
 
-    before do
-      CollectionsWellplate.create!(wellplate: wellplate, collection: collection_shared_with_user)
-      put "/api/v1/wellplates/#{wellplate.id}", params: params
+    context 'when the user can update the wellplate' do
+      before do
+        CollectionsWellplate.create!(wellplate: wellplate, collection: collection_shared_with_user)
+        put "/api/v1/wellplates/#{wellplate.id}", params: params
+      end
+
+      it 'is able to change a wellplate by id' do
+        expect(JSON.parse(response.body)['wellplate']['name']).to eq('Another Testname')
+      end
+
+      it 'returns the wellplate attachments' do
+        expect(response.parsed_body['attachments'].first['filename']).to eq(attachment.filename)
+      end
+
+      it 'returns can_update as true after a successful update' do
+        expect(JSON.parse(response.body)['wellplate']['can_update']).to be true
+      end
     end
 
-    it 'is able to change a wellplate by id' do
-      expect(JSON.parse(response.body)['wellplate']['name']).to eq('Another Testname')
-    end
+    context 'when the wellplate is in a read-only shared collection' do
+      let(:read_only_collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements],
+                                    wellplate_detail_level: 10)
+        end
+      end
 
-    it 'returns the wellplate attachments' do
-      expect(response.parsed_body['attachments'].first['filename']).to eq(attachment.filename)
+      before do
+        CollectionsWellplate.create!(wellplate: wellplate, collection: read_only_collection)
+        put "/api/v1/wellplates/#{wellplate.id}", params: params
+      end
+
+      it 'returns 401 unauthorized' do
+        expect(response).to have_http_status :unauthorized
+      end
+
+      it 'does not update the wellplate' do
+        expect(wellplate.reload.name).to eq('Testname')
+      end
     end
   end
 

--- a/spec/api/chemotion/wellplate_api_spec.rb
+++ b/spec/api/chemotion/wellplate_api_spec.rb
@@ -85,7 +85,7 @@ describe Chemotion::WellplateAPI do
 
       it 'includes can_update for listed wellplates' do
         get '/api/v1/wellplates/'
-        expect(JSON.parse(response.body)['wellplates'].map { |w| w['can_update'] }).to all(be true)
+        expect(JSON.parse(response.body)['wellplates'].pluck('can_update')).to all(be true)
       end
     end
 

--- a/spec/api/chemotion/wellplate_api_spec.rb
+++ b/spec/api/chemotion/wellplate_api_spec.rb
@@ -127,11 +127,45 @@ describe Chemotion::WellplateAPI do
       expect(JSON.parse(response.body)['wellplate']['name']).to eq(wellplate.name)
     end
 
+    it 'returns can_update as true for the owner' do
+      expect(JSON.parse(response.body)['wellplate']['can_update']).to be true
+    end
+
     context 'when permissions are inappropriate' do
       let(:collection) { other_user_collection }
 
       it 'returns 401 unauthorized status code' do
         expect(response).to have_http_status :unauthorized
+      end
+    end
+
+    context 'when the wellplate is in a read-only shared collection' do
+      let(:collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements],
+                                    wellplate_detail_level: 10)
+        end
+      end
+
+      it 'returns can_update as false' do
+        expect(response).to have_http_status :ok
+        expect(JSON.parse(response.body)['wellplate']['can_update']).to be false
+      end
+    end
+
+    context 'when the wellplate is in a writable shared collection' do
+      let(:collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare::PERMISSION_LEVELS[:edit_elements],
+                                    wellplate_detail_level: 10)
+        end
+      end
+
+      it 'returns can_update as true' do
+        expect(response).to have_http_status :ok
+        expect(JSON.parse(response.body)['wellplate']['can_update']).to be true
       end
     end
   end
@@ -177,17 +211,46 @@ describe Chemotion::WellplateAPI do
       }
     end
 
-    before do
-      CollectionsWellplate.create!(wellplate: wellplate, collection: collection_shared_with_user)
-      put "/api/v1/wellplates/#{wellplate.id}", params: params
+    context 'when the user can update the wellplate' do
+      before do
+        CollectionsWellplate.create!(wellplate: wellplate, collection: collection_shared_with_user)
+        put "/api/v1/wellplates/#{wellplate.id}", params: params
+      end
+
+      it 'is able to change a wellplate by id' do
+        expect(JSON.parse(response.body)['wellplate']['name']).to eq('Another Testname')
+      end
+
+      it 'returns the wellplate attachments' do
+        expect(response.parsed_body['attachments'].first['filename']).to eq(attachment.filename)
+      end
+
+      it 'returns can_update as true after a successful update' do
+        expect(JSON.parse(response.body)['wellplate']['can_update']).to be true
+      end
     end
 
-    it 'is able to change a wellplate by id' do
-      expect(JSON.parse(response.body)['wellplate']['name']).to eq('Another Testname')
-    end
+    context 'when the wellplate is in a read-only shared collection' do
+      let(:read_only_collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements],
+                                    wellplate_detail_level: 10)
+        end
+      end
 
-    it 'returns the wellplate attachments' do
-      expect(response.parsed_body['attachments'].first['filename']).to eq(attachment.filename)
+      before do
+        CollectionsWellplate.create!(wellplate: wellplate, collection: read_only_collection)
+        put "/api/v1/wellplates/#{wellplate.id}", params: params
+      end
+
+      it 'returns 401 unauthorized' do
+        expect(response).to have_http_status :unauthorized
+      end
+
+      it 'does not update the wellplate' do
+        expect(wellplate.reload.name).to eq('Testname')
+      end
     end
   end
 

--- a/spec/api/chemotion/wellplate_api_spec.rb
+++ b/spec/api/chemotion/wellplate_api_spec.rb
@@ -83,9 +83,9 @@ describe Chemotion::WellplateAPI do
         expect(JSON.parse(response.body)['wellplates'].size).to eq(1)
       end
 
-      it 'includes can_update for listed wellplates' do
+      it 'omits can_update for listed wellplates' do
         get '/api/v1/wellplates/'
-        expect(JSON.parse(response.body)['wellplates'].pluck('can_update')).to all(be true)
+        expect(JSON.parse(response.body)['wellplates']).to all(satisfy { |w| !w.key?('can_update') })
       end
     end
 

--- a/spec/api/entities/research_plan_entity_spec.rb
+++ b/spec/api/entities/research_plan_entity_spec.rb
@@ -119,6 +119,20 @@ describe Entities::ResearchPlanEntity do
       end
     end
 
+    context 'when represented with a read-only policy' do
+      let(:detail_level) { 10 }
+      let(:policy) do
+        Struct.new(:update?, :copy?).new(false, false)
+      end
+
+      it 'returns can_update as false' do
+        expect(grape_entity_as_hash).to include(
+          can_copy: false,
+          can_update: false,
+        )
+      end
+    end
+
     context 'when entity is displayed in list' do
       let(:displayed_in_list) { true }
       let(:detail_level) { 10 }

--- a/spec/api/entities/research_plan_entity_spec.rb
+++ b/spec/api/entities/research_plan_entity_spec.rb
@@ -167,8 +167,8 @@ describe Entities::ResearchPlanEntity do
       let(:displayed_in_list) { true }
       let(:detail_level) { 10 }
 
-      it 'does not expose can_update' do
-        expect(grape_entity_as_hash).not_to include(:can_update)
+      it 'exposes can_update as false without a policy' do
+        expect(grape_entity_as_hash).to include(can_update: false)
       end
 
       it 'returns a research_plan without a container' do

--- a/spec/api/entities/research_plan_entity_spec.rb
+++ b/spec/api/entities/research_plan_entity_spec.rb
@@ -133,6 +133,36 @@ describe Entities::ResearchPlanEntity do
       end
     end
 
+    context 'when nested wellplates have different permissions than the research plan policy' do
+      let(:detail_level) { 10 }
+      let(:user) { create(:person) }
+      let(:research_plan) do
+        read_only_shared_collection = create(:collection, user: create(:person)).tap do |collection|
+          create(
+            :collection_share,
+            collection: collection,
+            shared_with: user,
+            permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements],
+          )
+        end
+
+        create(
+          :research_plan,
+          collections: [create(:collection, user: user)],
+          wellplates: [create(:wellplate, collections: [read_only_shared_collection])],
+        )
+      end
+      let(:policy) { ElementPolicy.new(user, research_plan) }
+
+      it 'returns can_update true for the owned research plan' do
+        expect(grape_entity_as_hash[:can_update]).to be true
+      end
+
+      it 'returns can_update false for nested read-only wellplates' do
+        expect(grape_entity_as_hash[:wellplates].first[:can_update]).to be false
+      end
+    end
+
     context 'when entity is displayed in list' do
       let(:displayed_in_list) { true }
       let(:detail_level) { 10 }

--- a/spec/api/entities/research_plan_entity_spec.rb
+++ b/spec/api/entities/research_plan_entity_spec.rb
@@ -9,11 +9,13 @@ describe Entities::ResearchPlanEntity do
         research_plan,
         detail_levels: detail_levels,
         displayed_in_list: displayed_in_list,
+        policy: policy,
       )
     end
 
     let(:detail_levels) { { ResearchPlan => detail_level, Wellplate => detail_level } }
     let(:displayed_in_list) { false }
+    let(:policy) { nil }
     let(:research_plan) { create(:research_plan, wellplates: [build(:wellplate)]) }
 
     before do
@@ -92,9 +94,38 @@ describe Entities::ResearchPlanEntity do
       end
     end
 
+    context 'when represented without a policy' do
+      let(:detail_level) { 10 }
+
+      it 'returns can_update and can_copy as false' do
+        expect(grape_entity_as_hash).to include(
+          can_copy: false,
+          can_update: false,
+        )
+      end
+    end
+
+    context 'when represented with a policy' do
+      let(:detail_level) { 10 }
+      let(:policy) do
+        Struct.new(:update?, :copy?).new(true, true)
+      end
+
+      it 'returns the policy related attributes' do
+        expect(grape_entity_as_hash).to include(
+          can_copy: true,
+          can_update: true,
+        )
+      end
+    end
+
     context 'when entity is displayed in list' do
       let(:displayed_in_list) { true }
       let(:detail_level) { 10 }
+
+      it 'does not expose can_update' do
+        expect(grape_entity_as_hash).not_to include(:can_update)
+      end
 
       it 'returns a research_plan without a container' do
         expect(grape_entity_as_hash[:container]).to eq(nil)

--- a/spec/api/entities/research_plan_entity_spec.rb
+++ b/spec/api/entities/research_plan_entity_spec.rb
@@ -167,8 +167,8 @@ describe Entities::ResearchPlanEntity do
       let(:displayed_in_list) { true }
       let(:detail_level) { 10 }
 
-      it 'exposes can_update as false without a policy' do
-        expect(grape_entity_as_hash).to include(can_update: false)
+      it 'omits can_update' do
+        expect(grape_entity_as_hash).not_to have_key(:can_update)
       end
 
       it 'returns a research_plan without a container' do

--- a/spec/api/entities/screen_entity_spec.rb
+++ b/spec/api/entities/screen_entity_spec.rb
@@ -9,6 +9,7 @@ describe Entities::ScreenEntity do
         screen,
         detail_levels: detail_levels,
         displayed_in_list: displayed_in_list,
+        policy: policy,
       )
     end
 
@@ -21,6 +22,7 @@ describe Entities::ScreenEntity do
       }
     end
     let(:displayed_in_list) { false }
+    let(:policy) { nil }
     let(:screen) do
       create(
         :screen,
@@ -122,9 +124,39 @@ describe Entities::ScreenEntity do
       end
     end
 
+    context 'when represented without a policy' do
+      let(:detail_level) { 10 }
+
+      it 'returns can_update as false' do
+        expect(grape_entity_as_hash).to include(can_update: false)
+      end
+    end
+
+    context 'when represented with a policy' do
+      let(:detail_level) { 10 }
+      let(:policy) { Struct.new(:update?).new(true) }
+
+      it 'returns the policy related attributes' do
+        expect(grape_entity_as_hash).to include(can_update: true)
+      end
+    end
+
+    context 'when represented with a read-only policy' do
+      let(:detail_level) { 10 }
+      let(:policy) { Struct.new(:update?).new(false) }
+
+      it 'returns can_update as false' do
+        expect(grape_entity_as_hash).to include(can_update: false)
+      end
+    end
+
     context 'when entity is displayed in list' do
       let(:displayed_in_list) { true }
       let(:detail_level) { 10 }
+
+      it 'does not expose can_update' do
+        expect(grape_entity_as_hash).not_to include(:can_update)
+      end
 
       it 'returns a screen without a code_log' do
         expect(grape_entity_as_hash[:code_log]).to eq(nil)

--- a/spec/api/entities/screen_entity_spec.rb
+++ b/spec/api/entities/screen_entity_spec.rb
@@ -150,6 +150,42 @@ describe Entities::ScreenEntity do
       end
     end
 
+    context 'when nested elements have different permissions than the screen policy' do
+      let(:detail_level) { 10 }
+      let(:user) { create(:person) }
+      let(:screen) do
+        read_only_shared_collection = create(:collection, user: create(:person)).tap do |collection|
+          create(
+            :collection_share,
+            collection: collection,
+            shared_with: user,
+            permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements],
+          )
+        end
+
+        create(
+          :screen,
+          collections: [create(:collection, user: user)],
+          wellplates: [create(:wellplate, collections: [read_only_shared_collection])],
+          research_plans: [create(:research_plan, collections: [read_only_shared_collection])],
+          container: create(:container),
+        )
+      end
+      let(:policy) { ElementPolicy.new(user, screen) }
+
+      it 'returns can_update true for the owned screen' do
+        expect(grape_entity_as_hash[:can_update]).to be true
+      end
+
+      it 'returns can_update false for nested read-only research plans' do
+        expect(grape_entity_as_hash[:research_plans].first[:can_update]).to be false
+      end
+
+      it 'returns can_update false for nested read-only wellplates' do
+        expect(grape_entity_as_hash[:wellplates].first[:can_update]).to be false
+      end
+    end
+
     context 'when entity is displayed in list' do
       let(:displayed_in_list) { true }
       let(:detail_level) { 10 }

--- a/spec/api/entities/screen_entity_spec.rb
+++ b/spec/api/entities/screen_entity_spec.rb
@@ -190,8 +190,8 @@ describe Entities::ScreenEntity do
       let(:displayed_in_list) { true }
       let(:detail_level) { 10 }
 
-      it 'does not expose can_update' do
-        expect(grape_entity_as_hash).not_to include(:can_update)
+      it 'exposes can_update as false without a policy' do
+        expect(grape_entity_as_hash).to include(can_update: false)
       end
 
       it 'returns a screen without a code_log' do

--- a/spec/api/entities/screen_entity_spec.rb
+++ b/spec/api/entities/screen_entity_spec.rb
@@ -190,8 +190,8 @@ describe Entities::ScreenEntity do
       let(:displayed_in_list) { true }
       let(:detail_level) { 10 }
 
-      it 'exposes can_update as false without a policy' do
-        expect(grape_entity_as_hash).to include(can_update: false)
+      it 'omits can_update' do
+        expect(grape_entity_as_hash).not_to have_key(:can_update)
       end
 
       it 'returns a screen without a code_log' do

--- a/spec/api/entities/wellplate_entity_spec.rb
+++ b/spec/api/entities/wellplate_entity_spec.rb
@@ -9,11 +9,13 @@ describe Entities::WellplateEntity do
         wellplate,
         detail_levels: detail_levels,
         displayed_in_list: displayed_in_list,
+        policy: policy,
       )
     end
 
     let(:detail_levels) { { Wellplate => detail_level, Well => detail_level, Sample => detail_level } }
     let(:displayed_in_list) { false }
+    let(:policy) { nil }
     let(:wellplate) { create(:wellplate) }
     let(:sample) { build(:valid_sample) }
 
@@ -113,9 +115,39 @@ describe Entities::WellplateEntity do
       end
     end
 
+    context 'when represented without a policy' do
+      let(:detail_level) { 10 }
+
+      it 'returns can_update as false' do
+        expect(grape_entity_as_hash).to include(can_update: false)
+      end
+    end
+
+    context 'when represented with a policy' do
+      let(:detail_level) { 10 }
+      let(:policy) { Struct.new(:update?).new(true) }
+
+      it 'returns the policy related attributes' do
+        expect(grape_entity_as_hash).to include(can_update: true)
+      end
+    end
+
+    context 'when represented with a read-only policy' do
+      let(:detail_level) { 10 }
+      let(:policy) { Struct.new(:update?).new(false) }
+
+      it 'returns can_update as false' do
+        expect(grape_entity_as_hash).to include(can_update: false)
+      end
+    end
+
     context 'when entity is displayed in list' do
       let(:displayed_in_list) { true }
       let(:detail_level) { 10 }
+
+      it 'does not expose can_update' do
+        expect(grape_entity_as_hash).not_to include(:can_update)
+      end
 
       it 'returns a wellplate without a code_log' do
         expect(grape_entity_as_hash[:code_log]).to be_nil

--- a/spec/api/entities/wellplate_entity_spec.rb
+++ b/spec/api/entities/wellplate_entity_spec.rb
@@ -145,8 +145,8 @@ describe Entities::WellplateEntity do
       let(:displayed_in_list) { true }
       let(:detail_level) { 10 }
 
-      it 'does not expose can_update' do
-        expect(grape_entity_as_hash).not_to include(:can_update)
+      it 'exposes can_update as false without a policy' do
+        expect(grape_entity_as_hash).to include(can_update: false)
       end
 
       it 'returns a wellplate without a code_log' do

--- a/spec/api/entities/wellplate_entity_spec.rb
+++ b/spec/api/entities/wellplate_entity_spec.rb
@@ -145,8 +145,8 @@ describe Entities::WellplateEntity do
       let(:displayed_in_list) { true }
       let(:detail_level) { 10 }
 
-      it 'exposes can_update as false without a policy' do
-        expect(grape_entity_as_hash).to include(can_update: false)
+      it 'omits can_update' do
+        expect(grape_entity_as_hash).not_to have_key(:can_update)
       end
 
       it 'returns a wellplate without a code_log' do

--- a/spec/api/research_plan_api_spec.rb
+++ b/spec/api/research_plan_api_spec.rb
@@ -67,7 +67,8 @@ describe Chemotion::ResearchPlanAPI do
         it 'returns serialized research_plan body' do
           expect(JSON.parse(response.body)['research_plan']).not_to be_nil
           rp = ResearchPlan.find_by(name: 'test')
-          expected = Entities::ResearchPlanEntity.represent(rp, root: 'research_plan')
+          policy = ElementPolicy.new(user, rp)
+          expected = Entities::ResearchPlanEntity.represent(rp, root: 'research_plan', policy: policy)
           expect(response.body).to eq JSON.generate(expected)
         end
       end

--- a/spec/api/research_plan_api_spec.rb
+++ b/spec/api/research_plan_api_spec.rb
@@ -30,6 +30,46 @@ describe Chemotion::ResearchPlanAPI do
         it 'returns serialized research_plan' do
           expect(JSON.parse(response.body)['research_plan']['name']).to eq research_plan.name
         end
+
+        it 'returns can_update as true for the owner' do
+          expect(JSON.parse(response.body)['research_plan']['can_update']).to be true
+        end
+      end
+
+      context 'when the research plan is in a read-only shared collection' do
+        let(:other_user) { create(:person) }
+        let(:collection) do
+          create(:collection, user: other_user).tap do |c|
+            create(:collection_share, collection: c, shared_with: user,
+                                      permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements])
+          end
+        end
+        let(:research_plan) { create(:research_plan, collections: [collection]) }
+
+        before { get "/api/v1/research_plans/#{research_plan.id}" }
+
+        it 'returns can_update as false' do
+          expect(response).to have_http_status :ok
+          expect(JSON.parse(response.body)['research_plan']['can_update']).to be false
+        end
+      end
+
+      context 'when the research plan is in a writable shared collection' do
+        let(:other_user) { create(:person) }
+        let(:collection) do
+          create(:collection, user: other_user).tap do |c|
+            create(:collection_share, collection: c, shared_with: user,
+                                      permission_level: CollectionShare::PERMISSION_LEVELS[:edit_elements])
+          end
+        end
+        let(:research_plan) { create(:research_plan, collections: [collection]) }
+
+        before { get "/api/v1/research_plans/#{research_plan.id}" }
+
+        it 'returns can_update as true' do
+          expect(response).to have_http_status :ok
+          expect(JSON.parse(response.body)['research_plan']['can_update']).to be true
+        end
       end
     end
 

--- a/spec/api/research_plan_metadata_api_spec.rb
+++ b/spec/api/research_plan_metadata_api_spec.rb
@@ -5,36 +5,83 @@ require 'rails_helper'
 describe Chemotion::ResearchPlanMetadataAPI do
   context 'authorized user logged in' do
     let(:user) { create(:person) }
+    let(:other_user) { create(:person) }
+    let(:collection) { create(:collection, user: user) }
 
     before do
-      allow_any_instance_of(WardenAuthentication).to receive(:current_user).and_return(user)
+      allow_any_instance_of(WardenAuthentication).to receive(:current_user).and_return(user) # rubocop:disable RSpec/AnyInstance
     end
 
     describe 'GET /api/v1/research_plan_metadata/:id' do
-      context 'with appropriate permissions' do
-        let!(:c) { create(:collection, user_id: user.id) }
-        let(:research_plan) { create(:research_plan) }
-        let(:research_plan_metadata) { create(:research_plan_metadata, research_plan: research_plan) }
+      let(:research_plan) { create(:research_plan, collections: [collection]) }
+      let!(:research_plan_metadata) do
+        create(:research_plan_metadata, research_plan: research_plan)
+      end
 
+      context 'with read permissions' do
         before do
-          research_plan.research_plan_metadata = research_plan_metadata
-          research_plan.save
-
           get "/api/v1/research_plan_metadata/#{research_plan.id}"
         end
 
         it 'returns 200 status code' do
-          expect(response.status).to eq 200
+          expect(response).to have_http_status :ok
         end
 
         it 'returns serialized research_plan_metadata' do
           expect(JSON.parse(response.body)['research_plan_metadata']['title']).to eq research_plan_metadata.title
         end
       end
+
+      context 'when the research plan is in a read-only shared collection' do
+        let(:collection) do
+          create(:collection, user: other_user).tap do |c|
+            create(
+              :collection_share,
+              collection: c,
+              shared_with: user,
+              permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements],
+            )
+          end
+        end
+
+        before do
+          get "/api/v1/research_plan_metadata/#{research_plan.id}"
+        end
+
+        it 'returns 200 status code' do
+          expect(response).to have_http_status :ok
+        end
+
+        it 'returns serialized research_plan_metadata' do
+          expect(JSON.parse(response.body)['research_plan_metadata']['title']).to eq research_plan_metadata.title
+        end
+      end
+
+      context 'without read permissions' do
+        let(:collection) { create(:collection, user: other_user) }
+
+        before do
+          get "/api/v1/research_plan_metadata/#{research_plan.id}"
+        end
+
+        it 'returns 401 unauthorized' do
+          expect(response).to have_http_status :unauthorized
+        end
+      end
+
+      context 'when the research plan does not exist' do
+        before do
+          get '/api/v1/research_plan_metadata/0'
+        end
+
+        it 'returns 404 not found' do
+          expect(response).to have_http_status :not_found
+        end
+      end
     end
 
     describe 'POST /api/v1/research_plan_metadata' do
-      let(:research_plan) { create(:research_plan) }
+      let(:research_plan) { create(:research_plan, collections: [collection]) }
 
       let(:params) do
         {
@@ -45,30 +92,75 @@ describe Chemotion::ResearchPlanMetadataAPI do
           type: 'Test-Type',
           description: {
             description: 'Metadata for research plan',
-            descriptionType: 'Other'
+            descriptionType: 'Other',
           },
           geo_location: {
             geoLocationPoint: {
               pointLongitude: Faker::Address.longitude.to_s,
-              pointLatitude: Faker::Address.latitude.to_s
-            }
+              pointLatitude: Faker::Address.latitude.to_s,
+            },
           },
           funding_reference: {
             funderName: Faker::Name.name,
-            funderIdentifier: Faker::Internet.url
-          }
+            funderIdentifier: Faker::Internet.url,
+          },
         }
       end
 
-      describe 'when updating research plan metadata' do
+      context 'when the user can update the research plan' do
         before do
-          research_plan
-
           post '/api/v1/research_plan_metadata', params: params
         end
 
-        it 'Creates research plan metadata' do
-          expect(research_plan.research_plan_metadata).to have_attributes(params.deep_stringify_keys)
+        it 'creates research plan metadata' do
+          expect(research_plan.reload.research_plan_metadata).to have_attributes(params.deep_stringify_keys)
+        end
+      end
+
+      context 'when the research plan is in a read-only shared collection' do
+        let(:collection) do
+          create(:collection, user: other_user).tap do |c|
+            create(
+              :collection_share,
+              collection: c,
+              shared_with: user,
+              permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements],
+            )
+          end
+        end
+
+        before do
+          post '/api/v1/research_plan_metadata', params: params
+        end
+
+        it 'returns 401 unauthorized' do
+          expect(response).to have_http_status :unauthorized
+        end
+
+        it 'does not create research plan metadata' do
+          expect(research_plan.reload.research_plan_metadata).to be_nil
+        end
+      end
+
+      context 'without update permissions' do
+        let(:collection) { create(:collection, user: other_user) }
+
+        before do
+          post '/api/v1/research_plan_metadata', params: params
+        end
+
+        it 'returns 401 unauthorized' do
+          expect(response).to have_http_status :unauthorized
+        end
+      end
+
+      context 'when the research plan does not exist' do
+        before do
+          post '/api/v1/research_plan_metadata', params: params.merge(research_plan_id: 0)
+        end
+
+        it 'returns 404 not found' do
+          expect(response).to have_http_status :not_found
         end
       end
     end

--- a/spec/api/research_plan_metadata_api_spec.rb
+++ b/spec/api/research_plan_metadata_api_spec.rb
@@ -3,165 +3,163 @@
 require 'rails_helper'
 
 describe Chemotion::ResearchPlanMetadataAPI do
-  context 'authorized user logged in' do
-    let(:user) { create(:person) }
-    let(:other_user) { create(:person) }
-    let(:collection) { create(:collection, user: user) }
+  let(:user) { create(:person) }
+  let(:other_user) { create(:person) }
+  let(:collection) { create(:collection, user: user) }
 
-    before do
-      allow_any_instance_of(WardenAuthentication).to receive(:current_user).and_return(user) # rubocop:disable RSpec/AnyInstance
+  before do
+    allow_any_instance_of(WardenAuthentication).to receive(:current_user).and_return(user) # rubocop:disable RSpec/AnyInstance
+  end
+
+  describe 'GET /api/v1/research_plan_metadata/:id' do
+    let(:research_plan) { create(:research_plan, collections: [collection]) }
+    let!(:research_plan_metadata) do
+      create(:research_plan_metadata, research_plan: research_plan)
     end
 
-    describe 'GET /api/v1/research_plan_metadata/:id' do
-      let(:research_plan) { create(:research_plan, collections: [collection]) }
-      let!(:research_plan_metadata) do
-        create(:research_plan_metadata, research_plan: research_plan)
+    context 'with read permissions' do
+      before do
+        get "/api/v1/research_plan_metadata/#{research_plan.id}"
       end
 
-      context 'with read permissions' do
-        before do
-          get "/api/v1/research_plan_metadata/#{research_plan.id}"
-        end
-
-        it 'returns 200 status code' do
-          expect(response).to have_http_status :ok
-        end
-
-        it 'returns serialized research_plan_metadata' do
-          expect(JSON.parse(response.body)['research_plan_metadata']['title']).to eq research_plan_metadata.title
-        end
+      it 'returns 200 status code' do
+        expect(response).to have_http_status :ok
       end
 
-      context 'when the research plan is in a read-only shared collection' do
-        let(:collection) do
-          create(:collection, user: other_user).tap do |c|
-            create(
-              :collection_share,
-              collection: c,
-              shared_with: user,
-              permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements],
-            )
-          end
-        end
-
-        before do
-          get "/api/v1/research_plan_metadata/#{research_plan.id}"
-        end
-
-        it 'returns 200 status code' do
-          expect(response).to have_http_status :ok
-        end
-
-        it 'returns serialized research_plan_metadata' do
-          expect(JSON.parse(response.body)['research_plan_metadata']['title']).to eq research_plan_metadata.title
-        end
-      end
-
-      context 'without read permissions' do
-        let(:collection) { create(:collection, user: other_user) }
-
-        before do
-          get "/api/v1/research_plan_metadata/#{research_plan.id}"
-        end
-
-        it 'returns 401 unauthorized' do
-          expect(response).to have_http_status :unauthorized
-        end
-      end
-
-      context 'when the research plan does not exist' do
-        before do
-          get '/api/v1/research_plan_metadata/0'
-        end
-
-        it 'returns 404 not found' do
-          expect(response).to have_http_status :not_found
-        end
+      it 'returns serialized research_plan_metadata' do
+        expect(JSON.parse(response.body)['research_plan_metadata']['title']).to eq research_plan_metadata.title
       end
     end
 
-    describe 'POST /api/v1/research_plan_metadata' do
-      let(:research_plan) { create(:research_plan, collections: [collection]) }
+    context 'when the research plan is in a read-only shared collection' do
+      let(:collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(
+            :collection_share,
+            collection: c,
+            shared_with: user,
+            permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements],
+          )
+        end
+      end
 
-      let(:params) do
-        {
-          research_plan_id: research_plan.id,
-          title: 'Metadata',
-          subject: 'a subject',
-          version: '08.15',
-          type: 'Test-Type',
-          description: {
-            description: 'Metadata for research plan',
-            descriptionType: 'Other',
+      before do
+        get "/api/v1/research_plan_metadata/#{research_plan.id}"
+      end
+
+      it 'returns 200 status code' do
+        expect(response).to have_http_status :ok
+      end
+
+      it 'returns serialized research_plan_metadata' do
+        expect(JSON.parse(response.body)['research_plan_metadata']['title']).to eq research_plan_metadata.title
+      end
+    end
+
+    context 'without read permissions' do
+      let(:collection) { create(:collection, user: other_user) }
+
+      before do
+        get "/api/v1/research_plan_metadata/#{research_plan.id}"
+      end
+
+      it 'returns 401 unauthorized' do
+        expect(response).to have_http_status :unauthorized
+      end
+    end
+
+    context 'when the research plan does not exist' do
+      before do
+        get '/api/v1/research_plan_metadata/0'
+      end
+
+      it 'returns 404 not found' do
+        expect(response).to have_http_status :not_found
+      end
+    end
+  end
+
+  describe 'POST /api/v1/research_plan_metadata' do
+    let(:research_plan) { create(:research_plan, collections: [collection]) }
+
+    let(:params) do
+      {
+        research_plan_id: research_plan.id,
+        title: 'Metadata',
+        subject: 'a subject',
+        version: '08.15',
+        type: 'Test-Type',
+        description: {
+          description: 'Metadata for research plan',
+          descriptionType: 'Other',
+        },
+        geo_location: {
+          geoLocationPoint: {
+            pointLongitude: Faker::Address.longitude.to_s,
+            pointLatitude: Faker::Address.latitude.to_s,
           },
-          geo_location: {
-            geoLocationPoint: {
-              pointLongitude: Faker::Address.longitude.to_s,
-              pointLatitude: Faker::Address.latitude.to_s,
-            },
-          },
-          funding_reference: {
-            funderName: Faker::Name.name,
-            funderIdentifier: Faker::Internet.url,
-          },
-        }
+        },
+        funding_reference: {
+          funderName: Faker::Name.name,
+          funderIdentifier: Faker::Internet.url,
+        },
+      }
+    end
+
+    context 'when the user can update the research plan' do
+      before do
+        post '/api/v1/research_plan_metadata', params: params
       end
 
-      context 'when the user can update the research plan' do
-        before do
-          post '/api/v1/research_plan_metadata', params: params
-        end
-
-        it 'creates research plan metadata' do
-          expect(research_plan.reload.research_plan_metadata).to have_attributes(params.deep_stringify_keys)
-        end
+      it 'creates research plan metadata' do
+        expect(research_plan.reload.research_plan_metadata).to have_attributes(params.deep_stringify_keys)
       end
+    end
 
-      context 'when the research plan is in a read-only shared collection' do
-        let(:collection) do
-          create(:collection, user: other_user).tap do |c|
-            create(
-              :collection_share,
-              collection: c,
-              shared_with: user,
-              permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements],
-            )
-          end
-        end
-
-        before do
-          post '/api/v1/research_plan_metadata', params: params
-        end
-
-        it 'returns 401 unauthorized' do
-          expect(response).to have_http_status :unauthorized
-        end
-
-        it 'does not create research plan metadata' do
-          expect(research_plan.reload.research_plan_metadata).to be_nil
+    context 'when the research plan is in a read-only shared collection' do
+      let(:collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(
+            :collection_share,
+            collection: c,
+            shared_with: user,
+            permission_level: CollectionShare::PERMISSION_LEVELS[:read_elements],
+          )
         end
       end
 
-      context 'without update permissions' do
-        let(:collection) { create(:collection, user: other_user) }
-
-        before do
-          post '/api/v1/research_plan_metadata', params: params
-        end
-
-        it 'returns 401 unauthorized' do
-          expect(response).to have_http_status :unauthorized
-        end
+      before do
+        post '/api/v1/research_plan_metadata', params: params
       end
 
-      context 'when the research plan does not exist' do
-        before do
-          post '/api/v1/research_plan_metadata', params: params.merge(research_plan_id: 0)
-        end
+      it 'returns 401 unauthorized' do
+        expect(response).to have_http_status :unauthorized
+      end
 
-        it 'returns 404 not found' do
-          expect(response).to have_http_status :not_found
-        end
+      it 'does not create research plan metadata' do
+        expect(research_plan.reload.research_plan_metadata).to be_nil
+      end
+    end
+
+    context 'without update permissions' do
+      let(:collection) { create(:collection, user: other_user) }
+
+      before do
+        post '/api/v1/research_plan_metadata', params: params
+      end
+
+      it 'returns 401 unauthorized' do
+        expect(response).to have_http_status :unauthorized
+      end
+    end
+
+    context 'when the research plan does not exist' do
+      before do
+        post '/api/v1/research_plan_metadata', params: params.merge(research_plan_id: 0)
+      end
+
+      it 'returns 404 not found' do
+        expect(response).to have_http_status :not_found
       end
     end
   end

--- a/spec/javascripts/packs/src/models/Element.spec.js
+++ b/spec/javascripts/packs/src/models/Element.spec.js
@@ -1,0 +1,21 @@
+import expect from 'expect';
+import Element from 'src/models/Element';
+
+describe('Element', () => {
+  describe('isReadOnly', () => {
+    it('is read-only only when the backend sends an explicit can_update: false', () => {
+      const element = new Element({ id: 1, can_update: false });
+      expect(element.isReadOnly).toEqual(true);
+    });
+
+    it('is editable when can_update is true', () => {
+      const element = new Element({ id: 1, can_update: true });
+      expect(element.isReadOnly).toEqual(false);
+    });
+
+    it('is editable when the backend omits can_update (undefined defaults to editable)', () => {
+      const element = new Element({ id: 1 });
+      expect(element.isReadOnly).toEqual(false);
+    });
+  });
+});

--- a/spec/javascripts/packs/src/models/ResearchPlan.spec.js
+++ b/spec/javascripts/packs/src/models/ResearchPlan.spec.js
@@ -240,9 +240,9 @@ describe('ResearchPlan', () => {
   });
 
   describe('can_update', () => {
-    it('defaults to true when the backend omits the flag', () => {
+    it('does not invent can_update when the backend omits the flag', () => {
       const plan = new ResearchPlan({ name: 'Plan', type: 'research_plan' });
-      expect(plan.can_update).toEqual(true);
+      expect(plan.can_update).toEqual(undefined);
     });
 
     it('keeps an explicit false from the backend', () => {
@@ -252,6 +252,11 @@ describe('ResearchPlan', () => {
 
     it('keeps an explicit true from the backend', () => {
       const plan = new ResearchPlan({ name: 'Plan', type: 'research_plan', can_update: true });
+      expect(plan.can_update).toEqual(true);
+    });
+
+    it('defaults can_update to true for a newly built research plan', () => {
+      const plan = ResearchPlan.buildEmpty(1);
       expect(plan.can_update).toEqual(true);
     });
   });

--- a/spec/javascripts/packs/src/models/ResearchPlan.spec.js
+++ b/spec/javascripts/packs/src/models/ResearchPlan.spec.js
@@ -238,4 +238,21 @@ describe('ResearchPlan', () => {
       });
     });
   });
+
+  describe('can_update', () => {
+    it('defaults to true when the backend omits the flag', () => {
+      const plan = new ResearchPlan({ name: 'Plan', type: 'research_plan' });
+      expect(plan.can_update).toEqual(true);
+    });
+
+    it('keeps an explicit false from the backend', () => {
+      const plan = new ResearchPlan({ name: 'Plan', type: 'research_plan', can_update: false });
+      expect(plan.can_update).toEqual(false);
+    });
+
+    it('keeps an explicit true from the backend', () => {
+      const plan = new ResearchPlan({ name: 'Plan', type: 'research_plan', can_update: true });
+      expect(plan.can_update).toEqual(true);
+    });
+  });
 });

--- a/spec/javascripts/packs/src/models/Screen.spec.js
+++ b/spec/javascripts/packs/src/models/Screen.spec.js
@@ -3,9 +3,9 @@ import Screen from 'src/models/Screen';
 
 describe('Screen', () => {
   describe('can_update', () => {
-    it('defaults to true when the backend omits the flag', () => {
+    it('does not invent can_update when the backend omits the flag', () => {
       const screen = new Screen({ name: 'Screen', type: 'screen' });
-      expect(screen.can_update).toEqual(true);
+      expect(screen.can_update).toEqual(undefined);
     });
 
     it('keeps an explicit false from the backend', () => {

--- a/spec/javascripts/packs/src/models/Screen.spec.js
+++ b/spec/javascripts/packs/src/models/Screen.spec.js
@@ -1,0 +1,28 @@
+import expect from 'expect';
+import Screen from 'src/models/Screen';
+
+describe('Screen', () => {
+  describe('can_update', () => {
+    it('defaults to true when the backend omits the flag', () => {
+      const screen = new Screen({ name: 'Screen', type: 'screen' });
+      expect(screen.can_update).toEqual(true);
+    });
+
+    it('keeps an explicit false from the backend', () => {
+      const screen = new Screen({ name: 'Screen', type: 'screen', can_update: false });
+      expect(screen.can_update).toEqual(false);
+    });
+
+    it('keeps an explicit true from the backend', () => {
+      const screen = new Screen({ name: 'Screen', type: 'screen', can_update: true });
+      expect(screen.can_update).toEqual(true);
+    });
+  });
+
+  describe('buildEmpty()', () => {
+    it('defaults can_update to true for a new screen', () => {
+      const screen = Screen.buildEmpty(1);
+      expect(screen.can_update).toEqual(true);
+    });
+  });
+});

--- a/spec/javascripts/packs/src/models/Wellplate.spec.js
+++ b/spec/javascripts/packs/src/models/Wellplate.spec.js
@@ -270,9 +270,9 @@ describe('Wellplate', () => {
   });
 
   describe('can_update', () => {
-    it('defaults to true when the backend omits the flag', () => {
+    it('does not invent can_update when the backend omits the flag', () => {
       const wellplate = new Wellplate({ name: 'WP', type: 'wellplate', width: 2, height: 2, wells: [] });
-      expect(wellplate.can_update).toEqual(true);
+      expect(wellplate.can_update).toEqual(undefined);
     });
 
     it('keeps an explicit false from the backend', () => {
@@ -280,6 +280,11 @@ describe('Wellplate', () => {
         name: 'WP', type: 'wellplate', width: 2, height: 2, wells: [], can_update: false
       });
       expect(wellplate.can_update).toEqual(false);
+    });
+
+    it('defaults can_update to true for a newly built wellplate', () => {
+      const wellplate = Wellplate.buildEmpty(1, 2, 2);
+      expect(wellplate.can_update).toEqual(true);
     });
   });
 });

--- a/spec/javascripts/packs/src/models/Wellplate.spec.js
+++ b/spec/javascripts/packs/src/models/Wellplate.spec.js
@@ -268,4 +268,18 @@ describe('Wellplate', () => {
       });
     });
   });
+
+  describe('can_update', () => {
+    it('defaults to true when the backend omits the flag', () => {
+      const wellplate = new Wellplate({ name: 'WP', type: 'wellplate', width: 2, height: 2, wells: [] });
+      expect(wellplate.can_update).toEqual(true);
+    });
+
+    it('keeps an explicit false from the backend', () => {
+      const wellplate = new Wellplate({
+        name: 'WP', type: 'wellplate', width: 2, height: 2, wells: [], can_update: false
+      });
+      expect(wellplate.can_update).toEqual(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Expose `can_update` from research plan, screen, and wellplate detail APIs via `ElementPolicy`, and default models to editable when the flag is omitted from list payloads.
- Gate Save and close-overlay behavior, as well as fields, analyses, attachments, drop zones, designer/list editing, metadata, and related actions when `can_update` is false.
- Add API/entity/model specs covering owner, read-only share, and writable share permission cases.

## Test plan
- [x] Open a research plan / screen / wellplate shared read-only: Save disabled; fields and mutating controls not editable
- [x] Confirm Attachments tabs hide upload/edit/delete; download still works
- [x] Confirm Screen wellplates/research-plan drop zones and “Add” actions are hidden when empty/read-only
- [x] Confirm Wellplate designer and list cells cannot be edited when read-only
- [x] Confirm Research Plan metadata and wellplates tabs are read-only when shared that way
- [x] With edit-share permissions, editing and Save still work
- [x] Attempting Save on a read-only element does not offer “Save and Close”; Discard path works if local dirty state exists
- [x] Run relevant API/entity specs (`screen_api`, `wellplate_api`, `research_plan_api`, entity specs) and JS model specs

Closes https://github.com/ComPlat/chemotion_ELN/issues/1369