### PR TITLE
feat(molecules): on-demand PubChem refresh from the sample UI

### DIFF
--- a/app/api/chemotion/molecule_api.rb
+++ b/app/api/chemotion/molecule_api.rb
@@ -217,6 +217,28 @@ module Chemotion
         present molecule, with: Entities::MoleculeEntity
       end
 
+      desc 'Requery PubChem for this molecule (on-demand refresh of cid/iupac_name/names)'
+      params do
+        requires :id, type: Integer, desc: 'Molecule ID'
+      end
+      post :refresh do
+        # A molecule row is global, shared by every user who ever drew that structure, and
+        # this endpoint both mutates it and makes an outbound PubChem request — so it takes
+        # the same molecule_editor gate as the other molecule-mutating endpoints here.
+        error!({ msg: { level: 'error', message: '401 Unauthorized' } }, 401) unless current_user&.molecule_editor
+
+        molecule = Molecule.find(params[:id])
+        # enrich_from_pubchem, not refresh_molecule_data: it persists the cid atomically via
+        # #assign_pubchem_names_and_cid! (a plain save! would not — element_tags is a has_one
+        # without autosave:, so a taggable_data-only change never reaches the database), it
+        # leaves the structure fields alone rather than re-deriving them from an already
+        # normalised molfile, and it writes no new SVG per call.
+        molecule.enrich_from_pubchem
+        present molecule.reload, with: Entities::MoleculeEntity
+      rescue StandardError => e
+        error!({ msg: { level: 'error', message: e.message } }, 500)
+      end
+
       desc 'return names of the molecule'
       params do
         requires :id, type: String, desc: 'Molecule id'

--- a/app/api/entities/molecule_entity.rb
+++ b/app/api/entities/molecule_entity.rb
@@ -28,8 +28,19 @@ module Entities
 
     expose :ob_log, unless: ->(instance, options) { options[:ob_log].nil? }
 
+    expose :pubchem_cid
+
     def temp_svg
       options[:temp_svg]
+    end
+
+    # At sample detail level 0 {Entities::SampleEntity#molecule} represents a plain Hash of
+    # two keys instead of a Molecule, so guard like #molfile does — plainly +expose+d
+    # attributes yield nil for a missing Hash key, but a model call would raise.
+    def pubchem_cid
+      return unless object.respond_to?(:tag)
+
+      object.tag&.taggable_data&.fetch('pubchem_cid', nil)
     end
 
     def ob_log

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -209,6 +209,20 @@ export default class SampleForm extends React.Component {
     );
   }
 
+  refreshMoleculeButton() {
+    const { sample } = this.props;
+    return (
+      <Button
+        onClick={() => DetailActions.refreshMoleculeData(sample)}
+        disabled={!sample.can_update}
+        variant="light"
+        title="Requery PubChem for this molecule"
+      >
+        <i className="icon-pubchem" />
+      </Button>
+    );
+  }
+
   // Info button display info message when one hover over it
   infoButton() {
     return (
@@ -433,6 +447,7 @@ export default class SampleForm extends React.Component {
             className={`flex-grow-1${molNameInvalid ? ' is-invalid' : ''}`}
           />
           {this.structureEditorButton(!sample.can_update)}
+          {this.refreshMoleculeButton()}
           {molNameInvalid && (
             <Form.Control.Feedback type="invalid" style={{ display: 'block' }}>
               Name contains invalid characters (control or invisible characters are not allowed).

--- a/app/javascript/src/components/pubchem/PubchemLabels.js
+++ b/app/javascript/src/components/pubchem/PubchemLabels.js
@@ -1,26 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'react-bootstrap';
+import DetailActions from 'src/stores/alt/actions/DetailActions';
 
 function PubchemLabels({ element }) {
   const cid = element.pubchem_tag && element.pubchem_tag.pubchem_cid;
+  const canRefresh = element.can_update;
   const handleOnClick = (e) => {
     if (cid) {
       window.open(`https://pubchem.ncbi.nlm.nih.gov/compound/${cid}`, '_blank');
+    } else if (canRefresh) {
+      DetailActions.refreshMoleculeData(element);
     }
     e.stopPropagation();
   };
+  const title = () => {
+    if (cid) { return `PubChem CID: ${cid}`; }
+    if (canRefresh) { return 'No PubChem CID assigned — click to check PubChem again'; }
+    return 'No PubChem CID assigned';
+  };
   return (
     <Button
-      disabled={!cid}
+      disabled={!element.molecule?.id || (!cid && !canRefresh)}
       variant="neat"
       size="md"
       onClick={handleOnClick}
-      title={
-        cid
-          ? `PubChem CID: ${cid}`
-          : 'No PubChem CID assigned'
-      }
+      title={title()}
     >
       <i className="icon-pubchem" />
     </Button>

--- a/app/javascript/src/components/pubchem/PubchemLabels.js
+++ b/app/javascript/src/components/pubchem/PubchemLabels.js
@@ -19,9 +19,12 @@ function PubchemLabels({ element }) {
     if (canRefresh) { return 'No PubChem CID assigned — click to check PubChem again'; }
     return 'No PubChem CID assigned';
   };
+  // Only the refresh path needs a molecule id. Opening the PubChem page needs just the cid,
+  // which SampleEntity still exposes at detail level 0 — where `molecule` is a two-key hash
+  // with no id, so requiring one here would take the link away from shared-collection viewers.
   return (
     <Button
-      disabled={!element.molecule?.id || (!cid && !canRefresh)}
+      disabled={cid ? false : !(canRefresh && element.molecule?.id)}
       variant="neat"
       size="md"
       onClick={handleOnClick}

--- a/app/javascript/src/fetchers/MoleculesFetcher.js
+++ b/app/javascript/src/fetchers/MoleculesFetcher.js
@@ -62,6 +62,10 @@ export default class MoleculesFetcher {
     return ApiClient.postJson('/api/v1/molecules/decouple', { body: { molfile, svg_name: svgfile, decoupled } });
   }
 
+  static refresh(id) {
+    return ApiClient.postJson('/api/v1/molecules/refresh', { body: { id } });
+  }
+
   static calculateMolecularMassFromSumFormula(molecularFormula) {
     const encodedMolecularFormula = encodeURIComponent(molecularFormula);
     return ApiClient.getJson(`/api/v1/molecules/molecular_weight?molecular_formula=${encodedMolecularFormula}`);

--- a/app/javascript/src/stores/alt/actions/DetailActions.js
+++ b/app/javascript/src/stores/alt/actions/DetailActions.js
@@ -1,6 +1,7 @@
 import alt from 'src/stores/alt/alt'
 import _ from 'lodash'
 import MoleculesFetcher from 'src/fetchers/MoleculesFetcher'
+import { rootStore } from 'src/stores/mobx/RootStore';
 
 class DetailActions {
   select(index) {
@@ -32,13 +33,24 @@ class DetailActions {
   }
 
   refreshMoleculeData(sample) {
-    const id = sample.molecule.id;
+    const { id } = sample.molecule;
     if (!id) { return null; }
 
     return (dispatch) => {
       MoleculesFetcher
         .refresh(id)
         .then((result) => {
+          // An error envelope is not a molecule: spreading it would overwrite molecule.id and
+          // iupac_name with undefined, and blank a perfectly good cid label.
+          if (!result || result.msg) {
+            rootStore.notificationsStore.add({
+              title: 'PubChem refresh failed',
+              message: result?.msg?.message || 'No response from the server',
+              level: 'error',
+              position: 'tc',
+            });
+            return;
+          }
           sample.molecule = { ...sample.molecule, ...result };
           sample.pubchem_tag = { ...sample.pubchem_tag, pubchem_cid: result.pubchem_cid };
           dispatch(sample);
@@ -48,7 +60,7 @@ class DetailActions {
   }
 
   updateMoleculeNames(sample, newMolName = '') {
-    const id = sample.molecule.id;
+    const { id } = sample.molecule;
     if (!id) { return null; }
 
     return (dispatch) => {

--- a/app/javascript/src/stores/alt/actions/DetailActions.js
+++ b/app/javascript/src/stores/alt/actions/DetailActions.js
@@ -31,6 +31,22 @@ class DetailActions {
     }
   }
 
+  refreshMoleculeData(sample) {
+    const id = sample.molecule.id;
+    if (!id) { return null; }
+
+    return (dispatch) => {
+      MoleculesFetcher
+        .refresh(id)
+        .then((result) => {
+          sample.molecule = { ...sample.molecule, ...result };
+          sample.pubchem_tag = { ...sample.pubchem_tag, pubchem_cid: result.pubchem_cid };
+          dispatch(sample);
+        })
+        .catch(errorMessage => console.log(errorMessage));
+    };
+  }
+
   updateMoleculeNames(sample, newMolName = '') {
     const id = sample.molecule.id;
     if (!id) { return null; }

--- a/app/javascript/src/stores/alt/stores/ElementStore.js
+++ b/app/javascript/src/stores/alt/stores/ElementStore.js
@@ -1575,6 +1575,11 @@ class ElementStore {
   handleRefreshMoleculeData(updatedSample) {
     const { selecteds } = this.state;
     const index = this.elementIndex(selecteds, updatedSample);
+    // Unlike the other refresh handlers, this one is reachable from the element list
+    // (SampleGroupMoleculeHeader), where the sample usually has no open detail tab. With
+    // index -1, updateElement's slice(0, -1) would drop the last open tab and slice(0)
+    // re-append everything, doubling selecteds.
+    if (index === -1) { return; }
     const newSelecteds = this.updateElement(updatedSample, index);
     this.setState({ selecteds: newSelecteds });
   }

--- a/app/javascript/src/stores/alt/stores/ElementStore.js
+++ b/app/javascript/src/stores/alt/stores/ElementStore.js
@@ -296,6 +296,7 @@ class ElementStore {
       handleConfirmDelete: DetailActions.confirmDelete,
       handleChangeCurrentElement: DetailActions.changeCurrentElement,
       handleGetMoleculeCas: DetailActions.getMoleculeCas,
+      handleRefreshMoleculeData: DetailActions.refreshMoleculeData,
       handleUpdateMoleculeNames: DetailActions.updateMoleculeNames,
       handleUpdateMoleculeCas: DetailActions.updateMoleculeCas,
       handleUpdateLinkedElement: [
@@ -1565,6 +1566,13 @@ class ElementStore {
   }
 
   handleGetMoleculeCas(updatedSample) {
+    const { selecteds } = this.state;
+    const index = this.elementIndex(selecteds, updatedSample);
+    const newSelecteds = this.updateElement(updatedSample, index);
+    this.setState({ selecteds: newSelecteds });
+  }
+
+  handleRefreshMoleculeData(updatedSample) {
     const { selecteds } = this.state;
     const index = this.elementIndex(selecteds, updatedSample);
     const newSelecteds = this.updateElement(updatedSample, index);

--- a/app/jobs/concerns/pubchem_rate_limit_guard.rb
+++ b/app/jobs/concerns/pubchem_rate_limit_guard.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-# Shared concurrency guard for jobs that call out to PubChem's rate-limited LCSS
-# endpoint. PubchemLookupJob and PubchemLcssJob must never run at the same time
-# as each other, or as another instance of themselves.
+# Shared concurrency guard for jobs that call out to PubChem's rate-limited endpoints.
+# PubchemLookupJob, PubchemLcssJob, and PubchemCidJob all hit the same PubChem rate
+# limit (LCSS and CID/name lookups alike), so none of them may run at the same time as
+# each other, or as another instance of themselves.
 module PubchemRateLimitGuard
   extend ActiveSupport::Concern
 
-  GUARDED_JOB_CLASSES = %w[PubchemLcssJob PubchemLookupJob].freeze
+  GUARDED_JOB_CLASSES = %w[PubchemLcssJob PubchemLookupJob PubchemCidJob].freeze
   REQUEUE_DELAY = 15.minutes
 
   private

--- a/app/jobs/concerns/pubchem_rate_limit_guard.rb
+++ b/app/jobs/concerns/pubchem_rate_limit_guard.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 # Shared concurrency guard for jobs that call out to PubChem's rate-limited LCSS
-# endpoint. PubchemSingleLcssJob and PubchemLcssJob must never run at the same time
+# endpoint. PubchemLookupJob and PubchemLcssJob must never run at the same time
 # as each other, or as another instance of themselves.
 module PubchemRateLimitGuard
   extend ActiveSupport::Concern
 
-  GUARDED_JOB_CLASSES = %w[PubchemLcssJob PubchemSingleLcssJob].freeze
+  GUARDED_JOB_CLASSES = %w[PubchemLcssJob PubchemLookupJob].freeze
   REQUEUE_DELAY = 15.minutes
 
   private

--- a/app/jobs/pubchem_cid_job.rb
+++ b/app/jobs/pubchem_cid_job.rb
@@ -46,10 +46,28 @@ class PubchemCidJob < ApplicationJob
       sleep sleep_time
     end
 
-    requeue_next_chunk(sleep_time: sleep_time, batch_size: batch_size, chunk_size: chunk_size, last_id: last_id)
+    continue_or_chain(sleep_time: sleep_time, batch_size: batch_size,
+                      chunk_size: chunk_size, last_id: last_id)
   end
 
   private
+
+  # Triggers PubchemLcssJob once the rotation has drained, instead of leaving it on its own
+  # independently-scheduled cron cadence.
+  #
+  # Only fired on the final chunk. Firing per chunk enqueued one LCSS rotation per chunk with
+  # overlapping id ranges — a 50k-molecule backlog produced ~50 of them — and since
+  # PubchemRateLimitGuard serialises all PubChem jobs, all but one spent their lives bouncing
+  # on a 15-minute REQUEUE_DELAY, which in turn kept colliding with CID's own continuations
+  # and slowed the rotation it was meant to follow.
+  #
+  # start_id: 0 because by this point the whole range has been swept, so LCSS should scan it
+  # all rather than resume from a cursor into it.
+  def chain_lcss
+    return if ENV.fetch('CRON_CONFIG_PC_LCSS', nil) == 'disabled'
+
+    PubchemLcssJob.perform_later(start_id: 0)
+  end
 
   def pending_scope(after_id:)
     Molecule.select(:id, :inchikey).joins(:samples)
@@ -61,12 +79,19 @@ class PubchemCidJob < ApplicationJob
             .distinct
   end
 
-  # Requeues a one-off continuation carrying the rotation cursor (+last_id+) forward
-  # when pending molecules remain beyond it. If none remain, does nothing — the next
-  # cron tick fires with its fixed default args (start_id: 0) and starts over.
-  def requeue_next_chunk(sleep_time:, batch_size:, chunk_size:, last_id:)
-    return unless pending_scope(after_id: last_id).exists?
+  # Carries the rotation forward while molecules remain beyond +last_id+, and hands over to
+  # LCSS once it has drained. Exactly one of the two happens per run.
+  def continue_or_chain(sleep_time:, batch_size:, chunk_size:, last_id:)
+    if pending_scope(after_id: last_id).exists?
+      requeue_next_chunk(sleep_time: sleep_time, batch_size: batch_size,
+                         chunk_size: chunk_size, last_id: last_id)
+    else
+      chain_lcss
+    end
+  end
 
+  # Requeues a one-off continuation carrying the rotation cursor (+last_id+) forward.
+  def requeue_next_chunk(sleep_time:, batch_size:, chunk_size:, last_id:)
     self.class.set(wait: sleep_time.seconds)
         .perform_later(sleep_time: sleep_time, batch_size: batch_size,
                        chunk_size: chunk_size, start_id: last_id)

--- a/app/jobs/pubchem_cid_job.rb
+++ b/app/jobs/pubchem_cid_job.rb
@@ -4,52 +4,71 @@
 # associated CID (molecule tag) and iupac names (molecule_names) are updated if
 # inchikey found in PC db
 class PubchemCidJob < ApplicationJob
+  include PubchemRateLimitGuard
+
   queue_as :pubchem
+
+  # max molecules processed in a single invocation before requeuing a follow-up
+  # to continue from where this run left off — mirrors PubchemLcssJob's rotation design
+  CHUNK_SIZE = 1000
 
   # NB: PC has request restriction policy and timeout , hence the sleep_time and batch_size params
   # see http://pubchemdocs.ncbi.nlm.nih.gov/programmatic-access$_RequestVolumeLimitations
-  def perform(sleep_time: 10, batch_size: 10)
+  #
+  # @param start_id [Integer] resume point (exclusive) — only molecules with id > start_id
+  #   are considered. Together with the self-requeue below this rotates full coverage of
+  #   all pending molecules across successive runs instead of always restarting from the
+  #   newest end of the id range (the previous `order: :desc`, wall-clock-only cutoff could
+  #   starve older backlogged molecules indefinitely once the pending set outgrew a single
+  #   2-hour run).
+  def perform(sleep_time: 10, batch_size: 10, chunk_size: CHUNK_SIZE, start_id: 0)
+    if other_pubchem_job_running?
+      self.class.set(wait: PubchemRateLimitGuard::REQUEUE_DELAY)
+          .perform_later(sleep_time: sleep_time, batch_size: batch_size,
+                         chunk_size: chunk_size, start_id: start_id)
+      return
+    end
+
     t_limit = 2.hours.from_now
+    last_id = start_id
+    processed = 0
+
+    pending_scope(after_id: start_id).find_in_batches(batch_size: batch_size) do |batch|
+      pb_info = Chemotion::PubchemService.molecule_info_from_inchikeys(batch.map(&:inchikey))
+      pb_info.each do |obj|
+        Molecule.find_by(inchikey: obj[:inchikey], is_partial: false)&.assign_pubchem_names_and_cid!(obj)
+      end
+
+      last_id = batch.last.id
+      processed += batch.size
+      break if processed >= chunk_size || Time.zone.now > t_limit
+
+      sleep sleep_time
+    end
+
+    requeue_next_chunk(sleep_time: sleep_time, batch_size: batch_size, chunk_size: chunk_size, last_id: last_id)
+  end
+
+  private
+
+  def pending_scope(after_id:)
     Molecule.select(:id, :inchikey).joins(:samples)
             .joins("inner join element_tags et on et.taggable_id = molecules.id and et.taggable_type = 'Molecule'")
             .where(is_partial: false)
             .where("et.taggable_data->>'pubchem_cid' isnull")
+            .where('molecules.id > ?', after_id)
+            .order(:id)
             .distinct
-            .find_in_batches(batch_size: batch_size, order: :desc) do |batch|
-      iks = batch.map(&:inchikey)
+  end
 
-      ## This updates only cid
-      # json = JSON.parse(PubChem.get_cids_from_inchikeys(iks))
-      # props = json.dig('PropertyTable', 'Properties')
-      # return nil unless prop.is_a?(Array)
-      # props.each do |obj|
-      #   m = Molecule.find_by(inchikey: obj["InChIKey"], is_partial: false)
-      #   et = m.tag
-      #   data = et.taggable_data || {}
-      #   data["pubchem_cid"] = obj["CID"]
-      #   et.update_columns!(taggable_data: data)
-      # end
+  # Requeues a one-off continuation carrying the rotation cursor (+last_id+) forward
+  # when pending molecules remain beyond it. If none remain, does nothing — the next
+  # cron tick fires with its fixed default args (start_id: 0) and starts over.
+  def requeue_next_chunk(sleep_time:, batch_size:, chunk_size:, last_id:)
+    return unless pending_scope(after_id: last_id).exists?
 
-      ## This updates both the molecule cid and names
-      pb_info = Chemotion::PubchemService.molecule_info_from_inchikeys(iks)
-      pb_info.each do |obj|
-        m = Molecule.find_by(inchikey: obj[:inchikey], is_partial: false)
-        m.update_columns(iupac_name: obj[:iupac_name]) if m.iupac_name.blank?
-        et = m.tag
-        data = et.taggable_data || {}
-        data['pubchem_cid'] = obj[:cid]
-        et.update_columns(taggable_data: data)
-        obj[:names].each do |name|
-          MoleculeName.find_or_create_by(
-            molecule_id: m.id,
-            name: name,
-            description: 'iupac_name',
-          )
-        end
-      end
-      return if Time.zone.now > t_limit
-
-      sleep sleep_time
-    end
+    self.class.set(wait: sleep_time.seconds)
+        .perform_later(sleep_time: sleep_time, batch_size: batch_size,
+                       chunk_size: chunk_size, start_id: last_id)
   end
 end

--- a/app/jobs/pubchem_lcss_job.rb
+++ b/app/jobs/pubchem_lcss_job.rb
@@ -59,8 +59,9 @@ class PubchemLcssJob < ApplicationJob
   end
 
   # Requeues a one-off continuation carrying the rotation cursor (+last_id+) forward
-  # when pending molecules remain beyond it. If none remain, does nothing — the next
-  # weekly cron tick fires with its fixed default args (start_id: 0) and starts over.
+  # when pending molecules remain beyond it. If none remain, does nothing — this job has
+  # no independent cron schedule of its own; PubchemCidJob chains a fresh run (start_id: 0)
+  # at the end of its own cron cadence (see PubchemCidJob#chain_lcss).
   def requeue_next_chunk(sleep_time:, batch_size:, chunk_size:, last_id:)
     return unless pending_scope(after_id: last_id).exists?
 

--- a/app/jobs/pubchem_lookup_job.rb
+++ b/app/jobs/pubchem_lookup_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Per-molecule PubChem enrichment job, scheduled for every newly created molecule via
+# Per-molecule PubChem lookup job, scheduled for every newly created molecule via
 # Molecule.schedule_lcss_batch (directly for batch imports, or via the after_create_commit
 # :get_lcss hook). For each molecule it enriches names/iupac/cid from PubChem (see
 # Molecule#enrich_from_pubchem) and then updates the LCSS molecule tag. This is where the
@@ -33,26 +33,47 @@ class PubchemLookupJob < ApplicationJob
     return if ids.blank? && created_after.blank?
 
     if other_pubchem_job_running?
-      self.class.set(wait: PubchemRateLimitGuard::REQUEUE_DELAY)
-          .perform_later(ids, type: type, created_after: created_after,
-                              chunk_size: chunk_size, start_id: start_id)
-      return
+      return requeue_after_collision(ids, type: type, created_after: created_after,
+                                          chunk_size: chunk_size, start_id: start_id)
     end
 
-    molecule_ids = ids.present? && type.to_sym == :samples ? resolve_sample_molecule_ids(ids) : ids
+    molecule_ids = resolve_ids(ids, type)
     molecules = resolve_molecules(molecule_ids, created_after: created_after,
                                                 start_id: start_id, chunk_size: chunk_size)
-
-    molecules.each_with_index do |molecule, i|
-      sleep SLEEP_BETWEEN_REQUESTS if i.positive?
-      # Enrich (iupac_name/names/cid) before LCSS so the cid is already persisted and
-      # Molecule#pubchem_lcss doesn't fall back to its own get_cid_from_inchikey lookup.
-      molecule.enrich_from_pubchem
-      molecule.pubchem_lcss
-    end
     return if molecules.empty?
 
-    last_id = molecules.last.id
+    enrich_each(molecules)
+    continue_after(molecules.last.id, molecule_ids,
+                   created_after: created_after, chunk_size: chunk_size)
+  end
+
+  private
+
+  # A sibling PubChem job holds the rate-limit guard — retry after the standard backoff
+  # rather than competing for the same request budget.
+  def requeue_after_collision(ids, type:, created_after:, chunk_size:, start_id:)
+    self.class.set(wait: PubchemRateLimitGuard::REQUEUE_DELAY)
+        .perform_later(ids, type: type, created_after: created_after,
+                            chunk_size: chunk_size, start_id: start_id)
+  end
+
+  # @return [Array<Integer>, nil] molecule ids — +ids+ as given, or the molecule ids they
+  #   reference when the caller passed sample ids
+  def resolve_ids(ids, type)
+    return ids unless ids.present? && type.to_sym == :samples
+
+    resolve_sample_molecule_ids(ids)
+  end
+
+  def enrich_each(molecules)
+    molecules.each_with_index do |molecule, i|
+      sleep SLEEP_BETWEEN_REQUESTS if i.positive?
+      enrich_and_fetch_lcss(molecule)
+    end
+  end
+
+  # Picks up where this run stopped when +chunk_size+ cut the pending set short.
+  def continue_after(last_id, molecule_ids, created_after:, chunk_size:)
     return unless more_pending?(molecule_ids, created_after: created_after, after_id: last_id)
 
     # No wait — this isn't a collision backoff, just more work to continue with.
@@ -60,7 +81,17 @@ class PubchemLookupJob < ApplicationJob
                                            chunk_size: chunk_size, start_id: last_id)
   end
 
-  private
+  # pending_scope only filters on pubchem_lcss being unset, not on cid — a molecule can
+  # arrive here already enriched (e.g. PubchemCidJob's global sweep beat this job to it).
+  # Chain the two PubChem calls instead of always firing both: skip the full molecule-info
+  # fetch when a cid is already known, then only fetch LCSS when a cid actually exists —
+  # otherwise Molecule#pubchem_lcss's own cid fallback (get_cid_from_inchikey) would
+  # immediately re-ask PubChem the same "does this inchikey resolve?" question
+  # enrich_from_pubchem just answered.
+  def enrich_and_fetch_lcss(molecule)
+    molecule.enrich_from_pubchem unless molecule.pubchem_check
+    molecule.pubchem_lcss if molecule.pubchem_check
+  end
 
   def resolve_sample_molecule_ids(sample_ids)
     Sample.where(id: sample_ids).where.not(molecule_id: nil).distinct.pluck(:molecule_id)

--- a/app/jobs/pubchem_lookup_job.rb
+++ b/app/jobs/pubchem_lookup_job.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
-# Job to update molecule info for molecules with no LCSS
-# associated LCSS (molecule tag) is updated if cid found in PC db
+# Per-molecule PubChem enrichment job, scheduled for every newly created molecule via
+# Molecule.schedule_lcss_batch (directly for batch imports, or via the after_create_commit
+# :get_lcss hook). For each molecule it enriches names/iupac/cid from PubChem (see
+# Molecule#enrich_from_pubchem) and then updates the LCSS molecule tag. This is where the
+# PubChem network work moved to after it was removed from the synchronous create path.
 class PubchemLookupJob < ApplicationJob
   include PubchemRateLimitGuard
 
@@ -42,6 +45,9 @@ class PubchemLookupJob < ApplicationJob
 
     molecules.each_with_index do |molecule, i|
       sleep SLEEP_BETWEEN_REQUESTS if i.positive?
+      # Enrich (iupac_name/names/cid) before LCSS so the cid is already persisted and
+      # Molecule#pubchem_lcss doesn't fall back to its own get_cid_from_inchikey lookup.
+      molecule.enrich_from_pubchem
       molecule.pubchem_lcss
     end
     return if molecules.empty?

--- a/app/jobs/pubchem_lookup_job.rb
+++ b/app/jobs/pubchem_lookup_job.rb
@@ -2,10 +2,10 @@
 
 # Job to update molecule info for molecules with no LCSS
 # associated LCSS (molecule tag) is updated if cid found in PC db
-class PubchemSingleLcssJob < ApplicationJob
+class PubchemLookupJob < ApplicationJob
   include PubchemRateLimitGuard
 
-  queue_as :single_pubchem_lcss
+  queue_as :pubchem_lookup
 
   # NB: PC has request restriction policy, hence the sleep — matches the
   # spacing already used by the sibling cron batch job, PubchemLcssJob.

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -119,7 +119,11 @@ module Taggable
     return nil unless is_a?(Molecule)
     return tag.taggable_data['pubchem_cid'] if pubchem_check
 
-    pcid.presence || PubChem.get_cid_from_inchikey(inchikey)
+    # No synchronous network fallback here: the tag's pubchem_cid is backfilled asynchronously
+    # by the enrich job (PubchemLookupJob#enrich_from_pubchem) / PubchemCidJob, so molecule
+    # saves never block on a PubChem request. pcid is still honoured for the synchronous
+    # refresh_molecule_data path. On-demand cid lookups remain available via Molecule#cid.
+    pcid.presence
   end
 
   def user_labels

--- a/app/models/molecule.rb
+++ b/app/models/molecule.rb
@@ -371,7 +371,11 @@ class Molecule < ApplicationRecord
 
   def assign_pubchem_data(pubchem_info)
     self.iupac_name = pubchem_info[:iupac_name]
-    self.names = pubchem_info[:names]
+    # Array(...) rather than a bare assignment: with enrichment deferred, pubchem_info is {}
+    # on the create path, and assigning nil sends an explicit NULL that bypasses the column's
+    # default([]). Readers index into it without a nil guard (e.g. ChemicalAPI's
+    # +molecule.names[0]+ when fetching a safety datasheet by common name).
+    self.names = Array(pubchem_info[:names])
     self.pcid = pubchem_info[:cid]
   end
 

--- a/app/models/molecule.rb
+++ b/app/models/molecule.rb
@@ -111,11 +111,36 @@ class Molecule < ApplicationRecord
     formula = SumFormula.new(formula).remove_fragment('CH3').valid.to_s if is_partial
     molecule = Molecule.find_by(inchikey: inchikey, is_partial: is_partial, sum_formular: formula)
     if molecule.nil?
-      molecule = Molecule.create(inchikey: inchikey, is_partial: is_partial, sum_formular: formula) do |mol|
-        mol.skip_lcss_callback = true if defer_lcss
-        pubchem_info = Chemotion::PubchemService.molecule_info_from_inchikey(inchikey)
-        mol.molfile = (is_partial && partial_molfile) || molfile
-        mol.assign_molecule_data(babel_info, pubchem_info, molfile)
+      begin
+        # requires_new: true so the losing INSERT rolls back to a savepoint rather than
+        # poisoning an enclosing transaction. Most callers run inside one — Sample's
+        # before_save :find_or_create_molecule, Import::ImportSamples#write_to_db,
+        # Import::ImportCollections#import — and without the savepoint a real
+        # PG::UniqueViolation aborts that outer transaction, so the rescue's re-find below
+        # would itself raise PG::InFailedSqlTransaction and take the whole import with it.
+        #
+        # PubChem enrichment (iupac_name/names/cid) is deferred to the async enrich job
+        # (see .schedule_lcss_batch / .schedule_lcss_since / PubchemLookupJob) so no
+        # network call sits in the create/transaction critical section; create with
+        # babel-only data here. svg_molfile is still passed explicitly as the original
+        # (pre-partial-substitution) molfile so is_partial SVGs render from the R-group
+        # molfile rather than mol.molfile's CH3-substituted partial_molfile.
+        molecule = ActiveRecord::Base.transaction(requires_new: true) do
+          Molecule.create(inchikey: inchikey, is_partial: is_partial, sum_formular: formula) do |mol|
+            mol.skip_lcss_callback = true if defer_lcss
+            mol.molfile = (is_partial && partial_molfile) || molfile
+            mol.assign_molecule_data(babel_info, {}, molfile)
+          end
+        end
+      rescue ActiveRecord::RecordNotUnique
+        # A concurrent worker created the same molecule between our find_by and insert; re-find
+        # its row instead of letting PG::UniqueViolation abort the whole import
+        # (index_molecules_on_formula_and_inchikey_and_is_partial). Nothing to schedule from
+        # this losing call: the winning create's own after_create_commit hook (or the
+        # caller's schedule_lcss_since flush, when defer_lcss is set) already covers
+        # enrichment/LCSS for this row regardless of which concurrent call created it.
+        molecule = Molecule.find_by(inchikey: inchikey, is_partial: is_partial, sum_formular: formula)
+        raise if molecule.nil?
       end
     end
     molecule.ob_log = babel_info[:ob_log]
@@ -178,6 +203,54 @@ class Molecule < ApplicationRecord
     end
 
     mol_tag_data['pubchem_lcss']
+  end
+
+  # Idempotently persists PubChem-derived names/cid onto this molecule. Shared by the async
+  # per-molecule enrichment ({PubchemLookupJob}) and the periodic batch backfill
+  # ({PubchemCidJob}), so the write semantics are identical whichever path runs. Repeated calls
+  # are safe: +iupac_name+ is only set when blank, molecule names are found-or-created, and an
+  # existing +pubchem_cid+ is never overwritten with nil. The +pubchem_cid+ write is an atomic
+  # JSONB merge rather than a read/modify/write of the whole +taggable_data+ hash, so it can't
+  # itself clobber an unrelated key (e.g. +user_labels+, +chemrepo_id+) written concurrently by
+  # another path — those other writers still replace the full hash, though, so the reverse
+  # (them clobbering this key) isn't ruled out without touching {Taggable#update_tag} too.
+  #
+  # @param info [Hash] +{ cid:, iupac_name:, names: }+ as returned by
+  #   {Chemotion::PubchemService.molecule_info_from_inchikey}
+  # @return [void]
+  # rubocop:disable Rails/SkipsModelValidations
+  def assign_pubchem_names_and_cid!(info)
+    return if info.blank?
+
+    update_columns(iupac_name: info[:iupac_name]) if iupac_name.blank? && info[:iupac_name].present?
+
+    if info[:cid].present?
+      et = tag
+      ElementTag.where(id: et.id).update_all(
+        ["taggable_data = COALESCE(taggable_data, '{}'::jsonb) || jsonb_build_object('pubchem_cid', ?::jsonb)",
+         info[:cid].to_json],
+      )
+      # Mirror the merge onto the already-loaded association in memory (update_all bypasses
+      # it) so an immediate caller-side read — e.g. PubchemLookupJob#enrich_and_fetch_lcss
+      # checking pubchem_check right after this returns — sees the cid without a reload.
+      et.taggable_data = (et.taggable_data || {}).merge('pubchem_cid' => info[:cid])
+    end
+
+    Array(info[:names]).each do |name|
+      MoleculeName.find_or_create_by(molecule_id: id, name: name, description: 'iupac_name')
+    end
+  end
+  # rubocop:enable Rails/SkipsModelValidations
+
+  # Fetches PubChem data for this molecule's inchikey and persists it via
+  # {#assign_pubchem_names_and_cid!}. Performs a network call — intended for background jobs,
+  # not the synchronous create path (that is exactly what C2 moved off the request/import path).
+  #
+  # @return [void]
+  def enrich_from_pubchem
+    return if inchikey.blank?
+
+    assign_pubchem_names_and_cid!(Chemotion::PubchemService.molecule_info_from_inchikey(inchikey))
   end
 
   def chem_repo

--- a/app/models/molecule.rb
+++ b/app/models/molecule.rb
@@ -234,7 +234,7 @@ class Molecule < ApplicationRecord
     molecule_names.create(name: sum_formular, description: 'sum_formular')
   end
 
-  # Schedules a single PubchemSingleLcssJob for the given ids, re-querying
+  # Schedules a single PubchemLookupJob for the given ids, re-querying
   # first so only molecules that actually still exist get scheduled (e.g. a
   # caller's own transaction rolling back after collecting some ids into its
   # lcss_batch array shouldn't schedule a job for rows that never persisted).
@@ -244,14 +244,14 @@ class Molecule < ApplicationRecord
     existing_ids = Molecule.where(id: molecule_ids).pluck(:id)
     return if existing_ids.blank?
 
-    PubchemSingleLcssJob.perform_later(existing_ids)
+    PubchemLookupJob.perform_later(existing_ids)
   end
 
   def get_lcss
     self.class.schedule_lcss_batch([id])
   end
 
-  # Schedules a PubchemSingleLcssJob covering every molecule created after +timestamp+.
+  # Schedules a PubchemLookupJob covering every molecule created after +timestamp+.
   # The bulk importers use this instead of collecting new molecule ids into an array:
   # capture Time.current once before the import loop begins, pass defer_lcss: true to
   # suppress each new molecule's own immediate scheduling, then call this once at the
@@ -261,7 +261,7 @@ class Molecule < ApplicationRecord
     return if timestamp.blank?
     return unless Molecule.exists?(['created_at > ?', timestamp])
 
-    PubchemSingleLcssJob.perform_later(nil, created_after: timestamp)
+    PubchemLookupJob.perform_later(nil, created_after: timestamp)
   end
 
   def create_molecule_name_by_user(new_names, user_id)

--- a/app/models/molecule.rb
+++ b/app/models/molecule.rb
@@ -209,11 +209,10 @@ class Molecule < ApplicationRecord
   # per-molecule enrichment ({PubchemLookupJob}) and the periodic batch backfill
   # ({PubchemCidJob}), so the write semantics are identical whichever path runs. Repeated calls
   # are safe: +iupac_name+ is only set when blank, molecule names are found-or-created, and an
-  # existing +pubchem_cid+ is never overwritten with nil. The +pubchem_cid+ write is an atomic
-  # JSONB merge rather than a read/modify/write of the whole +taggable_data+ hash, so it can't
-  # itself clobber an unrelated key (e.g. +user_labels+, +chemrepo_id+) written concurrently by
-  # another path — those other writers still replace the full hash, though, so the reverse
-  # (them clobbering this key) isn't ruled out without touching {Taggable#update_tag} too.
+  # existing +pubchem_cid+ is never overwritten with nil. The +pubchem_cid+ write is atomic
+  # (see {#merge_pubchem_cid!}); other writers still replace the full +taggable_data+ hash,
+  # though, so the reverse — them clobbering this key — isn't ruled out without touching
+  # {Taggable#update_tag} too.
   #
   # @param info [Hash] +{ cid:, iupac_name:, names: }+ as returned by
   #   {Chemotion::PubchemService.molecule_info_from_inchikey}
@@ -223,22 +222,13 @@ class Molecule < ApplicationRecord
     return if info.blank?
 
     update_columns(iupac_name: info[:iupac_name]) if iupac_name.blank? && info[:iupac_name].present?
-
-    if info[:cid].present?
-      et = tag
-      ElementTag.where(id: et.id).update_all(
-        ["taggable_data = COALESCE(taggable_data, '{}'::jsonb) || jsonb_build_object('pubchem_cid', ?::jsonb)",
-         info[:cid].to_json],
-      )
-      # Mirror the merge onto the already-loaded association in memory (update_all bypasses
-      # it) so an immediate caller-side read — e.g. PubchemLookupJob#enrich_and_fetch_lcss
-      # checking pubchem_check right after this returns — sees the cid without a reload.
-      et.taggable_data = (et.taggable_data || {}).merge('pubchem_cid' => info[:cid])
-    end
+    merge_pubchem_cid!(info[:cid]) if info[:cid].present?
 
     Array(info[:names]).each do |name|
       MoleculeName.find_or_create_by(molecule_id: id, name: name, description: 'iupac_name')
     end
+
+    repoint_samples_to_iupac_name!
   end
   # rubocop:enable Rails/SkipsModelValidations
 
@@ -368,6 +358,56 @@ class Molecule < ApplicationRecord
   end
 
   private
+
+  # Writes +pubchem_cid+ as an atomic JSONB merge rather than a read/modify/write of the whole
+  # +taggable_data+ hash, so it can't clobber an unrelated key (+user_labels+, +chemrepo_id+)
+  # written concurrently by another path.
+  #
+  # @param cid [String, Integer] the PubChem compound id
+  # @return [void]
+  # rubocop:disable Rails/SkipsModelValidations
+  def merge_pubchem_cid!(cid)
+    et = tag
+    ElementTag.where(id: et.id).update_all(
+      ["taggable_data = COALESCE(taggable_data, '{}'::jsonb) || jsonb_build_object('pubchem_cid', ?::jsonb)",
+       cid.to_json],
+    )
+    # Mirror the merge onto the already-loaded association in memory (update_all bypasses it)
+    # so an immediate caller-side read — e.g. PubchemLookupJob#enrich_and_fetch_lcss checking
+    # pubchem_check right after this returns — sees the cid without a reload.
+    et.taggable_data = (et.taggable_data || {}).merge('pubchem_cid' => cid)
+  end
+  # rubocop:enable Rails/SkipsModelValidations
+
+  # Moves samples off the sum-formula placeholder now that the real IUPAC name has arrived.
+  #
+  # Sample's before_create :check_molecule_name resolves
+  # +molecule_iupac_name || molecule_sum_formular+. With enrichment deferred, iupac_name is
+  # still nil at that moment, so every sample of a freshly created molecule binds to the
+  # sum-formula MoleculeName — and nothing re-evaluates it afterwards, because
+  # #update_molecule_name only fires when molecule_id itself changes. Without this the
+  # sample would show and export as +H2O+ rather than +oxidane+ forever.
+  #
+  # Only samples still on that default binding are moved; one the user picked explicitly
+  # (sample_api's molecule_name_id, /save_name, #create_molecule_name_by_user) is left alone.
+  # update_all deliberately skips Sample's before_save chain — SVG regeneration, fingerprints,
+  # elemental composition — and keeps the correction out of the version history.
+  #
+  # @return [void]
+  # rubocop:disable Rails/SkipsModelValidations
+  def repoint_samples_to_iupac_name!
+    return if iupac_name.blank?
+
+    # PubChem's iupac_name is not guaranteed to appear in info[:names], so the row may not
+    # exist yet: find_or_create rather than assume #create_molecule_names made one.
+    iupac_row = molecule_names.find_or_create_by(name: iupac_name, description: 'iupac_name')
+    sum_row = molecule_names.find_by(description: 'sum_formular')
+    return if sum_row.nil? || iupac_row.id == sum_row.id
+
+    Sample.where(molecule_id: id, molecule_name_id: sum_row.id)
+          .update_all(molecule_name_id: iupac_row.id)
+  end
+  # rubocop:enable Rails/SkipsModelValidations
 
   def assign_pubchem_data(pubchem_info)
     self.iupac_name = pubchem_info[:iupac_name]

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -32,8 +32,8 @@ Delayed::Worker.logger = Logger.new($stdout) if Rails.env.test?
 ActiveSupport.on_load(:active_record) do
   next unless ActiveRecord::Base.connection.table_exists?('delayed_jobs') && Delayed::Job.column_names.include?('cron')
 
-  # List of recuringreccuring jobs with default attributes JobClass, enabled, cron_variable
-  reccuring_jobs = [
+  # List of recurring jobs with default attributes JobClass, enabled, cron_variable
+  recurring_jobs = [
     # Data Collectors Classes
     { job_class: CollectDataFromMailJob,  enabled: :datacollector },
     { job_class: CollectDataFromSftpJob,  enabled: :datacollector },
@@ -49,18 +49,22 @@ ActiveSupport.on_load(:active_record) do
     { job_class: ChemrepoIdJob,        enabled: false,    cron_variable: 'CRON_CONFIG_CHEMREPO_ID' },
   ]
 
-  # Delete all reccuring jobs
+  # Delete all recurring jobs. Scoped to cron IS NOT NULL: InitCronJobsJob sets `cron:` only
+  # on the recurring entry it creates below, so a same-class one-off job (e.g. a rotation
+  # continuation self-enqueued by PubchemCidJob/PubchemLcssJob/PubchemLookupJob via
+  # `self.class.set(wait: ...).perform_later(...)`) has `cron: nil` and must survive a
+  # reboot instead of being silently wiped along with the recurring entry.
   like_array = ['%InitCronJobsJob%']
-  like_array += reccuring_jobs.map { |job| "%#{job[:job_class].name}%" }
-  puts "Deleting all reccuring jobs: #{like_array}"
-  Rails.logger.info "Deleting all reccuring jobs: #{like_array}"
-  Delayed::Job.where('handler like any (array[?])', like_array).destroy_all
+  like_array += recurring_jobs.map { |job| "%#{job[:job_class].name}%" }
+  puts "Deleting all recurring jobs: #{like_array}"
+  Rails.logger.info "Deleting all recurring jobs: #{like_array}"
+  Delayed::Job.where('handler like any (array[?])', like_array).where.not(cron: nil).destroy_all
 
-  # Reschedule all reccuring jobs
-  #    InitCronJobsJob.perform_later(reccuring_jobs)
-  puts 'Rescheduling reccuring jobs'
-  Rails.logger.info 'Rescheduling reccuring jobs'
-  InitCronJobsJob.perform_now(reccuring_jobs)
+  # Reschedule all recurring jobs
+  #    InitCronJobsJob.perform_later(recurring_jobs)
+  puts 'Rescheduling recurring jobs'
+  Rails.logger.info 'Rescheduling recurring jobs'
+  InitCronJobsJob.perform_now(recurring_jobs)
 rescue PG::ConnectionBad, ActiveRecord::NoDatabaseError => e
   puts e.message
 end

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -29,6 +29,12 @@ Delayed::Worker.logger = Logger.new($stdout) if Rails.env.test?
 # ```
 # otherwise InitCronJobsJob will be called multiple times
 
+# PubchemLcssJob is normally chained off PubchemCidJob once its rotation drains (see
+# PubchemCidJob#chain_lcss) rather than independently scheduled. With CID itself disabled
+# nothing would trigger it at all, silently discarding a configured CRON_CONFIG_PC_LCSS — so
+# in that one case it keeps its own recurring entry.
+pubchem_lcss_enabled = ENV.fetch('CRON_CONFIG_PC_CID', nil) == 'disabled' ? :default : false
+
 ActiveSupport.on_load(:active_record) do
   next unless ActiveRecord::Base.connection.table_exists?('delayed_jobs') && Delayed::Job.column_names.include?('cron')
 
@@ -43,7 +49,10 @@ ActiveSupport.on_load(:active_record) do
 
     # Other Classes
     { job_class: PubchemCidJob,        enabled: :default, cron_variable: 'CRON_CONFIG_PC_CID' },
-    { job_class: PubchemLcssJob,       enabled: :default, cron_variable: 'CRON_CONFIG_PC_LCSS' },
+    # See pubchem_lcss_enabled above. Kept in this list even when disabled so a pre-existing
+    # recurring row from before the chaining change still gets cleaned up by the destroy step
+    # below instead of continuing to fire on its old schedule.
+    { job_class: PubchemLcssJob,       enabled: pubchem_lcss_enabled, cron_variable: 'CRON_CONFIG_PC_LCSS' },
     { job_class: RefreshElementTagJob, enabled: :default, cron_variable: 'CRON_CONFIG_REFRESH_ELEMENT_TAG' },
     { job_class: DiskUsageJob,         enabled: :default, cron_variable: 'CRON_CONFIG_DISK_USAGE' },
     { job_class: ChemrepoIdJob,        enabled: false,    cron_variable: 'CRON_CONFIG_CHEMREPO_ID' },

--- a/lib/import/import_samples.rb
+++ b/lib/import/import_samples.rb
@@ -283,12 +283,32 @@ module Import
         go_to_next = true
       else
         go_to_next = false
-        molecule = Molecule.find_or_create_by(inchikey: inchikey, is_partial: false) do |molecul|
-          molecul.skip_lcss_callback = true if @defer_lcss
-          pubchem_info =
-            Chemotion::PubchemService.molecule_info_from_inchikey(inchikey)
-          molecul.molfile = molfile_coord
-          molecul.assign_molecule_data babel_info, pubchem_info
+        formula = babel_info[:formula]
+        begin
+          # requires_new: true — see the note in Molecule.find_or_create_by_molfile.
+          # write_to_db wraps every row in one transaction, so without a savepoint the
+          # losing INSERT aborts it and the rescue's re-find below can't run.
+          molecule = ActiveRecord::Base.transaction(requires_new: true) do
+            Molecule.find_or_create_by(
+              inchikey: inchikey, is_partial: false, sum_formular: formula,
+            ) do |molecul|
+              molecul.skip_lcss_callback = true if @defer_lcss
+              # PubChem enrichment is deferred to the async enrich job (see Molecule
+              # #find_or_create_by_molfile); create with babel-only data, no network here.
+              molecul.molfile = molfile_coord
+              molecul.assign_molecule_data babel_info
+            end
+          end
+        rescue ActiveRecord::RecordNotUnique
+          # Lost a concurrent create race — re-find rather than aborting the whole import.
+          # Matches on the full (inchikey, sum_formular, is_partial) unique index so a legacy
+          # duplicate row sharing just the inchikey/is_partial pair can't be picked up instead
+          # of the row that actually just violated the constraint.
+          # Nothing to schedule here: the winning create's own after_create_commit hook (or
+          # the caller's schedule_lcss_since flush, when @defer_lcss is set) already covers
+          # enrichment/LCSS for this row regardless of which concurrent call created it.
+          molecule = Molecule.find_by(inchikey: inchikey, is_partial: false, sum_formular: formula)
+          raise if molecule.nil?
         end
       end
       [molecule, molfile_coord, go_to_next]

--- a/lib/import/import_samples.rb
+++ b/lib/import/import_samples.rb
@@ -278,40 +278,23 @@ module Import
       [molecule, raw_molfile]
     end
 
+    # Delegates to {Molecule.find_or_create_by_molfile} rather than re-implementing
+    # find-or-create. This branch used to key its lookup on
+    # +(inchikey, sum_formular, is_partial: false)+, but Molecule#assign_molecule_data assigns
+    # +is_partial+ from babel_info *after* +check_sum_formular+ has already returned early on
+    # the still-false value. An R-group structure was therefore INSERTed as
+    # +is_partial: true+ having been looked up as +false+ — a different tuple from the one it
+    # was searched under, so the next import missed it and inserted another row, and its
+    # masses kept the fictitious CH3 that check_sum_formular should have removed.
+    # find_or_create_by_molfile derives both +is_partial+ and the CH3-stripped formula before
+    # its lookup, and carries the savepoint and RecordNotUnique rescue.
+    #
+    # @return [Array(Molecule, String, Boolean)] +[molecule, molfile, go_to_next]+
     def assign_molecule_data(molfile_coord, babel_info, inchikey, _row, _index)
-      if inchikey.blank?
-        go_to_next = true
-      else
-        go_to_next = false
-        formula = babel_info[:formula]
-        begin
-          # requires_new: true — see the note in Molecule.find_or_create_by_molfile.
-          # write_to_db wraps every row in one transaction, so without a savepoint the
-          # losing INSERT aborts it and the rescue's re-find below can't run.
-          molecule = ActiveRecord::Base.transaction(requires_new: true) do
-            Molecule.find_or_create_by(
-              inchikey: inchikey, is_partial: false, sum_formular: formula,
-            ) do |molecul|
-              molecul.skip_lcss_callback = true if @defer_lcss
-              # PubChem enrichment is deferred to the async enrich job (see Molecule
-              # #find_or_create_by_molfile); create with babel-only data, no network here.
-              molecul.molfile = molfile_coord
-              molecul.assign_molecule_data babel_info
-            end
-          end
-        rescue ActiveRecord::RecordNotUnique
-          # Lost a concurrent create race — re-find rather than aborting the whole import.
-          # Matches on the full (inchikey, sum_formular, is_partial) unique index so a legacy
-          # duplicate row sharing just the inchikey/is_partial pair can't be picked up instead
-          # of the row that actually just violated the constraint.
-          # Nothing to schedule here: the winning create's own after_create_commit hook (or
-          # the caller's schedule_lcss_since flush, when @defer_lcss is set) already covers
-          # enrichment/LCSS for this row regardless of which concurrent call created it.
-          molecule = Molecule.find_by(inchikey: inchikey, is_partial: false, sum_formular: formula)
-          raise if molecule.nil?
-        end
-      end
-      [molecule, molfile_coord, go_to_next]
+      return [nil, molfile_coord, true] if inchikey.blank?
+
+      molecule = Molecule.find_or_create_by_molfile(molfile_coord, defer_lcss: @defer_lcss, **babel_info)
+      [molecule, molfile_coord, false]
     end
 
     def get_data_from_smiles(row, index)

--- a/spec/api/chemotion/sample_api_spec.rb
+++ b/spec/api/chemotion/sample_api_spec.rb
@@ -420,7 +420,7 @@ describe Chemotion::SampleAPI do
       }
     end
 
-    it 'imports all new molecules and schedules exactly one PubchemSingleLcssJob for the whole batch' do
+    it 'imports all new molecules and schedules exactly one PubchemLookupJob for the whole batch' do
       # chemotion#552 was a NoMethodError inside Molecule#get_lcss's own
       # per-molecule Delayed::Job query, triggered by a concurrently-running
       # worker draining that queue mid-import. get_lcss no longer queries
@@ -429,7 +429,7 @@ describe Chemotion::SampleAPI do
       # — this asserts the replacement behavior end-to-end: the whole SDF
       # import (2 new molecules) enqueues a single batched job, not one per molecule.
       started_at = Time.current
-      allow(PubchemSingleLcssJob).to receive(:perform_later)
+      allow(PubchemLookupJob).to receive(:perform_later)
 
       post(
         '/api/v1/samples/import/',
@@ -448,8 +448,8 @@ describe Chemotion::SampleAPI do
       # create_samples also flushes its own started_at, but finds nothing created
       # after it (all molecules were already created during find_or_create_mol_by_batch)
       # so Molecule.schedule_lcss_since no-ops for that second flush point.
-      expect(PubchemSingleLcssJob).to have_received(:perform_later).once
-      expect(PubchemSingleLcssJob).to have_received(:perform_later).with(nil, created_after: be >= started_at)
+      expect(PubchemLookupJob).to have_received(:perform_later).once
+      expect(PubchemLookupJob).to have_received(:perform_later).with(nil, created_after: be >= started_at)
     end
   end
 

--- a/spec/api/entities/sample_entity_spec.rb
+++ b/spec/api/entities/sample_entity_spec.rb
@@ -219,6 +219,9 @@ describe Entities::SampleEntity do
           names: nil,
           sum_formular: nil,
           molecule_names: nil,
+          # #molecule is a plain Hash at this detail level, so MoleculeEntity#pubchem_cid
+          # must not reach for the Molecule association.
+          pubchem_cid: nil,
         )
       end
     end

--- a/spec/api/molecule_api_spec.rb
+++ b/spec/api/molecule_api_spec.rb
@@ -102,6 +102,61 @@ describe Chemotion::MoleculeAPI do
       end
     end
 
+    describe 'Post /api/v1/molecules/refresh' do
+      let(:m) { create(:molecule, iupac_name: nil) }
+
+      context 'when the user may edit molecules' do
+        before do
+          allow(user).to receive(:molecule_editor).and_return(true)
+          allow(Chemotion::PubchemService).to receive(:molecule_info_from_inchikey)
+            .and_return(cid: 962, iupac_name: 'water', names: %w[water])
+        end
+
+        it 'requeries PubChem and returns the updated molecule' do
+          post '/api/v1/molecules/refresh', params: { id: m.id }
+
+          expect(response).to have_http_status(:created)
+          body = JSON.parse(response.body)
+          expect(body['iupac_name']).to eq('water')
+          expect(body['pubchem_cid']).to eq(962)
+        end
+
+        # The response used to carry a cid read off an in-memory tag that was never written:
+        # element_tags is a has_one without autosave:, so save! did not persist a
+        # taggable_data-only change and the label vanished on the next reload.
+        it 'actually persists the cid' do
+          post '/api/v1/molecules/refresh', params: { id: m.id }
+
+          expect(m.reload.tag.taggable_data['pubchem_cid']).to eq(962)
+          expect(m.iupac_name).to eq('water')
+        end
+
+        it 'does not write a new SVG file on every call' do
+          expect { post '/api/v1/molecules/refresh', params: { id: m.id } }
+            .not_to(change { m.reload.molecule_svg_file })
+        end
+
+        it 'reports a real error status when the refresh fails' do
+          allow_any_instance_of(Molecule).to receive(:enrich_from_pubchem).and_raise(StandardError, 'boom') # rubocop:disable RSpec/AnyInstance
+
+          post '/api/v1/molecules/refresh', params: { id: m.id }
+
+          expect(response).to have_http_status(:internal_server_error)
+          expect(JSON.parse(response.body)['msg']['level']).to eq('error')
+        end
+      end
+
+      it 'refuses a user who may not edit molecules' do
+        allow(user).to receive(:molecule_editor).and_return(false)
+        allow(Chemotion::PubchemService).to receive(:molecule_info_from_inchikey)
+
+        post '/api/v1/molecules/refresh', params: { id: m.id }
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(Chemotion::PubchemService).not_to have_received(:molecule_info_from_inchikey)
+      end
+    end
+
     describe 'Post /api/v1/molecules/save_name' do
       let(:m) { create(:molecule) }
 

--- a/spec/config/initializers/delayed_job_spec.rb
+++ b/spec/config/initializers/delayed_job_spec.rb
@@ -5,17 +5,19 @@ def delayed_job_scope
 end
 
 # rubocop:disable RSpec/DescribeClass
-RSpec.describe 'queuing of a reccuring job through delayed_job initializer' do
+RSpec.describe 'queuing of a recurring job through delayed_job initializer' do
   # env variable name that can be used to define the cron schedules
+  # NB: CRON_CONFIG_PC_LCSS is intentionally absent — PubchemLcssJob no longer gets an
+  # independent recurring entry; PubchemCidJob chains it at the end of its own cron cadence
+  # (see PubchemCidJob#chain_lcss), so this env var is a no-op regardless of its value.
   let(:env_var_names) do
     %w[
       CRON_CONFIG_PC_CID
-      CRON_CONFIG_PC_LCSS
       CRON_CONFIG_REFRESH_ELEMENT_TAG
       CRON_CONFIG_DISK_USAGE
     ]
   end
-  let(:days_from_now) { [2, 3, 4, 5] }
+  let(:days_from_now) { [2, 3, 4] }
   # map to week day as integers
   let(:wdays_from_now) { days_from_now.map { |num| Time.zone.now.next_day(num).wday } }
   # map to weekly cron schedules starting in x days
@@ -34,7 +36,7 @@ RSpec.describe 'queuing of a reccuring job through delayed_job initializer' do
                        .count
     end
   end
-  let(:expected_count) { [1, 1, 1, 1] }
+  let(:expected_count) { [1, 1, 1] }
 
   # rubocop:disable RSpec/BeforeAfterAll
   before(:all) do
@@ -46,10 +48,26 @@ RSpec.describe 'queuing of a reccuring job through delayed_job initializer' do
   end
   # rubocop:enable RSpec/BeforeAfterAll
 
-  it 'queues the reccuring jobs with the defined cron schedules and correct run_at times' do
+  it 'queues the recurring jobs with the defined cron schedules and correct run_at times' do
     # set env variables and trigger the initializers for example with a rake command
     `#{env_vars} bundle exec rake db:version`
     expect(jobs_count_with_correct_run_at).to eq(expected_count)
+  end
+
+  it 'does not give PubchemLcssJob its own recurring entry (it is chained off PubchemCidJob instead)' do
+    `#{env_vars} bundle exec rake db:version`
+
+    expect(delayed_job_scope.where("handler like '%PubchemLcssJob%'")).to be_none
+  end
+
+  # With CID off, nothing would chain LCSS, so a configured CRON_CONFIG_PC_LCSS would be
+  # silently discarded and the LCSS backfill would stop entirely with no way to turn it on.
+  it 'gives PubchemLcssJob its schedule back when PubchemCidJob is disabled' do
+    lcss_schedule = '5 5 * * 1'
+    `CRON_CONFIG_PC_CID='disabled' CRON_CONFIG_PC_LCSS='#{lcss_schedule}' bundle exec rake db:version`
+
+    expect(delayed_job_scope.where("handler like '%PubchemLcssJob%'").where(cron: lcss_schedule)).to be_present
+    expect(delayed_job_scope.where("handler like '%PubchemCidJob%'")).to be_none
   end
 
   it 'does not destroy an in-flight one-off continuation job (cron: nil) for a managed class on boot' do

--- a/spec/config/initializers/delayed_job_spec.rb
+++ b/spec/config/initializers/delayed_job_spec.rb
@@ -51,5 +51,18 @@ RSpec.describe 'queuing of a reccuring job through delayed_job initializer' do
     `#{env_vars} bundle exec rake db:version`
     expect(jobs_count_with_correct_run_at).to eq(expected_count)
   end
+
+  it 'does not destroy an in-flight one-off continuation job (cron: nil) for a managed class on boot' do
+    # A rotation continuation self-enqueued via `self.class.set(wait: ...).perform_later(...)`
+    # (see PubchemCidJob/PubchemLcssJob/PubchemLookupJob) never sets `cron:`, unlike the
+    # recurring entry InitCronJobsJob creates — it must survive the initializer's cleanup.
+    one_off = create_locked_delayed_job('PubchemCidJob')
+
+    `#{env_vars} bundle exec rake db:version`
+
+    expect(Delayed::Job.find_by(id: one_off.id)).to be_present
+  ensure
+    one_off&.destroy
+  end
 end
 # rubocop:enable RSpec/DescribeClass

--- a/spec/jobs/pubchem_cid_job_spec.rb
+++ b/spec/jobs/pubchem_cid_job_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PubchemCidJob do
+  let(:job) { described_class.new }
+
+  # PubchemCidJob's scope requires an associated sample (joins(:samples)); a bare
+  # create(:molecule) has none.
+  def make_pending_molecule
+    molecule = create(:molecule, iupac_name: nil)
+    molecule.tag.update!(taggable_data: molecule.tag.taggable_data.except('pubchem_cid'))
+    create(:sample, molecule: molecule)
+    molecule
+  end
+
+  def make_done_molecule(cid: 643_785)
+    molecule = create(:molecule)
+    molecule.tag.update!(taggable_data: molecule.tag.taggable_data.merge('pubchem_cid' => cid))
+    create(:sample, molecule: molecule)
+    molecule
+  end
+
+  def stub_pubchem_info_for(*molecules, cid: 643_785, iupac_name: 'water', names: %w[water])
+    allow(Chemotion::PubchemService).to receive(:molecule_info_from_inchikeys) do |inchikeys|
+      molecules.select { |m| inchikeys.include?(m.inchikey) }.map do |m|
+        { inchikey: m.inchikey, cid: cid, iupac_name: iupac_name, names: names }
+      end
+    end
+  end
+
+  before { allow(job).to receive(:sleep) }
+
+  describe '#perform' do
+    context 'when another guarded PubChem job is currently running' do
+      it 'requeues itself later without processing any molecules' do
+        create_locked_delayed_job('PubchemLcssJob')
+        pending = make_pending_molecule
+        stub_pubchem_info_for(pending)
+        allow(described_class).to receive(:set).and_return(described_class)
+        allow(described_class).to receive(:perform_later)
+
+        job.perform
+
+        expect(described_class).to have_received(:set).with(wait: PubchemRateLimitGuard::REQUEUE_DELAY)
+        expect(described_class).to have_received(:perform_later)
+          .with(sleep_time: 10, batch_size: 10, chunk_size: described_class::CHUNK_SIZE, start_id: 0)
+        expect(pending.reload.tag.taggable_data['pubchem_cid']).to be_nil
+      end
+
+      it 'proceeds normally when the other lock is stale (its worker died mid-run)' do
+        create_locked_delayed_job('PubchemLcssJob', locked_at: (Delayed::Worker.max_run_time + 1.minute).ago)
+        pending = make_pending_molecule
+        stub_pubchem_info_for(pending)
+        allow(described_class).to receive(:set)
+
+        job.perform
+
+        expect(described_class).not_to have_received(:set)
+        expect(pending.reload.tag.taggable_data['pubchem_cid']).to eq(643_785)
+      end
+    end
+
+    it 'processes only molecules with a sample, is_partial: false, and no pubchem_cid yet' do
+      pending = make_pending_molecule
+      make_done_molecule
+      stub_pubchem_info_for(pending)
+
+      job.perform
+
+      expect(pending.reload.tag.taggable_data['pubchem_cid']).to eq(643_785)
+    end
+
+    it 'persists iupac_name and molecule_names alongside the cid' do
+      pending = make_pending_molecule
+      stub_pubchem_info_for(pending, iupac_name: 'water', names: %w[water oxidane])
+
+      job.perform
+
+      pending.reload
+      expect(pending.iupac_name).to eq('water')
+      expect(pending.molecule_names.where(description: 'iupac_name').pluck(:name)).to include('water', 'oxidane')
+    end
+
+    it 'resumes after start_id, only considering molecules with a higher id' do
+      earlier = make_pending_molecule
+      later = make_pending_molecule
+      stub_pubchem_info_for(earlier, later)
+
+      job.perform(start_id: earlier.id)
+
+      expect(earlier.reload.tag.taggable_data['pubchem_cid']).to be_nil
+      expect(later.reload.tag.taggable_data['pubchem_cid']).to eq(643_785)
+    end
+
+    it 'bounds a single run to chunk_size molecules and requeues a follow-up with the resume cursor',
+       :aggregate_failures do
+      first = make_pending_molecule
+      second = make_pending_molecule
+      third = make_pending_molecule # beyond chunk_size, must not be touched this run
+      stub_pubchem_info_for(first, second, third)
+      allow(described_class).to receive(:set).and_return(described_class)
+      allow(described_class).to receive(:perform_later)
+
+      job.perform(chunk_size: 2, batch_size: 1)
+
+      expect(first.reload.tag.taggable_data['pubchem_cid']).to eq(643_785)
+      expect(second.reload.tag.taggable_data['pubchem_cid']).to eq(643_785)
+      expect(third.reload.tag.taggable_data['pubchem_cid']).to be_nil
+      expect(described_class).to have_received(:set).with(wait: 10.seconds)
+      expect(described_class).to have_received(:perform_later)
+        .with(sleep_time: 10, batch_size: 1, chunk_size: 2, start_id: second.id)
+    end
+
+    it 'does not requeue once every pending molecule has been processed' do
+      pending = make_pending_molecule
+      stub_pubchem_info_for(pending)
+      allow(described_class).to receive(:set)
+
+      job.perform
+
+      expect(described_class).not_to have_received(:set)
+    end
+  end
+end

--- a/spec/jobs/pubchem_cid_job_spec.rb
+++ b/spec/jobs/pubchem_cid_job_spec.rb
@@ -121,5 +121,54 @@ RSpec.describe PubchemCidJob do
 
       expect(described_class).not_to have_received(:set)
     end
+
+    context 'when chaining PubchemLcssJob' do
+      before { allow(PubchemLcssJob).to receive(:perform_later) }
+
+      it 'chains a full PubchemLcssJob sweep once the rotation has drained' do
+        pending = make_pending_molecule
+        stub_pubchem_info_for(pending)
+
+        job.perform(start_id: 0)
+
+        expect(PubchemLcssJob).to have_received(:perform_later).with(start_id: 0)
+      end
+
+      # Chaining per chunk enqueued one overlapping LCSS rotation per chunk. They are all
+      # serialised by PubchemRateLimitGuard, so every one but the first spent its life
+      # bouncing on the 15-minute REQUEUE_DELAY — and colliding with CID's own continuations.
+      it 'does not chain while chunks remain, only after the last one' do
+        earlier = make_pending_molecule
+        later = make_pending_molecule
+        stub_pubchem_info_for(earlier, later)
+
+        job.perform(sleep_time: 0, batch_size: 1, chunk_size: 1, start_id: 0)
+
+        expect(PubchemLcssJob).not_to have_received(:perform_later)
+      end
+
+      it 'chains even when this run enriched nothing (prior cid\'d-but-not-lcss\'d molecules may still be pending)' do
+        job.perform
+
+        expect(PubchemLcssJob).to have_received(:perform_later).with(start_id: 0)
+      end
+
+      it 'does not chain when the run backs off due to another guarded job running' do
+        create_locked_delayed_job('PubchemLcssJob')
+
+        job.perform
+
+        expect(PubchemLcssJob).not_to have_received(:perform_later)
+      end
+
+      it 'does not chain when LCSS is explicitly disabled by config' do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with('CRON_CONFIG_PC_LCSS', nil).and_return('disabled')
+
+        job.perform
+
+        expect(PubchemLcssJob).not_to have_received(:perform_later)
+      end
+    end
   end
 end

--- a/spec/jobs/pubchem_lcss_job_spec.rb
+++ b/spec/jobs/pubchem_lcss_job_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe PubchemLcssJob do
   describe '#perform' do
     context 'when another guarded PubChem job is currently running' do
       it 'requeues itself later without processing any molecules' do
-        create_locked_delayed_job('PubchemSingleLcssJob')
+        create_locked_delayed_job('PubchemLookupJob')
         make_pending_molecule
         allow(described_class).to receive(:set).and_return(described_class)
         allow(described_class).to receive(:perform_later)
@@ -53,7 +53,7 @@ RSpec.describe PubchemLcssJob do
       end
 
       it 'proceeds normally when the other lock is stale (its worker died mid-run)' do
-        create_locked_delayed_job('PubchemSingleLcssJob', locked_at: (Delayed::Worker.max_run_time + 1.minute).ago)
+        create_locked_delayed_job('PubchemLookupJob', locked_at: (Delayed::Worker.max_run_time + 1.minute).ago)
         pending_molecule = make_pending_molecule
         allow(described_class).to receive(:set)
 

--- a/spec/jobs/pubchem_lookup_job_spec.rb
+++ b/spec/jobs/pubchem_lookup_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe PubchemSingleLcssJob do
+RSpec.describe PubchemLookupJob do
   let(:job) { described_class.new }
 
   describe '#perform' do

--- a/spec/jobs/pubchem_lookup_job_spec.rb
+++ b/spec/jobs/pubchem_lookup_job_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe PubchemLookupJob do
       allow(job).to receive(:sleep)
     end
 
+    # Simulates a successful PubChem molecule-info fetch: real enrich_from_pubchem persists
+    # the cid via Molecule#assign_pubchem_names_and_cid!, which is exactly what flips
+    # Molecule#pubchem_check from false to true for the perform loop's second gate.
+    def stub_successful_enrich(molecule, cid: 643_785)
+      allow(molecule).to receive(:enrich_from_pubchem) do
+        molecule.tag.update!(taggable_data: molecule.tag.taggable_data.merge('pubchem_cid' => cid))
+      end
+    end
+
     it 'does nothing when both ids and created_after are blank' do
       allow(job).to receive(:resolve_molecules)
 
@@ -33,8 +42,8 @@ RSpec.describe PubchemLookupJob do
 
     it 'calls #pubchem_lcss on each resolved molecule in order' do
       allow(job).to receive_messages(resolve_molecules: [first_molecule, second_molecule], more_pending?: false)
-      allow(first_molecule).to receive(:enrich_from_pubchem)
-      allow(second_molecule).to receive(:enrich_from_pubchem)
+      stub_successful_enrich(first_molecule)
+      stub_successful_enrich(second_molecule)
       allow(first_molecule).to receive(:pubchem_lcss)
       allow(second_molecule).to receive(:pubchem_lcss)
 
@@ -46,7 +55,7 @@ RSpec.describe PubchemLookupJob do
 
     it 'enriches each molecule from PubChem before fetching its LCSS' do
       allow(job).to receive_messages(resolve_molecules: [first_molecule], more_pending?: false)
-      allow(first_molecule).to receive(:enrich_from_pubchem)
+      stub_successful_enrich(first_molecule)
       allow(first_molecule).to receive(:pubchem_lcss)
 
       job.perform([first_molecule.id])
@@ -55,12 +64,35 @@ RSpec.describe PubchemLookupJob do
       expect(first_molecule).to have_received(:pubchem_lcss).ordered
     end
 
+    it 'skips the enrich fetch when the molecule already has a cid (e.g. from PubchemCidJob)' do
+      first_molecule.tag.update!(taggable_data: first_molecule.tag.taggable_data.merge('pubchem_cid' => 643_785))
+      allow(job).to receive_messages(resolve_molecules: [first_molecule], more_pending?: false)
+      allow(first_molecule).to receive(:enrich_from_pubchem)
+      allow(first_molecule).to receive(:pubchem_lcss)
+
+      job.perform([first_molecule.id])
+
+      expect(first_molecule).not_to have_received(:enrich_from_pubchem)
+      expect(first_molecule).to have_received(:pubchem_lcss)
+    end
+
+    it 'skips the LCSS fetch when enrichment does not find a cid, instead of falling back to its own lookup' do
+      allow(job).to receive_messages(resolve_molecules: [first_molecule], more_pending?: false)
+      allow(first_molecule).to receive(:enrich_from_pubchem) # no-op: PubChem had nothing for this inchikey
+      allow(first_molecule).to receive(:pubchem_lcss)
+
+      job.perform([first_molecule.id])
+
+      expect(first_molecule).to have_received(:enrich_from_pubchem)
+      expect(first_molecule).not_to have_received(:pubchem_lcss)
+    end
+
     it 'sleeps between requests but not before the first one' do
       allow(job).to receive_messages(
         resolve_molecules: [first_molecule, second_molecule, third_molecule], more_pending?: false,
       )
       [first_molecule, second_molecule, third_molecule].each do |m|
-        allow(m).to receive(:enrich_from_pubchem)
+        stub_successful_enrich(m)
         allow(m).to receive(:pubchem_lcss)
       end
 
@@ -82,7 +114,6 @@ RSpec.describe PubchemLookupJob do
           'pubchem_cid' => 643_785, 'pubchem_lcss' => 'already fetched',
         ),
       )
-      allow(first_molecule).to receive(:enrich_from_pubchem)
       allow(Chemotion::PubchemService).to receive(:lcss_from_cid)
 
       job.perform([first_molecule.id])
@@ -113,7 +144,9 @@ RSpec.describe PubchemLookupJob do
         called_ids = []
         # The job re-queries its own molecules from the DB, so stubbing a specific
         # test object's #pubchem_lcss wouldn't be seen — stub the class instead.
-        allow_any_instance_of(Molecule).to receive(:enrich_from_pubchem) # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Molecule).to receive(:enrich_from_pubchem) do |instance| # rubocop:disable RSpec/AnyInstance
+          instance.tag.update!(taggable_data: instance.tag.taggable_data.merge('pubchem_cid' => 643_785))
+        end
         allow_any_instance_of(Molecule).to receive(:pubchem_lcss) { |instance| called_ids << instance.id } # rubocop:disable RSpec/AnyInstance
         allow(described_class).to receive(:perform_later)
 
@@ -127,7 +160,9 @@ RSpec.describe PubchemLookupJob do
       end
 
       it 'does not requeue once every given molecule has been processed' do
-        allow_any_instance_of(Molecule).to receive(:enrich_from_pubchem) # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Molecule).to receive(:enrich_from_pubchem) do |instance| # rubocop:disable RSpec/AnyInstance
+          instance.tag.update!(taggable_data: instance.tag.taggable_data.merge('pubchem_cid' => 643_785))
+        end
         allow_any_instance_of(Molecule).to receive(:pubchem_lcss) # rubocop:disable RSpec/AnyInstance
         allow(described_class).to receive(:perform_later)
 

--- a/spec/jobs/pubchem_lookup_job_spec.rb
+++ b/spec/jobs/pubchem_lookup_job_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe PubchemLookupJob do
 
     it 'calls #pubchem_lcss on each resolved molecule in order' do
       allow(job).to receive_messages(resolve_molecules: [first_molecule, second_molecule], more_pending?: false)
+      allow(first_molecule).to receive(:enrich_from_pubchem)
+      allow(second_molecule).to receive(:enrich_from_pubchem)
       allow(first_molecule).to receive(:pubchem_lcss)
       allow(second_molecule).to receive(:pubchem_lcss)
 
@@ -42,11 +44,25 @@ RSpec.describe PubchemLookupJob do
       expect(second_molecule).to have_received(:pubchem_lcss).ordered
     end
 
+    it 'enriches each molecule from PubChem before fetching its LCSS' do
+      allow(job).to receive_messages(resolve_molecules: [first_molecule], more_pending?: false)
+      allow(first_molecule).to receive(:enrich_from_pubchem)
+      allow(first_molecule).to receive(:pubchem_lcss)
+
+      job.perform([first_molecule.id])
+
+      expect(first_molecule).to have_received(:enrich_from_pubchem).ordered
+      expect(first_molecule).to have_received(:pubchem_lcss).ordered
+    end
+
     it 'sleeps between requests but not before the first one' do
       allow(job).to receive_messages(
         resolve_molecules: [first_molecule, second_molecule, third_molecule], more_pending?: false,
       )
-      [first_molecule, second_molecule, third_molecule].each { |m| allow(m).to receive(:pubchem_lcss) }
+      [first_molecule, second_molecule, third_molecule].each do |m|
+        allow(m).to receive(:enrich_from_pubchem)
+        allow(m).to receive(:pubchem_lcss)
+      end
 
       job.perform([first_molecule.id, second_molecule.id, third_molecule.id])
 
@@ -66,6 +82,7 @@ RSpec.describe PubchemLookupJob do
           'pubchem_cid' => 643_785, 'pubchem_lcss' => 'already fetched',
         ),
       )
+      allow(first_molecule).to receive(:enrich_from_pubchem)
       allow(Chemotion::PubchemService).to receive(:lcss_from_cid)
 
       job.perform([first_molecule.id])
@@ -96,6 +113,7 @@ RSpec.describe PubchemLookupJob do
         called_ids = []
         # The job re-queries its own molecules from the DB, so stubbing a specific
         # test object's #pubchem_lcss wouldn't be seen — stub the class instead.
+        allow_any_instance_of(Molecule).to receive(:enrich_from_pubchem) # rubocop:disable RSpec/AnyInstance
         allow_any_instance_of(Molecule).to receive(:pubchem_lcss) { |instance| called_ids << instance.id } # rubocop:disable RSpec/AnyInstance
         allow(described_class).to receive(:perform_later)
 
@@ -109,6 +127,7 @@ RSpec.describe PubchemLookupJob do
       end
 
       it 'does not requeue once every given molecule has been processed' do
+        allow_any_instance_of(Molecule).to receive(:enrich_from_pubchem) # rubocop:disable RSpec/AnyInstance
         allow_any_instance_of(Molecule).to receive(:pubchem_lcss) # rubocop:disable RSpec/AnyInstance
         allow(described_class).to receive(:perform_later)
 

--- a/spec/lib/import/import_samples_spec.rb
+++ b/spec/lib/import/import_samples_spec.rb
@@ -103,6 +103,10 @@ RSpec.describe 'Import::ImportSamples' do
         expect(PubchemLookupJob).to have_received(:perform_later).once
         expect(PubchemLookupJob).to have_received(:perform_later).with(nil, created_after: be >= started_at)
       end
+
+      # The savepoint that makes a real (Postgres-level) collision survivable inside this
+      # transaction is covered where it lives, in
+      # spec/models/molecule_spec.rb '.find_or_create_by_molfile'.
     end
   end
 

--- a/spec/lib/import/import_samples_spec.rb
+++ b/spec/lib/import/import_samples_spec.rb
@@ -245,4 +245,39 @@ RSpec.describe 'Import::ImportSamples' do
       end
     end
   end
+
+  describe '#assign_molecule_data' do
+    let(:babel_info) do
+      { inchikey: 'PARTIALMOL-UHFFFAOYSA-N', is_partial: true, formula: 'C7H8',
+        mol_wt: 92.1384, mass: 92.0626, molfile: "partial\n", molfile_version: 'V2000' }
+    end
+
+    before { allow(PubchemLookupJob).to receive(:perform_later) }
+
+    it 'returns [nil, molfile, true] when the inchikey is blank' do
+      expect(importer.send(:assign_molecule_data, 'molfile', {}, '', {}, 0))
+        .to eq([nil, 'molfile', true])
+    end
+
+    # An R-group structure must be stored under the same tuple it was looked up by, or the
+    # next import misses it and inserts a duplicate the finder can never see again.
+    it 'stores a partial molecule under the is_partial/stripped-formula tuple it was found by' do
+      molecule, = importer.send(:assign_molecule_data, "molfile\n", babel_info,
+                                babel_info[:inchikey], {}, 0)
+
+      expect(molecule.is_partial).to be true
+      expect(molecule.sum_formular).to eq(SumFormula.new('C7H8').remove_fragment('CH3').valid.to_s)
+      expect(Molecule.find_by(inchikey: babel_info[:inchikey], is_partial: molecule.is_partial,
+                              sum_formular: molecule.sum_formular)).to eq(molecule)
+    end
+
+    it 'reuses that row on a second import of the same structure instead of duplicating it' do
+      first, = importer.send(:assign_molecule_data, "molfile\n", babel_info, babel_info[:inchikey], {}, 0)
+
+      expect do
+        second, = importer.send(:assign_molecule_data, "molfile\n", babel_info, babel_info[:inchikey], {}, 0)
+        expect(second.id).to eq(first.id)
+      end.not_to change(Molecule, :count)
+    end
+  end
 end

--- a/spec/lib/import/import_samples_spec.rb
+++ b/spec/lib/import/import_samples_spec.rb
@@ -94,14 +94,14 @@ RSpec.describe 'Import::ImportSamples' do
         expect(molecule_names).to be_present
       end
 
-      it 'schedules exactly one PubchemSingleLcssJob for the whole import instead of one per molecule' do
+      it 'schedules exactly one PubchemLookupJob for the whole import instead of one per molecule' do
         started_at = Time.current
-        allow(PubchemSingleLcssJob).to receive(:perform_later)
+        allow(PubchemLookupJob).to receive(:perform_later)
 
         import_result
 
-        expect(PubchemSingleLcssJob).to have_received(:perform_later).once
-        expect(PubchemSingleLcssJob).to have_received(:perform_later).with(nil, created_after: be >= started_at)
+        expect(PubchemLookupJob).to have_received(:perform_later).once
+        expect(PubchemLookupJob).to have_received(:perform_later).with(nil, created_after: be >= started_at)
       end
     end
   end

--- a/spec/lib/import/import_sdf_spec.rb
+++ b/spec/lib/import/import_sdf_spec.rb
@@ -133,21 +133,21 @@ RSpec.describe Import::ImportSdf do
       end
     end
 
-    it 'schedules a single PubchemSingleLcssJob covering every new molecule, via a created_after timestamp' do
+    it 'schedules a single PubchemLookupJob covering every new molecule, via a created_after timestamp' do
       started_at = Time.current
-      allow(PubchemSingleLcssJob).to receive(:perform_later)
+      allow(PubchemLookupJob).to receive(:perform_later)
 
       expect { batch_import.find_or_create_mol_by_batch }.to change(Molecule, :count).by(2)
-      expect(PubchemSingleLcssJob).to have_received(:perform_later).once
-      expect(PubchemSingleLcssJob).to have_received(:perform_later).with(nil, created_after: be >= started_at)
+      expect(PubchemLookupJob).to have_received(:perform_later).once
+      expect(PubchemLookupJob).to have_received(:perform_later).with(nil, created_after: be >= started_at)
     end
 
-    it 'still schedules exactly one PubchemSingleLcssJob when batch_size splits the import into multiple chunks' do
-      allow(PubchemSingleLcssJob).to receive(:perform_later)
+    it 'still schedules exactly one PubchemLookupJob when batch_size splits the import into multiple chunks' do
+      allow(PubchemLookupJob).to receive(:perform_later)
 
       batch_import.find_or_create_mol_by_batch(1)
 
-      expect(PubchemSingleLcssJob).to have_received(:perform_later).once
+      expect(PubchemLookupJob).to have_received(:perform_later).once
     end
   end
 

--- a/spec/lib/import/import_sdf_spec.rb
+++ b/spec/lib/import/import_sdf_spec.rb
@@ -149,6 +149,44 @@ RSpec.describe Import::ImportSdf do
 
       expect(PubchemLookupJob).to have_received(:perform_later).once
     end
+
+    # Regression for the reported bug: one molecule losing the create race must not abort the
+    # whole import with PG::UniqueViolation (index_molecules_on_formula_and_inchikey_and_is_partial).
+    it 'survives a concurrent-create RecordNotUnique on one molecule and still imports the rest (C1)' do
+      allow(PubchemLookupJob).to receive(:perform_later)
+
+      raced_inchikey = "MOL#{Digest::SHA256.hexdigest(new_molfiles.first.to_s)[0..10]}-UHFFFAOYSA-N"
+      winner = create(:molecule, inchikey: raced_inchikey, is_partial: false,
+                                 sum_formular: nil, skip_lcss_callback: true)
+
+      # The raced molecule's decision-lookup misses first (winner committed in the gap),
+      # then the rescue re-find returns the winner; all other lookups behave normally.
+      first_lookup = true
+      allow(Molecule).to receive(:find_by).and_wrap_original do |orig, *args|
+        cond = args.first
+        if cond.is_a?(Hash) && cond[:inchikey] == raced_inchikey
+          next winner unless first_lookup
+
+          first_lookup = false
+          nil
+        else
+          orig.call(*args)
+        end
+      end
+
+      # The raced molecule's INSERT collides once; every other create proceeds normally.
+      allow(Molecule).to receive(:create).and_wrap_original do |orig, *args, &blk|
+        cond = args.first
+        raise ActiveRecord::RecordNotUnique if cond.is_a?(Hash) && cond[:inchikey] == raced_inchikey
+
+        orig.call(*args, &blk)
+      end
+
+      # Only the genuinely-new water molecule is inserted; the raced one reuses the winner
+      # (no duplicate, no aborted import). If the bug regressed, this block would raise.
+      expect { batch_import.find_or_create_mol_by_batch }.to change(Molecule, :count).by(1)
+      expect(batch_import.inchi_array).to include(raced_inchikey)
+    end
   end
 
   describe 'polymer molfile delegation to Import::PolymerMoleculeResolver' do

--- a/spec/models/molecule_spec.rb
+++ b/spec/models/molecule_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Molecule, type: :model do
   describe '#get_lcss' do
     it 'schedules a single-element batch for a normally-created molecule' do
       scheduled_ids = nil
-      allow(PubchemSingleLcssJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
+      allow(PubchemLookupJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
 
       molecule = create(:molecule)
 
@@ -142,11 +142,11 @@ RSpec.describe Molecule, type: :model do
 
   describe '#skip_lcss_callback' do
     it 'suppresses automatic scheduling when set true before create' do
-      allow(PubchemSingleLcssJob).to receive(:perform_later)
+      allow(PubchemLookupJob).to receive(:perform_later)
 
       build(:molecule, skip_lcss_callback: true).save!
 
-      expect(PubchemSingleLcssJob).not_to have_received(:perform_later)
+      expect(PubchemLookupJob).not_to have_received(:perform_later)
     end
   end
 
@@ -155,11 +155,11 @@ RSpec.describe Molecule, type: :model do
       first_molecule = create(:molecule, skip_lcss_callback: true)
       second_molecule = create(:molecule, skip_lcss_callback: true)
       scheduled_ids = nil
-      allow(PubchemSingleLcssJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
+      allow(PubchemLookupJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
 
       described_class.schedule_lcss_batch([first_molecule.id, second_molecule.id])
 
-      expect(PubchemSingleLcssJob).to have_received(:perform_later).once
+      expect(PubchemLookupJob).to have_received(:perform_later).once
       expect(scheduled_ids).to contain_exactly(first_molecule.id, second_molecule.id)
     end
 
@@ -168,7 +168,7 @@ RSpec.describe Molecule, type: :model do
       doomed = create(:molecule, skip_lcss_callback: true)
       doomed.destroy!
       scheduled_ids = nil
-      allow(PubchemSingleLcssJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
+      allow(PubchemLookupJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
 
       described_class.schedule_lcss_batch([survivor.id, doomed.id])
 
@@ -176,12 +176,12 @@ RSpec.describe Molecule, type: :model do
     end
 
     it 'schedules nothing when no given id still exists' do
-      allow(PubchemSingleLcssJob).to receive(:perform_later)
+      allow(PubchemLookupJob).to receive(:perform_later)
 
       described_class.schedule_lcss_batch([])
       described_class.schedule_lcss_batch([-1])
 
-      expect(PubchemSingleLcssJob).not_to have_received(:perform_later)
+      expect(PubchemLookupJob).not_to have_received(:perform_later)
     end
   end
 
@@ -195,16 +195,16 @@ RSpec.describe Molecule, type: :model do
     end
 
     it 'defers scheduling when given defer_lcss: true' do
-      allow(PubchemSingleLcssJob).to receive(:perform_later)
+      allow(PubchemLookupJob).to receive(:perform_later)
 
       described_class.find_or_create_by_molfile('molfile', defer_lcss: true, **babel_info)
 
-      expect(PubchemSingleLcssJob).not_to have_received(:perform_later)
+      expect(PubchemLookupJob).not_to have_received(:perform_later)
     end
 
     it 'schedules immediately when defer_lcss is not given' do
       scheduled_ids = nil
-      allow(PubchemSingleLcssJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
+      allow(PubchemLookupJob).to receive(:perform_later) { |ids| scheduled_ids = ids }
 
       molecule = described_class.find_or_create_by_molfile('molfile', **babel_info)
 
@@ -219,40 +219,40 @@ RSpec.describe Molecule, type: :model do
         sum_formular: babel_info[:formula],
         skip_lcss_callback: true,
       )
-      allow(PubchemSingleLcssJob).to receive(:perform_later)
+      allow(PubchemLookupJob).to receive(:perform_later)
 
       molecule = described_class.find_or_create_by_molfile('molfile', defer_lcss: true, **babel_info)
 
       expect(molecule.id).to eq(existing.id)
-      expect(PubchemSingleLcssJob).not_to have_received(:perform_later)
+      expect(PubchemLookupJob).not_to have_received(:perform_later)
     end
   end
 
   describe '.schedule_lcss_since' do
     it 'does nothing when timestamp is blank' do
-      allow(PubchemSingleLcssJob).to receive(:perform_later)
+      allow(PubchemLookupJob).to receive(:perform_later)
 
       described_class.schedule_lcss_since(nil)
 
-      expect(PubchemSingleLcssJob).not_to have_received(:perform_later)
+      expect(PubchemLookupJob).not_to have_received(:perform_later)
     end
 
     it 'does nothing when no molecule was created after the given timestamp' do
-      allow(PubchemSingleLcssJob).to receive(:perform_later)
+      allow(PubchemLookupJob).to receive(:perform_later)
 
       described_class.schedule_lcss_since(1.hour.from_now)
 
-      expect(PubchemSingleLcssJob).not_to have_received(:perform_later)
+      expect(PubchemLookupJob).not_to have_received(:perform_later)
     end
 
     it 'schedules a job covering molecules created after the given timestamp' do
       timestamp = 1.hour.ago
       create(:molecule)
-      allow(PubchemSingleLcssJob).to receive(:perform_later)
+      allow(PubchemLookupJob).to receive(:perform_later)
 
       described_class.schedule_lcss_since(timestamp)
 
-      expect(PubchemSingleLcssJob).to have_received(:perform_later).with(nil, created_after: timestamp)
+      expect(PubchemLookupJob).to have_received(:perform_later).with(nil, created_after: timestamp)
     end
   end
 

--- a/spec/models/molecule_spec.rb
+++ b/spec/models/molecule_spec.rb
@@ -50,9 +50,15 @@ RSpec.describe Molecule, type: :model do
       expect { invalid_molecule.save! }.to raise_error(ActiveRecord::RecordNotUnique)
     end
 
-    it 'have a tag with CID' do
+    it 'defers the PubChem CID tag to async enrichment (not populated synchronously on create)' do
       molecule.save!
-      expect(molecule.tag.taggable_data['pubchem_cid']).to eq('123456789')
+      expect(molecule.tag.taggable_data['pubchem_cid']).to be_nil
+    end
+
+    it 'backfills the PubChem CID tag idempotently via #assign_pubchem_names_and_cid!' do
+      molecule.save!
+      molecule.assign_pubchem_names_and_cid!(cid: '123456789', iupac_name: 'water', names: [])
+      expect(molecule.reload.tag.taggable_data['pubchem_cid']).to eq('123456789')
     end
 
     it 'has molecule_names' do
@@ -226,6 +232,82 @@ RSpec.describe Molecule, type: :model do
       expect(molecule.id).to eq(existing.id)
       expect(PubchemLookupJob).not_to have_received(:perform_later)
     end
+
+    it 'does not call PubChem synchronously on the create path (C2: enrichment is async)' do
+      allow(PubchemLookupJob).to receive(:perform_later)
+
+      described_class.find_or_create_by_molfile('molfile', **babel_info)
+
+      expect(Chemotion::PubchemService).not_to have_received(:molecule_info_from_inchikey)
+    end
+
+    context 'when a concurrent worker wins the create race (C1)' do
+      it 're-finds the existing row instead of raising PG::UniqueViolation, without re-enqueueing LCSS' do
+        existing = create(
+          :molecule,
+          inchikey: babel_info[:inchikey],
+          is_partial: false,
+          sum_formular: babel_info[:formula],
+          skip_lcss_callback: true,
+        )
+        # Simulate the TOCTOU race: find_by misses, then the INSERT collides with the row the
+        # winning worker committed in the gap.
+        allow(described_class).to receive(:find_by).and_return(nil, existing)
+        allow(described_class).to receive(:create).and_raise(ActiveRecord::RecordNotUnique)
+        allow(PubchemLookupJob).to receive(:perform_later)
+
+        molecule = described_class.find_or_create_by_molfile('molfile', **babel_info)
+
+        expect(molecule.id).to eq(existing.id)
+        # the losing call must NOT re-enqueue enrichment/LCSS for a row the winner already handled
+        # (its own failed Molecule.create never committed, so after_create_commit never fired)
+        expect(PubchemLookupJob).not_to have_received(:perform_later)
+      end
+
+      # The stubbed sibling above raises RecordNotUnique in Ruby, which never touches Postgres
+      # and so cannot detect a missing savepoint. This one drives a real unique-index
+      # violation from inside an enclosing transaction — the shape every transactional caller
+      # has (Sample's before_save :find_or_create_molecule, ImportSamples#write_to_db,
+      # ImportCollections#import). Without requires_new: true the aborted INSERT leaves the
+      # outer transaction in PG::InFailedSqlTransaction and the rescue's own re-find raises.
+      it 'recovers from a genuine unique-index violation inside an enclosing transaction' do
+        allow(PubchemLookupJob).to receive(:perform_later)
+        winner = nil
+
+        allow(described_class).to receive(:find_by).and_wrap_original do |orig, *args|
+          found = orig.call(*args)
+          next found unless found.nil? && winner.nil?
+
+          # Stand in for the competing worker committing in the TOCTOU gap: the winning row
+          # is created *before* the savepoint opens, so rolling back to it leaves the row.
+          winner = create(
+            :molecule,
+            inchikey: babel_info[:inchikey],
+            is_partial: false,
+            sum_formular: babel_info[:formula],
+            skip_lcss_callback: true,
+          )
+          nil
+        end
+
+        molecule = ActiveRecord::Base.transaction do
+          described_class.find_or_create_by_molfile('molfile', defer_lcss: true, **babel_info)
+        end
+
+        expect(winner).to be_present
+        expect(molecule.id).to eq(winner.id)
+        expect(described_class.where(inchikey: babel_info[:inchikey]).count).to eq 1
+      end
+
+      it 're-raises when the row is genuinely absent after RecordNotUnique' do
+        allow(described_class).to receive(:find_by).and_return(nil, nil)
+        allow(described_class).to receive(:create).and_raise(ActiveRecord::RecordNotUnique)
+
+        expect do
+          described_class.find_or_create_by_molfile('molfile', **babel_info)
+        end.to raise_error(ActiveRecord::RecordNotUnique)
+      end
+    end
   end
 
   describe '.schedule_lcss_since' do
@@ -389,6 +471,34 @@ RSpec.describe Molecule, type: :model do
 
       described_class.find_or_create_by_molfile(ball_only_molfile)
       expect(described_class).to have_received(:svg_reprocess).with(nil, ball_only_molfile)
+    end
+  end
+
+  describe '#assign_pubchem_names_and_cid!' do
+    let(:molecule) { create(:molecule, iupac_name: nil, names: []) }
+
+    it 'persists names/cid idempotently across repeated calls', :aggregate_failures do
+      2.times do
+        molecule.assign_pubchem_names_and_cid!(cid: '999', iupac_name: 'water', names: %w[aqua dihydrogen-oxide])
+      end
+
+      expect(molecule.reload.iupac_name).to eq('water')
+      expect(molecule.tag.taggable_data['pubchem_cid']).to eq('999')
+      expect(molecule.molecule_names.where(description: 'iupac_name').pluck(:name))
+        .to contain_exactly('aqua', 'dihydrogen-oxide')
+    end
+
+    it 'does not overwrite an existing cid/name with nil', :aggregate_failures do
+      molecule.assign_pubchem_names_and_cid!(cid: '999', iupac_name: 'water', names: [])
+
+      molecule.assign_pubchem_names_and_cid!(cid: nil, iupac_name: nil, names: [])
+
+      expect(molecule.reload.tag.taggable_data['pubchem_cid']).to eq('999')
+      expect(molecule.iupac_name).to eq('water')
+    end
+
+    it 'no-ops on blank info' do
+      expect { molecule.assign_pubchem_names_and_cid!({}) }.not_to(change { molecule.molecule_names.count })
     end
   end
 end

--- a/spec/models/molecule_spec.rb
+++ b/spec/models/molecule_spec.rb
@@ -241,6 +241,17 @@ RSpec.describe Molecule, type: :model do
       expect(Chemotion::PubchemService).not_to have_received(:molecule_info_from_inchikey)
     end
 
+    # names is nullable but defaults to []. Deferred enrichment passes {}, and assigning nil
+    # would send an explicit NULL that bypasses that default — readers index into it without
+    # a nil guard (ChemicalAPI's molecule.names[0]).
+    it 'stores names as an empty array, not NULL, when enrichment is deferred' do
+      allow(PubchemLookupJob).to receive(:perform_later)
+
+      molecule = described_class.find_or_create_by_molfile('molfile', **babel_info)
+
+      expect(molecule.reload.names).to eq([])
+    end
+
     context 'when a concurrent worker wins the create race (C1)' do
       it 're-finds the existing row instead of raising PG::UniqueViolation, without re-enqueueing LCSS' do
         existing = create(

--- a/spec/models/molecule_spec.rb
+++ b/spec/models/molecule_spec.rb
@@ -495,8 +495,10 @@ RSpec.describe Molecule, type: :model do
 
       expect(molecule.reload.iupac_name).to eq('water')
       expect(molecule.tag.taggable_data['pubchem_cid']).to eq('999')
+      # 'water' is the iupac_name and is not among names — PubChem does not guarantee it is.
+      # A row is created for it regardless, so a sample has something to be re-pointed to.
       expect(molecule.molecule_names.where(description: 'iupac_name').pluck(:name))
-        .to contain_exactly('aqua', 'dihydrogen-oxide')
+        .to contain_exactly('aqua', 'dihydrogen-oxide', 'water')
     end
 
     it 'does not overwrite an existing cid/name with nil', :aggregate_failures do

--- a/spec/models/sample_spec.rb
+++ b/spec/models/sample_spec.rb
@@ -174,18 +174,19 @@ RSpec.describe Sample do
       MOLFILE
     end
     let(:sample) { build(:sample, molfile: molfile) }
+    # PubChem-derived fields (iupac_name/names) are no longer populated synchronously at save
+    # time — enrichment is deferred to the async job (C2). Only the babel-derived structure
+    # data is available immediately.
     let(:mol_attributes) do
       {
         'boiling_point' => nil,
         'density' => 0.0,
         'inchikey' => 'XLYOFNOQVPJJNP-UHFFFAOYSA-N',
         'inchistring' => 'InChI=1S/H2O/h1H2',
-        'iupac_name' => 'oxidane',
         'melting_point' => nil,
         'molecular_weight' => 18.01528,
         #  "molecule_svg_file" => "XLYOFNOQVPJJNP-UHFFFAOYSA-N.svg", #todo
         'molfile' => molfile.rstrip,
-        'names' => %w[water oxidane],
         'sum_formular' => 'H2O',
       }
     end
@@ -207,6 +208,20 @@ RSpec.describe Sample do
       mol_attributes.each do |k, v|
         expect(molecule.attributes[k]).to eq(v)
       end
+    end
+
+    it 'defers PubChem-derived names to async enrichment' do
+      sample.save!
+      molecule = sample.molecule
+
+      # not populated synchronously on the create path (C2)
+      expect(molecule.iupac_name).to be_nil
+
+      # the async enrich path (PubchemLookupJob -> Molecule#enrich_from_pubchem) backfills
+      # the iupac_name column and molecule_names records.
+      molecule.enrich_from_pubchem
+      expect(molecule.reload.iupac_name).to eq('oxidane')
+      expect(molecule.molecule_names.where(description: 'iupac_name').pluck(:name)).to include('water', 'oxidane')
     end
 
     # #Fixme : now file are anonymised

--- a/spec/models/sample_spec.rb
+++ b/spec/models/sample_spec.rb
@@ -224,6 +224,36 @@ RSpec.describe Sample do
       expect(molecule.molecule_names.where(description: 'iupac_name').pluck(:name)).to include('water', 'oxidane')
     end
 
+    it 'binds molecule_name to the sum formula while enrichment is still pending' do
+      sample.save!
+
+      expect(sample.molecule_name.description).to eq('sum_formular')
+      expect(sample.molecule_name.name).to eq('H2O')
+    end
+
+    # Sample's before_create :check_molecule_name runs while iupac_name is still nil, and
+    # #update_molecule_name only re-evaluates when molecule_id changes — so without the
+    # re-point in #assign_pubchem_names_and_cid! the sample would show and export as H2O
+    # forever, even after enrichment supplied the real name.
+    it 're-points molecule_name to the IUPAC row once enrichment lands' do
+      sample.save!
+
+      sample.molecule.enrich_from_pubchem
+
+      expect(sample.reload.molecule_name.description).to eq('iupac_name')
+      expect(sample.molecule_name.name).to eq('oxidane')
+    end
+
+    it 'leaves a user-chosen molecule_name alone when enrichment lands' do
+      sample.save!
+      chosen = sample.molecule.molecule_names.create!(name: 'my label', description: 'defined by user 1')
+      sample.update_columns(molecule_name_id: chosen.id) # rubocop:disable Rails/SkipsModelValidations
+
+      sample.molecule.enrich_from_pubchem
+
+      expect(sample.reload.molecule_name_id).to eq(chosen.id)
+    end
+
     # #Fixme : now file are anonymised
     # it 'should create the molecule svg file' do
     #  expect(File).to receive(:new)


### PR DESCRIPTION
Extracted from #3407, which is named for the molecule find-or-create race fix and had grown to carry this unrelated feature. Splitting it keeps that PR focused and lets this one be reviewed on its own merits.

**Stacked on #3407** — it reuses `Molecule#enrich_from_pubchem`, which that PR introduces. Merge #3407 first, then rebase this onto `main`.

## What it does

`Molecule#refresh_molecule_data` already existed but nothing reached it. This exposes an on-demand re-query as `POST /api/v1/molecules/refresh`, plus a button in the sample properties form, and makes the existing PubChem icon trigger the refresh when no CID has been assigned yet.

Useful when async enrichment has not populated a CID — or never will, because PubChem does not recognise the inchikey.

## Review findings addressed while extracting

The feature as originally written did not work end to end. Fixed here:

- **The CID was never persisted.** `refresh_molecule_data` ends in `save!`, and `Taggable`'s `before_save` only mutates `tag.taggable_data` in memory; `element_tags` is a `has_one` declared without `autosave:`, so Rails never writes an attribute-only change to an already-persisted record. The response carried a CID that was gone on the next reload. The endpoint now calls `#enrich_from_pubchem`, which persists atomically.
- **No authorization.** Any authenticated user could mutate any molecule row — a globally shared record — and drive an outbound PubChem request by iterating ids. Now gated on `molecule_editor`, matching the other molecule-mutating endpoints in the file.
- **Not idempotent, and grew the disk.** `refresh_molecule_data` re-ran `assign_molecule_data` on an already-normalised molfile, so for `is_partial` molecules `check_sum_formular` subtracted a second CH3 from `molecular_weight` on every call, and `attach_svg` wrote a fresh SVG into `public/images/molecules` without removing the previous one. Both gone via the `#enrich_from_pubchem` switch.
- **Errors returned HTTP 200** with an error envelope, so the client's `.catch` never fired and the envelope was spread into `sample.molecule`, overwriting `id`/`iupac_name` with `undefined` and blanking a good CID. Now a real 5xx, and the action surfaces a notification.
- **`MoleculeEntity#pubchem_cid` crashed at detail level 0**, where `SampleEntity#molecule` represents a plain Hash — 32 failing entity specs. Guarded with `respond_to?(:tag)`, like the sibling `#molfile`.
- **The PubChem link disappeared for shared-collection viewers.** The disabled check required `molecule.id`, absent at detail level 0, although the CID is still exposed there.
- **Opening the icon from the element list corrupted the open-tab state.** `elementIndex` returns `-1` when the sample has no detail tab, and `updateElement`'s `slice(0, -1)` dropped the last open tab while `slice(0)` re-appended everything, doubling `selecteds`.

## Verification

`spec/api/molecule_api_spec.rb`, `spec/api/entities/`, `spec/models/molecule_spec.rb` — 198 examples, 0 failures. New specs assert the CID survives a reload, that no SVG is rewritten, and that a non-editor is refused. `rubocop` and `eslint` clean on all changed lines.