### PR TITLE
build(dev): add resource tiers and a delayed_job worker service

### DIFF
--- a/.dockerenv.example
+++ b/.dockerenv.example
@@ -71,6 +71,30 @@ IMG_NMRIUMWRAPPER=nfdi4chem/nmrium-react-wrapper:v1.1.0
 #HOST_PORT_APP=3000
 #HOST_PORT_WEBPACK=3035
 
+## Per-service CPU/memory tiers (low/medium/high, x-common-deploy-* anchors in
+## docker-compose.dev.yml): postgres/app=high, setup/webpacker=medium,
+## storybook=low. Each tier x resource value (cpus/memory x limit/reservation)
+## can be overridden individually here; anything left unset keeps the default
+## shown below.
+
+## -- high tier (defaults: postgres, app) --
+#RESOURCES_HIGH_CPU_LIMIT=4.0
+#RESOURCES_HIGH_MEM_LIMIT=8G
+#RESOURCES_HIGH_CPU_RESERVATION=1.0
+#RESOURCES_HIGH_MEM_RESERVATION=1G
+
+## -- medium tier (defaults: setup, webpacker) --
+#RESOURCES_MEDIUM_CPU_LIMIT=2.0
+#RESOURCES_MEDIUM_MEM_LIMIT=4G
+#RESOURCES_MEDIUM_CPU_RESERVATION=0.5
+#RESOURCES_MEDIUM_MEM_RESERVATION=512M
+
+## -- low tier (default: storybook) --
+#RESOURCES_LOW_CPU_LIMIT=1.0
+#RESOURCES_LOW_MEM_LIMIT=2G
+#RESOURCES_LOW_CPU_RESERVATION=0.25
+#RESOURCES_LOW_MEM_RESERVATION=256M
+
 # One time password secret key for 2FA (attr_encrypted uses aes-256-gcm, which
 # requires a key of at least 32 bytes)
 OTP_SECRET_KEY='change-this-to-a-random-32-byte-or-longer-secret'

--- a/.dockerenv.example
+++ b/.dockerenv.example
@@ -60,6 +60,30 @@ IMG_INDIGO=epmlsop/indigo-service:1.34.0-rc.1
 #HOST_PORT_APP=3000
 #HOST_PORT_WEBPACK=3035
 
+## Per-service CPU/memory tiers (low/medium/high, x-common-deploy-* anchors in
+## docker-compose.dev.yml): postgres/app=high, setup/webpacker=medium,
+## storybook=low. Each tier x resource value (cpus/memory x limit/reservation)
+## can be overridden individually here; anything left unset keeps the default
+## shown below.
+
+## -- high tier (defaults: postgres, app) --
+#RESOURCES_HIGH_CPU_LIMIT=4.0
+#RESOURCES_HIGH_MEM_LIMIT=8G
+#RESOURCES_HIGH_CPU_RESERVATION=1.0
+#RESOURCES_HIGH_MEM_RESERVATION=1G
+
+## -- medium tier (defaults: setup, webpacker) --
+#RESOURCES_MEDIUM_CPU_LIMIT=2.0
+#RESOURCES_MEDIUM_MEM_LIMIT=4G
+#RESOURCES_MEDIUM_CPU_RESERVATION=0.5
+#RESOURCES_MEDIUM_MEM_RESERVATION=512M
+
+## -- low tier (default: storybook) --
+#RESOURCES_LOW_CPU_LIMIT=1.0
+#RESOURCES_LOW_MEM_LIMIT=2G
+#RESOURCES_LOW_CPU_RESERVATION=0.25
+#RESOURCES_LOW_MEM_RESERVATION=256M
+
 # One time password secret key for 2FA (attr_encrypted uses aes-256-gcm, which
 # requires a key of at least 32 bytes)
 OTP_SECRET_KEY='change-this-to-a-random-32-byte-or-longer-secret'

--- a/.dockerenv.example
+++ b/.dockerenv.example
@@ -62,26 +62,25 @@ IMG_INDIGO=epmlsop/indigo-service:1.34.0-rc.1
 
 ## Per-service CPU/memory tiers (low/medium/high, x-common-deploy-* anchors in
 ## docker-compose.dev.yml): postgres/app=high, setup/webpacker=medium,
-## storybook=low. Each tier x resource value (cpus/memory x limit/reservation)
-## can be overridden individually here; anything left unset keeps the default
-## shown below.
+## storybook=low. Anchors use the flat `cpus`/`mem_limit`/`mem_reservation`
+## keys (not `deploy.resources`) so they're enforced by plain `docker compose
+## up` — no Swarm mode required. There's no flat CPU-reservation key (only
+## memory has a soft-limit counterpart), so each tier has three overridable
+## values; anything left unset keeps the default shown below.
 
 ## -- high tier (defaults: postgres, app) --
 #RESOURCES_HIGH_CPU_LIMIT=4.0
 #RESOURCES_HIGH_MEM_LIMIT=8G
-#RESOURCES_HIGH_CPU_RESERVATION=1.0
 #RESOURCES_HIGH_MEM_RESERVATION=1G
 
 ## -- medium tier (defaults: setup, webpacker) --
 #RESOURCES_MEDIUM_CPU_LIMIT=2.0
 #RESOURCES_MEDIUM_MEM_LIMIT=4G
-#RESOURCES_MEDIUM_CPU_RESERVATION=0.5
 #RESOURCES_MEDIUM_MEM_RESERVATION=512M
 
 ## -- low tier (default: storybook) --
 #RESOURCES_LOW_CPU_LIMIT=1.0
 #RESOURCES_LOW_MEM_LIMIT=2G
-#RESOURCES_LOW_CPU_RESERVATION=0.25
 #RESOURCES_LOW_MEM_RESERVATION=256M
 
 # One time password secret key for 2FA (attr_encrypted uses aes-256-gcm, which

--- a/.dockerenv.example
+++ b/.dockerenv.example
@@ -73,26 +73,25 @@ IMG_NMRIUMWRAPPER=nfdi4chem/nmrium-react-wrapper:v1.1.0
 
 ## Per-service CPU/memory tiers (low/medium/high, x-common-deploy-* anchors in
 ## docker-compose.dev.yml): postgres/app=high, setup/webpacker=medium,
-## storybook=low. Each tier x resource value (cpus/memory x limit/reservation)
-## can be overridden individually here; anything left unset keeps the default
-## shown below.
+## storybook=low. Anchors use the flat `cpus`/`mem_limit`/`mem_reservation`
+## keys (not `deploy.resources`) so they're enforced by plain `docker compose
+## up` — no Swarm mode required. There's no flat CPU-reservation key (only
+## memory has a soft-limit counterpart), so each tier has three overridable
+## values; anything left unset keeps the default shown below.
 
 ## -- high tier (defaults: postgres, app) --
 #RESOURCES_HIGH_CPU_LIMIT=4.0
 #RESOURCES_HIGH_MEM_LIMIT=8G
-#RESOURCES_HIGH_CPU_RESERVATION=1.0
 #RESOURCES_HIGH_MEM_RESERVATION=1G
 
 ## -- medium tier (defaults: setup, webpacker) --
 #RESOURCES_MEDIUM_CPU_LIMIT=2.0
 #RESOURCES_MEDIUM_MEM_LIMIT=4G
-#RESOURCES_MEDIUM_CPU_RESERVATION=0.5
 #RESOURCES_MEDIUM_MEM_RESERVATION=512M
 
 ## -- low tier (default: storybook) --
 #RESOURCES_LOW_CPU_LIMIT=1.0
 #RESOURCES_LOW_MEM_LIMIT=2G
-#RESOURCES_LOW_CPU_RESERVATION=0.25
 #RESOURCES_LOW_MEM_RESERVATION=256M
 
 # One time password secret key for 2FA (attr_encrypted uses aes-256-gcm, which

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,6 +27,12 @@
 #
 # - see .dockerenv.example for environment variables usage
 #
+# RESOURCES:
+# Each service is pinned to a default CPU/memory tier (low/medium/high, defined
+# as x-common-deploy-* anchors below). Every tier x resource combination
+# (cpus/memory x limit/reservation = 12 vars) can be overridden per-value via
+# .dockerenv — see .dockerenv.example for the full list and current defaults.
+#
 
 x-common-volumes: &common-volumes
   - homedir:/home/ubuntu
@@ -42,10 +48,41 @@ x-common-build: &common-build
 x-common-image:
   - &chemotion_eln_dev ${DOCKER_DEV_IMAGE:-chemotion_eln_dev}
 
+x-common-deploy-high: &common-deploy-high
+  deploy:
+    resources:
+      limits:
+        cpus: '${RESOURCES_HIGH_CPU_LIMIT:-4.0}'
+        memory: ${RESOURCES_HIGH_MEM_LIMIT:-8G}
+      reservations:
+        cpus: '${RESOURCES_HIGH_CPU_RESERVATION:-1.0}'
+        memory: ${RESOURCES_HIGH_MEM_RESERVATION:-1G}
+
+x-common-deploy-medium: &common-deploy-medium
+  deploy:
+    resources:
+      limits:
+        cpus: '${RESOURCES_MEDIUM_CPU_LIMIT:-2.0}'
+        memory: ${RESOURCES_MEDIUM_MEM_LIMIT:-4G}
+      reservations:
+        cpus: '${RESOURCES_MEDIUM_CPU_RESERVATION:-0.5}'
+        memory: ${RESOURCES_MEDIUM_MEM_RESERVATION:-512M}
+
+x-common-deploy-low: &common-deploy-low
+  deploy:
+    resources:
+      limits:
+        cpus: '${RESOURCES_LOW_CPU_LIMIT:-1.0}'
+        memory: ${RESOURCES_LOW_MEM_LIMIT:-2G}
+      reservations:
+        cpus: '${RESOURCES_LOW_CPU_RESERVATION:-0.25}'
+        memory: ${RESOURCES_LOW_MEM_RESERVATION:-256M}
+
 services:
   setup:
     build: *common-build
     image: *chemotion_eln_dev
+    <<: *common-deploy-medium
     depends_on:
       postgres:
         condition: service_healthy
@@ -61,6 +98,7 @@ services:
 
   postgres:
     image: ${DOCKER_PG_IMAGE:-complat/dev:postgres16-rdkit}
+    <<: *common-deploy-high
     environment:
       - 'POSTGRES_HOST_AUTH_METHOD=trust'
     expose: # expose port to app container
@@ -79,6 +117,7 @@ services:
 
   app:
     image: *chemotion_eln_dev
+    <<: *common-deploy-high
     depends_on:
       setup:
         condition: service_completed_successfully
@@ -110,6 +149,7 @@ services:
 
   webpacker:
     image: *chemotion_eln_dev
+    <<: *common-deploy-medium
     # Gate only on setup (which installs gems + node packages and prepares the
     # DB). app and webpacker then start in parallel instead of webpacker waiting
     # on app — node_modules/manifest are ready before either runtime boots.
@@ -142,6 +182,7 @@ services:
       setup:
         condition: service_completed_successfully
     image: *chemotion_eln_dev
+    <<: *common-deploy-low
     env_file:
       - .env.development
       - path: .env

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,9 +29,13 @@
 #
 # RESOURCES:
 # Each service is pinned to a default CPU/memory tier (low/medium/high, defined
-# as x-common-deploy-* anchors below). Every tier x resource combination
-# (cpus/memory x limit/reservation = 12 vars) can be overridden per-value via
-# .dockerenv — see .dockerenv.example for the full list and current defaults.
+# as x-common-deploy-* anchors below). These use the flat `cpus`/`mem_limit`/
+# `mem_reservation` keys rather than `deploy.resources`, since the latter's
+# `reservations` (and, depending on Compose version, `limits`) are Swarm-mode
+# semantics that a plain `docker compose up` dev stack doesn't get for free.
+# Every tier x resource combination (cpu limit, memory limit, memory
+# reservation = 9 vars) can be overridden per-value via .dockerenv — see
+# .dockerenv.example for the full list and current defaults.
 #
 
 x-common-volumes: &common-volumes
@@ -49,34 +53,19 @@ x-common-image:
   - &chemotion_eln_dev ${DOCKER_DEV_IMAGE:-chemotion_eln_dev}
 
 x-common-deploy-high: &common-deploy-high
-  deploy:
-    resources:
-      limits:
-        cpus: '${RESOURCES_HIGH_CPU_LIMIT:-4.0}'
-        memory: ${RESOURCES_HIGH_MEM_LIMIT:-8G}
-      reservations:
-        cpus: '${RESOURCES_HIGH_CPU_RESERVATION:-1.0}'
-        memory: ${RESOURCES_HIGH_MEM_RESERVATION:-1G}
+  cpus: '${RESOURCES_HIGH_CPU_LIMIT:-4.0}'
+  mem_limit: ${RESOURCES_HIGH_MEM_LIMIT:-8G}
+  mem_reservation: ${RESOURCES_HIGH_MEM_RESERVATION:-1G}
 
 x-common-deploy-medium: &common-deploy-medium
-  deploy:
-    resources:
-      limits:
-        cpus: '${RESOURCES_MEDIUM_CPU_LIMIT:-2.0}'
-        memory: ${RESOURCES_MEDIUM_MEM_LIMIT:-4G}
-      reservations:
-        cpus: '${RESOURCES_MEDIUM_CPU_RESERVATION:-0.5}'
-        memory: ${RESOURCES_MEDIUM_MEM_RESERVATION:-512M}
+  cpus: '${RESOURCES_MEDIUM_CPU_LIMIT:-2.0}'
+  mem_limit: ${RESOURCES_MEDIUM_MEM_LIMIT:-4G}
+  mem_reservation: ${RESOURCES_MEDIUM_MEM_RESERVATION:-512M}
 
 x-common-deploy-low: &common-deploy-low
-  deploy:
-    resources:
-      limits:
-        cpus: '${RESOURCES_LOW_CPU_LIMIT:-1.0}'
-        memory: ${RESOURCES_LOW_MEM_LIMIT:-2G}
-      reservations:
-        cpus: '${RESOURCES_LOW_CPU_RESERVATION:-0.25}'
-        memory: ${RESOURCES_LOW_MEM_RESERVATION:-256M}
+  cpus: '${RESOURCES_LOW_CPU_LIMIT:-1.0}'
+  mem_limit: ${RESOURCES_LOW_MEM_LIMIT:-2G}
+  mem_reservation: ${RESOURCES_LOW_MEM_RESERVATION:-256M}
 
 services:
   setup:

--- a/docker-compose.services.yml.example
+++ b/docker-compose.services.yml.example
@@ -122,6 +122,35 @@ services:
         ln -sfn "$$v" /out/default
         echo ">>> NMRium wrapper $$v available at /nmrium/default/"
 
+  # Runs delayed_job (delayed_job_active_record + delayed_cron_job) as a
+  # standalone worker, separate from the `app` web process. Meant to be layered
+  # on top of docker-compose.dev.yml (`-f docker-compose.dev.yml -f
+  # docker-compose.services.yml`), reusing its `postgres`/`setup` services and
+  # `homedir` volume — YAML anchors don't cross files, so image/volumes are
+  # spelled out again here rather than reusing docker-compose.dev.yml's anchors.
+  worker:
+    image: ${DOCKER_DEV_IMAGE:-chemotion_eln_dev}
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      setup:
+        condition: service_completed_successfully
+    env_file:
+      - .env.development
+      - path: .env
+        required: false
+    volumes:
+      - homedir:/home/ubuntu
+      - .:/home/ubuntu/app
+    working_dir: "/home/ubuntu/app"
+    # `run` (not `start`) keeps delayed_job in the foreground instead of
+    # daemonizing, which is required for it to be the container's main process.
+    command: bundle exec bin/delayed_job run
+    networks:
+      - default
+      - chemotion
+
 networks:
   chemotion:
 

--- a/docker-compose.services.yml.example
+++ b/docker-compose.services.yml.example
@@ -52,6 +52,35 @@ services:
       - 8002:80
     command: supervisord -n
 
+  # Runs delayed_job (delayed_job_active_record + delayed_cron_job) as a
+  # standalone worker, separate from the `app` web process. Meant to be layered
+  # on top of docker-compose.dev.yml (`-f docker-compose.dev.yml -f
+  # docker-compose.services.yml`), reusing its `postgres`/`setup` services and
+  # `homedir` volume — YAML anchors don't cross files, so image/volumes are
+  # spelled out again here rather than reusing docker-compose.dev.yml's anchors.
+  worker:
+    image: ${DOCKER_DEV_IMAGE:-chemotion_eln_dev}
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      setup:
+        condition: service_completed_successfully
+    env_file:
+      - .env.development
+      - path: .env
+        required: false
+    volumes:
+      - homedir:/home/ubuntu
+      - .:/home/ubuntu/app
+    working_dir: "/home/ubuntu/app"
+    # `run` (not `start`) keeps delayed_job in the foreground instead of
+    # daemonizing, which is required for it to be the container's main process.
+    command: bundle exec bin/delayed_job run
+    networks:
+      - default
+      - chemotion
+
 networks:
   chemotion:
 


### PR DESCRIPTION
## Summary
- Pin each dev-stack service to a default resource tier: `postgres`/`app` → high, `setup`/`webpacker` → medium, `storybook` → low (as `x-common-deploy-{low,medium,high}` anchors in `docker-compose.dev.yml`). Anchors use the flat `cpus`/`mem_limit`/`mem_reservation` keys rather than `deploy.resources`, since `reservations` (and, on older Compose versions, `limits`) are Swarm-mode semantics that a plain `docker compose up` dev stack doesn't get for free.
- Every tier x resource combination (cpu limit, memory limit, memory reservation = 9 values) is overridable individually via `.dockerenv` (`RESOURCES_{HIGH,MEDIUM,LOW}_{CPU_LIMIT,MEM_LIMIT,MEM_RESERVATION}`), falling back to the current defaults when unset. There's no flat CPU-reservation key (only memory has a soft-limit counterpart), so that override was dropped — it was a Swarm-only no-op anyway.
- `.dockerenv.example` documents all 9 vars grouped by tier, commented out, showing the default and which services use that tier.
- Add a standalone `worker` service to `docker-compose.services.yml.example` that runs `bundle exec bin/delayed_job run` (foreground, not daemonized) as its own container, separate from the `app` web process. Depends on `postgres` (healthy) and `setup` (gems installed) when layered on top of `docker-compose.dev.yml`.

## Test plan
- [x] `docker compose -f docker-compose.dev.yml config` — verified default tier values render correctly per service (postgres/app: 4 cpus/8589934592 bytes mem_limit; setup/webpacker: 2 cpus/4G; storybook: 1 cpu/2G)
- [x] `docker compose --env-file <custom> -f docker-compose.dev.yml config` — verified overriding e.g. `RESOURCES_HIGH_CPU_LIMIT`/`RESOURCES_HIGH_MEM_LIMIT` propagates correctly
- [x] `docker compose --env-file .dockerenv.example -f docker-compose.dev.yml -f docker-compose.services.yml.example config` — verified `worker` resolves depends_on/volumes/networks correctly and merges cleanly with `docker-compose.dev.yml`
- [ ] `docker compose -f docker-compose.dev.yml --env-file .dockerenv up -d` — sanity boot on a real dev machine
- [ ] `docker compose -f docker-compose.dev.yml -f docker-compose.services.yml up -d worker` — confirm delayed_job actually processes a queued job
