### PR TITLE
perf(collections): resolve list-endpoint detail levels once per page

### DIFF
--- a/app/api/chemotion/cell_line_api.rb
+++ b/app/api/chemotion/cell_line_api.rb
@@ -23,7 +23,7 @@ module Chemotion
 
       get do
         resolved_collection, scope = collection_scope_for(params[:collection_id], CelllineSample, :cellline_samples)
-        scope = scope.order('created_at DESC')
+        scope = scope.order(created_at: :desc)
 
         from = params[:from_date]
         to = params[:to_date]

--- a/app/api/chemotion/cell_line_api.rb
+++ b/app/api/chemotion/cell_line_api.rb
@@ -36,7 +36,9 @@ module Chemotion
 
         reset_pagination_page(scope)
 
-        detail_levels = ElementDetailLevelCalculator.for_list(collection: resolved_collection, user: current_user)
+        detail_levels = ElementDetailLevelCalculator.for_list(
+          collection: resolved_collection, user: current_user, owned_only: true,
+        )
 
         cell_line_samples = paginate(scope).map do |cell_line_sample|
           Entities::CellLineSampleEntity.represent(

--- a/app/api/chemotion/cell_line_api.rb
+++ b/app/api/chemotion/cell_line_api.rb
@@ -22,7 +22,7 @@ module Chemotion
       end
 
       get do
-        _resolved_collection, scope = collection_scope_for(params[:collection_id], CelllineSample, :cellline_samples)
+        resolved_collection, scope = collection_scope_for(params[:collection_id], CelllineSample, :cellline_samples)
         scope = scope.order('created_at DESC')
 
         from = params[:from_date]
@@ -36,12 +36,13 @@ module Chemotion
 
         reset_pagination_page(scope)
 
+        detail_levels = ElementDetailLevelCalculator.for_list(collection: resolved_collection, user: current_user)
+
         cell_line_samples = paginate(scope).map do |cell_line_sample|
           Entities::CellLineSampleEntity.represent(
             cell_line_sample,
             displayed_in_list: true,
-            detail_levels: ElementDetailLevelCalculator.new(user: current_user,
-                                                            element: cell_line_sample).detail_levels,
+            detail_levels: detail_levels,
           )
         end
         { cell_lines: cell_line_samples }

--- a/app/api/chemotion/cell_line_api.rb
+++ b/app/api/chemotion/cell_line_api.rb
@@ -12,7 +12,7 @@ module Chemotion
       error!('Resource not found', 404)
     end
     resource :cell_lines do
-      desc 'return cell lines of a collection'
+      desc "return cell lines of a collection. #{CollectionHelpers::LIST_DETAIL_LEVEL_DESC_NOTE}"
       params do
         use :cell_line_get_params
       end

--- a/app/api/chemotion/cell_line_api.rb
+++ b/app/api/chemotion/cell_line_api.rb
@@ -36,9 +36,7 @@ module Chemotion
 
         reset_pagination_page(scope)
 
-        detail_levels = ElementDetailLevelCalculator.for_list(
-          collection: resolved_collection, user: current_user, owned_only: true,
-        )
+        detail_levels = detail_levels_for_list(resolved_collection)
 
         cell_line_samples = paginate(scope).map do |cell_line_sample|
           Entities::CellLineSampleEntity.represent(

--- a/app/api/chemotion/cell_line_api.rb
+++ b/app/api/chemotion/cell_line_api.rb
@@ -22,22 +22,8 @@ module Chemotion
       end
 
       get do
-        scope = if params[:collection_id]
-                  begin
-                    Collection.accessible_for(current_user)
-                              .find(params[:collection_id])
-                              .cellline_samples
-                  rescue ActiveRecord::RecordNotFound
-                    CelllineSample.none
-                  end
-                else
-                  # All collection of current_user
-                  # TODO: Question? Only own collections or shared as well?
-                  # TODO: Question 2: When using .none, why join at all? It does not return any records anyway
-                  # TODO: Other thought... having seen the "All collection of current_user" comment...
-                  #       is this maybe the case for displaying the "All" collection? Which has a collection id though
-                  CelllineSample.none.joins(:collections).where(collections: { user_id: current_user.id }).distinct
-                end.order('created_at DESC')
+        _resolved_collection, scope = collection_scope_for(params[:collection_id], CelllineSample, :cellline_samples)
+        scope = scope.order('created_at DESC')
 
         from = params[:from_date]
         to = params[:to_date]

--- a/app/api/chemotion/device_description_api.rb
+++ b/app/api/chemotion/device_description_api.rb
@@ -136,7 +136,7 @@ module Chemotion
     end
 
     resource :device_descriptions do
-      # Return serialized device description by collection id
+      desc "Return serialized device descriptions by collection id. #{CollectionHelpers::LIST_DETAIL_LEVEL_DESC_NOTE}"
       params do
         optional :collection_id, type: Integer
         optional :filter_created_at, type: Boolean, desc: 'filter by created at or updated at'

--- a/app/api/chemotion/device_description_api.rb
+++ b/app/api/chemotion/device_description_api.rb
@@ -165,9 +165,7 @@ module Chemotion
 
         reset_pagination_page(scope)
 
-        detail_levels = ElementDetailLevelCalculator.for_list(
-          collection: resolved_collection, user: current_user, owned_only: true,
-        )
+        detail_levels = detail_levels_for_list(resolved_collection)
 
         device_descriptions = paginate(scope).map do |device_description|
           Entities::DeviceDescriptionEntity.represent(

--- a/app/api/chemotion/device_description_api.rb
+++ b/app/api/chemotion/device_description_api.rb
@@ -148,7 +148,7 @@ module Chemotion
         params[:per_page].to_i > 50 && (params[:per_page] = 50)
       end
       get do
-        _resolved_collection, scope = collection_scope_for(
+        resolved_collection, scope = collection_scope_for(
           params[:collection_id], DeviceDescription, :device_descriptions
         )
         scope = scope.order(updated_at: :desc)
@@ -165,12 +165,13 @@ module Chemotion
 
         reset_pagination_page(scope)
 
+        detail_levels = ElementDetailLevelCalculator.for_list(collection: resolved_collection, user: current_user)
+
         device_descriptions = paginate(scope).map do |device_description|
           Entities::DeviceDescriptionEntity.represent(
             device_description,
             displayed_in_list: true,
-            detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: device_description)
-                                                       .detail_levels,
+            detail_levels: detail_levels,
           )
         end
 

--- a/app/api/chemotion/device_description_api.rb
+++ b/app/api/chemotion/device_description_api.rb
@@ -148,19 +148,9 @@ module Chemotion
         params[:per_page].to_i > 50 && (params[:per_page] = 50)
       end
       get do
-        scope =
-          if params[:collection_id]
-            begin
-              Collection.accessible_for(current_user)
-                        .find(params[:collection_id]).device_descriptions
-            rescue ActiveRecord::RecordNotFound
-              DeviceDescription.none
-            end
-          else
-            # All collection of current_user
-            DeviceDescription.joins(:collections)
-                             .where(collections: { user_id: current_user.id }).distinct
-          end
+        _resolved_collection, scope = collection_scope_for(
+          params[:collection_id], DeviceDescription, :device_descriptions
+        )
         scope = scope.order(updated_at: :desc)
 
         from = params[:from_date]

--- a/app/api/chemotion/device_description_api.rb
+++ b/app/api/chemotion/device_description_api.rb
@@ -165,7 +165,9 @@ module Chemotion
 
         reset_pagination_page(scope)
 
-        detail_levels = ElementDetailLevelCalculator.for_list(collection: resolved_collection, user: current_user)
+        detail_levels = ElementDetailLevelCalculator.for_list(
+          collection: resolved_collection, user: current_user, owned_only: true,
+        )
 
         device_descriptions = paginate(scope).map do |device_description|
           Entities::DeviceDescriptionEntity.represent(

--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -33,14 +33,9 @@ module Chemotion
       end
 
       get do
+        resolved_collection = readable_collection_for(params[:collection_id])
         scope = if params[:collection_id]
-                  begin
-                    Collection.accessible_for(current_user)
-                              .find(params[:collection_id])
-                              .reactions
-                  rescue ActiveRecord::RecordNotFound
-                    Reaction.none
-                  end
+                  resolved_collection ? resolved_collection.reactions : Reaction.none
                 else
                   Reaction
                     .joins(:collections)

--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -33,15 +33,7 @@ module Chemotion
       end
 
       get do
-        resolved_collection = readable_collection_for(params[:collection_id])
-        scope = if params[:collection_id]
-                  resolved_collection ? resolved_collection.reactions : Reaction.none
-                else
-                  Reaction
-                    .joins(:collections)
-                    .merge(Collection.unscope(:order).own_collections_for(current_user))
-                    .distinct
-                end
+        resolved_collection, scope = collection_scope_for(params[:collection_id], Reaction, :reactions)
 
         from = params[:from_date]
         to = params[:to_date]

--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -61,11 +61,13 @@ module Chemotion
 
         reset_pagination_page(scope)
 
+        detail_levels = ElementDetailLevelCalculator.for_list(collection: resolved_collection, user: current_user)
+
         reactions = paginate(scope).map do |reaction|
           Entities::ReactionEntity.represent(
             reaction,
             displayed_in_list: true,
-            detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: reaction).detail_levels,
+            detail_levels: detail_levels,
           )
         end
 

--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -13,7 +13,7 @@ module Chemotion
     helpers UserLabelHelpers
 
     resource :reactions do
-      desc 'Return serialized reactions'
+      desc "Return serialized reactions. #{CollectionHelpers::LIST_DETAIL_LEVEL_DESC_NOTE}"
       params do
         optional :collection_id, type: Integer, desc: 'Collection id'
         optional :from_date, type: Integer, desc: 'created_date from in ms'

--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -61,7 +61,9 @@ module Chemotion
 
         reset_pagination_page(scope)
 
-        detail_levels = ElementDetailLevelCalculator.for_list(collection: resolved_collection, user: current_user)
+        detail_levels = ElementDetailLevelCalculator.for_list(
+          collection: resolved_collection, user: current_user, owned_only: true,
+        )
 
         reactions = paginate(scope).map do |reaction|
           Entities::ReactionEntity.represent(

--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -53,9 +53,7 @@ module Chemotion
 
         reset_pagination_page(scope)
 
-        detail_levels = ElementDetailLevelCalculator.for_list(
-          collection: resolved_collection, user: current_user, owned_only: true,
-        )
+        detail_levels = detail_levels_for_list(resolved_collection)
 
         reactions = paginate(scope).map do |reaction|
           Entities::ReactionEntity.represent(

--- a/app/api/chemotion/research_plan_api.rb
+++ b/app/api/chemotion/research_plan_api.rb
@@ -39,7 +39,9 @@ module Chemotion
 
         reset_pagination_page(scope)
 
-        detail_levels = ElementDetailLevelCalculator.for_list(collection: resolved_collection, user: current_user)
+        detail_levels = ElementDetailLevelCalculator.for_list(
+          collection: resolved_collection, user: current_user, owned_only: true,
+        )
 
         research_plans = paginate(scope).map do |research_plan|
           Entities::ResearchPlanEntity.represent(

--- a/app/api/chemotion/research_plan_api.rb
+++ b/app/api/chemotion/research_plan_api.rb
@@ -12,7 +12,7 @@ module Chemotion
     helpers LiteratureHelpers
 
     namespace :research_plans do
-      desc 'Return serialized research plans of current user'
+      desc "Return serialized research plans of current user. #{CollectionHelpers::LIST_DETAIL_LEVEL_DESC_NOTE}"
       params do
         optional :collection_id, type: Integer, desc: 'Collection id'
         optional :filter_created_at, type: Boolean, desc: 'filter by created at or updated at'

--- a/app/api/chemotion/research_plan_api.rb
+++ b/app/api/chemotion/research_plan_api.rb
@@ -39,9 +39,7 @@ module Chemotion
 
         reset_pagination_page(scope)
 
-        detail_levels = ElementDetailLevelCalculator.for_list(
-          collection: resolved_collection, user: current_user, owned_only: true,
-        )
+        detail_levels = detail_levels_for_list(resolved_collection)
 
         research_plans = paginate(scope).map do |research_plan|
           Entities::ResearchPlanEntity.represent(

--- a/app/api/chemotion/research_plan_api.rb
+++ b/app/api/chemotion/research_plan_api.rb
@@ -22,16 +22,8 @@ module Chemotion
       end
       paginate per_page: 7, offset: 0, max_per_page: 100
       get do
-        if params[:collection_id]
-          begin
-            scope = Collection.accessible_for(current_user).find(params[:collection_id]).research_plans
-          rescue ActiveRecord::RecordNotFound
-            scope = ResearchPlan.none
-          end
-        else
-          # All collection of current_user
-          ResearchPlan.joins(:collections).where(collections: { user_id: current_user.id }).distinct
-        end.order('research_plans.created_at DESC')
+        _resolved_collection, scope = collection_scope_for(params[:collection_id], ResearchPlan, :research_plans)
+        scope = scope.order('research_plans.created_at DESC')
 
         from = params[:from_date]
         to = params[:to_date]

--- a/app/api/chemotion/research_plan_api.rb
+++ b/app/api/chemotion/research_plan_api.rb
@@ -22,7 +22,7 @@ module Chemotion
       end
       paginate per_page: 7, offset: 0, max_per_page: 100
       get do
-        _resolved_collection, scope = collection_scope_for(params[:collection_id], ResearchPlan, :research_plans)
+        resolved_collection, scope = collection_scope_for(params[:collection_id], ResearchPlan, :research_plans)
         scope = scope.order('research_plans.created_at DESC')
 
         from = params[:from_date]
@@ -39,11 +39,13 @@ module Chemotion
 
         reset_pagination_page(scope)
 
+        detail_levels = ElementDetailLevelCalculator.for_list(collection: resolved_collection, user: current_user)
+
         research_plans = paginate(scope).map do |research_plan|
           Entities::ResearchPlanEntity.represent(
             research_plan,
             displayed_in_list: true,
-            detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: research_plan).detail_levels,
+            detail_levels: detail_levels,
           )
         end
 

--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -198,7 +198,9 @@ module Chemotion
         sample_scope = sample_scope.by_user_label(user_label) if user_label
 
         sample_list = []
-        detail_levels = ElementDetailLevelCalculator.for_list(collection: resolved_collection, user: current_user)
+        detail_levels = ElementDetailLevelCalculator.for_list(
+          collection: resolved_collection, user: current_user, owned_only: true,
+        )
 
         if params[:molecule_sort] == 1
           molecule_scope = Molecule

--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -178,17 +178,7 @@ module Chemotion
       paginate per_page: 7, offset: 0, max_per_page: 100
 
       get do
-        sample_scope = Sample.none
-        if params[:collection_id]
-          begin
-            sample_scope = Collection.accessible_for(current_user).find(params[:collection_id]).samples
-          rescue ActiveRecord::RecordNotFound
-            Sample.none
-          end
-        else
-          # All collection
-          sample_scope = Sample.for_user(current_user.id).distinct
-        end
+        _resolved_collection, sample_scope = collection_scope_for(params[:collection_id], Sample, :samples)
         sample_scope = sample_scope.includes_for_list_display
         prod_only = params[:product_only] || false
         sample_scope = if prod_only

--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -215,8 +215,9 @@ module Chemotion
               )
             end
           end
+          sample_count = sample_scope.count
         else
-          reset_pagination_page(sample_scope)
+          sample_count = reset_pagination_page(sample_scope)
           sample_scope = sample_scope.order('samples.updated_at DESC')
           paginate(sample_scope).each do |sample|
             sample_list.push(
@@ -227,7 +228,7 @@ module Chemotion
 
         return {
           samples: sample_list,
-          samples_count: sample_scope.count,
+          samples_count: sample_count,
         }
       end
 

--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -198,9 +198,7 @@ module Chemotion
         sample_scope = sample_scope.by_user_label(user_label) if user_label
 
         sample_list = []
-        detail_levels = ElementDetailLevelCalculator.for_list(
-          collection: resolved_collection, user: current_user, owned_only: true,
-        )
+        detail_levels = detail_levels_for_list(resolved_collection)
 
         if params[:molecule_sort] == 1
           molecule_scope = Molecule

--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -165,7 +165,7 @@ module Chemotion
         end
       end
 
-      desc 'Return serialized molecules_samples_groups of current user'
+      desc "Return serialized molecules_samples_groups of current user. #{CollectionHelpers::LIST_DETAIL_LEVEL_DESC_NOTE}"
       params do
         optional :collection_id, type: Integer, desc: 'Collection id'
         optional :molecule_sort, type: Integer, desc: 'Sort by parameter'

--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -178,7 +178,7 @@ module Chemotion
       paginate per_page: 7, offset: 0, max_per_page: 100
 
       get do
-        _resolved_collection, sample_scope = collection_scope_for(params[:collection_id], Sample, :samples)
+        resolved_collection, sample_scope = collection_scope_for(params[:collection_id], Sample, :samples)
         sample_scope = sample_scope.includes_for_list_display
         prod_only = params[:product_only] || false
         sample_scope = if prod_only
@@ -198,6 +198,7 @@ module Chemotion
         sample_scope = sample_scope.by_user_label(user_label) if user_label
 
         sample_list = []
+        detail_levels = ElementDetailLevelCalculator.for_list(collection: resolved_collection, user: current_user)
 
         if params[:molecule_sort] == 1
           molecule_scope = Molecule
@@ -209,7 +210,6 @@ module Chemotion
             samples_group = sample_scope.select { |v| v.molecule_id == molecule.id }
             samples_group = samples_group.sort { |x, y| y.updated_at <=> x.updated_at }
             samples_group.each do |sample|
-              detail_levels = ElementDetailLevelCalculator.new(user: current_user, element: sample).detail_levels
               sample_list.push(
                 Entities::SampleEntity.represent(sample, detail_levels: detail_levels, displayed_in_list: true),
               )
@@ -219,7 +219,6 @@ module Chemotion
           reset_pagination_page(sample_scope)
           sample_scope = sample_scope.order('samples.updated_at DESC')
           paginate(sample_scope).each do |sample|
-            detail_levels = ElementDetailLevelCalculator.new(user: current_user, element: sample).detail_levels
             sample_list.push(
               Entities::SampleEntity.represent(sample, detail_levels: detail_levels, displayed_in_list: true),
             )

--- a/app/api/chemotion/screen_api.rb
+++ b/app/api/chemotion/screen_api.rb
@@ -10,7 +10,7 @@ module Chemotion
     helpers UserLabelHelpers
 
     resource :screens do
-      desc 'Return serialized screens'
+      desc "Return serialized screens. #{CollectionHelpers::LIST_DETAIL_LEVEL_DESC_NOTE}"
       params do
         optional :collection_id, type: Integer, desc: 'Collection id'
         optional :filter_created_at, type: Boolean, desc: 'filter by created at or updated at'

--- a/app/api/chemotion/screen_api.rb
+++ b/app/api/chemotion/screen_api.rb
@@ -23,17 +23,7 @@ module Chemotion
         params[:per_page].to_i > 50 && (params[:per_page] = 50)
       end
       get do
-        screen_scope = Screen.none
-        if params[:collection_id]
-          begin
-            screen_scope = Collection.accessible_for(current_user).find(params[:collection_id]).screens
-          rescue ActiveRecord::RecordNotFound
-            Screen.none
-          end
-        else
-          # All collection of current_user
-          screen_scope = Screen.for_user(current_user.id).distinct
-        end
+        _resolved_collection, screen_scope = collection_scope_for(params[:collection_id], Screen, :screens)
 
         from = params[:from_date]
         to = params[:to_date]

--- a/app/api/chemotion/screen_api.rb
+++ b/app/api/chemotion/screen_api.rb
@@ -38,9 +38,7 @@ module Chemotion
 
         reset_pagination_page(screen_scope)
 
-        detail_levels = ElementDetailLevelCalculator.for_list(
-          collection: resolved_collection, user: current_user, owned_only: true,
-        )
+        detail_levels = detail_levels_for_list(resolved_collection)
 
         screens = paginate(screen_scope).map do |screen|
           Entities::ScreenEntity.represent(

--- a/app/api/chemotion/screen_api.rb
+++ b/app/api/chemotion/screen_api.rb
@@ -38,7 +38,9 @@ module Chemotion
 
         reset_pagination_page(screen_scope)
 
-        detail_levels = ElementDetailLevelCalculator.for_list(collection: resolved_collection, user: current_user)
+        detail_levels = ElementDetailLevelCalculator.for_list(
+          collection: resolved_collection, user: current_user, owned_only: true,
+        )
 
         screens = paginate(screen_scope).map do |screen|
           Entities::ScreenEntity.represent(

--- a/app/api/chemotion/screen_api.rb
+++ b/app/api/chemotion/screen_api.rb
@@ -23,7 +23,7 @@ module Chemotion
         params[:per_page].to_i > 50 && (params[:per_page] = 50)
       end
       get do
-        _resolved_collection, screen_scope = collection_scope_for(params[:collection_id], Screen, :screens)
+        resolved_collection, screen_scope = collection_scope_for(params[:collection_id], Screen, :screens)
 
         from = params[:from_date]
         to = params[:to_date]
@@ -38,10 +38,12 @@ module Chemotion
 
         reset_pagination_page(screen_scope)
 
+        detail_levels = ElementDetailLevelCalculator.for_list(collection: resolved_collection, user: current_user)
+
         screens = paginate(screen_scope).map do |screen|
           Entities::ScreenEntity.represent(
             screen,
-            detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: screen).detail_levels,
+            detail_levels: detail_levels,
             displayed_in_list: true,
           )
         end

--- a/app/api/chemotion/vessel_api.rb
+++ b/app/api/chemotion/vessel_api.rb
@@ -30,17 +30,8 @@ module Chemotion
         params[:per_page].to_i > 50 && (params[:per_page] = 50)
       end
       get do
-        scope = if params[:collection_id]
-                  begin
-                    Collection.accessible_for(current_user)
-                              .find(params[:collection_id])
-                              .vessels
-                  rescue ActiveRecord::RecordNotFound
-                    Vessel.none
-                  end
-                else
-                  Vessel.none.joins(:collections).where(collections: { user_id: current_user.id }).distinct
-                end.order('created_at DESC')
+        _resolved_collection, scope = collection_scope_for(params[:collection_id], Vessel, :vessels)
+        scope = scope.order('created_at DESC')
 
         from = params[:from_date]
         to = params[:to_date]

--- a/app/api/chemotion/vessel_api.rb
+++ b/app/api/chemotion/vessel_api.rb
@@ -31,7 +31,7 @@ module Chemotion
       end
       get do
         _resolved_collection, scope = collection_scope_for(params[:collection_id], Vessel, :vessels)
-        scope = scope.order('created_at DESC')
+        scope = scope.order(created_at: :desc)
 
         from = params[:from_date]
         to = params[:to_date]

--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -80,9 +80,7 @@ module Chemotion
 
         reset_pagination_page(scope)
 
-        detail_levels = ElementDetailLevelCalculator.for_list(
-          collection: resolved_collection, user: current_user, owned_only: true,
-        )
+        detail_levels = detail_levels_for_list(resolved_collection)
 
         wellplates = paginate(scope).map do |wellplate|
           Entities::WellplateEntity.represent(

--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -50,7 +50,7 @@ module Chemotion
         end
       end
 
-      desc 'Return serialized wellplates'
+      desc "Return serialized wellplates. #{CollectionHelpers::LIST_DETAIL_LEVEL_DESC_NOTE}"
       params do
         optional :collection_id, type: Integer, desc: 'Collection id'
         optional :filter_created_at, type: Boolean, desc: 'filter by created at or updated at'

--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -63,17 +63,8 @@ module Chemotion
         params[:per_page].to_i > 50 && (params[:per_page] = 50)
       end
       get do
-        scope = if params[:collection_id]
-                  begin
-                    Collection.accessible_for(current_user)
-                              .find(params[:collection_id]).wellplates
-                  rescue ActiveRecord::RecordNotFound
-                    Wellplate.none
-                  end
-                else
-                  # All collection of current_user
-                  Wellplate.joins(:collections).where(collections: { user_id: current_user.id }).distinct
-                end.order('wellplates.created_at DESC')
+        _resolved_collection, scope = collection_scope_for(params[:collection_id], Wellplate, :wellplates)
+        scope = scope.order('wellplates.created_at DESC')
 
         from = params[:from_date]
         to = params[:to_date]

--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -63,7 +63,7 @@ module Chemotion
         params[:per_page].to_i > 50 && (params[:per_page] = 50)
       end
       get do
-        _resolved_collection, scope = collection_scope_for(params[:collection_id], Wellplate, :wellplates)
+        resolved_collection, scope = collection_scope_for(params[:collection_id], Wellplate, :wellplates)
         scope = scope.order('wellplates.created_at DESC')
 
         from = params[:from_date]
@@ -80,11 +80,13 @@ module Chemotion
 
         reset_pagination_page(scope)
 
+        detail_levels = ElementDetailLevelCalculator.for_list(collection: resolved_collection, user: current_user)
+
         wellplates = paginate(scope).map do |wellplate|
           Entities::WellplateEntity.represent(
             wellplate,
             displayed_in_list: true,
-            detail_levels: ElementDetailLevelCalculator.new(user: current_user, element: wellplate).detail_levels,
+            detail_levels: detail_levels,
           )
         end
 

--- a/app/api/chemotion/wellplate_api.rb
+++ b/app/api/chemotion/wellplate_api.rb
@@ -80,7 +80,9 @@ module Chemotion
 
         reset_pagination_page(scope)
 
-        detail_levels = ElementDetailLevelCalculator.for_list(collection: resolved_collection, user: current_user)
+        detail_levels = ElementDetailLevelCalculator.for_list(
+          collection: resolved_collection, user: current_user, owned_only: true,
+        )
 
         wellplates = paginate(scope).map do |wellplate|
           Entities::WellplateEntity.represent(

--- a/app/api/entities/sample_entity.rb
+++ b/app/api/entities/sample_entity.rb
@@ -137,19 +137,22 @@ module Entities
     end
 
     def comment_count
-      object.comments.count
+      # Use size so the preloaded :comments association (see
+      # Sample.includes_for_list_display) is counted in memory, avoiding an
+      # N+1 COUNT(*) query per sample in the list endpoint.
+      object.comments.size
     end
 
     def gas_type
-      object.reactions_samples.pick(:gas_type)
+      object.reactions_samples.first&.gas_type
     end
 
     def gas_phase_data
-      object.reactions_samples.pick(:gas_phase_data)
+      object.reactions_samples.first&.gas_phase_data
     end
 
     def weight_percentage
-      object.reactions_samples.pick(:weight_percentage)
+      object.reactions_samples.first&.weight_percentage
     end
   end
 end

--- a/app/api/helpers/collection_helpers.rb
+++ b/app/api/helpers/collection_helpers.rb
@@ -3,6 +3,12 @@
 module CollectionHelpers
   extend Grape::API::Helpers
 
+  # Appended to a list endpoint's `desc` wherever detail levels are resolved once per page
+  # (see ElementDetailLevelCalculator) — defined once so the 7 call sites don't each repeat it.
+  LIST_DETAIL_LEVEL_DESC_NOTE =
+    'Detail level is applied per collection share; each entry is only partially serialized ' \
+    'compared to fetching the element by id directly.'
+
   def writable_collection_for(collection_id)
     return nil if collection_id.blank?
 

--- a/app/api/helpers/collection_helpers.rb
+++ b/app/api/helpers/collection_helpers.rb
@@ -10,15 +10,11 @@ module CollectionHelpers
     'compared to fetching the element by id directly.'
 
   def writable_collection_for(collection_id)
-    return nil if collection_id.blank?
-
-    Collection.writable_by(current_user).find_by(id: collection_id)
+    Collection.resolve_for(current_user, collection_id, scope: :writable_by)
   end
 
   def readable_collection_for(collection_id)
-    return nil if collection_id.blank?
-
-    Collection.accessible_for(current_user).find_by(id: collection_id)
+    Collection.resolve_for(current_user, collection_id, scope: :accessible_for)
   end
 
   # Resolves a list endpoint's scope: either the +association+ off the collection

--- a/app/api/helpers/collection_helpers.rb
+++ b/app/api/helpers/collection_helpers.rb
@@ -3,7 +3,7 @@
 module CollectionHelpers
   extend Grape::API::Helpers
 
-  # Appended to a list endpoint's `desc` wherever detail levels are resolved once per page
+  # Appended to a list endpoint's +desc+ wherever detail levels are resolved once per page
   # (see ElementDetailLevelCalculator) — defined once so the 7 call sites don't each repeat it.
   LIST_DETAIL_LEVEL_DESC_NOTE =
     'Detail level is applied per collection share; each entry is only partially serialized ' \
@@ -35,6 +35,18 @@ module CollectionHelpers
               klass.for_user(current_user.id).distinct
             end
     [resolved_collection, scope]
+  end
+
+  # The once-per-page detail levels for a list endpoint's resolved collection. Every one of the
+  # 7 call sites asserted +owned_only: true+ identically (the "All" branch each resolves is
+  # always owner-only — see {CollectionHelpers#collection_scope_for}), so sharing the call here
+  # removes the repetition without losing that assertion: it's still made in exactly one place,
+  # just not copy-pasted seven times.
+  #
+  # @param resolved_collection [Collection, nil] as returned by {#collection_scope_for}
+  # @return [Hash{Class => Integer}]
+  def detail_levels_for_list(resolved_collection)
+    ElementDetailLevelCalculator.for_list(collection: resolved_collection, user: current_user, owned_only: true)
   end
 
   def set_var(c_id = params[:collection_id])

--- a/app/api/helpers/collection_helpers.rb
+++ b/app/api/helpers/collection_helpers.rb
@@ -9,6 +9,32 @@ module CollectionHelpers
     Collection.writable_by(current_user).find_by(id: collection_id)
   end
 
+  def readable_collection_for(collection_id)
+    return nil if collection_id.blank?
+
+    Collection.accessible_for(current_user).find_by(id: collection_id)
+  end
+
+  # Resolves a list endpoint's scope: either the +association+ off the collection
+  # named by +collection_id+ (or an empty scope if that collection is missing or
+  # inaccessible), or every element the current user owns when no +collection_id+
+  # is given.
+  #
+  # @param collection_id [Integer, nil] params[:collection_id]
+  # @param klass [Class] the element class — must respond to +.none+ and +.for_user+
+  # @param association [Symbol] the {Collection} association to read from (e.g. +:samples+)
+  # @return [Array(Collection, ActiveRecord::Relation)] the resolved collection
+  #   (nil if none given, or not accessible) and the resulting scope
+  def collection_scope_for(collection_id, klass, association)
+    resolved_collection = readable_collection_for(collection_id)
+    scope = if collection_id
+              resolved_collection ? resolved_collection.public_send(association) : klass.none
+            else
+              klass.for_user(current_user.id).distinct
+            end
+    [resolved_collection, scope]
+  end
+
   def set_var(c_id = params[:collection_id])
     @c = Collection.accessible_for(current_user).find(c_id)
     @c_id = @c.id

--- a/app/api/helpers/params_helpers.rb
+++ b/app/api/helpers/params_helpers.rb
@@ -230,6 +230,7 @@ module ParamsHelpers
     your_page = 1 if total_recs.positive? && your_page > total_page
 
     params[:page] = your_page
+    total_recs
   end
 end
 # rubocop:enable Metrics/ModuleLength, Metrics/BlockLength

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable Rails/HasManyOrHasOneDependent
+# rubocop:disable Rails/HasManyOrHasOneDependent, Metrics/ClassLength
 
 # == Schema Information
 #
@@ -256,6 +256,23 @@ class Collection < ApplicationRecord
     find_by(user_id: user_id, label: 'All', is_locked: true)
   end
 
+  # Resolves +collection_id+ against +user+'s access under +scope+ (e.g. :writable_by,
+  # :accessible_for — any class-level scope that takes a user and returns a Collection
+  # relation). Consolidates what were two near-identical Grape helpers
+  # (writable_collection_for/readable_collection_for in CollectionHelpers) that differed only
+  # in which scope they queried — a real permission-level difference between the two scopes,
+  # not incidental duplication, so keep the distinction but share the lookup.
+  #
+  # @param user [User]
+  # @param collection_id [Integer, nil]
+  # @param scope [Symbol] a Collection class method/scope name
+  # @return [Collection, nil]
+  def self.resolve_for(user, collection_id, scope:)
+    return nil if collection_id.blank?
+
+    public_send(scope, user).find_by(id: collection_id)
+  end
+
   # The keys {#detail_levels_for_user} resolves. Extend when a new element type gains a detail level.
   DETAIL_LEVEL_KEYS = %i[
     permission_level
@@ -322,4 +339,4 @@ class Collection < ApplicationRecord
                    .pluck(:collection_id)
   end
 end
-# rubocop:enable Rails/HasManyOrHasOneDependent
+# rubocop:enable Rails/HasManyOrHasOneDependent, Metrics/ClassLength

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -178,7 +178,9 @@ class Sample < ApplicationRecord
                                      joins(:reactions_samples).where(reactions_samples: { reaction_id: ids })
                                    }
   scope :by_literature_ids,        ->(ids) { joins(:literals).where(literals: { literature_id: ids }) }
-  scope :includes_for_list_display, -> { includes(:molecule_name, :tag, :comments, molecule: :tag) }
+  scope :includes_for_list_display, lambda {
+    includes(:molecule_name, :tag, :comments, :reactions_samples, molecule: %i[tag computed_props])
+  }
 
   scope :product_only, -> { joins(:reactions_samples).where("reactions_samples.type = 'ReactionsProductSample'") }
   scope :sample_or_startmat_or_products, lambda {

--- a/app/services/element_detail_level_calculator.rb
+++ b/app/services/element_detail_level_calculator.rb
@@ -4,11 +4,68 @@
 class ElementDetailLevelCalculator
   attr_reader :user, :element, :detail_levels
 
+  # Maps each of Collection::DETAIL_LEVEL_KEYS (minus :permission_level, which has no
+  # class-keyed analog) to the element class {#calculate_detail_levels} keys its hash by.
+  CLASS_BY_DETAIL_KEY = {
+    sample_detail_level: Sample,
+    reaction_detail_level: Reaction,
+    wellplate_detail_level: Wellplate,
+    screen_detail_level: Screen,
+    researchplan_detail_level: ResearchPlan,
+    element_detail_level: Labimotion::Element,
+    celllinesample_detail_level: CelllineSample,
+    devicedescription_detail_level: DeviceDescription,
+    sequencebasedmacromoleculesample_detail_level: SequenceBasedMacromoleculeSample,
+  }.freeze
+
   def initialize(user:, element:)
     @user = user
     @element = element
     @detail_levels = calculate_detail_levels
   end
+
+  # Class-keyed detail levels for every element on a page fetched via a single +collection+ —
+  # one query (or zero, if +collection+ is owned) instead of one {ElementDetailLevelCalculator}
+  # per element. Intended for list/index endpoints where every element on the page is known to
+  # come from exactly one resolved collection.
+  #
+  # This does not check any *other* collection an element might also belong to (the per-element
+  # instance method does); an element that's also independently owned or better-shared elsewhere
+  # will show the browsed collection's level here, not its best available level. Acceptable for a
+  # summary list — opening the individual element re-resolves the accurate value.
+  #
+  # @param collection [Collection] the single collection the current page was fetched from
+  # @param user [User]
+  # @return [Hash{Class => Integer}]
+  def self.for_collection(collection:, user:)
+    class_hash_for(collection.detail_levels_for_user(user))
+  end
+
+  # Class-keyed detail levels for a page drawn only from collections the user owns (the
+  # "no collection_id" / merged view) — always full access, with zero queries.
+  #
+  # @return [Hash{Class => Integer}]
+  def self.owned_levels
+    class_hash_for(Collection::DETAIL_LEVEL_KEYS.index_with { Collection::OWNER_LEVEL })
+  end
+
+  # Class-keyed detail levels for a list/index page, given the possibly-nil collection
+  # resolved from an optional +collection_id+ param. Combines {.for_collection} and
+  # {.owned_levels} — the branch every list endpoint needs to pick between them.
+  #
+  # @param collection [Collection, nil] the resolved collection, or nil for the "All" view
+  # @param user [User]
+  # @return [Hash{Class => Integer}]
+  def self.for_list(collection:, user:)
+    collection ? for_collection(collection: collection, user: user) : owned_levels
+  end
+
+  def self.class_hash_for(key_hash)
+    hash = CLASS_BY_DETAIL_KEY.each_with_object({}) { |(key, klass), acc| acc[klass] = key_hash[key] || 0 }
+    hash[Well] = hash[Wellplate]
+    hash
+  end
+  private_class_method :class_hash_for
 
   private
 

--- a/app/services/element_detail_level_calculator.rb
+++ b/app/services/element_detail_level_calculator.rb
@@ -1,22 +1,32 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/CyclomaticComplexity
 class ElementDetailLevelCalculator
   attr_reader :user, :element, :detail_levels
 
+  # Class per key suffix — the values can't be derived mechanically from the key names
+  # (e.g. "researchplan" doesn't classify to ResearchPlan, "element" doesn't namespace to
+  # Labimotion::Element), so this mapping must stay hand-written.
+  CLASS_BY_KEY_SUFFIX = {
+    'sample' => Sample,
+    'reaction' => Reaction,
+    'wellplate' => Wellplate,
+    'screen' => Screen,
+    'researchplan' => ResearchPlan,
+    'element' => Labimotion::Element,
+    'celllinesample' => CelllineSample,
+    'devicedescription' => DeviceDescription,
+    'sequencebasedmacromoleculesample' => SequenceBasedMacromoleculeSample,
+  }.freeze
+  private_constant :CLASS_BY_KEY_SUFFIX
+
   # Maps each of Collection::DETAIL_LEVEL_KEYS (minus :permission_level, which has no
   # class-keyed analog) to the element class {#calculate_detail_levels} keys its hash by.
-  CLASS_BY_DETAIL_KEY = {
-    sample_detail_level: Sample,
-    reaction_detail_level: Reaction,
-    wellplate_detail_level: Wellplate,
-    screen_detail_level: Screen,
-    researchplan_detail_level: ResearchPlan,
-    element_detail_level: Labimotion::Element,
-    celllinesample_detail_level: CelllineSample,
-    devicedescription_detail_level: DeviceDescription,
-    sequencebasedmacromoleculesample_detail_level: SequenceBasedMacromoleculeSample,
-  }.freeze
+  # Single-sourced from Collection::DETAIL_LEVEL_KEYS so a future key added there with no
+  # matching entry here raises at class-load time instead of silently resolving to 0 at
+  # request time (see {.class_hash_for}).
+  CLASS_BY_DETAIL_KEY = (Collection::DETAIL_LEVEL_KEYS - [:permission_level]).index_with do |key|
+    CLASS_BY_KEY_SUFFIX.fetch(key.to_s.delete_suffix('_detail_level'))
+  end.freeze
 
   def initialize(user:, element:)
     @user = user
@@ -53,11 +63,24 @@ class ElementDetailLevelCalculator
   # resolved from an optional +collection_id+ param. Combines {.for_collection} and
   # {.owned_levels} — the branch every list endpoint needs to pick between them.
   #
+  # +owned_only+ has no default: every call site's "All" (no collection_id) branch must
+  # declare, at the call site, that its scope is owner-only (never anything reachable only
+  # via a CollectionShare) — {.owned_levels} is only correct under that assumption, and this
+  # makes it a required, reviewable claim instead of a silent one. There is deliberately no
+  # "owned_only: false" behavior; nothing in this codebase has an "All" branch that isn't
+  # owner-only today, so this is an explicit assertion, not a real toggle.
+  #
   # @param collection [Collection, nil] the resolved collection, or nil for the "All" view
   # @param user [User]
+  # @param owned_only [Boolean] must be true — asserts the nil-collection branch's scope is owner-only
+  # @raise [ArgumentError] if +collection+ is nil and +owned_only+ is not true
   # @return [Hash{Class => Integer}]
-  def self.for_list(collection:, user:)
-    collection ? for_collection(collection: collection, user: user) : owned_levels
+  def self.for_list(collection:, user:, owned_only:)
+    return for_collection(collection: collection, user: user) if collection
+
+    raise ArgumentError, 'the "All" (no collection_id) branch must be owner-only' unless owned_only
+
+    owned_levels
   end
 
   def self.class_hash_for(key_hash)
@@ -69,19 +92,10 @@ class ElementDetailLevelCalculator
 
   private
 
-  def calculate_detail_levels # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
-    detail_levels = Hash.new(0)
-
-    detail_levels[Labimotion::Element] = detail_level_for(:element_detail_level) || 0
-    detail_levels[Reaction] = detail_level_for(:reaction_detail_level) || 0
-    detail_levels[ResearchPlan] = detail_level_for(:researchplan_detail_level) || 0
-    detail_levels[Sample] = detail_level_for(:sample_detail_level) || 0
-    detail_levels[Screen] = detail_level_for(:screen_detail_level) || 0
-    detail_levels[Wellplate] = detail_level_for(:wellplate_detail_level) || 0
-    detail_levels[CelllineSample] = detail_level_for(:celllinesample_detail_level) || 0
-    detail_levels[DeviceDescription] = detail_level_for(:devicedescription_detail_level) || 0
-    detail_levels[SequenceBasedMacromoleculeSample] =
-      detail_level_for(:sequencebasedmacromoleculesample_detail_level) || 0
+  def calculate_detail_levels
+    detail_levels = CLASS_BY_DETAIL_KEY.each_with_object(Hash.new(0)) do |(key, klass), acc|
+      acc[klass] = detail_level_for(key) || 0
+    end
     detail_levels[Well] = detail_levels[Wellplate]
 
     detail_levels
@@ -112,4 +126,3 @@ class ElementDetailLevelCalculator
     @shared_collections_with_element ||= element.collections.shared_collections_for(user)
   end
 end
-# rubocop:enable Metrics/CyclomaticComplexity Metrics/PerceivedComplexity

--- a/app/usecases/sbmm/samples.rb
+++ b/app/usecases/sbmm/samples.rb
@@ -20,14 +20,11 @@ module Usecases
 
       def base_list_scope(params)
         if params[:collection_id]
-          Collection.accessible_for(current_user)
-                    .find(params[:collection_id])
-                    .sequence_based_macromolecule_samples
+          collection = Collection.accessible_for(current_user).find_by(id: params[:collection_id])
+          collection ? collection.sequence_based_macromolecule_samples : SequenceBasedMacromoleculeSample.none
         else
           SequenceBasedMacromoleculeSample.for_user(current_user.id).distinct
         end
-      rescue ActiveRecord::RecordNotFound
-        SequenceBasedMacromoleculeSample.none
       end
 
       # rubocop:disable Metrics/AbcSize,  Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/spec/api/chemotion/cell_line_api_spec.rb
+++ b/spec/api/chemotion/cell_line_api_spec.rb
@@ -119,6 +119,46 @@ describe Chemotion::CellLineAPI do
         end
       end
     end
+
+    context 'when no collection_id is given (All)' do
+      it 'returns the cell lines from the collections owned by the user' do
+        get '/api/v1/cell_lines/'
+
+        expect(response).to have_http_status :ok
+        expect(parsed_json_response['cell_lines'].pluck('id')).to contain_exactly(cell_line.id, cell_line2.id)
+      end
+    end
+
+    context 'when collection_id does not resolve (nonexistent or inaccessible)' do
+      let(:params) { { collection_id: collection.id + 1_000_000 } }
+
+      it 'returns an empty list rather than an error' do
+        get '/api/v1/cell_lines/', params: params
+
+        expect(response).to have_http_status :ok
+        expect(parsed_json_response['cell_lines']).to eq([])
+      end
+    end
+
+    context 'when collection_id points to a collection shared with the user' do
+      let(:other_user) { create(:person) }
+      let(:shared_collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare.permission_level(:read_elements))
+        end
+      end
+      let!(:shared_cell_line) do
+        create(:cellline_sample, collections: [shared_collection], cellline_material: material)
+      end
+
+      it 'returns the cell lines from the shared collection' do
+        get '/api/v1/cell_lines/', params: { collection_id: shared_collection.id }
+
+        expect(response).to have_http_status :ok
+        expect(parsed_json_response['cell_lines'].pluck('id')).to include(shared_cell_line.id)
+      end
+    end
   end
 
   describe 'GET /api/v1/cell_lines/{:id}' do

--- a/spec/api/chemotion/device_description_api_spec.rb
+++ b/spec/api/chemotion/device_description_api_spec.rb
@@ -25,6 +25,29 @@ describe Chemotion::DeviceDescriptionAPI do
 
       expect(parsed_json_response['device_descriptions'].size).to be(1)
     end
+
+    context 'when collection_id points to a collection shared with the user' do
+      let(:shared_collection) do
+        create(:collection, user: create(:person)).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare.permission_level(:read_elements))
+        end
+      end
+      let(:shared_device_description) do
+        create(:device_description, :with_ontologies, creator: shared_collection.user)
+      end
+
+      before do
+        create(:collections_device_description,
+               device_description: shared_device_description, collection: shared_collection)
+      end
+
+      it 'returns the device descriptions from the shared collection' do
+        get '/api/v1/device_descriptions/', params: { collection_id: shared_collection.id }
+
+        expect(parsed_json_response['device_descriptions'].pluck('id')).to include(shared_device_description.id)
+      end
+    end
   end
 
   describe 'POST /api/v1/device_descriptions' do

--- a/spec/api/chemotion/reaction_api_spec.rb
+++ b/spec/api/chemotion/reaction_api_spec.rb
@@ -49,6 +49,18 @@ describe Chemotion::ReactionAPI do
       end
     end
 
+    context 'without params, when a reaction is only in a group-owned collection' do
+      let(:group) { create(:group, users: [user]) }
+      let(:group_collection) { create(:collection, user: group) }
+      let!(:group_reaction) { create(:reaction, name: 'group reaction', collections: [group_collection]) }
+
+      it 'does not return it -- the "All" view is owner-only, not group-aware' do
+        get '/api/v1/reactions'
+        reactions = parsed_json_response['reactions']
+        expect(reactions.pluck('id')).not_to include(group_reaction.id)
+      end
+    end
+
     context 'with ID of collection' do
       before { get '/api/v1/reactions', params: { collection_id: collection1.id } }
 

--- a/spec/api/chemotion/reaction_api_spec.rb
+++ b/spec/api/chemotion/reaction_api_spec.rb
@@ -58,6 +58,22 @@ describe Chemotion::ReactionAPI do
       end
     end
 
+    context 'with ID of a collection shared with the user' do
+      let(:shared_collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare.permission_level(:read_elements))
+        end
+      end
+      let!(:shared_reaction) { create(:reaction, name: 'shared reaction', collections: [shared_collection]) }
+
+      it 'returns the reaction from the shared collection' do
+        get '/api/v1/reactions', params: { collection_id: shared_collection.id }
+        reactions = JSON.parse(response.body)['reactions']
+        expect(reactions.pluck('id')).to include(shared_reaction.id)
+      end
+    end
+
     context 'with ID of non-existing collection' do
       before { get '/api/v1/reactions', params: { collection_id: -1 } }
 

--- a/spec/api/chemotion/research_plan_api_spec.rb
+++ b/spec/api/chemotion/research_plan_api_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Chemotion::ResearchPlanAPI do
+  include_context 'api request authorization context'
+
+  let(:collection) { create(:collection, user: user) }
+  let!(:research_plan) { create(:research_plan, collections: [collection], creator: user) }
+
+  describe 'GET /api/v1/research_plans' do
+    context 'when collection_id is given' do
+      it 'returns the research plans in that collection' do
+        get '/api/v1/research_plans', params: { collection_id: collection.id }
+
+        expect(response).to have_http_status :ok
+        expect(parsed_json_response['research_plans'].pluck('id')).to contain_exactly(research_plan.id)
+      end
+    end
+
+    context 'when no collection_id is given (All)' do
+      it 'returns the research plans owned by the user instead of raising' do
+        get '/api/v1/research_plans'
+
+        expect(response).to have_http_status :ok
+        expect(parsed_json_response['research_plans'].pluck('id')).to contain_exactly(research_plan.id)
+      end
+    end
+
+    context 'when collection_id does not resolve (nonexistent or inaccessible)' do
+      it 'returns an empty list rather than an error' do
+        get '/api/v1/research_plans', params: { collection_id: collection.id + 1_000_000 }
+
+        expect(response).to have_http_status :ok
+        expect(parsed_json_response['research_plans']).to eq([])
+      end
+    end
+
+    context 'when collection_id points to a collection shared with the user' do
+      let(:other_user) { create(:person) }
+      let(:shared_collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare.permission_level(:read_elements))
+        end
+      end
+      let!(:shared_research_plan) { create(:research_plan, collections: [shared_collection], creator: other_user) }
+
+      it 'returns the research plans from the shared collection' do
+        get '/api/v1/research_plans', params: { collection_id: shared_collection.id }
+
+        expect(response).to have_http_status :ok
+        expect(parsed_json_response['research_plans'].pluck('id')).to include(shared_research_plan.id)
+      end
+    end
+  end
+end

--- a/spec/api/chemotion/sample_api_spec.rb
+++ b/spec/api/chemotion/sample_api_spec.rb
@@ -505,6 +505,16 @@ describe Chemotion::SampleAPI do
       end
     end
 
+    context 'when collection_id points to a collection shared with the user' do
+      let(:permission_level) { CollectionShare.permission_level(:read_elements) }
+      let!(:shared_sample) { create(:sample, collections: [shared_collection]) }
+
+      it 'returns the samples from the shared collection' do
+        get '/api/v1/samples', params: { collection_id: shared_collection.id }
+        expect(JSON.parse(response.body)['samples'].pluck('id')).to include(shared_sample.id)
+      end
+    end
+
     context 'when collection_id is given and no samples found' do
       let(:empty_collection) { create(:collection, label: 'empty collection', user: user) }
 

--- a/spec/api/chemotion/sample_api_spec.rb
+++ b/spec/api/chemotion/sample_api_spec.rb
@@ -505,6 +505,28 @@ describe Chemotion::SampleAPI do
       end
     end
 
+    context 'when a page mixes an owned-and-shared sample and a merely-shared sample' do
+      let(:other_users_collection) do
+        create(:collection, user: other_user).tap do |collection|
+          create(:collection_share, collection: collection, shared_with: user, sample_detail_level: 2)
+        end
+      end
+      let!(:owned_and_shared_sample) { create(:sample, collections: [other_users_collection, personal_collection]) }
+      let!(:shared_only_sample) { create(:sample, collections: [other_users_collection]) }
+
+      it 'applies the browsed (shared) collection detail level uniformly to every sample on the page' do
+        get '/api/v1/samples', params: { collection_id: other_users_collection.id }
+
+        samples = JSON.parse(response.body)['samples'].index_by { |s| s['id'] }
+        expect(samples.keys).to contain_exactly(owned_and_shared_sample.id, shared_only_sample.id)
+        # Even though owned_and_shared_sample also sits in the user's own personal_collection, it's
+        # being listed here via the *shared* collection, so it gets that collection's detail level —
+        # not the full access it would show if it were listed via personal_collection instead.
+        expect(samples[owned_and_shared_sample.id]['is_restricted']).to be true
+        expect(samples[shared_only_sample.id]['is_restricted']).to be true
+      end
+    end
+
     context 'when collection_id points to a collection shared with the user' do
       let(:permission_level) { CollectionShare.permission_level(:read_elements) }
       let!(:shared_sample) { create(:sample, collections: [shared_collection]) }

--- a/spec/api/chemotion/screen_api_spec.rb
+++ b/spec/api/chemotion/screen_api_spec.rb
@@ -71,6 +71,15 @@ describe Chemotion::ScreenAPI do
         end
       end
     end
+
+    context 'when collection_id points to a collection shared with the user' do
+      let!(:shared_screen) { create(:screen, collections: [other_shared_collection]) }
+
+      it 'returns the screens from the shared collection' do
+        get '/api/v1/screens', params: { collection_id: other_shared_collection.id }, headers: request_headers
+        expect(JSON.parse(response.body)['screens'].pluck('id')).to include(shared_screen.id)
+      end
+    end
   end
 
   describe 'GET /api/v1/screens/{id}' do

--- a/spec/api/chemotion/vessel_api_spec.rb
+++ b/spec/api/chemotion/vessel_api_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Chemotion::VesselAPI do
+  include_context 'api request authorization context'
+
+  let(:collection) { create(:collection, user: user) }
+  let!(:vessel) { create(:vessel, collections: [collection], creator: user) }
+
+  describe 'GET /api/v1/vessels' do
+    context 'when collection_id is given' do
+      it 'returns the vessels in that collection' do
+        get '/api/v1/vessels', params: { collection_id: collection.id }
+
+        expect(response).to have_http_status :ok
+        expect(parsed_json_response['vessels'].pluck('id')).to contain_exactly(vessel.id)
+      end
+    end
+
+    context 'when no collection_id is given (All)' do
+      it 'returns the vessels owned by the user instead of always returning none' do
+        get '/api/v1/vessels'
+
+        expect(response).to have_http_status :ok
+        expect(parsed_json_response['vessels'].pluck('id')).to contain_exactly(vessel.id)
+      end
+    end
+
+    context 'when collection_id does not resolve (nonexistent or inaccessible)' do
+      it 'returns an empty list rather than an error' do
+        get '/api/v1/vessels', params: { collection_id: collection.id + 1_000_000 }
+
+        expect(response).to have_http_status :ok
+        expect(parsed_json_response['vessels']).to eq([])
+      end
+    end
+
+    context 'when collection_id points to a collection shared with the user' do
+      let(:other_user) { create(:person) }
+      let(:shared_collection) do
+        create(:collection, user: other_user).tap do |c|
+          create(:collection_share, collection: c, shared_with: user,
+                                    permission_level: CollectionShare.permission_level(:read_elements))
+        end
+      end
+      let!(:shared_vessel) do
+        create(:vessel, collections: [shared_collection], creator: other_user,
+                        vessel_template: create(:vessel_template, name: 'Shared Vessel Template'))
+      end
+
+      it 'returns the vessels from the shared collection' do
+        get '/api/v1/vessels', params: { collection_id: shared_collection.id }
+
+        expect(response).to have_http_status :ok
+        expect(parsed_json_response['vessels'].pluck('id')).to include(shared_vessel.id)
+      end
+    end
+  end
+end

--- a/spec/api/chemotion/wellplate_api_spec.rb
+++ b/spec/api/chemotion/wellplate_api_spec.rb
@@ -103,6 +103,15 @@ describe Chemotion::WellplateAPI do
         expect(JSON.parse(response.body)['wellplates'].size).to eq(0)
       end
     end
+
+    context 'when collection_id points to a collection shared with the user' do
+      let!(:shared_wellplate) { create(:wellplate, collections: [collection_shared_with_user]) }
+
+      it 'returns the wellplates from the shared collection' do
+        get '/api/v1/wellplates/', params: { collection_id: collection_shared_with_user.id }
+        expect(JSON.parse(response.body)['wellplates'].pluck('id')).to include(shared_wellplate.id)
+      end
+    end
   end
 
   describe 'GET /api/v1/wellplates/:id' do

--- a/spec/services/element_detail_level_calculator_spec.rb
+++ b/spec/services/element_detail_level_calculator_spec.rb
@@ -92,16 +92,27 @@ describe ElementDetailLevelCalculator do
 
   describe '.for_list' do
     context 'when collection is given' do
-      it 'delegates to .for_collection' do
-        result = described_class.for_list(collection: owned_collection, user: user)
+      it 'delegates to .for_collection regardless of owned_only' do
+        result = described_class.for_list(collection: owned_collection, user: user, owned_only: true)
         expect(result).to eq described_class.for_collection(collection: owned_collection, user: user)
       end
     end
 
     context 'when collection is nil' do
-      it 'delegates to .owned_levels' do
-        expect(described_class.for_list(collection: nil, user: user)).to eq described_class.owned_levels
+      it 'delegates to .owned_levels when owned_only is true' do
+        result = described_class.for_list(collection: nil, user: user, owned_only: true)
+        expect(result).to eq described_class.owned_levels
       end
+
+      it 'raises when owned_only is not true' do
+        expect { described_class.for_list(collection: nil, user: user, owned_only: false) }
+          .to raise_error(ArgumentError, /owner-only/)
+      end
+    end
+
+    it 'requires the owned_only keyword' do
+      expect { described_class.for_list(collection: owned_collection, user: user) }
+        .to raise_error(ArgumentError, /owned_only/)
     end
   end
 end

--- a/spec/services/element_detail_level_calculator_spec.rb
+++ b/spec/services/element_detail_level_calculator_spec.rb
@@ -53,4 +53,55 @@ describe ElementDetailLevelCalculator do
       end
     end
   end
+
+  describe '.for_collection' do
+    context 'when the collection is owned by the user' do
+      it 'returns full access for every detail-level key' do
+        result = described_class.for_collection(collection: owned_collection, user: user)
+        expect(result[Sample]).to eq 10
+        expect(result[Reaction]).to eq 10
+        expect(result[Well]).to eq result[Wellplate]
+      end
+    end
+
+    context 'when the collection is shared with the user' do
+      it 'returns the configured detail levels, class-keyed' do
+        result = described_class.for_collection(collection: other_users_shared_collection, user: user)
+        expect(result[Sample]).to eq 2
+        expect(result[Reaction]).to eq 2
+        expect(result[Well]).to eq result[Wellplate]
+      end
+    end
+
+    context 'when the collection is neither owned nor shared with the user' do
+      it 'returns 0 for every detail-level key' do
+        result = described_class.for_collection(collection: other_users_unshared_collection, user: user)
+        expect(result.values.max).to eq 0
+      end
+    end
+  end
+
+  describe '.owned_levels' do
+    it 'returns full access for every detail-level key, without needing a collection' do
+      result = described_class.owned_levels
+      expect(result[Sample]).to eq 10
+      expect(result[Reaction]).to eq 10
+      expect(result[Well]).to eq result[Wellplate]
+    end
+  end
+
+  describe '.for_list' do
+    context 'when collection is given' do
+      it 'delegates to .for_collection' do
+        result = described_class.for_list(collection: owned_collection, user: user)
+        expect(result).to eq described_class.for_collection(collection: owned_collection, user: user)
+      end
+    end
+
+    context 'when collection is nil' do
+      it 'delegates to .owned_levels' do
+        expect(described_class.for_list(collection: nil, user: user)).to eq described_class.owned_levels
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Supersedes #3396. That PR batches the per-sample *owned*-collection check for
one endpoint (samples), which helps the common case but leaves the
*shared*-collection path just as slow, and doesn't touch the other 6 list
endpoints with the same problem. This PR instead resolves detail levels once
per page (not per element) for every affected endpoint, using the collection
the page was already fetched from — O(1) regardless of page size or access
path.

Benchmarked against the dev environment (100-item pages, `main` vs #3396 vs
this branch, owned vs shared collection access):

| Endpoint | Access | main | #3396 | this PR |
|---|---|---|---|---|
| samples | owned | 2192ms | 1363ms | 1416ms |
| samples | shared | 5396ms | 4693ms | **1340ms** |
| reactions | owned | 1175ms | 579ms | 322ms |
| reactions | shared | 4475ms | 3802ms | **218ms** |
| wellplates | owned | 768ms | 335ms | 254ms |
| wellplates | shared | 2273ms | 2027ms | **202ms** |

On the shared-collection path specifically — which #3396 doesn't
address — this PR is 10-17x faster than #3396, because #3396's batching only
covers the *owned* check; shared access still resolves
`shared_collections_with_element.maximum(key)` per element per key.

## What changed

1. **`fix(api): eliminate exception-driven collection lookup on list endpoints`**
   — samples, reactions, wellplates, screens, research plans, cell lines,
   device descriptions, and vessels each resolved `collection_id` via a
   hand-copied `begin`/`rescue ActiveRecord::RecordNotFound` block. Replaced
   with `CollectionHelpers#readable_collection_for` (a `find_by`-based
   helper mirroring the existing `writable_collection_for`) and, for 7 of
   the 8 endpoints, a shared `collection_scope_for` helper. Along the way
   this fixes two real bugs the duplicated boilerplate had drifted into:
   `research_plan_api.rb`'s "All" branch was raising `NoMethodError` (a
   dropped scope assignment), and `cell_line_api.rb`/`vessel_api.rb`'s "All"
   branch was always empty (a dead `.none.joins(...)` prefix).
2. **`perf(collections): resolve detail levels once per page, not per element`**
   — replaces the per-element `ElementDetailLevelCalculator.new(...)` call
   inside each pagination loop with a single `ElementDetailLevelCalculator.for_list`
   call before the loop, using the page's already-resolved collection.
   Trade-off: an element reached via a shared collection that's also
   independently owned elsewhere now shows that shared collection's level in
   the *list*, not full access — opening the individual element still
   resolves the accurate value via the unchanged per-element instance path.
3. Follow-up commits address review feedback: a blocking `Rails/OrderArguments`
   fix; `ElementDetailLevelCalculator`'s class map is now derived from
   `Collection::DETAIL_LEVEL_KEYS` so a future detail-level key with no
   matching entry fails loudly instead of silently reporting 0, and
   `for_list`'s "All" branch now takes a required `owned_only:` keyword so
   every call site has to declare that assumption explicitly; a shared
   sentence documents, once, that list entries are only partially serialized
   compared to fetching by id; `writable_collection_for`/`readable_collection_for`
   now share their lookup via `Collection.resolve_for`; and `reaction_api.rb`'s
   "All" branch — the only one of the 8 that resolved group-owned reactions
   too — was brought in line with the other 7 (traced to a likely-unintentional
   side effect of an unrelated commit back in March, not a deliberate
   reactions-specific decision).
4. **`perf(samples): eliminate N+1 queries in list-endpoint serialization`**
   (`1565cfe0ee`) — once the collection/detail-level cost above was equalized
   across endpoints, `GET /api/v1/samples` still measured 5-6x slower than
   `GET /api/v1/reactions` on an identically-sized page. Root cause:
   `Entities::SampleEntity` had four per-row N+1 sources `Entities::ReactionEntity`
   was already fixed for — `comment_count` used `.count` instead of `.size`
   (ignoring the preloaded `:comments` association), and `gas_type`/
   `gas_phase_data`/`weight_percentage`/`molecule_computed_props` each hit the
   DB separately per row because `reactions_samples` and `molecule.computed_props`
   weren't in `Sample.includes_for_list_display`. ~500 extra queries removed on
   a 100-row page. Plus **`perf(samples): stop double-counting the list-endpoint
   total`** (`dae71932e9`) — `samples_count` re-ran a count query
   `reset_pagination_page` had already computed. Benchmarked before/after on the
   same seeded dev collection: samples dropped from ~1200-1400ms to ~450-570ms
   (owned and shared both improve equally, confirming this was a per-row cost
   independent of access path).

Both commits include spec coverage for the behavior they change (collection_id
resolving shared collections, not just owned ones; a page mixing an
owned-and-shared element with a merely-shared one).

## Known follow-up (not in this PR)

Four other code paths still resolve detail levels per element in a loop —
`search_api.rb`, `usecases/search/shared_methods.rb`, `usecases/search/by_ids.rb`,
and `element_api.rb`'s `load_report` action. Each already resolves exactly one
collection per request, the same invariant this PR's batching relies on, so the
same once-per-page approach would be safe there too — but it trades an
element's true best access (owned-anywhere-or-shared-anywhere, as these paths
compute today) for the browsed collection's access only, the same trade-off
already accepted above. Three of the four already compute the needed
collection/detail-level hash once per request and just don't thread it down,
so that part is a smaller change than it looks; `load_report` specifically is
an export path where under-reporting access is more likely to surprise a user
than in a paginated list, so it may be worth a semantics-preserving
grouped-query alternative instead of the simple batching used here. Tracking
as a separate follow-up rather than expanding this PR's scope further.

## Test plan
- [x] `bundle exec rspec` on all 8 touched API specs + `element_detail_level_calculator_spec.rb` + `sample_entity_spec.rb` — 253+ examples, 0 failures, pre-existing pending only (unrelated TODOs)
- [x] `bundle exec rubocop` on all touched files — only pre-existing offenses (verified identical before/after this change)
- [x] Manually benchmarked owned vs. shared collection access for samples/reactions/wellplates against a seeded dev DB (see table above)

---
*Note added post-merge: commits `1565cfe0ee`/`dae71932e9` (item 4 above) were
pushed after this PR's squash-merge commit message on `main` had already been
finalized, so that commit message covers items 1-3 only. This description was
updated afterward to keep the full picture in one place — see the PR's commit
list for the actual, complete diff.*
