### PR TITLE
chore(converter): bump converter-client to 0.16.2, converter-app to v1.9.3

### DIFF
--- a/.service-dependencies
+++ b/.service-dependencies
@@ -1,5 +1,5 @@
 #syntax=v1
-CONVERTER=ComPlat/chemotion-converter-app@v1.9.1
+CONVERTER=ComPlat/chemotion-converter-app@v1.9.3
 KETCHER=ptrxyz/chemotion-ketchersvc@main
 SPECTRA=ComPlat/chem-spectra-app@v1.5.1
 NMRIUMWRAPPER=NFDI4Chem/nmrium-react-wrapper@v1.1.0

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@babel/runtime": "7",
     "@citation-js/plugin-isbn": "0.3.0",
     "@complat/chem-spectra-client": "1.3.5",
-    "@complat/chemotion-converter-client": "~0.16.0",
+    "@complat/chemotion-converter-client": "~0.16.2",
     "@complat/react-spectra-editor": "1.8.0",
     "@novnc/novnc": "~1.5.0",
     "@sentry/react": "^7.73.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1136,10 +1136,10 @@
     redux-form "^8.3.7"
     redux-saga "^1.1.3"
 
-"@complat/chemotion-converter-client@~0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@complat/chemotion-converter-client/-/chemotion-converter-client-0.16.0.tgz#bfb997d47c24effc772ebf02d9379584a46928d1"
-  integrity sha512-TgzTlBScCVPLj/d0PWXSNXfjgDW+4WEJSTERx6R5LL6EltsxO6w1P4P8Y0h33f+OYILeiW/LPNBXY2fs19BgHQ==
+"@complat/chemotion-converter-client@~0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@complat/chemotion-converter-client/-/chemotion-converter-client-0.16.2.tgz#e6a3c43a1c68878953c530dbe012df27e2559319"
+  integrity sha512-ZxdNwRjFQQ1tpGk1n30rdaKnRqWJcnVhFSrU39r49f9qKUlnfsE0g6N25OlRPPSPAdohFJ73nPV1xsQ4hzguxQ==
   dependencies:
     "@rdfjs/namespace" "^2.0.1"
     bootstrap "^5.3.8"


### PR DESCRIPTION
## What

- `@complat/chemotion-converter-client` `~0.16.0` → `~0.16.2`
- `.service-dependencies`: `CONVERTER=ComPlat/chemotion-converter-app@v1.9.1` → `@v1.9.3`

## Why

converter-client 0.16.2 (`ComPlat/chemotion-converter-client#173`) scopes its scroll-lock
CSS to its own root container instead of `body`/`main`, fixing the app-wide scrollbar loss
reported in `ComPlat/chemotion#542` — that unscoped rule was killing body scroll on every
ELN page ≥ 990px wide, not just the converter admin page.

converter-app v1.9.2/v1.9.3 are backend patch releases fixing profile-migration crashes
(resume-safe migration chain, backfilling missing fields) and stale JCAMP output
(`##XYPOINTS=` header). Neither changes any endpoint or payload shape `ConverterAdmin`
calls, so this is a mechanical pin bump — no ELN-side code changes required.

## Testing

- `yarn install` inside the dev container to resolve/update `yarn.lock`; confirmed
  `node_modules/@complat/chemotion-converter-client/package.json` resolves to `0.16.2`.
- Restarted the webpacker dev-server container for a clean rebuild against the bumped
  lockfile — compiles successfully.