### PR TITLE
perf(import): schedule LCSS via created_after instead of per-import id arrays

### DIFF
--- a/app/jobs/pubchem_single_lcss_job.rb
+++ b/app/jobs/pubchem_single_lcss_job.rb
@@ -17,36 +17,65 @@ class PubchemSingleLcssJob < ApplicationJob
   # @param created_after [ActiveSupport::TimeWithZone, nil] only include molecules
   #   created after this time; combines with +ids+ (or its resolved molecule ids) as
   #   an intersection (AND), narrowing rather than extending the set
-  def perform(ids = nil, type: :molecules, created_after: nil)
+  # @param chunk_size [Integer] max molecules processed in a single invocation before
+  #   self-requeuing a follow-up to continue from where this run left off — a wide-open
+  #   +created_after+ (e.g. from a large import) could otherwise resolve to thousands of
+  #   molecules and run long enough to hit Delayed::Worker.max_run_time
+  # @param start_id [Integer] resume point (exclusive) — only molecules with id > start_id
+  #   are considered
+  def perform(ids = nil, type: :molecules, created_after: nil,
+              chunk_size: PubchemLcssJob::CHUNK_SIZE, start_id: 0)
     # TODO: > stub request for testing
     return if Rails.env.test?
     return if ids.blank? && created_after.blank?
 
     if other_pubchem_job_running?
       self.class.set(wait: PubchemRateLimitGuard::REQUEUE_DELAY)
-          .perform_later(ids, type: type, created_after: created_after)
+          .perform_later(ids, type: type, created_after: created_after,
+                          chunk_size: chunk_size, start_id: start_id)
       return
     end
 
-    resolve_molecules(ids, type: type, created_after: created_after)
-      .each_with_index do |molecule, i|
-        sleep SLEEP_BETWEEN_REQUESTS if i.positive?
-        molecule.pubchem_lcss
-      end
+    molecule_ids = ids.present? && type.to_sym == :samples ? resolve_sample_molecule_ids(ids) : ids
+    molecules = resolve_molecules(molecule_ids, created_after: created_after,
+                                   start_id: start_id, chunk_size: chunk_size)
+
+    molecules.each_with_index do |molecule, i|
+      sleep SLEEP_BETWEEN_REQUESTS if i.positive?
+      molecule.pubchem_lcss
+    end
+    return if molecules.empty?
+
+    last_id = molecules.last.id
+    return unless more_pending?(molecule_ids, created_after: created_after, after_id: last_id)
+
+    # No wait — this isn't a collision backoff, just more work to continue with.
+    self.class.perform_later(molecule_ids, type: :molecules, created_after: created_after,
+                              chunk_size: chunk_size, start_id: last_id)
   end
 
   private
 
-  # @return [ActiveRecord::Relation<Molecule>] molecules still missing LCSS data, ordered
-  #   by id, with +:tag+ eager loaded (single query, also used to filter out molecules
-  #   a competing job already finished — e.g. during this job's own requeue delay)
-  def resolve_molecules(ids, type:, created_after:)
-    if ids.present? && type.to_sym == :samples
-      ids = Sample.where(id: ids).where.not(molecule_id: nil).distinct.pluck(:molecule_id)
-    end
+  def resolve_sample_molecule_ids(sample_ids)
+    Sample.where(id: sample_ids).where.not(molecule_id: nil).distinct.pluck(:molecule_id)
+  end
 
+  # @return [Array<Molecule>] up to +chunk_size+ molecules still missing LCSS data,
+  #   ordered by id, with +:tag+ eager loaded (single query, also used to filter out
+  #   molecules a competing job already finished — e.g. during this job's own requeue delay)
+  def resolve_molecules(ids, created_after:, start_id:, chunk_size: nil)
+    pending_scope(ids, created_after: created_after, after_id: start_id).limit(chunk_size).to_a
+  end
+
+  # @return [Boolean] whether any pending molecule remains beyond +after_id+
+  def more_pending?(ids, created_after:, after_id:)
+    pending_scope(ids, created_after: created_after, after_id: after_id).exists?
+  end
+
+  def pending_scope(ids, created_after:, after_id:)
     scope = Molecule.eager_load(:tag)
                     .where("element_tags.taggable_data->>'pubchem_lcss' is null")
+                    .where('molecules.id > ?', after_id)
                     .order(:id)
     scope = scope.where(id: ids) if ids.present?
     scope = scope.where('molecules.created_at > ?', created_after) if created_after.present?

--- a/app/models/molecule.rb
+++ b/app/models/molecule.rb
@@ -36,8 +36,8 @@
 class Molecule < ApplicationRecord
   acts_as_paranoid
 
-  # skip_lcss_callback lets a caller that's collecting ids into its own
-  # lcss_batch array (see .schedule_lcss_batch) suppress this particular
+  # skip_lcss_callback lets a caller that's deferring LCSS scheduling for a batch of
+  # creations (see .schedule_lcss_batch / .schedule_lcss_since) suppress this particular
   # instance's automatic scheduling; it's a plain per-object attribute, not
   # shared/ambient state, so it's inherently thread-safe.
   attr_accessor :pcid, :ob_log, :skip_lcss_callback
@@ -91,12 +91,12 @@ class Molecule < ApplicationRecord
     molecule = Molecule.find_or_create_by(inchikey: 'DUMMY')
   end
 
-  # @param lcss_batch [Array<Integer>, nil] when given, a newly-created molecule's
-  #   id is pushed here (and its own automatic LCSS scheduling is suppressed) instead
-  #   of scheduling immediately — the caller is responsible for flushing it via
-  #   .schedule_lcss_batch once its own batch of creations is done.
+  # @param defer_lcss [Boolean] when true, a newly-created molecule's own automatic LCSS
+  #   scheduling is suppressed instead of firing immediately — the caller is responsible
+  #   for triggering it later via .schedule_lcss_since once its own batch of creations
+  #   is done.
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
-  def self.find_or_create_by_molfile(molfile, lcss_batch: nil, **babel_info)
+  def self.find_or_create_by_molfile(molfile, defer_lcss: false, **babel_info)
     unless babel_info && babel_info[:inchikey]
       babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile)
     end
@@ -112,21 +112,20 @@ class Molecule < ApplicationRecord
     molecule = Molecule.find_by(inchikey: inchikey, is_partial: is_partial, sum_formular: formula)
     if molecule.nil?
       molecule = Molecule.create(inchikey: inchikey, is_partial: is_partial, sum_formular: formula) do |mol|
-        mol.skip_lcss_callback = true if lcss_batch
+        mol.skip_lcss_callback = true if defer_lcss
         pubchem_info = Chemotion::PubchemService.molecule_info_from_inchikey(inchikey)
         mol.molfile = (is_partial && partial_molfile) || molfile
         mol.assign_molecule_data(babel_info, pubchem_info)
       end
-      lcss_batch << molecule.id if lcss_batch && molecule.persisted?
     end
     molecule.ob_log = babel_info[:ob_log]
     molecule
   end
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
 
-  def self.find_or_create_by_cano_smiles(cano_smiles, lcss_batch: nil)
+  def self.find_or_create_by_cano_smiles(cano_smiles, defer_lcss: false)
     molfile = Chemotion::OpenBabelService.molfile_from_cano_smiles(cano_smiles)
-    Molecule.find_or_create_by_molfile(molfile, lcss_batch: lcss_batch)
+    Molecule.find_or_create_by_molfile(molfile, defer_lcss: defer_lcss)
   end
 
   def self.find_or_create_by_molfiles(molfiles_array)
@@ -254,6 +253,19 @@ class Molecule < ApplicationRecord
 
   def get_lcss
     self.class.schedule_lcss_batch([id])
+  end
+
+  # Schedules a PubchemSingleLcssJob covering every molecule created after +timestamp+.
+  # The bulk importers use this instead of collecting new molecule ids into an array:
+  # capture Time.current once before the import loop begins, pass defer_lcss: true to
+  # suppress each new molecule's own immediate scheduling, then call this once at the
+  # end (even a method that turned out to create nothing new can safely call this
+  # unconditionally — the existence check below keeps that a no-op).
+  def self.schedule_lcss_since(timestamp)
+    return if timestamp.blank?
+    return unless Molecule.where('created_at > ?', timestamp).exists?
+
+    PubchemSingleLcssJob.perform_later(nil, created_after: timestamp)
   end
 
   def create_molecule_name_by_user(new_names, user_id)

--- a/lib/import/import_collections.rb
+++ b/lib/import/import_collections.rb
@@ -103,7 +103,8 @@ module Import
     end
 
     def import
-      @lcss_batch = []
+      started_at = Time.current
+      @defer_lcss = true
       ActiveRecord::Base.transaction do
         gate_collection if @gt == true
         import_collections if @gt == false
@@ -134,7 +135,7 @@ module Import
       end
       reprocess_reaction_svgs
     ensure
-      Molecule.schedule_lcss_batch(@lcss_batch)
+      Molecule.schedule_lcss_since(started_at)
     end
 
     def import!
@@ -288,12 +289,12 @@ module Import
         end
         # Always use molfile if available (highest priority)
         if molfile.present?
-          molecule ||= Molecule.find_or_create_by_molfile(molfile, lcss_batch: @lcss_batch)
+          molecule ||= Molecule.find_or_create_by_molfile(molfile, defer_lcss: @defer_lcss)
         end
 
         # Use cano_smiles if molfile is missing or invalid but cano_smiles is available
         if cano_smiles.present?
-          molecule ||= Molecule.find_or_create_by_cano_smiles(cano_smiles, lcss_batch: @lcss_batch)
+          molecule ||= Molecule.find_or_create_by_cano_smiles(cano_smiles, defer_lcss: @defer_lcss)
         end
         # Create dummy only for decoupled samples with no structure data
         molecule ||= Molecule.find_or_create_dummy if fields.fetch('decoupled', nil)
@@ -841,7 +842,7 @@ module Import
     # Mirrors logic in Import::ImportSamples#get_data_from_molfile.
     # @return [Molecule, nil] the molecule or nil if cleaned molfile is blank
     def find_or_create_molecule_for_polymer_molfile(raw_molfile)
-      Import::PolymerMoleculeResolver.call(raw_molfile, lcss_batch: @lcss_batch, unescape_octal: false).molecule
+      Import::PolymerMoleculeResolver.call(raw_molfile, defer_lcss: @defer_lcss, unescape_octal: false).molecule
     end
 
     # Sort records by created_at timestamp

--- a/lib/import/import_samples.rb
+++ b/lib/import/import_samples.rb
@@ -215,7 +215,8 @@ module Import
     end
 
     def write_to_db
-      @lcss_batch = []
+      started_at = Time.current
+      @defer_lcss = true
       unprocessable_count = 0
       begin
         ActiveRecord::Base.transaction do
@@ -235,7 +236,7 @@ module Import
         raise 'More than 1 row can not be processed' if unprocessable_count.positive?
       end
     ensure
-      Molecule.schedule_lcss_batch(@lcss_batch)
+      Molecule.schedule_lcss_since(started_at)
     end
 
     def structure?(row)
@@ -261,7 +262,7 @@ module Import
       raw_molfile = row_value_case_insensitive(row, 'molfile').to_s.strip
       # When molfile has > <PolymersList>, use full molfile and Molecule.svg_reprocess so polymers use SvgRenderer.
       if raw_molfile.include?(Chemotion::MolfilePolymerSupport::POLYMERS_LIST_TAG)
-        result = Import::PolymerMoleculeResolver.call(raw_molfile, lcss_batch: @lcss_batch)
+        result = Import::PolymerMoleculeResolver.call(raw_molfile, defer_lcss: @defer_lcss)
         return [result.molecule, result.raw_molfile]
       end
 
@@ -272,7 +273,7 @@ module Import
       babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile_for_babel)
       inchikey = babel_info[:inchikey]
       if inchikey.presence
-        molecule = Molecule.find_or_create_by_molfile(molfile_for_babel, lcss_batch: @lcss_batch, **babel_info)
+        molecule = Molecule.find_or_create_by_molfile(molfile_for_babel, defer_lcss: @defer_lcss, **babel_info)
       end
       [molecule, raw_molfile]
     end
@@ -282,16 +283,13 @@ module Import
         go_to_next = true
       else
         go_to_next = false
-        created = false
         molecule = Molecule.find_or_create_by(inchikey: inchikey, is_partial: false) do |molecul|
-          created = true
-          molecul.skip_lcss_callback = true if @lcss_batch
+          molecul.skip_lcss_callback = true if @defer_lcss
           pubchem_info =
             Chemotion::PubchemService.molecule_info_from_inchikey(inchikey)
           molecul.molfile = molfile_coord
           molecul.assign_molecule_data babel_info, pubchem_info
         end
-        @lcss_batch << molecule.id if created && @lcss_batch
       end
       [molecule, molfile_coord, go_to_next]
     end
@@ -584,10 +582,9 @@ module Import
     end
 
     # NB: always called nested inside #write_to_db's row loop (via
-    # handle_sample_components), which already has its own @lcss_batch
-    # active — this appends to that same accumulator rather than managing
-    # its own, so a component's molecule doesn't get double-scheduled or
-    # cause the outer batch to lose ids collected before this call.
+    # handle_sample_components), which already has @defer_lcss set — a
+    # component's molecule creation is deferred the same way as the outer
+    # row's, and both flush together via #write_to_db's own Molecule.schedule_lcss_since.
     def create_components(sample, sample_components_data)
       unprocessable_count = 0
       xlsx.default_sheet = 'sample_components'

--- a/lib/import/import_sdf.rb
+++ b/lib/import/import_sdf.rb
@@ -102,12 +102,12 @@ class Import::ImportSdf < Import::ImportSamples
     n = batch_size - 1
     inchikeys = []
     @processed_mol = []
+    started_at = Time.current
+    @defer_lcss = true
     data = raw_data.dup
     until data.empty?
       batch = data.slice!(0..n)
-      @lcss_batch = []
       molecules = find_or_create_by_molfiles(batch)
-      Molecule.schedule_lcss_batch(@lcss_batch)
       inchikeys += molecules.map { |m| (m && m[:inchikey]) || nil }
       @processed_mol += molecules
     end
@@ -119,6 +119,8 @@ class Import::ImportSdf < Import::ImportSamples
       @message[:error] << 'No Molecule processed. '
     end
     @inchi_array += inchikeys.compact
+  ensure
+    Molecule.schedule_lcss_since(started_at)
   end
 
   # Runs the whole raw-SDF/mol import in one pass, off the web request (worker context):
@@ -167,7 +169,8 @@ class Import::ImportSdf < Import::ImportSamples
   end
 
   def create_samples
-    @lcss_batch = []
+    started_at = Time.current
+    @defer_lcss = true
     ids = []
     read_data if raw_data.empty? && rows.empty?
     if !raw_data.empty? && inchi_array.empty?
@@ -319,7 +322,7 @@ class Import::ImportSdf < Import::ImportSamples
 
     samples
   ensure
-    Molecule.schedule_lcss_batch(@lcss_batch)
+    Molecule.schedule_lcss_since(started_at)
   end
 
   def find_or_create_by_molfiles(molfiles)
@@ -330,7 +333,7 @@ class Import::ImportSdf < Import::ImportSamples
       if Chemotion::MolfilePolymerSupport.has_polymers_list_tag?(mf.to_s)
         find_or_create_polymer_molfile_entry(mf.to_s.strip, babel_info)
       elsif babel_info && babel_info[:inchikey].present?
-        m = Molecule.find_or_create_by_molfile(mf, lcss_batch: @lcss_batch, **babel_info)
+        m = Molecule.find_or_create_by_molfile(mf, defer_lcss: @defer_lcss, **babel_info)
         process_molfile_opt_data(mf).merge(
           inchikey: m.inchikey,
           svg: "molecules/#{m.molecule_svg_file}",
@@ -345,7 +348,7 @@ class Import::ImportSdf < Import::ImportSamples
 
   # When molfile has PolymersList/TextNode: keep full molfile, clean for babel, find/create molecule, reprocess SVG.
   def find_or_create_polymer_molfile_entry(raw_molfile, _babel_info_from_batch)
-    result = Import::PolymerMoleculeResolver.call(raw_molfile, lcss_batch: @lcss_batch)
+    result = Import::PolymerMoleculeResolver.call(raw_molfile, defer_lcss: @defer_lcss)
     return { name: nil, inchikey: nil, svg: 'no_image_180.svg' } if result.molecule.blank?
 
     process_molfile_opt_data(result.raw_molfile).merge(
@@ -371,7 +374,7 @@ class Import::ImportSdf < Import::ImportSamples
   def molecule_and_molfile_for_row(molfile)
     raw = molfile.to_s.strip
     if Chemotion::MolfilePolymerSupport.has_polymers_list_tag?(raw)
-      result = Import::PolymerMoleculeResolver.call(raw, lcss_batch: @lcss_batch)
+      result = Import::PolymerMoleculeResolver.call(raw, defer_lcss: @defer_lcss)
       [result.molecule, result.raw_molfile, result.babel_info]
     else
       san_molfile = sanitize_molfile(molfile)

--- a/lib/import/polymer_molecule_resolver.rb
+++ b/lib/import/polymer_molecule_resolver.rb
@@ -18,19 +18,19 @@ module Import
     Result = Struct.new(:molecule, :raw_molfile, :babel_info, keyword_init: true)
 
     # @param raw_molfile [String] the full molfile, including the PolymersList/TextNode blocks
-    # @param lcss_batch [Array<Integer>, nil] forwarded to Molecule.find_or_create_by_molfile /
+    # @param defer_lcss [Boolean] forwarded to Molecule.find_or_create_by_molfile /
     #   the synthetic-inchikey fallback, same semantics as elsewhere in the importers
     # @param unescape_octal [Boolean] whether to run unescape_textnode_octal_in_molfile first
     #   (true for xlsx/SDF-sourced molfiles that can have Excel octal-escaping; false for
     #   export.json-sourced molfiles, which don't have this problem -- see Import::ImportCollections)
     # @return [Result] molecule may be nil if the cleaned molfile was blank
-    def self.call(raw_molfile, lcss_batch: nil, unescape_octal: true)
-      new(raw_molfile, lcss_batch: lcss_batch, unescape_octal: unescape_octal).call
+    def self.call(raw_molfile, defer_lcss: false, unescape_octal: true)
+      new(raw_molfile, defer_lcss: defer_lcss, unescape_octal: unescape_octal).call
     end
 
-    def initialize(raw_molfile, lcss_batch:, unescape_octal:)
+    def initialize(raw_molfile, defer_lcss:, unescape_octal:)
       @raw_molfile = raw_molfile
-      @lcss_batch = lcss_batch
+      @defer_lcss = defer_lcss
       @unescape_octal = unescape_octal
     end
 
@@ -41,9 +41,9 @@ module Import
 
       babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(pad(cleaned))
       molecule = if babel_info[:inchikey].present?
-                   Molecule.find_or_create_by_molfile(raw, lcss_batch: @lcss_batch, **babel_info)
+                   Molecule.find_or_create_by_molfile(raw, defer_lcss: @defer_lcss, **babel_info)
                  else
-                   find_or_create_polymer_molecule_without_inchikey(raw, babel_info, lcss_batch: @lcss_batch)
+                   find_or_create_polymer_molecule_without_inchikey(raw, babel_info, defer_lcss: @defer_lcss)
                  end
       reattach_svg_if_present(molecule, raw) if molecule.present?
 
@@ -70,7 +70,7 @@ module Import
     # When Open Babel returns blank inchikey for a PolymersList molfile, create a molecule with a
     # synthetic inchikey so we can store the full molfile; SVG is generated separately via svg_reprocess.
     # Moved here (was byte-identical, copy-pasted between Import::ImportSamples and Import::ImportCollections).
-    def find_or_create_polymer_molecule_without_inchikey(raw_molfile, babel_info, lcss_batch: nil)
+    def find_or_create_polymer_molecule_without_inchikey(raw_molfile, babel_info, defer_lcss: false)
       synthetic_inchikey = "POLYMER_#{Digest::SHA256.hexdigest(raw_molfile)}"
       formula = babel_info[:formula].to_s.presence || ''
       molecule = Molecule.find_by(inchikey: synthetic_inchikey, is_partial: true, sum_formular: formula)
@@ -85,9 +85,8 @@ module Import
           molfile: raw_molfile,
         )
       end
-      molecule.skip_lcss_callback = true if is_new && lcss_batch
+      molecule.skip_lcss_callback = true if is_new && defer_lcss
       molecule.save!
-      lcss_batch << molecule.id if is_new && lcss_batch
       molecule
     end
 

--- a/spec/api/chemotion/sample_api_spec.rb
+++ b/spec/api/chemotion/sample_api_spec.rb
@@ -425,11 +425,11 @@ describe Chemotion::SampleAPI do
       # per-molecule Delayed::Job query, triggered by a concurrently-running
       # worker draining that queue mid-import. get_lcss no longer queries
       # Delayed::Job at all (see Molecule.find_or_create_by_molfile's
-      # lcss_batch: parameter and Import::ImportSdf#find_or_create_mol_by_batch)
+      # defer_lcss: parameter and Import::ImportSdf#find_or_create_mol_by_batch)
       # — this asserts the replacement behavior end-to-end: the whole SDF
       # import (2 new molecules) enqueues a single batched job, not one per molecule.
-      scheduled_ids = nil
-      allow(PubchemSingleLcssJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
+      started_at = Time.current
+      allow(PubchemSingleLcssJob).to receive(:perform_later)
 
       post(
         '/api/v1/samples/import/',
@@ -445,8 +445,11 @@ describe Chemotion::SampleAPI do
       # LCSS scheduling now happens inside ImportSamplesJob (find_or_create_mol_by_batch)
       perform_enqueued_jobs
 
+      # create_samples also flushes its own started_at, but finds nothing created
+      # after it (all molecules were already created during find_or_create_mol_by_batch)
+      # so Molecule.schedule_lcss_since no-ops for that second flush point.
       expect(PubchemSingleLcssJob).to have_received(:perform_later).once
-      expect(scheduled_ids.size).to eq 2
+      expect(PubchemSingleLcssJob).to have_received(:perform_later).with(nil, created_after: be >= started_at)
     end
   end
 

--- a/spec/jobs/pubchem_single_lcss_job_spec.rb
+++ b/spec/jobs/pubchem_single_lcss_job_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe PubchemSingleLcssJob do
     end
 
     it 'calls #pubchem_lcss on each resolved molecule in order' do
-      allow(job).to receive(:resolve_molecules).and_return([first_molecule, second_molecule])
+      allow(job).to receive_messages(resolve_molecules: [first_molecule, second_molecule], more_pending?: false)
       allow(first_molecule).to receive(:pubchem_lcss)
       allow(second_molecule).to receive(:pubchem_lcss)
 
@@ -43,7 +43,9 @@ RSpec.describe PubchemSingleLcssJob do
     end
 
     it 'sleeps between requests but not before the first one' do
-      allow(job).to receive(:resolve_molecules).and_return([first_molecule, second_molecule, third_molecule])
+      allow(job).to receive_messages(
+        resolve_molecules: [first_molecule, second_molecule, third_molecule], more_pending?: false,
+      )
       [first_molecule, second_molecule, third_molecule].each { |m| allow(m).to receive(:pubchem_lcss) }
 
       job.perform([first_molecule.id, second_molecule.id, third_molecule.id])
@@ -81,50 +83,109 @@ RSpec.describe PubchemSingleLcssJob do
         job.perform([first_molecule.id])
 
         expect(described_class).to have_received(:set).with(wait: PubchemRateLimitGuard::REQUEUE_DELAY)
-        expect(described_class).to have_received(:perform_later)
-          .with([first_molecule.id], type: :molecules, created_after: nil)
+        expect(described_class).to have_received(:perform_later).with(
+          [first_molecule.id], type: :molecules, created_after: nil,
+                               chunk_size: PubchemLcssJob::CHUNK_SIZE, start_id: 0
+        )
         expect(job).not_to have_received(:resolve_molecules)
+      end
+    end
+
+    context 'when more pending molecules exist than chunk_size allows in one run' do
+      it 'bounds a single run to chunk_size molecules and requeues a follow-up with the resume cursor' do
+        called_ids = []
+        # The job re-queries its own molecules from the DB, so stubbing a specific
+        # test object's #pubchem_lcss wouldn't be seen — stub the class instead.
+        allow_any_instance_of(Molecule).to receive(:pubchem_lcss) { |instance| called_ids << instance.id } # rubocop:disable RSpec/AnyInstance
+        allow(described_class).to receive(:perform_later)
+
+        job.perform([first_molecule.id, second_molecule.id, third_molecule.id], chunk_size: 2)
+
+        expect(called_ids).to contain_exactly(first_molecule.id, second_molecule.id)
+        expect(described_class).to have_received(:perform_later).with(
+          [first_molecule.id, second_molecule.id, third_molecule.id], type: :molecules, created_after: nil,
+                                                                      chunk_size: 2, start_id: second_molecule.id
+        )
+      end
+
+      it 'does not requeue once every given molecule has been processed' do
+        allow_any_instance_of(Molecule).to receive(:pubchem_lcss) # rubocop:disable RSpec/AnyInstance
+        allow(described_class).to receive(:perform_later)
+
+        job.perform([first_molecule.id, second_molecule.id])
+
+        expect(described_class).not_to have_received(:perform_later)
       end
     end
   end
 
-  describe '#resolve_molecules' do
-    let!(:old_molecule) { create(:molecule, created_at: 2.days.ago) }
-    let!(:new_molecule) { create(:molecule, created_at: 1.minute.ago) }
-    let!(:sample) { create(:sample, molecule: new_molecule) }
-
-    it 'scopes to the given molecule ids when type: :molecules' do
-      result = job.send(:resolve_molecules, [old_molecule.id], type: :molecules, created_after: nil)
-
-      expect(result.pluck(:id)).to eq([old_molecule.id])
+  describe '#resolve_sample_molecule_ids' do
+    let!(:molecule) { create(:molecule) }
+    let!(:sample) { create(:sample, molecule: molecule) }
+    let!(:sample_without_molecule) do
+      create(:sample, molecule: molecule).tap { |s| s.update_column(:molecule_id, nil) } # rubocop:disable Rails/SkipsModelValidations
     end
 
-    it 'resolves sample ids to their distinct referenced molecule ids when type: :samples' do
-      result = job.send(:resolve_molecules, [sample.id], type: :samples, created_after: nil)
+    it 'resolves sample ids to their distinct referenced molecule ids, dropping samples with no molecule' do
+      result = job.send(:resolve_sample_molecule_ids, [sample.id, sample_without_molecule.id])
 
-      expect(result.pluck(:id)).to eq([new_molecule.id])
+      expect(result).to eq([molecule.id])
+    end
+  end
+
+  describe '#resolve_molecules and #more_pending?' do
+    let!(:old_molecule) { create(:molecule, created_at: 2.days.ago) }
+    let!(:new_molecule) { create(:molecule, created_at: 1.minute.ago) }
+
+    it 'scopes to the given molecule ids' do
+      result = job.send(:resolve_molecules, [old_molecule.id], created_after: nil, start_id: 0)
+
+      expect(result.map(&:id)).to eq([old_molecule.id])
     end
 
     it 'filters by created_after alone when ids is blank' do
-      result = job.send(:resolve_molecules, nil, type: :molecules, created_after: 1.hour.ago)
+      result = job.send(:resolve_molecules, nil, created_after: 1.hour.ago, start_id: 0)
 
-      expect(result.pluck(:id)).to eq([new_molecule.id])
+      expect(result.map(&:id)).to eq([new_molecule.id])
     end
 
     it 'AND-combines ids with created_after, narrowing rather than extending the set' do
       result = job.send(
-        :resolve_molecules, [old_molecule.id, new_molecule.id], type: :molecules, created_after: 1.hour.ago
+        :resolve_molecules, [old_molecule.id, new_molecule.id], created_after: 1.hour.ago, start_id: 0
       )
 
-      expect(result.pluck(:id)).to eq([new_molecule.id])
+      expect(result.map(&:id)).to eq([new_molecule.id])
     end
 
     it 'excludes molecules a competing job already finished, even when explicitly given by id' do
       old_molecule.tag.update!(taggable_data: old_molecule.tag.taggable_data.merge('pubchem_lcss' => 'already fetched'))
 
-      result = job.send(:resolve_molecules, [old_molecule.id, new_molecule.id], type: :molecules, created_after: nil)
+      result = job.send(:resolve_molecules, [old_molecule.id, new_molecule.id], created_after: nil, start_id: 0)
 
-      expect(result.pluck(:id)).to eq([new_molecule.id])
+      expect(result.map(&:id)).to eq([new_molecule.id])
+    end
+
+    it 'only considers molecules with id greater than start_id' do
+      result = job.send(:resolve_molecules, nil, created_after: 2.days.ago - 1.hour, start_id: old_molecule.id)
+
+      expect(result.map(&:id)).to eq([new_molecule.id])
+    end
+
+    it 'bounds the result to chunk_size when given' do
+      result = job.send(:resolve_molecules, nil, created_after: 2.days.ago - 1.hour, start_id: 0, chunk_size: 1)
+
+      expect(result.map(&:id)).to eq([old_molecule.id])
+    end
+
+    describe '#more_pending?' do
+      it 'is true when a pending molecule exists beyond after_id' do
+        expect(job.send(:more_pending?, nil, created_after: 2.days.ago - 1.hour, after_id: old_molecule.id)).to be(true)
+      end
+
+      it 'is false when no pending molecule remains beyond after_id' do
+        expect(job.send(:more_pending?, nil, created_after: 2.days.ago - 1.hour,
+                                             after_id: new_molecule.id)).to be(false)
+      end
     end
   end
 end

--- a/spec/lib/import/import_collections_spec.rb
+++ b/spec/lib/import/import_collections_spec.rb
@@ -355,12 +355,12 @@ RSpec.describe 'ImportCollection' do
         molecule: resolved_molecule, raw_molfile: polymer_molfile, babel_info: {},
       )
       allow(Import::PolymerMoleculeResolver).to receive(:call).and_return(result)
-      importer.instance_variable_set(:@lcss_batch, [])
+      importer.instance_variable_set(:@defer_lcss, true)
 
       molecule = importer.send(:find_or_create_molecule_for_polymer_molfile, polymer_molfile)
 
       expect(Import::PolymerMoleculeResolver).to have_received(:call)
-        .with(polymer_molfile, lcss_batch: [], unescape_octal: false)
+        .with(polymer_molfile, defer_lcss: true, unescape_octal: false)
       expect(molecule).to eq(resolved_molecule)
     end
   end

--- a/spec/lib/import/import_samples_spec.rb
+++ b/spec/lib/import/import_samples_spec.rb
@@ -95,13 +95,13 @@ RSpec.describe 'Import::ImportSamples' do
       end
 
       it 'schedules exactly one PubchemSingleLcssJob for the whole import instead of one per molecule' do
-        scheduled_ids = nil
-        allow(PubchemSingleLcssJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
+        started_at = Time.current
+        allow(PubchemSingleLcssJob).to receive(:perform_later)
 
         import_result
 
         expect(PubchemSingleLcssJob).to have_received(:perform_later).once
-        expect(scheduled_ids.size).to be > 1
+        expect(PubchemSingleLcssJob).to have_received(:perform_later).with(nil, created_after: be >= started_at)
       end
     end
   end
@@ -235,7 +235,7 @@ RSpec.describe 'Import::ImportSamples' do
         molecule, raw_molfile = importer.get_data_from_molfile({ 'molfile' => polymer_molfile })
 
         expect(Import::PolymerMoleculeResolver).to have_received(:call)
-          .with(polymer_molfile, lcss_batch: importer.instance_variable_get(:@lcss_batch))
+          .with(polymer_molfile, defer_lcss: importer.instance_variable_get(:@defer_lcss))
         expect(molecule).to eq(resolved_molecule)
         expect(raw_molfile).to eq(polymer_molfile)
       end

--- a/spec/lib/import/import_sdf_spec.rb
+++ b/spec/lib/import/import_sdf_spec.rb
@@ -133,21 +133,21 @@ RSpec.describe Import::ImportSdf do
       end
     end
 
-    it 'schedules a single PubchemSingleLcssJob covering every new molecule in one chunk' do
-      scheduled_ids = nil
-      allow(PubchemSingleLcssJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
+    it 'schedules a single PubchemSingleLcssJob covering every new molecule, via a created_after timestamp' do
+      started_at = Time.current
+      allow(PubchemSingleLcssJob).to receive(:perform_later)
 
       expect { batch_import.find_or_create_mol_by_batch }.to change(Molecule, :count).by(2)
       expect(PubchemSingleLcssJob).to have_received(:perform_later).once
-      expect(scheduled_ids.size).to eq(2)
+      expect(PubchemSingleLcssJob).to have_received(:perform_later).with(nil, created_after: be >= started_at)
     end
 
-    it 'schedules one PubchemSingleLcssJob per chunk when batch_size splits the import' do
+    it 'still schedules exactly one PubchemSingleLcssJob when batch_size splits the import into multiple chunks' do
       allow(PubchemSingleLcssJob).to receive(:perform_later)
 
       batch_import.find_or_create_mol_by_batch(1)
 
-      expect(PubchemSingleLcssJob).to have_received(:perform_later).twice
+      expect(PubchemSingleLcssJob).to have_received(:perform_later).once
     end
   end
 
@@ -170,7 +170,7 @@ RSpec.describe Import::ImportSdf do
         row = mapper.find_or_create_polymer_molfile_entry(polymer_molfile, nil)
 
         expect(Import::PolymerMoleculeResolver).to have_received(:call)
-          .with(polymer_molfile, lcss_batch: mapper.instance_variable_get(:@lcss_batch))
+          .with(polymer_molfile, defer_lcss: mapper.instance_variable_get(:@defer_lcss))
         expect(row).to include(
           inchikey: resolved_molecule.inchikey,
           svg: 'molecules/x.svg',
@@ -197,7 +197,7 @@ RSpec.describe Import::ImportSdf do
         tuple = mapper.molecule_and_molfile_for_row(polymer_molfile)
 
         expect(Import::PolymerMoleculeResolver).to have_received(:call)
-          .with(polymer_molfile, lcss_batch: mapper.instance_variable_get(:@lcss_batch))
+          .with(polymer_molfile, defer_lcss: mapper.instance_variable_get(:@defer_lcss))
         expect(tuple).to eq([resolved_molecule, polymer_molfile, {}])
       end
     end

--- a/spec/lib/import/polymer_molecule_resolver_spec.rb
+++ b/spec/lib/import/polymer_molecule_resolver_spec.rb
@@ -52,10 +52,10 @@ RSpec.describe Import::PolymerMoleculeResolver do
       end
 
       it 'delegates to Molecule.find_or_create_by_molfile with the full (uncleaned) molfile' do
-        result = described_class.call(polymer_molfile, lcss_batch: [1, 2])
+        result = described_class.call(polymer_molfile, defer_lcss: true)
 
         expect(Molecule).to have_received(:find_or_create_by_molfile)
-          .with(polymer_molfile, lcss_batch: [1, 2], **babel_info)
+          .with(polymer_molfile, defer_lcss: true, **babel_info)
         expect(result.molecule).to eq(molecule)
       end
 

--- a/spec/models/molecule_spec.rb
+++ b/spec/models/molecule_spec.rb
@@ -185,17 +185,15 @@ RSpec.describe Molecule, type: :model do
       allow(Chemotion::PubchemService).to receive(:molecule_info_from_inchikey).and_return({})
     end
 
-    it 'defers scheduling and collects the new id when given lcss_batch:' do
-      lcss_batch = []
+    it 'defers scheduling when given defer_lcss: true' do
       allow(PubchemSingleLcssJob).to receive(:perform_later)
 
-      molecule = described_class.find_or_create_by_molfile('molfile', lcss_batch: lcss_batch, **babel_info)
+      described_class.find_or_create_by_molfile('molfile', defer_lcss: true, **babel_info)
 
-      expect(lcss_batch).to eq([molecule.id])
       expect(PubchemSingleLcssJob).not_to have_received(:perform_later)
     end
 
-    it 'schedules immediately when lcss_batch is not given' do
+    it 'schedules immediately when defer_lcss is not given' do
       scheduled_ids = nil
       allow(PubchemSingleLcssJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
 
@@ -204,7 +202,7 @@ RSpec.describe Molecule, type: :model do
       expect(scheduled_ids).to eq([molecule.id])
     end
 
-    it 'does not push to lcss_batch when the molecule already existed' do
+    it 'does not schedule anything when the molecule already existed, regardless of defer_lcss' do
       existing = create(
         :molecule,
         inchikey: babel_info[:inchikey],
@@ -212,12 +210,40 @@ RSpec.describe Molecule, type: :model do
         sum_formular: babel_info[:formula],
         skip_lcss_callback: true,
       )
-      lcss_batch = []
+      allow(PubchemSingleLcssJob).to receive(:perform_later)
 
-      molecule = described_class.find_or_create_by_molfile('molfile', lcss_batch: lcss_batch, **babel_info)
+      molecule = described_class.find_or_create_by_molfile('molfile', defer_lcss: true, **babel_info)
 
       expect(molecule.id).to eq(existing.id)
-      expect(lcss_batch).to be_empty
+      expect(PubchemSingleLcssJob).not_to have_received(:perform_later)
+    end
+  end
+
+  describe '.schedule_lcss_since' do
+    it 'does nothing when timestamp is blank' do
+      allow(PubchemSingleLcssJob).to receive(:perform_later)
+
+      described_class.schedule_lcss_since(nil)
+
+      expect(PubchemSingleLcssJob).not_to have_received(:perform_later)
+    end
+
+    it 'does nothing when no molecule was created after the given timestamp' do
+      allow(PubchemSingleLcssJob).to receive(:perform_later)
+
+      described_class.schedule_lcss_since(1.hour.from_now)
+
+      expect(PubchemSingleLcssJob).not_to have_received(:perform_later)
+    end
+
+    it 'schedules a job covering molecules created after the given timestamp' do
+      timestamp = 1.hour.ago
+      create(:molecule)
+      allow(PubchemSingleLcssJob).to receive(:perform_later)
+
+      described_class.schedule_lcss_since(timestamp)
+
+      expect(PubchemSingleLcssJob).to have_received(:perform_later).with(nil, created_after: timestamp)
     end
   end
 end


### PR DESCRIPTION
## Summary
- Bulk importers (SDF, xlsx/csv, ZIP) threaded a mutable `lcss_batch` array through `find_or_create_by_molfile`/`find_or_create_by_cano_smiles`/`PolymerMoleculeResolver` purely to suppress and later flush each new molecule's LCSS scheduling. Replaced with a captured `started_at` timestamp + `Molecule.schedule_lcss_since`, letting `PubchemSingleLcssJob`'s `created_after:` filter (from #3416) do the work instead.
- This collapses `Import::ImportSdf#find_or_create_mol_by_batch` from one job enqueue per 50-record chunk (incidental reuse of an unrelated SDF-parsing chunking loop) down to **one per import** — a 20k-molecule SDF import previously enqueued roughly 400 separate jobs, each serializing behind the mutual-exclusion guard.
- Since a single job invocation can now cover far more molecules, `PubchemSingleLcssJob` gains the same bounded `chunk_size` + self-requeue design `PubchemLcssJob` already uses, to avoid exceeding `delayed_job`'s `max_run_time` on a large sweep.
- `lcss_batch:` (Array) becomes `defer_lcss:` (Boolean) throughout, since there's nothing left to collect once the timestamp does the filtering. `Molecule.schedule_lcss_since` checks for a matching molecule before enqueuing, so a flush point that created nothing new stays a no-op (e.g. `create_samples`'s own flush after `find_or_create_mol_by_batch` already handled everything).

Stacked on #3416 (base branch is `perf/pubchem-lcss-job-rate-limit`, not `main`) since this builds directly on that job's `created_after:`/mutual-exclusion/chunking work.

## Test plan
- [x] `bundle exec rspec spec/jobs/pubchem_single_lcss_job_spec.rb spec/jobs/pubchem_lcss_job_spec.rb spec/models/molecule_spec.rb spec/api/chemotion/sample_api_spec.rb spec/lib/import/import_sdf_spec.rb spec/lib/import/import_samples_spec.rb spec/lib/import/import_collections_spec.rb spec/lib/import/polymer_molecule_resolver_spec.rb` — 176 examples, 0 failures
- [x] `bundle exec rubocop` on all changed files — no new offenses (verified pre-existing offenses in touched files are unchanged from `main`)