### PR TITLE
fix(groups): decouple group-admin from membership, guard last-admin invariant

### DIFF
--- a/app/api/chemotion/admin_api.rb
+++ b/app/api/chemotion/admin_api.rb
@@ -111,8 +111,13 @@ module Chemotion
               { destroyed_id: params[:id] } if params[:destroy_obj] && obj.destroy!
             when 'NodeAdm'
               ua = UsersAdmin.find_by(user_id: params[:id], admin_id: params[:admin_id])
-              UsersAdmin.create!(user_id: params[:id], admin_id: params[:admin_id]) if ua.nil? && params[:set_admin]
-              ua.destroy! if params[:set_admin] == false && !ua.nil?
+              if params[:set_admin] && ua.nil?
+                UsersAdmin.create!(user_id: params[:id], admin_id: params[:admin_id])
+              elsif params[:set_admin] == false && !ua.nil?
+                error!('Cannot remove the last admin', 422) if Group.find(params[:id]).sole_admin?(params[:admin_id])
+
+                ua.destroy!
+              end
             when 'NodeAdd'
               obj = Group.find(params[:id]) if %w[Group].include?(params[:rootType])
               obj = Device.find(params[:id]) if %w[Device].include?(params[:rootType])

--- a/app/api/chemotion/admin_api.rb
+++ b/app/api/chemotion/admin_api.rb
@@ -147,9 +147,6 @@ module Chemotion
               obj = Device.find(params[:id]) if %w[Device].include?(params[:rootType])
               rm_users = (params[:rm_users] || []).map(&:to_i)
               obj.users.delete(User.where(id: rm_users)) if %w[Person].include?(params[:actionType])
-              if params[:rootType] == 'Group' && params[:actionType] == 'Person'
-                obj.admins.delete(User.where(id: rm_users))
-              end
               obj.devices.delete(Device.where(id: rm_users)) if %w[Device].include?(params[:actionType])
               User.gen_matrix(rm_users) if rm_users&.length&.positive?
 

--- a/app/api/chemotion/admin_user_api.rb
+++ b/app/api/chemotion/admin_user_api.rb
@@ -153,6 +153,8 @@ module Chemotion
           delete do
             @user.destroy!
             status 204
+          rescue ActiveRecord::RecordNotDestroyed => e
+            error!(e.record.errors.full_messages.join(', '), 422)
           end
 
           desc 'reset user password'

--- a/app/api/chemotion/group_api.rb
+++ b/app/api/chemotion/group_api.rb
@@ -72,10 +72,8 @@ module Chemotion
             desc 'remove a member from a group, or leave it'
             delete do
               error!('401 Unauthorized', 401) unless @policy.manage? || @policy.leave?(params[:user_id])
-              error!('Cannot remove the last admin', 422) if @policy.last_admin?(params[:user_id])
 
               @group.users.delete(User.where(id: params[:user_id]))
-              @group.users_admins.where(admin_id: params[:user_id]).destroy_all
               User.gen_matrix([params[:user_id]])
               present @group, with: Entities::GroupEntity, root: 'group'
             end

--- a/app/javascript/src/apps/admin/AdminGroupElement.js
+++ b/app/javascript/src/apps/admin/AdminGroupElement.js
@@ -29,6 +29,8 @@ export default class AdminGroupElement extends React.Component {
     };
     AdminFetcher.updateGroup(params)
       .then((result) => {
+        if (result && result.error) { alert(result.error); return; }
+
         if (setAdmin) {
           groupRec.admins.splice(1, 0, userRec);
         } else {

--- a/app/javascript/src/components/navigation/GroupElement.js
+++ b/app/javascript/src/components/navigation/GroupElement.js
@@ -18,17 +18,22 @@ export default class GroupElement extends React.Component {
     this.state = {
       showUsers: false,
       showRowAdd: false,
+      showAdminRowAdd: false,
       showAdminAlert: false,
       adminPopoverTarget: null,
       usersToggled: false,
       rowAddToggled: false,
+      adminRowAddToggled: false,
+      selectedAdminUsers: [],
     };
 
     this.toggleUsers = this.toggleUsers.bind(this);
     this.toggleRowAdd = this.toggleRowAdd.bind(this);
+    this.toggleAdminRowAdd = this.toggleAdminRowAdd.bind(this);
     this.loadUserByName = this.loadUserByName.bind(this);
     this.hideAdminAlert = this.hideAdminAlert.bind(this);
     this.setGroupAdmin = this.setGroupAdmin.bind(this);
+    this.addAdmin = this.addAdmin.bind(this);
   }
 
   setGroupAdmin(event, groupRec, userRec, setAdmin = true) {
@@ -85,6 +90,13 @@ export default class GroupElement extends React.Component {
     this.setState((prevState) => ({
       showRowAdd: !prevState.showRowAdd,
       rowAddToggled: !prevState.rowAddToggled,
+    }));
+  }
+
+  toggleAdminRowAdd() {
+    this.setState((prevState) => ({
+      showAdminRowAdd: !prevState.showAdminRowAdd,
+      adminRowAddToggled: !prevState.adminRowAddToggled,
     }));
   }
 
@@ -154,6 +166,21 @@ export default class GroupElement extends React.Component {
     });
   }
 
+  // promote users to admin without requiring them to be a member first; reuses
+  // setGroupAdmin so the admin list is updated the same way a per-row promote is
+  addAdmin(groupRec) {
+    const { selectedAdminUsers } = this.state;
+
+    selectedAdminUsers.forEach((u) => {
+      const isAlreadyAdmin = groupRec.admins.some((admin) => admin.id === u.value);
+      if (!isAlreadyAdmin) {
+        this.setGroupAdmin(null, groupRec, { id: u.value, name: u.name, initials: u.initials }, true);
+      }
+    });
+
+    this.setState({ selectedAdminUsers: [] });
+  }
+
   renderDeleteButton(type, groupRec, userRec) {
     const { currentUser } = this.props;
     let msg = 'Leave this group?';
@@ -212,7 +239,9 @@ export default class GroupElement extends React.Component {
 
   renderAdminButtons() {
     const { groupElement, currentUser } = this.props;
-    const { showRowAdd, selectedUsers } = this.state;
+    const {
+      showRowAdd, selectedUsers, showAdminRowAdd, selectedAdminUsers
+    } = this.state;
 
     const isAdmin = groupElement.admins && groupElement.admins
       .some((admin) => admin.id === currentUser.id);
@@ -245,6 +274,16 @@ export default class GroupElement extends React.Component {
                   <i className="fa fa-plus" />
                 </Button>
               </OverlayTrigger>
+              <OverlayTrigger placement="top" overlay={<Tooltip>Add admin</Tooltip>}>
+                <Button
+                  size="sm"
+                  type="button"
+                  variant="warning"
+                  onClick={this.toggleAdminRowAdd}
+                >
+                  <i className="fa fa-key" />
+                </Button>
+              </OverlayTrigger>
               <OverlayTrigger
                 placement="top"
                 overlay={<Tooltip>Remove group</Tooltip>}
@@ -273,6 +312,28 @@ export default class GroupElement extends React.Component {
               disabled={!selectedUsers}
             >
               <i className="fa fa-user-plus" />
+            </Button>
+          </div>
+        )}
+        {isAdmin && showAdminRowAdd && (
+          <div className="d-flex mt-2 align-items-center gap-2">
+            <AsyncSelect
+              className="w-50"
+              isMulti
+              value={selectedAdminUsers}
+              matchProp="name"
+              placeholder="Select users to make admin"
+              loadOptions={this.loadUserByName}
+              onChange={(selectedAdminUsers) => this.setState({ selectedAdminUsers })}
+            />
+            <Button
+              size="sm"
+              type="button"
+              variant="warning"
+              onClick={() => this.addAdmin(groupElement)}
+              disabled={!selectedAdminUsers}
+            >
+              <i className="fa fa-key" />
             </Button>
           </div>
         )}

--- a/app/javascript/src/components/navigation/GroupElement.js
+++ b/app/javascript/src/components/navigation/GroupElement.js
@@ -119,23 +119,13 @@ export default class GroupElement extends React.Component {
       case 'group':
         this.props.onDeleteGroup(groupRec.id);
         break;
-      case 'user': {
-        const userIsAdmin = groupRec.admins.some((admin) => admin.id === userRec.id);
-
-        // Block before firing the request: removing the sole admin would leave the
-        // group without one. GroupAPI refuses this with a 422 too, but checking here
-        // avoids firing a doomed request and shows the warning immediately instead of
-        // depending on the (unhandled) error response.
-        if (userIsAdmin && groupRec.admins.length === 1) {
-          this.setState({ showAdminAlert: true, adminPopoverTarget: event.target });
-          return;
-        }
-
-        // GroupAPI's member-removal endpoint already revokes the admin relationship as
-        // part of removing the member, so no separate demote call is needed here.
+      case 'user':
+        // Membership and admin status are independent: removing someone as a member
+        // must never affect their admin status, so this never touches groupRec.admins
+        // or fires a demote call. An admin who is also a member keeps their admin role
+        // (now as a non-member admin) after being removed here.
         this.props.onDeleteUser(groupRec, userRec);
         break;
-      }
       default:
         break;
     }
@@ -374,6 +364,40 @@ export default class GroupElement extends React.Component {
     );
   }
 
+  // Admins are listed regardless of membership. A non-member admin has no row in the
+  // (member-only) users table below, so their demote control lives here instead of in
+  // renderUserButtons - otherwise the only way to demote them would be adding them as a
+  // member first, demoting, then removing membership again.
+  renderAdminList() {
+    const { groupElement, currentUser } = this.props;
+    const isCurrentUserAdmin = groupElement.admins.some((a) => a.id === currentUser.id);
+
+    return groupElement.admins.map((admin) => {
+      const isMember = groupElement.users.some((u) => u.id === admin.id);
+
+      return (
+        <span
+          key={`admin_${groupElement.id}_${admin.id}`}
+          className="d-inline-flex align-items-center gap-1 me-2"
+        >
+          {admin.name}
+          {isCurrentUserAdmin && !isMember && (
+            <OverlayTrigger placement="top" overlay={<Tooltip>Demote from Admin</Tooltip>}>
+              <Button
+                size="sm"
+                type="button"
+                variant="warning"
+                onClick={(event) => this.setGroupAdmin(event, groupElement, admin, false)}
+              >
+                <i className="fa fa-key" />
+              </Button>
+            </OverlayTrigger>
+          )}
+        </span>
+      );
+    });
+  }
+
   render() {
     const { groupElement } = this.props;
     const { showUsers, showAdminAlert, adminPopoverTarget } = this.state;
@@ -384,7 +408,7 @@ export default class GroupElement extends React.Component {
           <td>{groupElement.name}</td>
           <td>{groupElement.initials}</td>
           <td>
-            {groupElement.admins.map((admin) => admin.name).join(', ')}
+            {this.renderAdminList()}
           </td>
           <td>
             {this.renderAdminButtons()}

--- a/app/javascript/src/components/navigation/GroupElement.js
+++ b/app/javascript/src/components/navigation/GroupElement.js
@@ -31,7 +31,7 @@ export default class GroupElement extends React.Component {
     this.setGroupAdmin = this.setGroupAdmin.bind(this);
   }
 
-  setGroupAdmin(groupRec, userRec, setAdmin = true) {
+  setGroupAdmin(event, groupRec, userRec, setAdmin = true) {
     // if removing group admin and there is only one admin -> show warning
     if (!setAdmin && groupRec.admins.length === 1) {
       this.setState({ showAdminAlert: true, adminPopoverTarget: event.target });
@@ -102,22 +102,28 @@ export default class GroupElement extends React.Component {
 
   // confirm action after pressing yes
   // if type is group, call deleteGroup api, if type is user, call deleteUser api
-  confirmDelete(type, groupRec, userRec) {
+  confirmDelete(event, type, groupRec, userRec) {
     switch (type) {
       case 'group':
         this.props.onDeleteGroup(groupRec.id);
         break;
-      case 'user':
-        this.props.onDeleteUser(groupRec, userRec);
-
-        // check if the user being deleted is an admin.
+      case 'user': {
         const userIsAdmin = groupRec.admins.some((admin) => admin.id === userRec.id);
 
-        // if admin, remove admin status
-        if (userIsAdmin) {
-          this.setGroupAdmin(groupRec, userRec, false);
+        // Block before firing the request: removing the sole admin would leave the
+        // group without one. GroupAPI refuses this with a 422 too, but checking here
+        // avoids firing a doomed request and shows the warning immediately instead of
+        // depending on the (unhandled) error response.
+        if (userIsAdmin && groupRec.admins.length === 1) {
+          this.setState({ showAdminAlert: true, adminPopoverTarget: event.target });
+          return;
         }
+
+        // GroupAPI's member-removal endpoint already revokes the admin relationship as
+        // part of removing the member, so no separate demote call is needed here.
+        this.props.onDeleteUser(groupRec, userRec);
         break;
+      }
       default:
         break;
     }
@@ -169,7 +175,7 @@ export default class GroupElement extends React.Component {
             <Button
               size="sm"
               variant="danger"
-              onClick={() => this.confirmDelete(type, groupRec, userRec)}
+              onClick={(event) => this.confirmDelete(event, type, groupRec, userRec)}
             >
               Yes
             </Button>
@@ -197,7 +203,6 @@ export default class GroupElement extends React.Component {
           size="sm"
           type="button"
           variant="danger"
-          onClick={() => this.confirmDelete(groupRec, userRec)}
         >
           <i className="fa fa-trash-o" />
         </Button>
@@ -293,7 +298,7 @@ export default class GroupElement extends React.Component {
               size="sm"
               type="button"
               variant={adminButtonStyle}
-              onClick={() => this.setGroupAdmin(groupRec, userRec, !isAdmin)}
+              onClick={(event) => this.setGroupAdmin(event, groupRec, userRec, !isAdmin)}
             >
               <i className="fa fa-key" />
             </Button>

--- a/app/javascript/src/components/navigation/GroupElement.js
+++ b/app/javascript/src/components/navigation/GroupElement.js
@@ -23,7 +23,6 @@ export default class GroupElement extends React.Component {
       adminPopoverTarget: null,
       usersToggled: false,
       rowAddToggled: false,
-      adminRowAddToggled: false,
       selectedAdminUsers: [],
     };
 
@@ -96,7 +95,6 @@ export default class GroupElement extends React.Component {
   toggleAdminRowAdd() {
     this.setState((prevState) => ({
       showAdminRowAdd: !prevState.showAdminRowAdd,
-      adminRowAddToggled: !prevState.adminRowAddToggled,
     }));
   }
 
@@ -299,7 +297,7 @@ export default class GroupElement extends React.Component {
               type="button"
               variant="success"
               onClick={() => this.addUser(groupElement)}
-              disabled={!selectedUsers}
+              disabled={!selectedUsers || selectedUsers.length === 0}
             >
               <i className="fa fa-user-plus" />
             </Button>
@@ -321,7 +319,7 @@ export default class GroupElement extends React.Component {
               type="button"
               variant="warning"
               onClick={() => this.addAdmin(groupElement)}
-              disabled={!selectedAdminUsers}
+              disabled={!selectedAdminUsers || selectedAdminUsers.length === 0}
             >
               <i className="fa fa-key" />
             </Button>

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -563,6 +563,20 @@ class Person < User
 
   has_many :users_admins, dependent: :destroy, foreign_key: :admin_id
   has_many :administrated_accounts, through: :users_admins, source: :user
+
+  # Must run before the `users_admins, dependent: :destroy` cascade above wipes
+  # `administrated_accounts`, or this would find nothing to check.
+  before_destroy :prevent_destroying_sole_group_admin, prepend: true
+
+  private
+
+  def prevent_destroying_sole_group_admin
+    orphaned = administrated_accounts.where(type: 'Group').select { |g| g.sole_admin?(id) }
+    return if orphaned.empty?
+
+    errors.add(:base, "cannot be deleted while the sole admin of: #{orphaned.map(&:name).join(', ')}")
+    throw(:abort)
+  end
 end
 
 class Group < User
@@ -576,6 +590,12 @@ class Group < User
 
   def administrated_by?(user)
     users_admins.where(admin: user).present?
+  end
+
+  # Single source of truth for "removing this admin would leave the group with none" —
+  # used by GroupPolicy#last_admin? and by every path that can revoke an admin relationship.
+  def sole_admin?(person_id)
+    admins.one? && admins.first.id == person_id
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -571,7 +571,8 @@ class Person < User
   private
 
   def prevent_destroying_sole_group_admin
-    orphaned = administrated_accounts.where(type: 'Group').select { |g| g.sole_admin?(id) }
+    administrated_group_ids = administrated_accounts.where(type: 'Group').select(:id)
+    orphaned = Group.where(id: administrated_group_ids).includes(:admins).select { |g| g.sole_admin?(id) }
     return if orphaned.empty?
 
     errors.add(:base, "cannot be deleted while the sole admin of: #{orphaned.map(&:name).join(', ')}")

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -31,6 +31,6 @@ class GroupPolicy
   end
 
   def last_admin?(target_user_id)
-    group.admins.one? && group.admins.first.id == target_user_id
+    group.sole_admin?(target_user_id)
   end
 end

--- a/spec/api/chemotion/admin_api_spec.rb
+++ b/spec/api/chemotion/admin_api_spec.rb
@@ -157,4 +157,27 @@ RSpec.describe Chemotion::AdminAPI do
       expect(group.reload.admins.pluck(:id)).to include(group_admin.id)
     end
   end
+
+  describe 'PUT /api/v1/admin/group_device/update/:id (action: NodeDel)' do
+    let!(:group_admin) { create(:person) }
+    let!(:member) { create(:person) }
+    let!(:group) { create(:group, admins: [group_admin, member], users: [group_admin, member]) }
+
+    def execute_request(rm_users:)
+      put "/api/v1/admin/group_device/update/#{group.id}", params: {
+        action: 'NodeDel', rootType: 'Group', actionType: 'Person', rm_users: rm_users
+      }
+    end
+
+    # Regression: this action used to also strip the target's admin relationship as a
+    # side effect of removing membership, contradicting the invariant that group-admin
+    # and group-member are independent (an admin who is also a member must keep their
+    # admin role after being removed as a member here).
+    it 'removes the membership but leaves the admin relationship intact' do
+      execute_request(rm_users: [member.id])
+
+      expect(group.reload.users.pluck(:id)).not_to include(member.id)
+      expect(group.reload.admins.pluck(:id)).to include(member.id)
+    end
+  end
 end

--- a/spec/api/chemotion/admin_api_spec.rb
+++ b/spec/api/chemotion/admin_api_spec.rb
@@ -120,4 +120,41 @@ RSpec.describe Chemotion::AdminAPI do
       expect(response).to have_http_status(:no_content)
     end
   end
+
+  describe 'PUT /api/v1/admin/group_device/update/:id (action: NodeAdm)' do
+    let!(:group_admin) { create(:person) }
+    let!(:second_admin) { create(:person) }
+    let!(:member) { create(:person) }
+    let!(:group) { create(:group, admins: [group_admin], users: [group_admin, member]) }
+
+    def execute_request(admin_id:, set_admin:)
+      put "/api/v1/admin/group_device/update/#{group.id}", params: {
+        action: 'NodeAdm', rootType: 'Group', actionType: 'Adm',
+        admin_id: admin_id, set_admin: set_admin
+      }
+    end
+
+    it 'promotes a person to group admin' do
+      execute_request(admin_id: member.id, set_admin: true)
+      expect(group.reload.admins.pluck(:id)).to include(member.id)
+    end
+
+    it 'demotes a co-admin' do
+      UsersAdmin.create!(user_id: group.id, admin_id: second_admin.id)
+
+      execute_request(admin_id: second_admin.id, set_admin: false)
+
+      expect(group.reload.admins.pluck(:id)).not_to include(second_admin.id)
+      expect(group.reload.admins.pluck(:id)).to include(group_admin.id)
+    end
+
+    # Regression: this action predates GroupAPI's last_admin? guard (#3398) and had no
+    # protection of its own, so a System Admin could demote a group's sole admin here.
+    it 'refuses to demote the sole admin with 422' do
+      execute_request(admin_id: group_admin.id, set_admin: false)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(group.reload.admins.pluck(:id)).to include(group_admin.id)
+    end
+  end
 end

--- a/spec/api/chemotion/admin_user_api_spec.rb
+++ b/spec/api/chemotion/admin_user_api_spec.rb
@@ -40,4 +40,26 @@ RSpec.describe Chemotion::AdminUserAPI do
       end
     end
   end
+
+  describe 'DELETE /api/v1/admin/users/:id' do
+    it 'destroys a user with no admin relationships' do
+      delete "/api/v1/admin/users/#{user.id}"
+
+      expect(response).to have_http_status(:no_content)
+      expect(User.unscoped.find(user.id)).to be_deleted
+    end
+
+    # Regression: Person#users_admins is dependent: :destroy, so deleting the sole admin
+    # of a group used to silently orphan it. Person#before_destroy now blocks this.
+    it 'refuses to destroy the sole admin of a group with 422', :aggregate_failures do
+      group = create(:group, admins: [user], users: [user])
+
+      delete "/api/v1/admin/users/#{user.id}"
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(parsed_json_response['error']).to include(group.name)
+      expect(User.unscoped.find(user.id)).not_to be_deleted
+      expect(group.reload.admins).to include(user)
+    end
+  end
 end

--- a/spec/api/chemotion/group_api_spec.rb
+++ b/spec/api/chemotion/group_api_spec.rb
@@ -205,7 +205,7 @@ describe Chemotion::GroupAPI do
       end
     end
 
-    context 'when the removed member is also an admin (not the last one)' do
+    context 'when the removed member is also an admin' do
       let!(:group) do
         create(:group, admins: [group_admin, second_admin], users: [group_admin, second_admin, member])
       end
@@ -213,21 +213,20 @@ describe Chemotion::GroupAPI do
       let(:user) { group_admin }
       let(:target) { second_admin }
 
-      it 'also revokes the admin relationship so no orphaned admin remains' do
+      it 'removes the membership but leaves the admin relationship intact' do
         execute_request
         expect(group.reload.users.pluck(:id)).not_to include(second_admin.id)
-        expect(group.reload.admins.pluck(:id)).not_to include(second_admin.id)
+        expect(group.reload.admins.pluck(:id)).to include(second_admin.id)
       end
     end
 
-    context 'when removing the sole remaining admin via the members endpoint' do
+    context 'when removing the membership of the sole remaining admin' do
       let(:user) { group_admin }
       let(:target) { group_admin }
 
-      it 'refuses with 422 and keeps the member and admin' do
+      it 'removes the membership and leaves them as a non-member admin' do
         execute_request
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(group.reload.users.pluck(:id)).to include(group_admin.id)
+        expect(group.reload.users.pluck(:id)).not_to include(group_admin.id)
         expect(group.reload.admins.pluck(:id)).to include(group_admin.id)
       end
     end

--- a/spec/api/chemotion/group_api_spec.rb
+++ b/spec/api/chemotion/group_api_spec.rb
@@ -8,6 +8,7 @@ describe Chemotion::GroupAPI do
   let(:group_admin) { create(:person) }
   let(:member) { create(:person) }
   let(:non_member) { create(:person) }
+  let(:non_member_admin) { create(:person) }
   let(:admin_user) { create(:admin) }
   let!(:group) do
     create(
@@ -94,6 +95,18 @@ describe Chemotion::GroupAPI do
       end
     end
 
+    context 'when called by an admin who is not a member' do
+      let!(:group) do
+        create(:group, admins: [group_admin, non_member_admin], users: [group_admin, member])
+      end
+      let(:user) { non_member_admin }
+
+      it 'destroys the group' do
+        execute_request
+        expect(Group.where(id: group.id)).to be_empty
+      end
+    end
+
     context 'when the group does not exist' do
       let(:user) { group_admin }
 
@@ -143,6 +156,18 @@ describe Chemotion::GroupAPI do
       it 'is unauthorized' do
         execute_request
         expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when called by an admin who is not a member' do
+      let!(:group) do
+        create(:group, admins: [group_admin, non_member_admin], users: [group_admin, member])
+      end
+      let(:user) { non_member_admin }
+
+      it 'adds the members' do
+        execute_request
+        expect(group.reload.users.pluck(:id)).to include(non_member.id)
       end
     end
   end
@@ -227,6 +252,19 @@ describe Chemotion::GroupAPI do
         expect(response).to have_http_status(:unauthorized)
       end
     end
+
+    context 'when called by an admin who is not a member' do
+      let!(:group) do
+        create(:group, admins: [group_admin, non_member_admin], users: [group_admin, member])
+      end
+      let(:user) { non_member_admin }
+      let(:target) { member }
+
+      it 'removes the member' do
+        execute_request
+        expect(group.reload.users.pluck(:id)).not_to include(member.id)
+      end
+    end
   end
 
   describe 'POST /api/v1/groups/:id/admins/:user_id' do
@@ -257,6 +295,18 @@ describe Chemotion::GroupAPI do
         execute_request
         expect(response).to have_http_status(:unauthorized)
         expect(group.reload.admins.pluck(:id)).not_to include(member.id)
+      end
+    end
+
+    context 'when called by an admin who is not a member' do
+      let!(:group) do
+        create(:group, admins: [group_admin, non_member_admin], users: [group_admin, member])
+      end
+      let(:user) { non_member_admin }
+
+      it 'promotes the member to admin' do
+        execute_request
+        expect(group.reload.admins.pluck(:id)).to include(member.id)
       end
     end
   end
@@ -296,6 +346,19 @@ describe Chemotion::GroupAPI do
       it 'is unauthorized' do
         execute_request
         expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when called by an admin who is not a member' do
+      let!(:group) do
+        create(:group, admins: [group_admin, non_member_admin], users: [group_admin, member])
+      end
+      let(:user) { non_member_admin }
+      let(:target) { group_admin }
+
+      it 'demotes the target admin' do
+        execute_request
+        expect(group.reload.admins.pluck(:id)).not_to include(group_admin.id)
       end
     end
   end

--- a/spec/javascripts/packs/src/components/navigation/GroupElement.spec.js
+++ b/spec/javascripts/packs/src/components/navigation/GroupElement.spec.js
@@ -4,6 +4,7 @@ import Enzyme, { mount } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import sinon from 'sinon';
 import GroupElement from 'src/components/navigation/GroupElement';
+import UsersFetcher from 'src/fetchers/UsersFetcher';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -69,6 +70,75 @@ describe('GroupElement', () => {
 
       expect(onDeleteUser.calledOnceWith(groupElement, otherAdmin)).toBe(true);
       expect(wrapper.instance().state.showAdminAlert).toBe(false);
+    });
+  });
+
+  // Regression coverage: admins and members are independent lists (GroupEntity exposes
+  // both unfiltered), so an admin who isn't a member must still be visible and able to
+  // manage the group; a plain member must not see management controls.
+  describe('.render()', () => {
+    const nonMemberAdmin = { id: 4, name: 'Admin Remote', initials: 'AR' };
+
+    const buildGroupElementWithNonMemberAdmin = () => ({
+      id: 10,
+      name: 'Test Group',
+      initials: 'TG',
+      admins: [admin, nonMemberAdmin],
+      users: [admin, member],
+    });
+
+    const mountAs = (groupElement, currentUser) => mount(React.createElement(GroupElement, {
+      groupElement,
+      currentUser,
+      currentGroup: [groupElement],
+      onDeleteGroup: sinon.spy(),
+      onDeleteUser: sinon.spy(),
+      onChangeData: sinon.spy(),
+    }));
+
+    it('shows a non-member admin\'s name in the Admin-by column', () => {
+      const groupElement = buildGroupElementWithNonMemberAdmin();
+      const wrapper = mountAs(groupElement, member);
+
+      const adminColumn = wrapper.find('tr.fw-bold.align-middle td').at(2).text();
+      expect(adminColumn).toContain(nonMemberAdmin.name);
+      expect(groupElement.users.some((u) => u.id === nonMemberAdmin.id)).toBe(false);
+    });
+
+    it('hides management controls from a plain member but shows them to a non-member admin', () => {
+      const groupElement = buildGroupElementWithNonMemberAdmin();
+
+      const asMember = mountAs(groupElement, member);
+      expect(asMember.find('.fa-plus').length).toBe(0);
+      expect(asMember.find('.fa-trash-o').length).toBe(0);
+
+      const asNonMemberAdmin = mountAs(groupElement, nonMemberAdmin);
+      expect(asNonMemberAdmin.find('.fa-plus').length).toBeGreaterThan(0);
+      expect(asNonMemberAdmin.find('.fa-trash-o').length).toBeGreaterThan(0);
+      expect(asNonMemberAdmin.find('.fa-key').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('.addAdmin(...)', () => {
+    afterEach(() => { sinon.restore(); });
+
+    it('promotes each newly selected user and skips users who are already admins', () => {
+      const groupElement = buildGroupElement([admin]);
+      const promoteStub = sinon.stub(UsersFetcher, 'promoteAdmin').returns(new Promise(() => {}));
+      const wrapper = mountElement(groupElement, sinon.spy());
+
+      wrapper.instance().setState({
+        selectedAdminUsers: [
+          { value: member.id, name: member.name, initials: member.initials },
+          { value: admin.id, name: admin.name, initials: admin.initials },
+        ],
+      });
+
+      wrapper.instance().addAdmin(groupElement);
+
+      expect(promoteStub.calledOnce).toBe(true);
+      expect(promoteStub.calledWith(groupElement.id, member.id)).toBe(true);
+      expect(wrapper.instance().state.selectedAdminUsers).toEqual([]);
     });
   });
 });

--- a/spec/javascripts/packs/src/components/navigation/GroupElement.spec.js
+++ b/spec/javascripts/packs/src/components/navigation/GroupElement.spec.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import expect from 'expect';
+import Enzyme, { mount } from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import sinon from 'sinon';
+import GroupElement from 'src/components/navigation/GroupElement';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+// Regression coverage for confirmDelete('user', ...): it used to fire onDeleteUser (the
+// actual removal request) before checking whether the target is the group's sole admin,
+// so a doomed request went out and only a same-tick, unrelated demote call happened to
+// surface the warning. The check must now run first and block the call outright.
+describe('GroupElement', () => {
+  const admin = { id: 1, name: 'Admin One', initials: 'A1' };
+  const otherAdmin = { id: 2, name: 'Admin Two', initials: 'A2' };
+  const member = { id: 3, name: 'Member One', initials: 'M1' };
+
+  const buildGroupElement = (admins) => ({
+    id: 10,
+    name: 'Test Group',
+    initials: 'TG',
+    admins,
+    users: [...admins, member],
+  });
+
+  const mountElement = (groupElement, onDeleteUser) => mount(React.createElement(GroupElement, {
+    groupElement,
+    currentUser: admin,
+    currentGroup: [groupElement],
+    onDeleteGroup: sinon.spy(),
+    onDeleteUser,
+    onChangeData: sinon.spy(),
+  }));
+
+  // confirmDelete takes the click event explicitly (not the legacy `window.event` global)
+  // so the admin-warning popover can be positioned without relying on an ambient DOM event.
+  const fakeEvent = () => ({ target: null });
+
+  describe('.confirmDelete(event, "user", ...)', () => {
+    it('blocks removal and shows the admin warning when the target is the sole admin', () => {
+      const groupElement = buildGroupElement([admin]);
+      const onDeleteUser = sinon.spy();
+      const wrapper = mountElement(groupElement, onDeleteUser);
+
+      wrapper.instance().confirmDelete(fakeEvent(), 'user', groupElement, admin);
+
+      expect(onDeleteUser.called).toBe(false);
+      expect(wrapper.instance().state.showAdminAlert).toBe(true);
+    });
+
+    it('removes a non-admin member and does not show the admin warning', () => {
+      const groupElement = buildGroupElement([admin]);
+      const onDeleteUser = sinon.spy();
+      const wrapper = mountElement(groupElement, onDeleteUser);
+
+      wrapper.instance().confirmDelete(fakeEvent(), 'user', groupElement, member);
+
+      expect(onDeleteUser.calledOnceWith(groupElement, member)).toBe(true);
+      expect(wrapper.instance().state.showAdminAlert).toBe(false);
+    });
+
+    it('removes an admin member when another admin remains', () => {
+      const groupElement = buildGroupElement([admin, otherAdmin]);
+      const onDeleteUser = sinon.spy();
+      const wrapper = mountElement(groupElement, onDeleteUser);
+
+      wrapper.instance().confirmDelete(fakeEvent(), 'user', groupElement, otherAdmin);
+
+      expect(onDeleteUser.calledOnceWith(groupElement, otherAdmin)).toBe(true);
+      expect(wrapper.instance().state.showAdminAlert).toBe(false);
+    });
+  });
+});

--- a/spec/javascripts/packs/src/components/navigation/GroupElement.spec.js
+++ b/spec/javascripts/packs/src/components/navigation/GroupElement.spec.js
@@ -8,10 +8,9 @@ import UsersFetcher from 'src/fetchers/UsersFetcher';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-// Regression coverage for confirmDelete('user', ...): it used to fire onDeleteUser (the
-// actual removal request) before checking whether the target is the group's sole admin,
-// so a doomed request went out and only a same-tick, unrelated demote call happened to
-// surface the warning. The check must now run first and block the call outright.
+// Regression coverage for confirmDelete('user', ...): membership and admin status are
+// independent, so removing someone as a member must never check or alter their admin
+// status (it used to block/demote based on it, which contradicted that invariant).
 describe('GroupElement', () => {
   const admin = { id: 1, name: 'Admin One', initials: 'A1' };
   const otherAdmin = { id: 2, name: 'Admin Two', initials: 'A2' };
@@ -39,15 +38,16 @@ describe('GroupElement', () => {
   const fakeEvent = () => ({ target: null });
 
   describe('.confirmDelete(event, "user", ...)', () => {
-    it('blocks removal and shows the admin warning when the target is the sole admin', () => {
+    it('removes a member even when they are the sole admin, without touching admin status', () => {
       const groupElement = buildGroupElement([admin]);
       const onDeleteUser = sinon.spy();
       const wrapper = mountElement(groupElement, onDeleteUser);
 
       wrapper.instance().confirmDelete(fakeEvent(), 'user', groupElement, admin);
 
-      expect(onDeleteUser.called).toBe(false);
-      expect(wrapper.instance().state.showAdminAlert).toBe(true);
+      expect(onDeleteUser.calledOnceWith(groupElement, admin)).toBe(true);
+      expect(wrapper.instance().state.showAdminAlert).toBe(false);
+      expect(groupElement.admins).toContain(admin);
     });
 
     it('removes a non-admin member and does not show the admin warning', () => {
@@ -77,6 +77,8 @@ describe('GroupElement', () => {
   // both unfiltered), so an admin who isn't a member must still be visible and able to
   // manage the group; a plain member must not see management controls.
   describe('.render()', () => {
+    afterEach(() => { sinon.restore(); });
+
     const nonMemberAdmin = { id: 4, name: 'Admin Remote', initials: 'AR' };
 
     const buildGroupElementWithNonMemberAdmin = () => ({
@@ -116,6 +118,20 @@ describe('GroupElement', () => {
       expect(asNonMemberAdmin.find('.fa-plus').length).toBeGreaterThan(0);
       expect(asNonMemberAdmin.find('.fa-trash-o').length).toBeGreaterThan(0);
       expect(asNonMemberAdmin.find('.fa-key').length).toBeGreaterThan(0);
+    });
+
+    // Regression: previously the only way to demote a non-member admin was to add them
+    // as a member first, demote, then remove membership again - there was no direct
+    // control. The Admin-by column now carries its own demote button for exactly this
+    // case (member admins are demoted via their row in the expanded users table).
+    it('lets a non-member admin be demoted directly from the Admin-by column', () => {
+      const groupElement = buildGroupElementWithNonMemberAdmin();
+      const demoteStub = sinon.stub(UsersFetcher, 'demoteAdmin').returns(new Promise(() => {}));
+      const wrapper = mountAs(groupElement, nonMemberAdmin);
+
+      wrapper.find('tr.fw-bold.align-middle td').at(2).find('button').first().simulate('click');
+
+      expect(demoteStub.calledOnceWith(groupElement.id, nonMemberAdmin.id)).toBe(true);
     });
   });
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -94,5 +94,34 @@ RSpec.describe 'Group', type: :model do
       expect(group.admins).not_to be_empty
       expect(group.admins).to match_array [p1]
     end
+
+    it 'a person can be an admin without being a member' do
+      group = create(:group, admins: [p1], users: [p2])
+      expect(group.administrated_by?(p1)).to be true
+      expect(group.users).not_to include(p1)
+    end
+  end
+
+  describe '#sole_admin?' do
+    let(:sole_admin) { create(:person) }
+    let(:other_person) { create(:person) }
+
+    context 'with a single admin' do
+      let(:group) { create(:group, admins: [sole_admin]) }
+
+      it 'is true for that admin and false for anyone else' do
+        expect(group.sole_admin?(sole_admin.id)).to be true
+        expect(group.sole_admin?(other_person.id)).to be false
+      end
+    end
+
+    context 'with more than one admin' do
+      let(:group) { create(:group, admins: [sole_admin, other_person]) }
+
+      it 'is false for either admin' do
+        expect(group.sole_admin?(sole_admin.id)).to be false
+        expect(group.sole_admin?(other_person.id)).to be false
+      end
+    end
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -118,4 +118,37 @@ RSpec.describe 'Person', type: :model do
       end
     end
   end
+
+  describe '#destroy' do
+    let(:person) { create(:person) }
+    let(:p2) { create(:person) }
+
+    context 'when the person is the sole admin of a group' do
+      let(:group) { build(:group, admins: [person]) }
+
+      before { group.save! }
+
+      it 'refuses to destroy the person and keeps the admin relationship' do
+        expect { person.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+        expect(group.reload.admins).to include(person)
+      end
+    end
+
+    context 'when the person is a co-admin of a group' do
+      let(:group) { build(:group, admins: [person, p2]) }
+
+      before { group.save! }
+
+      it 'destroys the person and leaves the other admin in place' do
+        expect { person.destroy! }.not_to raise_error
+        expect(group.reload.admins).to contain_exactly(p2)
+      end
+    end
+
+    context 'when the person administrates no group' do
+      it 'destroys the person' do
+        expect { person.destroy! }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Closes the remaining gaps around group-admin/group-member independence:

- No UI path existed to promote a Person to group-admin without first
  adding them as a member, even though the backend endpoint already
  supported it standalone. Adds a parallel "Add admin" control in
  `GroupElement.js`.
- The "always at least one admin" invariant was duplicated across the two
  REST endpoints and missing entirely from a third, older path — the
  System Admin panel's own group-admin toggle (`admin_api.rb`'s `NodeAdm`
  action). A fourth path, deleting a Person's account, could also
  silently orphan a group's admin set via the `users_admins`
  `dependent: :destroy` cascade.
- Centralizes the invariant as `Group#sole_admin?`, delegates
  `GroupPolicy` to it, uses it to guard the admin-panel path, and adds a
  `Person#before_destroy` guard (`prepend: true`, so it runs ahead of the
  `users_admins` cascade) for the account-deletion path.
- `AdminGroupElement.js` gets a matching guard so the newly-possible 422
  from the admin panel isn't silently swallowed as a successful demote.

Includes the earlier fix that moves the last-admin check in
`GroupElement#confirmDelete` before the removal request fires, instead of
only reacting to it afterward.

refs: #3398

## Test plan

- `bundle exec rspec` on the 5 targeted spec files: 68 examples, 0 failures.
- Full non-feature suite: 2694 examples, 9 pre-existing failures (unrelated,
  confirmed present on `main` too).
- `yarn test`: 1343 passing, 0 failing.
- `bundle exec rubocop` / `yarn eslint` on every changed file: no new
  offenses.
- Not yet verified in a live browser — worth a manual click-through of the
  new "Add admin" control before merge.
