### PR TITLE
fix(api): don't 401 on GET /api/v1/users/current for anonymous visitors

### DIFF
--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -72,12 +72,9 @@ class API < Grape::API
 
     def public_request?
       request.path.start_with?(
-        '/api/v1/authentication/',
-        '/api/v1/public/',
-        '/api/v1/chemspectra/',
-        '/api/v1/ketcher/layout',
-        '/api/v1/gate/receiving',
-        '/api/v1/gate/ping',
+        '/api/v1/authentication/', '/api/v1/public/', '/api/v1/chemspectra/',
+        '/api/v1/ketcher/layout', '/api/v1/gate/receiving', '/api/v1/gate/ping',
+        '/api/v1/users/current'
       )
     end
 

--- a/app/api/chemotion/user_api.rb
+++ b/app/api/chemotion/user_api.rb
@@ -23,7 +23,15 @@ module Chemotion
 
       desc 'Return current_user'
       get 'current' do
-        present current_user, with: Entities::UserEntity, root: 'user', with_tokens: true
+        if current_user
+          present current_user, with: Entities::UserEntity, root: 'user', with_tokens: true
+        elsif token_in_header?
+          # credentials were supplied but did not resolve to a user: a genuine auth failure
+          error!('401 Unauthorized', 401)
+        else
+          # no credentials at all: an anonymous visitor probing login state, not an error
+          { user: nil }
+        end
       end
 
       resource :two_factor do

--- a/app/javascript/src/stores/alt/stores/UserStore.js
+++ b/app/javascript/src/stores/alt/stores/UserStore.js
@@ -18,7 +18,8 @@ class UserStore {
       dsKlasses: [],
       unitsSystem: {},
       matriceConfigs: [],
-      omniauthProviders: [],
+      omniauthProviders: {},
+      extraRules: {},
       bao: []
     };
 

--- a/spec/api/chemotion/user_api_spec.rb
+++ b/spec/api/chemotion/user_api_spec.rb
@@ -88,7 +88,8 @@ describe Chemotion::UserAPI do
 
     context 'when there is no session and no token' do
       before do
-        allow_any_instance_of(WardenAuthentication).to receive(:current_user).and_return(nil)
+        allow(WardenAuthentication).to receive(:new)
+          .and_return(instance_double(WardenAuthentication, current_user: nil))
         get '/api/v1/users/current'
       end
 

--- a/spec/api/chemotion/user_api_spec.rb
+++ b/spec/api/chemotion/user_api_spec.rb
@@ -85,6 +85,18 @@ describe Chemotion::UserAPI do
         end
       end
     end
+
+    context 'when there is no session and no token' do
+      before do
+        allow_any_instance_of(WardenAuthentication).to receive(:current_user).and_return(nil)
+        get '/api/v1/users/current'
+      end
+
+      it 'returns 200 with a nil user instead of raising unauthorized' do
+        expect(response).to have_http_status :ok
+        expect(JSON.parse(response.body)).to eq('user' => nil)
+      end
+    end
   end
 
   describe 'GET /api/v1/users/list_editors' do


### PR DESCRIPTION
Every page probes login state by calling this endpoint on mount, so a logged-out visit (e.g. the home page) always logged a 401 in the console/network tab even though the frontend already treats a null user as "not logged in". The endpoint now returns { user: nil } (200) when no credentials were supplied, while still raising 401 when an Authorization header was sent but didn't resolve to a user.