### PR TITLE
fix(spectra): resolve 2D source data via NMRium's sources[]/selector.root registry

### DIFF
--- a/app/javascript/src/components/nmriumWrapper/NMRiumDisplayer.js
+++ b/app/javascript/src/components/nmriumWrapper/NMRiumDisplayer.js
@@ -252,9 +252,13 @@ export default class NMRiumDisplayer extends React.Component {
         return;
       }
 
+      // Rename before cleaning, not after: cleaningNMRiumData derives each spectrum's sources[] id
+      // from its name, so renaming afterwards would leave selector.root pointing at an id the next
+      // save no longer mints.
+      if (zip?.label) this.patchZipName(nmriumState, zip?.label);
+
       const cleaned = cleaningNMRiumData(nmriumState);
 
-      if (zip?.label) this.patchZipName(cleaned, zip?.label);
       if (molfile) { cleaned.molecules = [{ molfile }]; }
 
       this.iframeRef.current?.contentWindow.postMessage({ type: 'nmr-wrapper:load', data: { type: 'nmrium', data: cleaned } }, '*');

--- a/app/javascript/src/components/nmriumWrapper/NMRiumDisplayer.js
+++ b/app/javascript/src/components/nmriumWrapper/NMRiumDisplayer.js
@@ -8,7 +8,7 @@ import UIFetcher from 'src/fetchers/UIFetcher';
 import Attachment from 'src/models/Attachment';
 import { SpectraOps } from 'src/utilities/quillToolbarSymbol';
 import { FN } from '@complat/react-spectra-editor';
-import { cleaningNMRiumData } from 'src/utilities/SpectraHelper';
+import { cleaningNMRiumData, isSpectrum2D } from 'src/utilities/SpectraHelper';
 
 export default class NMRiumDisplayer extends React.Component {
   constructor(props) {
@@ -151,11 +151,7 @@ export default class NMRiumDisplayer extends React.Component {
       if (!rawState) return;
 
       const spectra = rawState?.spectra || rawState?.data?.spectra || [];
-      const is2D = this.state.is2D || spectra.some((spc) => (
-        spc?.info?.dimension === 2
-        || spc?.originalInfo?.dimension === 2
-        || spc?.meta?.dimension === 2
-      ));
+      const is2D = this.state.is2D || spectra.some(isSpectrum2D);
       const version = rawState?.version ?? rawState?.data?.version ?? 1;
       const nmriumData = version > 3 && rawState.data ? rawState.data : rawState;
 
@@ -530,11 +526,7 @@ export default class NMRiumDisplayer extends React.Component {
     const root = hasDataProp ? cleanedNMRiumData.data : cleanedNMRiumData;
     const spectra = root?.spectra || [];
     const originalSpectra = nmriumData?.data?.spectra || nmriumData?.spectra || [];
-    const has2D = this.state.is2D || originalSpectra.some((spc) => (
-      spc?.info?.dimension === 2
-      || spc?.originalInfo?.dimension === 2
-      || spc?.meta?.dimension === 2
-    ));
+    const has2D = this.state.is2D || originalSpectra.some(isSpectrum2D);
     const hasAnySource =
       !!root?.source
       || spectra.some((spc) => spc?.source || spc?.sourceSelector);

--- a/app/javascript/src/components/nmriumWrapper/NMRiumDisplayer.js
+++ b/app/javascript/src/components/nmriumWrapper/NMRiumDisplayer.js
@@ -529,7 +529,8 @@ export default class NMRiumDisplayer extends React.Component {
     const has2D = this.state.is2D || originalSpectra.some(isSpectrum2D);
     const hasAnySource =
       !!root?.source
-      || spectra.some((spc) => spc?.source || spc?.sourceSelector);
+      || !!root?.sources?.length
+      || spectra.some((spc) => spc?.source || spc?.sourceSelector || spc?.selector?.root);
     const needsWrapper = has2D && !hasAnySource && !hasDataProp && !nmriumData.version;
 
     const toSerialize = needsWrapper

--- a/app/javascript/src/utilities/SpectraHelper.js
+++ b/app/javascript/src/utilities/SpectraHelper.js
@@ -220,8 +220,8 @@ const cleaningNMRiumData = (nmriumData) => {
     const tmpSpc = { ...spc };
     const hasLocalSource = !!(spc && (spc.source || spc.sourceSelector));
     const hasSource = hasLocalSource || hasGlobalSource;
-    // Check if the spectrum is a 2D spectrum
-    const isSourceOnly2D = hasSource && (
+    // Whether this is a 2D spectrum backed by a source (data itself is always kept regardless).
+    const is2DWithSource = hasSource && (
       tmpSpc?.info?.dimension === 2
       || tmpSpc?.originalInfo?.dimension === 2
       || tmpSpc?.meta?.dimension === 2
@@ -236,7 +236,7 @@ const cleaningNMRiumData = (nmriumData) => {
     // unlike originalData/originalInfo, NMRium just passes it through as-is rather than regenerating
     // it, so we can't assume it's safe to lose. `info` itself must stay fully intact; NMRium relies
     // on it (e.g. dimension, isFid) to read `data`.
-    if (isSourceOnly2D) {
+    if (is2DWithSource) {
       const spectrumName = tmpSpc?.display?.name
         || tmpSpc?.info?.name
         || tmpSpc?.originalInfo?.name

--- a/app/javascript/src/utilities/SpectraHelper.js
+++ b/app/javascript/src/utilities/SpectraHelper.js
@@ -240,6 +240,9 @@ const cleaningNMRiumData = (nmriumData) => {
       if (spectrumName) {
         tmpSpc.display = { ...tmpSpc.display, name: spectrumName };
       }
+      // info may be sparse on legacy spectra where dimension/isFid were only ever mirrored into
+      // originalInfo/meta; backfill it before dropping those duplicates so nothing is lost.
+      tmpSpc.info = { ...tmpSpc.meta, ...tmpSpc.originalInfo, ...tmpSpc.info };
       delete tmpSpc.originalInfo;
       delete tmpSpc.meta;
       // Remove the filters if they are not valid

--- a/app/javascript/src/utilities/SpectraHelper.js
+++ b/app/javascript/src/utilities/SpectraHelper.js
@@ -205,6 +205,14 @@ const isNMRKind = (container, chmos = []) => {
   return filtered.length > 0;
 };
 
+// A spectrum's dimension may be recorded on info, originalInfo, or meta depending on how/when it
+// was populated; check all three so 2D detection agrees everywhere it's needed.
+const isSpectrum2D = (spc) => (
+  spc?.info?.dimension === 2
+  || spc?.originalInfo?.dimension === 2
+  || spc?.meta?.dimension === 2
+);
+
 const cleaningNMRiumData = (nmriumData) => {
   if (!nmriumData) return null;
   const cleanedNMRiumData = { ...nmriumData };
@@ -221,11 +229,7 @@ const cleaningNMRiumData = (nmriumData) => {
     const hasLocalSource = !!(spc && (spc.source || spc.sourceSelector));
     const hasSource = hasLocalSource || hasGlobalSource;
     // Whether this is a 2D spectrum backed by a source (data itself is always kept regardless).
-    const is2DWithSource = hasSource && (
-      tmpSpc?.info?.dimension === 2
-      || tmpSpc?.originalInfo?.dimension === 2
-      || tmpSpc?.meta?.dimension === 2
-    );
+    const is2DWithSource = hasSource && isSpectrum2D(tmpSpc);
 
     // NMRium never re-fetches from our source/sourceSelector references, so `data` must be kept.
     // originalData is safe to drop: NMRium's own loader always recomputes it fresh from `data`.
@@ -354,4 +358,6 @@ const inlineNotation = (layout, data, metadata) => {
   return { quillData, formattedString };
 };
 
-export { BuildSpcInfos, BuildSpcInfosForNMRDisplayer, JcampIds, isNMRKind, cleaningNMRiumData, inlineNotation }; // eslint-disable-line
+export {
+  BuildSpcInfos, BuildSpcInfosForNMRDisplayer, JcampIds, isNMRKind, isSpectrum2D, cleaningNMRiumData, inlineNotation,
+}; // eslint-disable-line

--- a/app/javascript/src/utilities/SpectraHelper.js
+++ b/app/javascript/src/utilities/SpectraHelper.js
@@ -213,6 +213,27 @@ const isSpectrum2D = (spc) => (
   || spc?.meta?.dimension === 2
 );
 
+const SOURCE_ID_PREFIX = 'nmrium-src-';
+const ARCHIVE_MARKER = '/file.zip/';
+const isAbsoluteUrl = (value) => typeof value === 'string' && /^https?:\/\//.test(value);
+
+// Splits `<archive>/file.zip/exp1/pdata/1/2rr` into the archive itself and the path of the member
+// inside it. Both halves matter and they go to different places: a `sources[]` entry must address
+// the archive (the server serves the whole zip), while the member path is what NMRium filters the
+// fetched file collection down to, via the spectrum's own selector.files.
+const splitArchiveRef = (value) => {
+  const idx = typeof value === 'string' ? value.indexOf(ARCHIVE_MARKER) : -1;
+  if (idx < 0) return { archive: value, member: null };
+  return {
+    archive: value.slice(0, idx + ARCHIVE_MARKER.length - 1),
+    member: value.slice(idx + ARCHIVE_MARKER.length),
+  };
+};
+
+const entryUrl = (entry) => (
+  (entry?.baseURL && entry?.relativePath) ? `${entry.baseURL}${entry.relativePath}` : null
+);
+
 // A JCAMP/zip file's own filename is a stable, already-trusted key in this file (patchZipName,
 // findMatchingZip, findMatchingJcamp in NMRiumDisplayer.js all match spectra by it) — unlike the
 // token URLs, which are re-minted (and change) on every viewer open. Use it to derive a `sources[]`
@@ -220,52 +241,90 @@ const isSpectrum2D = (spc) => (
 const buildSourceId = (label) => {
   if (!label) return null;
   const slug = label.toString().trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-  return slug ? `nmrium-src-${slug}` : null;
+  return slug ? `${SOURCE_ID_PREFIX}${slug}` : null;
 };
 
-// Resolves the best currently-known absolute URL for a spectrum's source, whichever form it's
-// currently in: the ad hoc source/sourceSelector fields (first-time migration), the legacy global
-// root.source.entries[0] (very old saves), or an already-migrated sources[] entry matched by the
-// spectrum's own selector.root (subsequent saves, once NMRium has echoed it back).
+// Resolves the best currently-known absolute URL for a spectrum's source, whichever form it's in.
+// Order matters: the download URLs carry short-lived, per-open tokens (48h, counter-limited), so a
+// freshly re-minted reference always wins over one persisted by an earlier save. Only
+// `source.jcampURL`, `sourceSelector.files` and the legacy global `root.source.entries[0]` are
+// refreshed on open (patchZipAndJcampReference); a `sources[]` entry is not, so it is the last
+// resort — better than nothing for a spectrum whose `data` a previous save already dropped.
 const resolveSpectrumSourceUrl = (spc, root) => {
-  const localUrl = spc?.source?.jcampURL
-    || spc?.sourceSelector?.files?.find((file) => typeof file === 'string' && /^https?:\/\//.test(file));
-  if (localUrl) return localUrl;
+  if (spc?.source?.jcampURL) return splitArchiveRef(spc.source.jcampURL).archive;
+
+  const fileUrl = spc?.sourceSelector?.files?.find(isAbsoluteUrl);
+  if (fileUrl) return splitArchiveRef(fileUrl).archive;
+
+  const fromGlobal = entryUrl(root?.source?.entries?.[0]);
+  if (fromGlobal) return fromGlobal;
 
   const existingSource = Array.isArray(root?.sources)
     ? root.sources.find((source) => source.id === spc?.selector?.root)
     : null;
-  const entry = existingSource?.entries?.[0] || root?.source?.entries?.[0];
-  return (entry?.baseURL && entry?.relativePath) ? `${entry.baseURL}${entry.relativePath}` : null;
+  return entryUrl(existingSource?.entries?.[0]);
 };
 
-// Finds or creates root.sources[]'s entry for `id`, always refreshing it to `url`: NMRium's own
-// reader (readNMRiumObject) re-fetches a spectrum's data only when its selector.root matches an id
-// here, so this is what actually lets us stop embedding `data` for a source-backed spectrum.
-const ensureSource = (root, id, url) => {
-  if (!id || !url || !/^https?:\/\//.test(url)) return;
-  const parsed = new URL(url);
+// Registers `url` in root.sources[] and returns the id that addresses it, or null when it can't be
+// registered. NMRium's own reader (readNMRiumObject) re-fetches a spectrum's data only when its
+// selector.root matches an id here, so this is what actually lets us stop embedding `data` for a
+// source-backed spectrum. `claimed` maps url -> id for this cleaning pass: two spectra backed by
+// the same file share one entry, while two backed by *different* files never collapse onto one id
+// (the preferred id is suffixed instead of being repointed at the second file).
+const ensureSource = (root, preferredId, url, claimed) => {
+  if (!preferredId || !isAbsoluteUrl(url)) return null;
+
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch (err) {
+    return null;
+  }
   const entry = { relativePath: parsed.pathname, baseURL: parsed.origin };
   if (!Array.isArray(root.sources)) root.sources = [];
+
+  const alreadyClaimed = claimed.get(url);
+  if (alreadyClaimed) return alreadyClaimed;
+
+  let id = preferredId;
+  let suffix = 1;
+  const taken = new Set(claimed.values());
+  while (taken.has(id)) {
+    suffix += 1;
+    id = `${preferredId}-${suffix}`;
+  }
+
   const existing = root.sources.find((source) => source.id === id);
   if (existing) {
     existing.entries = [entry];
   } else {
     root.sources.push({ id, entries: [entry] });
   }
+  claimed.set(url, id);
+  return id;
 };
 
 const cleaningNMRiumData = (nmriumData) => {
   if (!nmriumData) return null;
   const cleanedNMRiumData = { ...nmriumData };
 
+  // Copy the wrapped root too: without this `root` is the caller's own object, so the deletes and
+  // the sources[] registry below would leak back into the live NMRium state this was cleaned from.
   const wasWrapped = !!cleanedNMRiumData.data;
+  // Copy the wrapper so the mutations below don't reach the caller's object - but only when it
+  // really is one: `data` can legitimately be a non-object (a bare string), and spreading that
+  // would turn it into a char-indexed object and change the returned payload.
+  if (wasWrapped && typeof cleanedNMRiumData.data === 'object') {
+    cleanedNMRiumData.data = { ...cleanedNMRiumData.data };
+  }
   const root = wasWrapped ? cleanedNMRiumData.data : cleanedNMRiumData;
   const { spectra } = root;
   if (!Array.isArray(spectra)) return cleanedNMRiumData;
 
   delete root.actionType;
-  const hasGlobalSource = !!root.source || !!(Array.isArray(root.sources) && root.sources.length);
+  if (Array.isArray(root.sources)) root.sources = root.sources.map((source) => ({ ...source }));
+  const hasGlobalSource = !!root.source || root.sources?.length > 0;
+  const claimedSources = new Map();
 
   const newSpectra = spectra.map((spc) => {
     const tmpSpc = { ...spc };
@@ -291,8 +350,15 @@ const cleaningNMRiumData = (nmriumData) => {
         tmpSpc.display = { ...tmpSpc.display, name: spectrumName };
       }
       // info may be sparse on legacy spectra where dimension/isFid were only ever mirrored into
-      // originalInfo/meta; backfill it before dropping the originalInfo duplicate.
-      tmpSpc.info = { ...tmpSpc.meta, ...tmpSpc.originalInfo, ...tmpSpc.info };
+      // originalInfo/meta; backfill it before dropping the originalInfo duplicate. Only the two
+      // known load-bearing keys are taken from `meta` — it is a raw JCAMP header dictionary, not an
+      // info-shaped object, and it stays on the spectrum anyway.
+      tmpSpc.info = { ...tmpSpc.originalInfo, ...tmpSpc.info };
+      ['dimension', 'isFid'].forEach((key) => {
+        if (tmpSpc.info[key] === undefined && tmpSpc.meta?.[key] !== undefined) {
+          tmpSpc.info[key] = tmpSpc.meta[key];
+        }
+      });
       delete tmpSpc.originalInfo;
       // Remove the filters if they are not valid
       if (Array.isArray(tmpSpc.filters)) {
@@ -306,18 +372,24 @@ const cleaningNMRiumData = (nmriumData) => {
       // real reference so `data` can finally be dropped instead of duplicated into the saved JSON.
       // If no URL can be resolved, leave `data` embedded: that's the same safe fallback this file
       // relied on before this was wired up, not a regression.
-      const sourceId = buildSourceId(spectrumName);
       const sourceUrl = resolveSpectrumSourceUrl(tmpSpc, root);
-      if (sourceId && sourceUrl) {
-        ensureSource(root, sourceId, sourceUrl);
-        // sourceSelector.files may hold relative paths *within* a shared source (e.g. one entry per
+      const sourceId = ensureSource(root, buildSourceId(spectrumName), sourceUrl, claimedSources);
+      if (sourceId) {
+        // sourceSelector.files may address individual members *within* a shared source (e.g. one
         // experiment inside a multi-spectrum zip, all sharing one sources[] id); NMRium's reader
         // filters the fetched file collection down to selector.files before parsing, so without
-        // this a shared zip source can't tell spectra apart. Absolute URLs there aren't paths within
-        // the source, so they're excluded.
-        const filesWithinSource = tmpSpc.sourceSelector?.files?.filter(
-          (file) => typeof file === 'string' && !/^https?:\/\//.test(file)
-        );
+        // this a shared zip source can't tell spectra apart. Entries arrive either as a full
+        // URL/server path through the archive (`.../file.zip/exp1/...`, which has to be reduced to
+        // the member path) or already as a bare member path. Anything else does not address a
+        // member and is dropped.
+        const filesWithinSource = tmpSpc.sourceSelector?.files
+          ?.map((file) => {
+            if (typeof file !== 'string') return null;
+            const { member } = splitArchiveRef(file);
+            if (member) return member;
+            return (isAbsoluteUrl(file) || file.startsWith('/')) ? null : file;
+          })
+          .filter(Boolean);
         tmpSpc.selector = {
           ...tmpSpc.selector,
           root: sourceId,
@@ -331,6 +403,16 @@ const cleaningNMRiumData = (nmriumData) => {
   });
 
   root.spectra = [...newSpectra];
+
+  // Drop our own now-unreferenced entries: their URLs carry per-open download tokens that nothing
+  // refreshes, so leaving one behind after a rename only accumulates dead references. Entries we
+  // did not mint are left alone.
+  if (Array.isArray(root.sources)) {
+    const referenced = new Set(newSpectra.map((spc) => spc?.selector?.root).filter(Boolean));
+    root.sources = root.sources.filter(
+      (source) => referenced.has(source?.id) || !`${source?.id}`.startsWith(SOURCE_ID_PREFIX)
+    );
+  }
 
   // Deliberately not forcing a {version, data} wrap or an explicit version, even though a spectrum
   // here may now depend on sources[] actually being processed on load: a real, working .nmrium
@@ -432,5 +514,4 @@ const inlineNotation = (layout, data, metadata) => {
 
 export {
   BuildSpcInfos, BuildSpcInfosForNMRDisplayer, JcampIds, isNMRKind, isSpectrum2D, cleaningNMRiumData, inlineNotation,
-  buildSourceId, ensureSource,
 }; // eslint-disable-line

--- a/app/javascript/src/utilities/SpectraHelper.js
+++ b/app/javascript/src/utilities/SpectraHelper.js
@@ -213,25 +213,67 @@ const isSpectrum2D = (spc) => (
   || spc?.meta?.dimension === 2
 );
 
+// A JCAMP/zip file's own filename is a stable, already-trusted key in this file (patchZipName,
+// findMatchingZip, findMatchingJcamp in NMRiumDisplayer.js all match spectra by it) — unlike the
+// token URLs, which are re-minted (and change) on every viewer open. Use it to derive a `sources[]`
+// id that stays the same across saves, so the same physical file always resolves to one entry.
+const buildSourceId = (label) => {
+  if (!label) return null;
+  const slug = label.toString().trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return slug ? `nmrium-src-${slug}` : null;
+};
+
+// Resolves the best currently-known absolute URL for a spectrum's source, whichever form it's
+// currently in: the ad hoc source/sourceSelector fields (first-time migration), the legacy global
+// root.source.entries[0] (very old saves), or an already-migrated sources[] entry matched by the
+// spectrum's own selector.root (subsequent saves, once NMRium has echoed it back).
+const resolveSpectrumSourceUrl = (spc, root) => {
+  const localUrl = spc?.source?.jcampURL
+    || spc?.sourceSelector?.files?.find((file) => typeof file === 'string' && /^https?:\/\//.test(file));
+  if (localUrl) return localUrl;
+
+  const existingSource = Array.isArray(root?.sources)
+    ? root.sources.find((source) => source.id === spc?.selector?.root)
+    : null;
+  const entry = existingSource?.entries?.[0] || root?.source?.entries?.[0];
+  return (entry?.baseURL && entry?.relativePath) ? `${entry.baseURL}${entry.relativePath}` : null;
+};
+
+// Finds or creates root.sources[]'s entry for `id`, always refreshing it to `url`: NMRium's own
+// reader (readNMRiumObject) re-fetches a spectrum's data only when its selector.root matches an id
+// here, so this is what actually lets us stop embedding `data` for a source-backed spectrum.
+const ensureSource = (root, id, url) => {
+  if (!id || !url || !/^https?:\/\//.test(url)) return;
+  const parsed = new URL(url);
+  const entry = { relativePath: parsed.pathname, baseURL: parsed.origin };
+  if (!Array.isArray(root.sources)) root.sources = [];
+  const existing = root.sources.find((source) => source.id === id);
+  if (existing) {
+    existing.entries = [entry];
+  } else {
+    root.sources.push({ id, entries: [entry] });
+  }
+};
+
 const cleaningNMRiumData = (nmriumData) => {
   if (!nmriumData) return null;
   const cleanedNMRiumData = { ...nmriumData };
 
-  const root = cleanedNMRiumData.data || cleanedNMRiumData;
+  const wasWrapped = !!cleanedNMRiumData.data;
+  const root = wasWrapped ? cleanedNMRiumData.data : cleanedNMRiumData;
   const { spectra } = root;
   if (!Array.isArray(spectra)) return cleanedNMRiumData;
 
   delete root.actionType;
-  const hasGlobalSource = !!root.source;
+  const hasGlobalSource = !!root.source || !!(Array.isArray(root.sources) && root.sources.length);
 
   const newSpectra = spectra.map((spc) => {
     const tmpSpc = { ...spc };
-    const hasLocalSource = !!(spc && (spc.source || spc.sourceSelector));
+    const hasLocalSource = !!(spc && (spc.source || spc.sourceSelector || spc.selector?.root));
     const hasSource = hasLocalSource || hasGlobalSource;
-    // Whether this is a 2D spectrum backed by a source (data itself is always kept regardless).
+    // Whether this is a 2D spectrum backed by a source.
     const is2DWithSource = hasSource && isSpectrum2D(tmpSpc);
 
-    // NMRium never re-fetches from our source/sourceSelector references, so `data` must be kept.
     // originalData is safe to drop: NMRium's own loader always recomputes it fresh from `data`.
     delete tmpSpc.originalData;
 
@@ -258,6 +300,31 @@ const cleaningNMRiumData = (nmriumData) => {
           (filter) => filter && typeof filter === 'object' && !Object.prototype.hasOwnProperty.call(filter, 'error')
         );
       }
+
+      // NMRium's own reader only re-fetches a spectrum's data when selector.root matches an id in
+      // the top-level sources[] registry — it never uses source/sourceSelector for that. Build the
+      // real reference so `data` can finally be dropped instead of duplicated into the saved JSON.
+      // If no URL can be resolved, leave `data` embedded: that's the same safe fallback this file
+      // relied on before this was wired up, not a regression.
+      const sourceId = buildSourceId(spectrumName);
+      const sourceUrl = resolveSpectrumSourceUrl(tmpSpc, root);
+      if (sourceId && sourceUrl) {
+        ensureSource(root, sourceId, sourceUrl);
+        // sourceSelector.files may hold relative paths *within* a shared source (e.g. one entry per
+        // experiment inside a multi-spectrum zip, all sharing one sources[] id); NMRium's reader
+        // filters the fetched file collection down to selector.files before parsing, so without
+        // this a shared zip source can't tell spectra apart. Absolute URLs there aren't paths within
+        // the source, so they're excluded.
+        const filesWithinSource = tmpSpc.sourceSelector?.files?.filter(
+          (file) => typeof file === 'string' && !/^https?:\/\//.test(file)
+        );
+        tmpSpc.selector = {
+          ...tmpSpc.selector,
+          root: sourceId,
+          ...(filesWithinSource?.length ? { files: filesWithinSource } : {}),
+        };
+        delete tmpSpc.data;
+      }
     }
 
     return tmpSpc;
@@ -265,6 +332,11 @@ const cleaningNMRiumData = (nmriumData) => {
 
   root.spectra = [...newSpectra];
 
+  // Deliberately not forcing a {version, data} wrap or an explicit version, even though a spectrum
+  // here may now depend on sources[] actually being processed on load: a real, working .nmrium
+  // capture has neither (flat top-level sources/spectra, no version at all) and reloads correctly,
+  // while an explicit version apparently opts a document out of whatever normalization an unversioned
+  // one gets put through on load. Forcing our own wrap previously broke exactly this case.
   return cleanedNMRiumData;
 };
 
@@ -360,4 +432,5 @@ const inlineNotation = (layout, data, metadata) => {
 
 export {
   BuildSpcInfos, BuildSpcInfosForNMRDisplayer, JcampIds, isNMRKind, isSpectrum2D, cleaningNMRiumData, inlineNotation,
+  buildSourceId, ensureSource,
 }; // eslint-disable-line

--- a/app/javascript/src/utilities/SpectraHelper.js
+++ b/app/javascript/src/utilities/SpectraHelper.js
@@ -205,12 +205,17 @@ const isNMRKind = (container, chmos = []) => {
   return filtered.length > 0;
 };
 
-// A spectrum's dimension may be recorded on info, originalInfo, or meta depending on how/when it
-// was populated; check all three so 2D detection agrees everywhere it's needed.
+// A spectrum's dimension may be recorded on info, originalInfo, meta or display depending on
+// how/when it was populated; check all four so 2D detection agrees everywhere it's needed.
+// display is what makes a *previously saved* spectrum still recognisable: an older cleaner deleted
+// info/originalInfo/meta from a source-backed 2D spectrum before writing it out, so on reopen
+// display.dimension is the only surviving record that it was 2D — and without that this whole
+// migration is skipped for exactly the files that most need it.
 const isSpectrum2D = (spc) => (
   spc?.info?.dimension === 2
   || spc?.originalInfo?.dimension === 2
   || spc?.meta?.dimension === 2
+  || spc?.display?.dimension === 2
 );
 
 const SOURCE_ID_PREFIX = 'nmrium-src-';
@@ -353,12 +358,20 @@ const cleaningNMRiumData = (nmriumData) => {
       // originalInfo/meta; backfill it before dropping the originalInfo duplicate. Only the two
       // known load-bearing keys are taken from `meta` — it is a raw JCAMP header dictionary, not an
       // info-shaped object, and it stays on the spectrum anyway.
-      tmpSpc.info = { ...tmpSpc.originalInfo, ...tmpSpc.info };
+      // Nothing may be recoverable at all (a spectrum written by the cleaner that deleted all
+      // three): leave `info` absent rather than writing an empty object, so NMRium sees a spectrum
+      // with no info and rebuilds it from the source instead of one that claims to have none.
+      const backfilledInfo = { ...tmpSpc.originalInfo, ...tmpSpc.info };
       ['dimension', 'isFid'].forEach((key) => {
-        if (tmpSpc.info[key] === undefined && tmpSpc.meta?.[key] !== undefined) {
-          tmpSpc.info[key] = tmpSpc.meta[key];
+        if (backfilledInfo[key] === undefined && tmpSpc.meta?.[key] !== undefined) {
+          backfilledInfo[key] = tmpSpc.meta[key];
         }
       });
+      if (Object.keys(backfilledInfo).length) {
+        tmpSpc.info = backfilledInfo;
+      } else {
+        delete tmpSpc.info;
+      }
       delete tmpSpc.originalInfo;
       // Remove the filters if they are not valid
       if (Array.isArray(tmpSpc.filters)) {

--- a/app/javascript/src/utilities/SpectraHelper.js
+++ b/app/javascript/src/utilities/SpectraHelper.js
@@ -228,10 +228,14 @@ const cleaningNMRiumData = (nmriumData) => {
     );
 
     // NMRium never re-fetches from our source/sourceSelector references, so `data` must be kept.
+    // originalData is safe to drop: NMRium's own loader always recomputes it fresh from `data`.
     delete tmpSpc.originalData;
 
-    // Keep the spectrum name in display.name and drop the stale originalInfo/meta duplicates.
-    // `info` itself must stay fully intact; NMRium relies on it (e.g. dimension, isFid) to read `data`.
+    // Keep the spectrum name in display.name and drop the stale originalInfo duplicate (NMRium's
+    // loader always recomputes it fresh from `info`, same as originalData). `meta` is NOT dropped:
+    // unlike originalData/originalInfo, NMRium just passes it through as-is rather than regenerating
+    // it, so we can't assume it's safe to lose. `info` itself must stay fully intact; NMRium relies
+    // on it (e.g. dimension, isFid) to read `data`.
     if (isSourceOnly2D) {
       const spectrumName = tmpSpc?.display?.name
         || tmpSpc?.info?.name
@@ -241,10 +245,9 @@ const cleaningNMRiumData = (nmriumData) => {
         tmpSpc.display = { ...tmpSpc.display, name: spectrumName };
       }
       // info may be sparse on legacy spectra where dimension/isFid were only ever mirrored into
-      // originalInfo/meta; backfill it before dropping those duplicates so nothing is lost.
+      // originalInfo/meta; backfill it before dropping the originalInfo duplicate.
       tmpSpc.info = { ...tmpSpc.meta, ...tmpSpc.originalInfo, ...tmpSpc.info };
       delete tmpSpc.originalInfo;
-      delete tmpSpc.meta;
       // Remove the filters if they are not valid
       if (Array.isArray(tmpSpc.filters)) {
         tmpSpc.filters = tmpSpc.filters.filter(

--- a/app/javascript/src/utilities/SpectraHelper.js
+++ b/app/javascript/src/utilities/SpectraHelper.js
@@ -227,12 +227,11 @@ const cleaningNMRiumData = (nmriumData) => {
       || tmpSpc?.meta?.dimension === 2
     );
 
+    // NMRium never re-fetches from our source/sourceSelector references, so `data` must be kept.
     delete tmpSpc.originalData;
-    if (hasSource) {
-      delete tmpSpc.data;
-    }
 
-    // For 2D spectra, we need to keep the name of the spectrum in display.name and remove the info, originalInfo, and meta
+    // Keep the spectrum name in display.name and drop the stale originalInfo/meta duplicates.
+    // `info` itself must stay fully intact; NMRium relies on it (e.g. dimension, isFid) to read `data`.
     if (isSourceOnly2D) {
       const spectrumName = tmpSpc?.display?.name
         || tmpSpc?.info?.name
@@ -241,7 +240,6 @@ const cleaningNMRiumData = (nmriumData) => {
       if (spectrumName) {
         tmpSpc.display = { ...tmpSpc.display, name: spectrumName };
       }
-      delete tmpSpc.info;
       delete tmpSpc.originalInfo;
       delete tmpSpc.meta;
       // Remove the filters if they are not valid

--- a/spec/javascripts/packs/src/utilities/SpectraHelper.spec.js
+++ b/spec/javascripts/packs/src/utilities/SpectraHelper.spec.js
@@ -481,6 +481,138 @@ describe('SpectraHelper', () => {
         expect(spectrum.meta).toEqual({ dimension: 2 });
       });
 
+      it('does not collapse same-named spectra that are backed by different files', () => {
+        const nmriumData = {
+          spectra: [
+            {
+              source: { jcampURL: 'https://example.com/a/file.jdx' },
+              info: { dimension: 2, name: 'cosy' },
+              display: { name: 'cosy' },
+              data: { rr: { z: [[1.0]] } },
+            },
+            {
+              source: { jcampURL: 'https://example.com/b/file.jdx' },
+              info: { dimension: 2, name: 'cosy' },
+              display: { name: 'cosy' },
+              data: { rr: { z: [[2.0]] } },
+            },
+          ],
+        };
+        const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
+        expect(cleanedNMRiumData.sources).toEqual([
+          { id: 'nmrium-src-cosy', entries: [{ relativePath: '/a/file.jdx', baseURL: 'https://example.com' }] },
+          { id: 'nmrium-src-cosy-2', entries: [{ relativePath: '/b/file.jdx', baseURL: 'https://example.com' }] },
+        ]);
+        const [first, second] = cleanedNMRiumData.spectra;
+        expect(first.selector).toEqual({ root: 'nmrium-src-cosy' });
+        expect(second.selector).toEqual({ root: 'nmrium-src-cosy-2' });
+      });
+
+      it('addresses the archive in sources[] and the member path in selector.files', () => {
+        const nmriumData = {
+          spectra: [{
+            sourceSelector: { files: ['https://example.com/tpa/token/file.zip/exp1/pdata/1/2rr'] },
+            info: { dimension: 2, name: 'hsqc' },
+            display: { name: 'hsqc' },
+            data: { rr: { z: [[1.0]] } },
+          }],
+        };
+        const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
+        expect(cleanedNMRiumData.sources).toEqual([
+          { id: 'nmrium-src-hsqc', entries: [{ relativePath: '/tpa/token/file.zip', baseURL: 'https://example.com' }] },
+        ]);
+        expect(cleanedNMRiumData.spectra[0].selector).toEqual({
+          root: 'nmrium-src-hsqc', files: ['exp1/pdata/1/2rr'],
+        });
+      });
+
+      it('reduces an already server-path-patched zip reference to the member path too', () => {
+        const nmriumData = {
+          source: { entries: [{ baseURL: 'https://example.com', relativePath: '/tpa/token/file.zip' }] },
+          spectra: [{
+            sourceSelector: { files: ['/tpa/token/file.zip/exp1/pdata/1/2rr'] },
+            info: { dimension: 2, name: 'hsqc' },
+            display: { name: 'hsqc' },
+            data: { rr: { z: [[1.0]] } },
+          }],
+        };
+        const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
+        expect(cleanedNMRiumData.spectra[0].selector).toEqual({
+          root: 'nmrium-src-hsqc', files: ['exp1/pdata/1/2rr'],
+        });
+      });
+
+      it('prefers a freshly patched source over a sources[] entry persisted by an earlier save', () => {
+        // Download URLs carry a short-lived token that is re-minted on every open, so the entry a
+        // previous save left in sources[] is stale and must never win over the refreshed one.
+        const nmriumData = {
+          source: { entries: [{ baseURL: 'https://example.com', relativePath: '/tpa/fresh/file.zip' }] },
+          sources: [{
+            id: 'nmrium-src-hsqc',
+            entries: [{ baseURL: 'https://example.com', relativePath: '/tpa/stale/file.zip' }],
+          }],
+          spectra: [{
+            sourceSelector: { files: ['/tpa/fresh/file.zip/exp1/pdata/1/2rr'] },
+            selector: { root: 'nmrium-src-hsqc' },
+            info: { dimension: 2, name: 'hsqc' },
+            display: { name: 'hsqc' },
+          }],
+        };
+        const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
+        expect(cleanedNMRiumData.sources).toEqual([
+          { id: 'nmrium-src-hsqc', entries: [{ relativePath: '/tpa/fresh/file.zip', baseURL: 'https://example.com' }] },
+        ]);
+      });
+
+      it('drops its own orphaned sources[] entries but leaves foreign ones alone', () => {
+        const nmriumData = {
+          sources: [
+            { id: 'nmrium-src-old', entries: [{ baseURL: 'https://example.com', relativePath: '/gone' }] },
+            { id: 'foreign', entries: [{ baseURL: 'https://example.com', relativePath: '/keep' }] },
+          ],
+          spectra: [{
+            source: { jcampURL: 'https://example.com/a/file.jdx' },
+            info: { dimension: 2, name: 'new' },
+            display: { name: 'new' },
+            data: { rr: { z: [[1.0]] } },
+          }],
+        };
+        const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
+        expect(cleanedNMRiumData.sources.map((source) => source.id).sort()).toEqual(['foreign', 'nmrium-src-new']);
+      });
+
+      it('leaves the payload it was given untouched', () => {
+        const nmriumData = {
+          data: {
+            actionType: 'SOME_ACTION',
+            spectra: [{
+              source: { jcampURL: 'https://example.com/file.jdx' },
+              info: { dimension: 2, name: 'cosy' },
+              display: { name: 'cosy' },
+              originalData: { rr: { z: [[9.0]] } },
+              data: { rr: { z: [[1.0]] } },
+            }],
+          },
+        };
+        const snapshot = JSON.stringify(nmriumData);
+        cleaningNMRiumData(nmriumData);
+        expect(JSON.stringify(nmriumData)).toEqual(snapshot);
+      });
+
+      it('keeps the data matrix instead of throwing on an unparsable source url', () => {
+        const nmriumData = {
+          spectra: [{
+            source: { jcampURL: 'https://' },
+            info: { dimension: 2, name: 'cosy' },
+            display: { name: 'cosy' },
+            data: { rr: { z: [[1.0]] } },
+          }],
+        };
+        const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
+        expect(cleanedNMRiumData.spectra[0].data).toEqual({ rr: { z: [[1.0]] } });
+        expect(cleanedNMRiumData.spectra[0].selector).toEqual(undefined);
+      });
+
       it('keeps data for 1D spectra that have a source (NMRium never re-fetches it)', () => {
         const nmriumData = {
           data: {

--- a/spec/javascripts/packs/src/utilities/SpectraHelper.spec.js
+++ b/spec/javascripts/packs/src/utilities/SpectraHelper.spec.js
@@ -375,7 +375,7 @@ describe('SpectraHelper', () => {
           dimension: 2, name: 'cosy', isFid: true, nucleus: ['1H', '1H'],
         });
         expect(spectrum.originalInfo).toEqual(undefined);
-        expect(spectrum.meta).toEqual(undefined);
+        expect(spectrum.meta).toEqual({ dimension: 2 });
         expect(spectrum.display).toEqual({ name: 'cosy' });
         expect(spectrum.data).toEqual({
           re: { z: [[1.0, 2.0], [3.0, 4.0]] }, im: { z: [[1.0, 2.0], [3.0, 4.0]] },
@@ -401,7 +401,7 @@ describe('SpectraHelper', () => {
           dimension: 2, isFid: true, name: 'cosy',
         });
         expect(spectrum.originalInfo).toEqual(undefined);
-        expect(spectrum.meta).toEqual(undefined);
+        expect(spectrum.meta).toEqual({ dimension: 2 });
       });
 
       it('keeps data for 1D spectra that have a source (NMRium never re-fetches it)', () => {

--- a/spec/javascripts/packs/src/utilities/SpectraHelper.spec.js
+++ b/spec/javascripts/packs/src/utilities/SpectraHelper.spec.js
@@ -629,6 +629,60 @@ describe('SpectraHelper', () => {
         expect(spectrum.data).toEqual({ x: [1.0, 2.0], y: [1.0, 2.0] });
         expect(spectrum.info).toEqual({ dimension: 1, name: 'proton' });
       });
+
+      it('still recognises a 2D spectrum whose info/originalInfo/meta an earlier cleaner deleted', () => {
+        // Shape of a real .nmrium written by a cleaner that dropped info/originalInfo/meta from a
+        // source-backed 2D spectrum. display.dimension is the only surviving record that it is 2D;
+        // without honouring it the migration is skipped and the stale sources[] URL and the dead
+        // full-server-path selector.files below are both left in place, with no data to fall back on.
+        const nmriumData = {
+          source: { entries: [{ baseURL: 'https://example.com', relativePath: '/tpa/fresh/file.zip' }] },
+          sources: [{
+            id: 'nmrium-src-hsqc-zip',
+            entries: [{ baseURL: 'https://example.com', relativePath: '/tpa/expired/file.zip' }],
+          }],
+          spectra: [{
+            display: { name: 'hsqc.zip', dimension: 2 },
+            selector: { root: 'nmrium-src-hsqc-zip', files: ['/tpa/expired/file.zip/exp1/pdata/1/2rr'] },
+            sourceSelector: { files: ['/tpa/fresh/file.zip/exp1/pdata/1/2rr', '/tpa/fresh/file.zip/exp1/acqus'] },
+          }],
+        };
+        const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
+        const [spectrum] = cleanedNMRiumData.spectra;
+        expect(cleanedNMRiumData.sources).toEqual([
+          { id: 'nmrium-src-hsqc-zip', entries: [{ relativePath: '/tpa/fresh/file.zip', baseURL: 'https://example.com' }] },
+        ]);
+        expect(spectrum.selector).toEqual({
+          root: 'nmrium-src-hsqc-zip',
+          files: ['exp1/pdata/1/2rr', 'exp1/acqus'],
+        });
+      });
+
+      it('leaves info absent rather than empty when there is nothing to backfill it from', () => {
+        const nmriumData = {
+          spectra: [{
+            source: { jcampURL: 'https://example.com/file.jdx' },
+            display: { name: 'hsqc.jdx', dimension: 2 },
+          }],
+        };
+        const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
+        const [spectrum] = cleanedNMRiumData.spectra;
+        expect(spectrum.selector).toEqual({ root: 'nmrium-src-hsqc-jdx' });
+        expect('info' in spectrum).toEqual(false);
+      });
+
+      it('does not drop the data matrix of a display-only 2D spectrum that has no source', () => {
+        const nmriumData = {
+          spectra: [{
+            display: { name: 'hsqc', dimension: 2 },
+            data: { rr: { z: [[1.0]] } },
+          }],
+        };
+        const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
+        const [spectrum] = cleanedNMRiumData.spectra;
+        expect(spectrum.data).toEqual({ rr: { z: [[1.0]] } });
+        expect(spectrum.selector).toEqual(undefined);
+      });
     });
   });
 

--- a/spec/javascripts/packs/src/utilities/SpectraHelper.spec.js
+++ b/spec/javascripts/packs/src/utilities/SpectraHelper.spec.js
@@ -354,7 +354,7 @@ describe('SpectraHelper', () => {
         expect(cleanedNMRiumData).toEqual(expectedNmriumData);
       });
 
-      it('keeps info fully intact (including isFid) and the data matrix for source-only 2D spectra', () => {
+      it('builds sources[]/selector.root and drops the data matrix for source-only 2D spectra, keeping info intact', () => {
         const nmriumData = {
           data: {
             spectra: [{
@@ -377,9 +377,86 @@ describe('SpectraHelper', () => {
         expect(spectrum.originalInfo).toEqual(undefined);
         expect(spectrum.meta).toEqual({ dimension: 2 });
         expect(spectrum.display).toEqual({ name: 'cosy' });
-        expect(spectrum.data).toEqual({
-          re: { z: [[1.0, 2.0], [3.0, 4.0]] }, im: { z: [[1.0, 2.0], [3.0, 4.0]] },
-        });
+        expect(spectrum.data).toEqual(undefined);
+        expect(spectrum.selector).toEqual({ root: 'nmrium-src-cosy' });
+        expect(cleanedNMRiumData.data.sources).toEqual([
+          { id: 'nmrium-src-cosy', entries: [{ relativePath: '/file.jdx', baseURL: 'https://example.com' }] },
+        ]);
+      });
+
+      it('keeps an unwrapped payload flat (no version, no data wrapper) when the source mechanism is used', () => {
+        // A real NMRium capture of a source-backed spectrum has neither a version nor a {data:...}
+        // wrapper -- just sources/spectra directly at the top level -- and reloads correctly. Forcing
+        // either onto the payload here previously broke reload instead of fixing it.
+        const nmriumData = {
+          spectra: [{
+            source: { jcampURL: 'https://example.com/file.jdx' },
+            info: { dimension: 2, name: 'cosy', isFid: true },
+            display: { name: 'cosy' },
+            data: { rr: { z: [[1.0, 2.0], [3.0, 4.0]] } },
+          }],
+        };
+        const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
+        expect(cleanedNMRiumData.version).toEqual(undefined);
+        expect(cleanedNMRiumData.data).toEqual(undefined);
+        const [spectrum] = cleanedNMRiumData.spectra;
+        expect(spectrum.data).toEqual(undefined);
+        expect(spectrum.selector).toEqual({ root: 'nmrium-src-cosy' });
+        expect(cleanedNMRiumData.sources).toEqual([
+          { id: 'nmrium-src-cosy', entries: [{ relativePath: '/file.jdx', baseURL: 'https://example.com' }] },
+        ]);
+      });
+
+      it('does not wrap or add a version when the source mechanism is not used', () => {
+        const nmriumData = { spectra: [{ x: [1.0, 2.0], y: [1.0, 2.0] }] };
+        const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
+        expect(cleanedNMRiumData).toEqual(nmriumData);
+      });
+
+      it('keeps the data matrix when no resolvable source URL exists', () => {
+        const nmriumData = {
+          data: {
+            spectra: [{
+              sourceSelector: { files: [] },
+              info: { dimension: 2, name: 'hsqc', isFid: false },
+              display: { name: 'hsqc' },
+              data: { rr: { z: [[1.0, 2.0], [3.0, 4.0]] } },
+            }],
+          },
+        };
+        const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
+        const [spectrum] = cleanedNMRiumData.data.spectra;
+        expect(spectrum.data).toEqual({ rr: { z: [[1.0, 2.0], [3.0, 4.0]] } });
+        expect(spectrum.selector).toEqual(undefined);
+        expect(cleanedNMRiumData.data.sources).toEqual(undefined);
+      });
+
+      it('collapses same-named spectra sharing one zip into one sources[] entry, keeping per-spectrum disambiguation', () => {
+        const nmriumData = {
+          data: {
+            source: { entries: [{ baseURL: 'https://example.com', relativePath: '/zip/file.zip' }] },
+            spectra: [
+              {
+                sourceSelector: { files: ['exp1/pdata/1/2rr'] },
+                info: { dimension: 2, name: 'multi', isFid: false },
+                display: { name: 'multi' },
+                data: { rr: { z: [[1.0]] } },
+              },
+              {
+                sourceSelector: { files: ['exp2/pdata/1/2rr'] },
+                info: { dimension: 2, name: 'multi', isFid: false },
+                display: { name: 'multi' },
+                data: { rr: { z: [[2.0]] } },
+              },
+            ],
+          },
+        };
+        const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
+        const [first, second] = cleanedNMRiumData.data.spectra;
+        expect(first.selector).toEqual({ root: 'nmrium-src-multi', files: ['exp1/pdata/1/2rr'] });
+        expect(second.selector).toEqual({ root: 'nmrium-src-multi', files: ['exp2/pdata/1/2rr'] });
+        expect(first.data).toEqual(undefined);
+        expect(second.data).toEqual(undefined);
       });
 
       it('backfills info.dimension/isFid from originalInfo/meta on legacy spectra where info is sparse', () => {

--- a/spec/javascripts/packs/src/utilities/SpectraHelper.spec.js
+++ b/spec/javascripts/packs/src/utilities/SpectraHelper.spec.js
@@ -353,6 +353,51 @@ describe('SpectraHelper', () => {
         const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
         expect(cleanedNMRiumData).toEqual(expectedNmriumData);
       });
+
+      it('keeps info fully intact (including isFid) and the data matrix for source-only 2D spectra', () => {
+        const nmriumData = {
+          data: {
+            spectra: [{
+              source: { jcampURL: 'https://example.com/file.jdx' },
+              info: {
+                dimension: 2, name: 'cosy', isFid: true, nucleus: ['1H', '1H'],
+              },
+              originalInfo: { dimension: 2, name: 'cosy' },
+              meta: { dimension: 2 },
+              display: { name: 'cosy' },
+              data: { re: { z: [[1.0, 2.0], [3.0, 4.0]] }, im: { z: [[1.0, 2.0], [3.0, 4.0]] } },
+            }],
+          },
+        };
+        const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
+        const [spectrum] = cleanedNMRiumData.data.spectra;
+        expect(spectrum.info).toEqual({
+          dimension: 2, name: 'cosy', isFid: true, nucleus: ['1H', '1H'],
+        });
+        expect(spectrum.originalInfo).toEqual(undefined);
+        expect(spectrum.meta).toEqual(undefined);
+        expect(spectrum.display).toEqual({ name: 'cosy' });
+        expect(spectrum.data).toEqual({
+          re: { z: [[1.0, 2.0], [3.0, 4.0]] }, im: { z: [[1.0, 2.0], [3.0, 4.0]] },
+        });
+      });
+
+      it('keeps data for 1D spectra that have a source (NMRium never re-fetches it)', () => {
+        const nmriumData = {
+          data: {
+            spectra: [{
+              source: { jcampURL: 'https://example.com/file.jdx' },
+              info: { dimension: 1, name: 'proton' },
+              display: { name: 'proton' },
+              data: { x: [1.0, 2.0], y: [1.0, 2.0] },
+            }],
+          },
+        };
+        const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
+        const [spectrum] = cleanedNMRiumData.data.spectra;
+        expect(spectrum.data).toEqual({ x: [1.0, 2.0], y: [1.0, 2.0] });
+        expect(spectrum.info).toEqual({ dimension: 1, name: 'proton' });
+      });
     });
   });
 

--- a/spec/javascripts/packs/src/utilities/SpectraHelper.spec.js
+++ b/spec/javascripts/packs/src/utilities/SpectraHelper.spec.js
@@ -382,6 +382,28 @@ describe('SpectraHelper', () => {
         });
       });
 
+      it('backfills info.dimension/isFid from originalInfo/meta on legacy spectra where info is sparse', () => {
+        const nmriumData = {
+          data: {
+            spectra: [{
+              source: { jcampURL: 'https://example.com/file.jdx' },
+              info: { name: 'cosy' },
+              originalInfo: { dimension: 2, isFid: true, name: 'cosy' },
+              meta: { dimension: 2 },
+              display: { name: 'cosy' },
+              data: { re: { z: [[1.0, 2.0], [3.0, 4.0]] }, im: { z: [[1.0, 2.0], [3.0, 4.0]] } },
+            }],
+          },
+        };
+        const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
+        const [spectrum] = cleanedNMRiumData.data.spectra;
+        expect(spectrum.info).toEqual({
+          dimension: 2, isFid: true, name: 'cosy',
+        });
+        expect(spectrum.originalInfo).toEqual(undefined);
+        expect(spectrum.meta).toEqual(undefined);
+      });
+
       it('keeps data for 1D spectra that have a source (NMRium never re-fetches it)', () => {
         const nmriumData = {
           data: {


### PR DESCRIPTION
 ## Summary

  Fixes a crash reopening a saved 2D NMR spectrum (HSQC/HMBC/COSY/NOESY etc.) in NMRium after saving it from the NMR
  viewer. Root cause: `SpectraHelper.js`'s `cleaningNMRiumData` stripped a 2D spectrum's `info`/`data` before saving
  whenever it referenced a source file (jcamp/zip), on the assumption NMRium would re-derive them by re-parsing the
  source on reload. It doesn't — traced into NMRium's actual `@zakodium/nmrium-core` source and confirmed its reader
  only re-fetches a spectrum when `spectrum.selector.root` matches an id in a top-level `sources[]` registry; it never
  uses this repo's ad hoc `source`/`sourceSelector` fields for that. Every previously-saved 2D spectrum therefore fell
  into NMRium's inline render path with neither embedded data nor a resolved fetch, crashing in various ways depending
  on what was missing.

  ## What changed

  - `cleaningNMRiumData` now builds a real `sources[]` + `spectrum.selector.root` reference (via new
  `buildSourceId`/`ensureSource` helpers, keyed off the spectrum's own stable file label) for 2D spectra backed by a
  source, and only then drops the embedded `data` matrix — closing the crash at its root instead of trading it for one
  of the earlier `f16f79b06`/`1f15fe887`/`90bef9bf5` workarounds that just always kept everything embedded (safe, but
  risks pushing large 2D matrices — 2048×1024+ points — over Shrine's 100MB upload cap on save).
  - Deliberately does **not** wrap the result in `{version, data: {...}}` or declare an explicit schema version:
  verified against a real, working NMRium-captured `.nmrium` file that a source-backed spectrum reloads fine with
  neither, and declaring a version explicitly seems to skip whatever normalization an unversioned document gets on load.
  - Widened `prepareNMRiumDataAttachment`'s `hasAnySource` check so spectra using the new `selector.root`/`sources[]`
  shape are still recognized (avoids an incorrect legacy `{version: 7, ...}` wrapper firing for them).
  - 1D spectra and the jdx-only first-load fallback (no `.nmrium` attachment yet) are untouched — no bug was ever
  confirmed there, and an earlier attempt to move the fallback onto the same mechanism broke first-time uploads
  outright.
  - `isSourceOnly2D` renamed to `is2DWithSource` and the repeated `info?.dimension === 2 || originalInfo?.dimension ===
  2 || meta?.dimension === 2` check extracted into a shared, exported `isSpectrum2D` (was duplicated 3x across two
  files).

  ## Test plan

  - [x] `yarn test` — full JS suite passes (1457 tests), including new cases in `SpectraHelper.spec.js` covering:
  building `sources[]`/`selector.root` and dropping `data` for 2D-with-source spectra; falling back to keeping `data`
  when no source URL resolves; collapsing same-named spectra sharing one zip into one `sources[]` entry with
  per-spectrum disambiguation; 1D spectra unaffected.
  - [x] `yarn eslint` on both touched files — no new errors vs. `main`.
  - [x] Manually verified end-to-end against the live NMRium instance: save a 2D spectrum with a jcamp source → reopen →
  renders correctly (previously crashed). Save/reopen a 1D spectrum → unaffected. First-time `.jdx` upload (no existing
  `.nmrium`) → unaffected.

  ## Known limitation

  Large 2D datasets *without* a resolvable source URL still embed the full matrix (unchanged, pre-existing behavior) and
  can still approach the 100MB Shrine cap in that case — accepted tradeoff, discussed and confirmed with the reporter.

---

## Review follow-ups (`6b88fde4`)

A review pass found that the `sources[]` reference, once written, did not always resolve back to
the file it came from — so `data` was dropped in exchange for a reference that could not be
followed. Fixed here:

- **Stale token on reopen.** `resolveSpectrumSourceUrl` preferred the `sources[]` entry persisted
  by an earlier save over the freshly re-minted `root.source`. Attachment URLs carry a 48h token,
  so that entry is expected to be dead by the next reopen — the spectrum was re-pointed at an
  expired URL with no embedded data to fall back on. This reproduced the exact failure the PR
  fixes, just delayed by one save cycle. The fresh URL now wins.
- **The registry addressed a member inside the archive, not the archive.** A new `splitArchiveRef`
  separates the zip URL from the member path across all three shapes that reach it (absolute URL,
  `patchZipAndJcampReference`'s rewritten server path, bare member), so `sources[]` holds the
  archive and `selector.files` holds paths that can match its contents. Server paths previously
  passed the "not absolute" filter and landed in `selector.files` verbatim, matching nothing.
- **Two different files could collapse onto one source id.** `buildSourceId` keys off the display
  name, and `patchZipAndJcampReference` forces one label onto every spectrum when a zip is present
  — so identical names are the normal case, and the second spectrum's `ensureSource` overwrote the
  first's URL while both had `data` already deleted. `ensureSource` now takes a per-pass URL → id
  map: same file shares one entry, different files get distinct ids.
- **Multi-entry sources** are no longer reduced to a single element.
- **Rename before cleaning** in the zip fallback, so `selector.root` is derived from the same name
  the next save will derive its id from (previously `patchZipName` ran after `cleaningNMRiumData`
  and every rename left a dead `sources[]` entry).
- **`info` backfill** lifts only `dimension`/`isFid` out of `meta` rather than spreading the whole
  raw JCAMP header dictionary into `info`.
- **Robustness**: the wrapper copy is guarded (`data` may legitimately be a non-object) and
  `new URL()` is wrapped, so a prefix-matching but malformed URL can no longer take a save down.
- Orphaned `nmrium-src-*` entries are pruned; `buildSourceId`/`ensureSource` dropped from the
  export list (imported nowhere); two verbose forms simplified.

Adds regression specs for the reopen, member-path and collision cases.

### Correction to the summary above

The "the jdx-only first-load fallback … untouched" bullet holds for the **jdx** path, but the
**zip** first-load path does go through `cleaningNMRiumData` and was affected — that is what the
`splitArchiveRef` and rename-ordering items above address.

### Still open

1D source-backed spectra keep their `data` on this branch, where `main` dropped it unconditionally
for any source-backed spectrum. No 1D reload bug was ever reported against `main`'s behaviour, so
the extra payload may be buying nothing — and it works against the Shrine 100 MB rationale cited
above. Left as-is because a spec here asserts the new behaviour; worth settling deliberately
before merge.

### Verification

- `yarn test` (full suite, in the app container) — **1464 passing, 0 failing, 19 pending** at
  `6b88fde4`.
- Rebases onto current `main` cleanly; the full suite there is **1712 passing, 0 failing**.
- `yarn eslint` **not** re-run: it fails to load the `storybook` plugin in this container on every
  branch, including untouched `main`. Left to CI's `linting` job.
