### PR TITLE
build(dev): add collection-sharing and screening demo seed data

### DIFF
--- a/db/seeds/development/05_collection_sharing.seed.rb
+++ b/db/seeds/development/05_collection_sharing.seed.rb
@@ -27,9 +27,13 @@ else
 
   detail_keys = Collection::DETAIL_LEVEL_KEYS - [:permission_level]
 
+  # Scope the lookup to the parent, not just the label: an unrelated collection
+  # of the owner's that happens to be called e.g. "Tree A" must not be adopted
+  # into the demo tree and silently shared with CU2 / the demo group.
   find_or_create_collection = lambda do |owner, label, parent: nil|
-    Collection.find_by(user: owner, label: label) ||
-      Collection.create!(user: owner, label: label, parent: parent)
+    scope = Collection.where(user: owner, label: label)
+    scope = parent ? scope.where(ancestry: parent.child_ancestry) : scope.roots
+    scope.first || Collection.create!(user: owner, label: label, parent: parent)
   end
 
   share = lambda do |collection, shared_with, permission, detail: 0|
@@ -37,6 +41,11 @@ else
     row.assign_attributes(detail_keys.index_with { detail })
     row.permission_level = CollectionShare.permission_level(permission)
     row.save!
+    # collections.shared mirrors "has at least one CollectionShare". It is
+    # maintained by the API (CollectionShareAPI#refresh_shared_flag!), not by a
+    # model callback, so the seed has to set it or the owner's tree never shows
+    # the share badge and the management menu takes the wrong branch.
+    collection.update!(shared: true)
   end
 
   root = find_or_create_collection.call(cu1, 'Sharing Demo')
@@ -55,6 +64,13 @@ else
   # User only
   user_only = find_or_create_collection.call(cu1, 'User Only', parent: root)
   share.call(user_only, cu3, :add_elements, detail: 5)
+
+  # Full detail (OWNER_LEVEL): entities only branch at `> 0` and `< 10`, and
+  # Collection.full_detail_access_ids requires MAX(...) >= 10, so without a
+  # share at 10 the un-anonymized entity and raw-export paths are never
+  # exercised and the 3/5/8 spread is indistinguishable at runtime.
+  full_detail = find_or_create_collection.call(cu1, 'Full Detail', parent: root)
+  share.call(full_detail, cu2, :edit_elements, detail: Collection::OWNER_LEVEL)
 
   # Group + user mixed, different permission levels (MAX-resolution demo)
   mixed = find_or_create_collection.call(cu1, 'Group + User Mixed', parent: root)

--- a/db/seeds/development/05_collection_sharing.seed.rb
+++ b/db/seeds/development/05_collection_sharing.seed.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Collection-sharing demo data: permission-level ladder, group vs. user shares
+# (including a mixed group+user case exercising MAX-resolution), a fully-shared
+# collection tree, and a truncated tree (root + grandchild shared, middle
+# child deliberately left unshared). Assumes 00_persons.seed.rb already ran
+# (numeric prefix guarantees load order); soft-skips otherwise.
+
+required_emails = (1..4).map { |n| "complat.user#{n}@eln.edu" }
+missing = required_emails.reject { |email| Person.exists?(email: email) }
+
+if missing.any?
+  puts "*** Skipping collection-sharing demo seed — missing users: #{missing.join(', ')}"
+else
+  cu1, cu2, cu3, cu4 = required_emails.map { |email| Person.find_by!(email: email) }
+
+  group = Group.find_by(email: 'sharing-demo-group@eln.edu') || Group.create!(
+    email: 'sharing-demo-group@eln.edu',
+    password: '@complat',
+    first_name: 'Sharing',
+    last_name: 'Demo Group',
+    name_abbreviation: 'SDG',
+    confirmed_at: Time.now,
+  )
+  [cu3, cu4].each { |member| group.users << member unless group.users.exists?(id: member.id) }
+  group.admins << cu1 unless group.admins.exists?(id: cu1.id)
+
+  detail_keys = Collection::DETAIL_LEVEL_KEYS - [:permission_level]
+
+  find_or_create_collection = lambda do |owner, label, parent: nil|
+    Collection.find_by(user: owner, label: label) ||
+      Collection.create!(user: owner, label: label, parent: parent)
+  end
+
+  share = lambda do |collection, shared_with, permission, detail: 0|
+    row = CollectionShare.find_or_initialize_by(collection: collection, shared_with: shared_with)
+    row.assign_attributes(detail_keys.index_with { detail })
+    row.permission_level = CollectionShare.permission_level(permission)
+    row.save!
+  end
+
+  root = find_or_create_collection.call(cu1, 'Sharing Demo')
+
+  # Permission-level ladder
+  pl_root = find_or_create_collection.call(cu1, 'Permission Levels', parent: root)
+  CollectionShare::PERMISSION_LEVELS.each_key do |level|
+    col = find_or_create_collection.call(cu1, level.to_s, parent: pl_root)
+    share.call(col, cu2, level, detail: 5)
+  end
+
+  # Group only
+  group_only = find_or_create_collection.call(cu1, 'Group Only', parent: root)
+  share.call(group_only, group, :edit_elements, detail: 5)
+
+  # User only
+  user_only = find_or_create_collection.call(cu1, 'User Only', parent: root)
+  share.call(user_only, cu3, :add_elements, detail: 5)
+
+  # Group + user mixed, different permission levels (MAX-resolution demo)
+  mixed = find_or_create_collection.call(cu1, 'Group + User Mixed', parent: root)
+  share.call(mixed, group, :read_elements, detail: 3)
+  share.call(mixed, cu3, :manage_shares, detail: 8)
+
+  # Fully-shared tree A -> B -> C
+  tree_a = find_or_create_collection.call(cu1, 'Tree A', parent: root)
+  tree_b = find_or_create_collection.call(cu1, 'Tree B', parent: tree_a)
+  tree_c = find_or_create_collection.call(cu1, 'Tree C', parent: tree_b)
+  [tree_a, tree_b, tree_c].each { |col| share.call(col, cu2, :edit_elements, detail: 5) }
+
+  # Truncated tree: A and C shared, B deliberately skipped
+  trunc_a = find_or_create_collection.call(cu1, 'Truncated Tree A', parent: root)
+  trunc_b = find_or_create_collection.call(cu1, 'Truncated Tree B', parent: trunc_a)
+  trunc_c = find_or_create_collection.call(cu1, 'Truncated Tree C', parent: trunc_b)
+  share.call(trunc_a, cu2, :edit_elements, detail: 5)
+  share.call(trunc_c, cu2, :edit_elements, detail: 5)
+
+  puts '*** Seeded collection-sharing demo data under CU1 / "Sharing Demo"'
+end

--- a/db/seeds/development/06_wellplates_screens_research_plans.seed.rb
+++ b/db/seeds/development/06_wellplates_screens_research_plans.seed.rb
@@ -19,6 +19,12 @@ else
   demo_collection = Collection.find_by(user: cu1, label: 'Screening Demo') ||
     Collection.create!(user: cu1, label: 'Screening Demo')
 
+  # Every element must also sit in the owner's locked "All" collection — the
+  # API always adds it explicitly on create (no model callback does it), so a
+  # seed that skips it produces elements invisible from the "All" view.
+  all_collection = Collection.get_all_collection_for_user(cu1.id)
+  demo_collections = [demo_collection, all_collection].compact
+
   build_sample = lambda do
     molecule = molecule_pool.sample
     sample = Sample.new(
@@ -29,7 +35,7 @@ else
       purity: rand(0.85..1.0).round(3),
       creator: cu1,
     )
-    sample.collections = [demo_collection]
+    sample.collections = demo_collections
     sample.save!
     sample
   end
@@ -42,7 +48,7 @@ else
         description: { 'ops' => [{ 'insert' => Faker::Lorem.sentence }] },
         readout_titles: [Faker::Science.element_subcategory, 'Activity'],
       )
-      wp.collections = [demo_collection]
+      wp.collections = demo_collections
       wp.save!
       wp.set_short_label(user: cu1)
 
@@ -60,6 +66,30 @@ else
     end
   end
 
+  # ag-Grid column definitions, not bare header strings: the frontend mutates
+  # each column (`item.cellEditor = ...`) and keys row values by `field`.
+  # See app/javascript/src/models/ResearchPlan.js.
+  wellplate_table_columns = [
+    { 'headerName' => 'Position', 'field' => 'position', 'colId' => 'position' },
+    { 'headerName' => 'Sample', 'field' => 'sample', 'colId' => 'sample' },
+  ].freeze
+
+  wellplate_table_field = lambda do |wp|
+    occupied = wp.wells.where.not(sample_id: nil).includes(:sample)
+    {
+      'id' => SecureRandom.uuid,
+      'type' => 'table',
+      'title' => wp.name,
+      'wellplate_id' => wp.id,
+      'value' => {
+        'columns' => wellplate_table_columns,
+        'rows' => occupied.map do |w|
+          { 'position' => w.alphanumeric_position, 'sample' => w.sample&.name }
+        end,
+      },
+    }
+  end
+
   research_plans = (1..10).map do |n|
     label = "Screening Demo Research Plan #{n}"
     ResearchPlan.joins(:collections).where(collections: { id: demo_collection.id }).find_by(name: label) || begin
@@ -69,22 +99,10 @@ else
         { 'id' => SecureRandom.uuid, 'type' => 'richtext',
           'value' => { 'ops' => [{ 'insert' => "#{Faker::Lorem.paragraph}\n" }] } },
       ]
-      linked_wellplates.each do |wp|
-        occupied = wp.wells.where.not(sample_id: nil).includes(:sample)
-        body << {
-          'id' => SecureRandom.uuid,
-          'type' => 'table',
-          'title' => wp.name,
-          'wellplate_id' => wp.id,
-          'value' => {
-            'columns' => ['Position', 'Sample'],
-            'rows' => occupied.map { |w| [w.alphanumeric_position, w.sample&.name] },
-          },
-        }
-      end
+      body.concat(linked_wellplates.map(&wellplate_table_field))
 
       rp = ResearchPlan.new(name: label, body: body, creator: cu1)
-      rp.collections = [demo_collection]
+      rp.collections = demo_collections
       rp.wellplates = linked_wellplates
       rp.save!
       rp
@@ -103,7 +121,7 @@ else
       conditions: Faker::Lorem.sentence,
       requirements: Faker::Science.tool,
     )
-    screen.collections = [demo_collection]
+    screen.collections = demo_collections
     screen.research_plans = research_plans.sample(rand(0..2))
     screen.save!
   end

--- a/db/seeds/development/06_wellplates_screens_research_plans.seed.rb
+++ b/db/seeds/development/06_wellplates_screens_research_plans.seed.rb
@@ -40,6 +40,25 @@ else
     sample
   end
 
+  readout_units = %w[s h nM µM m g kg %].freeze
+
+  fill_wells = lambda do |wp|
+    (1..12).to_a.product((1..8).to_a).sample(10).each do |(x, y)|
+      Well.create!(
+        wellplate: wp,
+        sample: build_sample.call,
+        position_x: x,
+        position_y: y,
+        # One readout per readout_title: the grid indexes readouts by title
+        # position (`readouts[index].value`), so a short array throws.
+        readouts: wp.readout_titles.map do
+          { value: rand(0.0..100.0).round(2), unit: readout_units.sample }
+        end,
+        color_code: format('#%06x', rand(0xffffff)),
+      )
+    end
+  end
+
   wellplates = (1..10).map do |n|
     label = "Screening Demo Wellplate #{n}"
     Wellplate.joins(:collections).where(collections: { id: demo_collection.id }).find_by(name: label) || begin
@@ -49,19 +68,13 @@ else
         readout_titles: [Faker::Science.element_subcategory, 'Activity'],
       )
       wp.collections = demo_collections
+      # Wellplate has no after_create :create_root_container (unlike Sample and
+      # ResearchPlan) — the client supplies it on POST /api/v1/wellplates. Without
+      # it the Analyses tab dereferences a null container and throws.
+      wp.container = Container.create_root_container
       wp.save!
       wp.set_short_label(user: cu1)
-
-      (1..12).to_a.product((1..8).to_a).sample(10).each do |(x, y)|
-        Well.create!(
-          wellplate: wp,
-          sample: build_sample.call,
-          position_x: x,
-          position_y: y,
-          readouts: [{ value: rand(0.0..100.0).round(2), unit: %w[s h nM µM m g kg %].sample }],
-          color_code: format('#%06x', rand(0xffffff)),
-        )
-      end
+      fill_wells.call(wp)
       wp
     end
   end
@@ -123,6 +136,8 @@ else
     )
     screen.collections = demo_collections
     screen.research_plans = research_plans.sample(rand(0..2))
+    # Screen, like Wellplate, has no root-container callback — see above.
+    screen.container = Container.create_root_container
     screen.save!
   end
 

--- a/db/seeds/development/06_wellplates_screens_research_plans.seed.rb
+++ b/db/seeds/development/06_wellplates_screens_research_plans.seed.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+# Screening demo data for CU1: 10 wellplates (10 randomly-placed samples
+# each), 10 research plans (0-3 linked wellplates each, with a summary table
+# body field per link), 5 screens (0-2 linked research plans each). Assumes
+# 00_persons.seed.rb and shared/molecules.seed.rb already ran (numeric
+# prefix + db/seeds.rb load order guarantee this); soft-skips otherwise.
+
+require 'faker'
+
+cu1 = Person.find_by(email: 'complat.user1@eln.edu')
+molecule_pool = cu1 && Molecule.order(Arel.sql('RANDOM()')).limit(100).to_a
+
+if cu1.nil?
+  puts '*** Skipping wellplate/screen/research-plan demo seed — missing complat.user1@eln.edu'
+elsif molecule_pool.blank?
+  puts '*** Skipping wellplate/screen/research-plan demo seed — no molecules seeded yet'
+else
+  demo_collection = Collection.find_by(user: cu1, label: 'Screening Demo') ||
+    Collection.create!(user: cu1, label: 'Screening Demo')
+
+  build_sample = lambda do
+    molecule = molecule_pool.sample
+    sample = Sample.new(
+      name: "#{Faker::Color.color_name.capitalize} #{molecule.sum_formular}",
+      molecule: molecule,
+      target_amount_value: Faker::Number.decimal(l_digits: 1, r_digits: 2).to_f,
+      target_amount_unit: %w[g mg mol mmol].sample,
+      purity: rand(0.85..1.0).round(3),
+      creator: cu1,
+    )
+    sample.collections = [demo_collection]
+    sample.save!
+    sample
+  end
+
+  wellplates = (1..10).map do |n|
+    label = "Screening Demo Wellplate #{n}"
+    Wellplate.joins(:collections).where(collections: { id: demo_collection.id }).find_by(name: label) || begin
+      wp = Wellplate.new(
+        name: label,
+        description: { 'ops' => [{ 'insert' => Faker::Lorem.sentence }] },
+        readout_titles: [Faker::Science.element_subcategory, 'Activity'],
+      )
+      wp.collections = [demo_collection]
+      wp.save!
+      wp.set_short_label(user: cu1)
+
+      (1..12).to_a.product((1..8).to_a).sample(10).each do |(x, y)|
+        Well.create!(
+          wellplate: wp,
+          sample: build_sample.call,
+          position_x: x,
+          position_y: y,
+          readouts: [{ value: rand(0.0..100.0).round(2), unit: %w[s h nM µM m g kg %].sample }],
+          color_code: format('#%06x', rand(0xffffff)),
+        )
+      end
+      wp
+    end
+  end
+
+  research_plans = (1..10).map do |n|
+    label = "Screening Demo Research Plan #{n}"
+    ResearchPlan.joins(:collections).where(collections: { id: demo_collection.id }).find_by(name: label) || begin
+      linked_wellplates = wellplates.sample(rand(0..3))
+
+      body = [
+        { 'id' => SecureRandom.uuid, 'type' => 'richtext',
+          'value' => { 'ops' => [{ 'insert' => "#{Faker::Lorem.paragraph}\n" }] } },
+      ]
+      linked_wellplates.each do |wp|
+        occupied = wp.wells.where.not(sample_id: nil).includes(:sample)
+        body << {
+          'id' => SecureRandom.uuid,
+          'type' => 'table',
+          'title' => wp.name,
+          'wellplate_id' => wp.id,
+          'value' => {
+            'columns' => ['Position', 'Sample'],
+            'rows' => occupied.map { |w| [w.alphanumeric_position, w.sample&.name] },
+          },
+        }
+      end
+
+      rp = ResearchPlan.new(name: label, body: body, creator: cu1)
+      rp.collections = [demo_collection]
+      rp.wellplates = linked_wellplates
+      rp.save!
+      rp
+    end
+  end
+
+  (1..5).each do |n|
+    label = "Screening Demo Screen #{n}"
+    next if Screen.joins(:collections).where(collections: { id: demo_collection.id }).exists?(name: label)
+
+    screen = Screen.new(
+      name: label,
+      description: { 'ops' => [{ 'insert' => Faker::Lorem.sentence }] },
+      result: Faker::Lorem.sentence,
+      collaborator: Faker::Name.name,
+      conditions: Faker::Lorem.sentence,
+      requirements: Faker::Science.tool,
+    )
+    screen.collections = [demo_collection]
+    screen.research_plans = research_plans.sample(rand(0..2))
+    screen.save!
+  end
+
+  puts '*** Seeded 10 wellplates / 10 research plans / 5 screens under CU1 / "Screening Demo"'
+end


### PR DESCRIPTION
## Summary
- Adds `db/seeds/development/05_collection_sharing.seed.rb` — dev-only `CollectionShare` demo data for CU1 covering every sharing use case the model supports: the full permission-level ladder, a group-only share, a user-only share, a collection shared to both a group and a user at different levels (exercises `Collection#detail_levels_for_user`'s MAX-resolution), a fully shared collection tree, and a truncated tree (root + grandchild shared, middle child deliberately left unshared).
- Adds `db/seeds/development/06_wellplates_screens_research_plans.seed.rb` — 10 wellplates (10 randomly placed samples each), 10 research plans (0-3 linked wellplates each, with a summary table body field per link), and 5 screens (0-2 linked research plans each) for CU1, exercising the Wellplate/Screen/ResearchPlan join associations end to end.
- Both files are auto-loaded by the existing `db/seeds.rb` loader (no other file needs editing), dev-only by directory placement, idempotent (find-or-create keyed on label/name), and soft-skip if their prerequisite dev users/molecules aren't present yet.

## Test plan
- [x] Ran `bundle exec rake db:seed` twice against the dev DB — second run created nothing new (idempotent), no errors.
- [x] Verified via `rails runner`: 10 wellplates each with exactly 10 sample-bearing wells (100 samples total); research-plan↔wellplate link counts land in [0,3]; screen↔research-plan link counts land in [0,2].
- [x] Verified collection-sharing scenarios directly: permission-level ladder resolves 0-5 correctly; group+user mixed share resolves to the MAX of the two (permission 4/detail 8) for the user who is both a direct sharee and a group member, vs. the group-only level (0/3) for a group-only member; truncated tree — `Collection.accessible_for` includes the shared root and grandchild but not the unshared middle child.