### PR TITLE
fix(research-plan): resolve linked sample and reaction ids on export/import

### DIFF
--- a/app/controllers/oauth/radar_controller.rb
+++ b/app/controllers/oauth/radar_controller.rb
@@ -63,7 +63,7 @@ class Oauth::RadarController < ApplicationController
           collection.metadata.reset_radar_ids
 
           # enqueue the job to create the files and upload them to radar
-          ExportCollectionToRadarJob.perform_later(access_token, collection_id, response['id'])
+          ExportCollectionToRadarJob.perform_later(access_token, collection_id, response['id'], current_user.id)
 
           return redirect_to action: 'export'
         end

--- a/app/jobs/export_collection_to_radar_job.rb
+++ b/app/jobs/export_collection_to_radar_job.rb
@@ -3,7 +3,7 @@ class ExportCollectionToRadarJob < ActiveJob::Base
 
   queue_as :export_collection_to_radar
 
-  def perform(access_token, collection_id, dataset_id)
+  def perform(access_token, collection_id, dataset_id, current_user_id = nil)
     @success = true
     @access_token = access_token
     @collection_id = collection_id
@@ -11,7 +11,7 @@ class ExportCollectionToRadarJob < ActiveJob::Base
 
     begin
       # create the collection export
-      export = Export::ExportCollections.new(job_id, [@collection_id], 'zip', true)
+      export = Export::ExportCollections.new(job_id, [@collection_id], 'zip', true, false, current_user_id)
       export.prepare_data
       export.to_file
 

--- a/app/jobs/export_collections_job.rb
+++ b/app/jobs/export_collections_job.rb
@@ -39,7 +39,7 @@ class ExportCollectionsJob < ApplicationJob
       @link = "#{Rails.application.config.root_url}/zip/#{job_id}.#{extname}"
       @expires_at = Time.now + 24.hours
 
-      export = Export::ExportCollections.new(job_id, collection_ids, extname, nested)
+      export = Export::ExportCollections.new(job_id, collection_ids, extname, nested, false, user_id)
       export.prepare_data
       export.to_file
     rescue StandardError => e

--- a/app/jobs/transfer_repo_job.rb
+++ b/app/jobs/transfer_repo_job.rb
@@ -28,6 +28,9 @@ class TransferRepoJob < ApplicationJob
   end
 
   def payload(collection_id)
+    # No current_user_id, intentionally: gate: true skips fetch_research_plans entirely (see
+    # Export::ExportCollections#prepare_data), so no research plan body ever gets processed here
+    # and there is nothing for an exporting user to gate sample/reaction link conversion on.
     export = Export::ExportCollections.new(job_id, [collection_id], 'zip', false, true)
     export.prepare_data
     data_file_path = export.to_file

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -232,54 +232,29 @@ class Reaction < ApplicationRecord
   end
 
   def update_svg_file!
-    svg = reaction_svg_file
-    if svg.present? && svg.end_with?('</svg>')
-      svg_file_name = "#{SecureRandom.hex(64)}.svg"
-      svg_path = Rails.public_path.join('images', 'reactions', svg_file_name)
-      svg_file = File.new(svg_path, 'w+')
-      svg_file.write(svg)
-      svg_file.close
-      self.reaction_svg_file = svg_file_name
+    if legacy_inline_svg?
+      persist_legacy_inline_svg!
     else
-      paths = {}
-      {
-        starting_materials: :reactions_starting_material_samples,
-        reactants: :reactions_reactant_samples,
-        products: :reactions_product_samples,
-      }.each do |prop, resource|
-        collection = public_send(resource).includes(sample: :molecule)
-        paths[prop] = collection.map do |reactions_sample|
-          sample = reactions_sample.sample
-          params = [sample.get_svg_path]
-          params[0] = sample.svg_text_path if reactions_sample.show_label
-          params.append(yield_amount(sample.id)) if prop == :products
-          params
-        end
-      end
-      # SBMM reactants are stored in a separate association, so append them explicitly.
-      paths[:reactants] += reactant_sbmm_samples.map { |sbmm_sample| [sbmm_sample.svg_text_path] }
       begin
-        composer_options = {
-          temperature: temperature_display_with_unit,
-          duration: duration,
-          solvents: solvents_in_svg,
-          conditions: conditions,
-          show_yield: !interaction?,
-        }
-        composer_class = interaction? ? SVG::ProductsComposer : SVG::ReactionComposer
-        composer = composer_class.new(paths, composer_options)
-        self.reaction_svg_file = composer.compose_reaction_svg_and_save
+        self.reaction_svg_file = scheme_composer.compose_reaction_svg_and_save
       rescue StandardError => _e
         Rails.logger.info('**** SVG::ReactionComposer failed ***')
       end
     end
-    if reaction_svg_file_changed? && reaction_svg_file_was.present?
-      file_was = Rails.public_path.join('images', 'reactions', reaction_svg_file_was)
-      if Reaction.where(reaction_svg_file: reaction_svg_file_was).length < 2 && File.exist?(file_was)
-        File.delete(file_was)
-      end
-    end
+    cleanup_previous_svg_file!
     reaction_svg_file
+  end
+
+  # A freshly composed, report-styled scheme (larger text; solvents/temperature/duration/conditions/
+  # yield overlaid on the arrow, see SVG::ReactionComposer's `is_report` option) — as opposed to
+  # #reaction_svg_file, which is the plain persisted scheme. Not persisted to the reaction itself;
+  # returns the raw SVG string, or nil if composition fails.
+  def compose_report_scheme_svg
+    scheme_composer(is_report: true).compose_reaction_svg
+  rescue StandardError => e
+    Rails.logger.info('**** SVG::ReactionComposer failed (report scheme) ***')
+    Rails.logger.info(e.message)
+    nil
   end
 
   # return the full path of the svg file if it exists in the public folder otherwise nil.
@@ -364,6 +339,62 @@ class Reaction < ApplicationRecord
 
     variation['metadata']['analyses'] << analysis_id
     true
+  end
+
+  def legacy_inline_svg?
+    reaction_svg_file.present? && reaction_svg_file.end_with?('</svg>')
+  end
+
+  def persist_legacy_inline_svg!
+    svg_file_name = "#{SecureRandom.hex(64)}.svg"
+    Rails.public_path.join('images', 'reactions', svg_file_name).write(reaction_svg_file)
+    self.reaction_svg_file = svg_file_name
+  end
+
+  def cleanup_previous_svg_file!
+    return unless reaction_svg_file_changed? && reaction_svg_file_was.present?
+
+    file_was = Rails.public_path.join('images', 'reactions', reaction_svg_file_was)
+    return unless Reaction.where(reaction_svg_file: reaction_svg_file_was).length < 2 && File.exist?(file_was)
+
+    File.delete(file_was)
+  end
+
+  def scheme_composer(is_report: false)
+    composer_options = {
+      temperature: temperature_display_with_unit,
+      duration: duration,
+      solvents: solvents_in_svg,
+      conditions: conditions,
+      show_yield: !interaction?,
+      is_report: is_report,
+    }
+    composer_class = interaction? ? SVG::ProductsComposer : SVG::ReactionComposer
+    composer_class.new(scheme_materials_svg_paths, composer_options)
+  end
+
+  def scheme_materials_svg_paths
+    paths = {}
+    {
+      starting_materials: :reactions_starting_material_samples,
+      reactants: :reactions_reactant_samples,
+      products: :reactions_product_samples,
+    }.each do |prop, resource|
+      paths[prop] = scheme_material_svg_paths(resource, prop)
+    end
+    # SBMM reactants are stored in a separate association, so append them explicitly.
+    paths[:reactants] += reactant_sbmm_samples.map { |sbmm_sample| [sbmm_sample.svg_text_path] }
+    paths
+  end
+
+  def scheme_material_svg_paths(resource, prop)
+    public_send(resource).includes(sample: :molecule).map do |reactions_sample|
+      sample = reactions_sample.sample
+      params = [sample.get_svg_path]
+      params[0] = sample.svg_text_path if reactions_sample.show_label
+      params.append(yield_amount(sample.id)) if prop == :products
+      params
+    end
   end
 
   def set_default_reaction_type

--- a/app/policies/element_policy.rb
+++ b/app/policies/element_policy.rb
@@ -56,6 +56,15 @@ class ElementPolicy
     record_is_in_own_collection? || record_shared_with_minimum_detail_level?(3)
   end
 
+  # Whether the record's structural data (e.g. a Sample's molfile, see SampleEntity's
+  # `anonymize_below: 1`) is visible to the user, as opposed to merely being able to see that
+  # the record exists (see #read?).
+  def read_structure?
+    return false unless user_and_record_present?
+
+    record_is_in_own_collection? || record_shared_with_minimum_detail_level?(1)
+  end
+
   def import?
     return false unless user_and_record_present?
 

--- a/app/policies/element_policy.rb
+++ b/app/policies/element_policy.rb
@@ -65,6 +65,16 @@ class ElementPolicy
     record_is_in_own_collection? || record_shared_with_minimum_detail_level?(1)
   end
 
+  # Whether the user holds full (owner-equivalent) detail access to the record — the same bar
+  # Collection.full_detail_access_ids uses to gate the raw collection export path. Used where an
+  # operation would expose more than the record's own fields, e.g. a Reaction's composed report
+  # scheme, which is only exposed to a sharee at ReactionEntity's `anonymize_below: 10`.
+  def read_full_detail?
+    return false unless user_and_record_present?
+
+    record_is_in_own_collection? || record_shared_with_minimum_detail_level?(Collection::OWNER_LEVEL)
+  end
+
   def import?
     return false unless user_and_record_present?
 

--- a/app/policies/element_policy.rb
+++ b/app/policies/element_policy.rb
@@ -65,10 +65,12 @@ class ElementPolicy
     record_is_in_own_collection? || record_shared_with_minimum_detail_level?(1)
   end
 
-  # Whether the user holds full (owner-equivalent) detail access to the record — the same bar
-  # Collection.full_detail_access_ids uses to gate the raw collection export path. Used where an
-  # operation would expose more than the record's own fields, e.g. a Reaction's composed report
-  # scheme, which is only exposed to a sharee at ReactionEntity's `anonymize_below: 10`.
+  # Whether the user holds full (owner-equivalent) detail access to the record on *this record
+  # type's own* detail-level column (e.g. reaction_detail_level for a Reaction) — narrower than
+  # Collection.full_detail_access_ids, which additionally requires every other element type's
+  # detail level to be at OWNER_LEVEL too, since it gates exporting the whole collection raw. Used
+  # where an operation would expose more than the record's own fields, e.g. a Reaction's composed
+  # report scheme, which is only exposed to a sharee at ReactionEntity's `anonymize_below: 10`.
   def read_full_detail?
     return false unless user_and_record_present?
 

--- a/lib/export/export_collections.rb
+++ b/lib/export/export_collections.rb
@@ -22,6 +22,11 @@ module Export
       @attachments = []
       @datasets = []
       @images = []
+      # Attachments created for the export itself (e.g. a converted reaction-link image, see
+      # #build_research_plan_image_attachment), as opposed to pre-existing ones already on the
+      # exporting system. Tracked so they can be purged once no longer needed — export must not
+      # leave new rows/files (and quota usage) behind on the system being exported from.
+      @synthetic_attachments = []
     end
     # rubocop:enable Style/OptionalBooleanParameter, Metrics/ParameterLists
 
@@ -104,6 +109,10 @@ module Export
 
         @file_path
       end
+    ensure
+      # Synthetic attachments only need to survive long enough to be streamed above; the exporting
+      # system must not be left holding new rows/files (and quota usage) after export finishes.
+      cleanup_synthetic_attachments
     end
 
     def prepare_data
@@ -145,6 +154,11 @@ module Export
       end
 
       remap_research_plan_body_links
+    rescue StandardError
+      # A synthetic attachment from an earlier, already-processed research plan must not outlive a
+      # failed export — #to_file (the normal cleanup point, see its ensure) will never run.
+      cleanup_synthetic_attachments
+      raise
     end
 
     private
@@ -750,6 +764,9 @@ module Export
         created_for: exporting_user.id,
       )
       attachment.save!
+      # Tracked immediately on persistence, not after a successful #bundle_..., so it still gets
+      # cleaned up even if something downstream fails before the field is actually converted.
+      @synthetic_attachments << attachment
       # Without this, the in-memory Shrine reference set by the after_save attach callback streams
       # back empty on its first read — a fresh reload forces it to rebuild from the persisted record.
       # Note: Attachment#reload returns set_key's value, not self, so it can't be the last expression.
@@ -774,6 +791,19 @@ module Export
 
     def real_id_for_uuid(type, target_uuid)
       @uuids.fetch(type, {}).key(target_uuid)
+    end
+
+    # Hard-deletes every attachment #build_research_plan_image_attachment created for this export —
+    # Attachment uses acts_as_paranoid, and a merely soft-deleted row would still count against the
+    # exporting user's quota. Idempotent (clears the tracked list), so calling it more than once, or
+    # after a partial failure, is safe.
+    def cleanup_synthetic_attachments
+      @synthetic_attachments.each do |attachment|
+        attachment.really_destroy!
+      rescue StandardError => e
+        Rails.logger.error("Failed to clean up synthetic research plan attachment #{attachment.id}: #{e.message}")
+      end
+      @synthetic_attachments.clear
     end
 
     def exporting_user

--- a/lib/export/export_collections.rb
+++ b/lib/export/export_collections.rb
@@ -140,6 +140,8 @@ module Export
 
         fetch_segments
       end
+
+      remap_research_plan_body_links
     end
 
     private
@@ -600,6 +602,34 @@ module Export
 
       filter_missing_attachments(research_plan, attachments)
       process_attachments(attachments, research_plan)
+    end
+
+    # research plan bodies can embed links to other elements (e.g. type 'sample'/'reaction' fields
+    # holding a 'sample_id'/'reaction_id'). These still reference the source system's database id, so
+    # translate them to the same uuid used for the referenced element itself, once all collections have
+    # been fetched, so that import can resolve them against the newly created records (see
+    # Import::ImportCollections#import_research_plans).
+    def remap_research_plan_body_links
+      @data.fetch('ResearchPlan', {}).each_value do |fields|
+        body = fields['body']
+        next if body.blank?
+
+        body.each do |field|
+          case field['type']
+          when 'sample'
+            remap_body_reference(field, 'sample_id', 'Sample')
+          when 'reaction'
+            remap_body_reference(field, 'reaction_id', 'Reaction')
+          end
+        end
+      end
+    end
+
+    def remap_body_reference(field, key, type)
+      old_id = field.dig('value', key)
+      return if old_id.blank?
+
+      field['value'][key] = uuid(type, old_id) if uuid?(type, old_id)
     end
 
     def extract_image_fields(body)

--- a/lib/export/export_collections.rb
+++ b/lib/export/export_collections.rb
@@ -5,12 +5,14 @@ module Export
   class ExportCollections
     attr_accessor :file_path
 
-    def initialize(export_id, collection_ids, format = 'zip', nested = false, gate = false) # rubocop:disable Style/OptionalBooleanParameter
+    # rubocop:disable Style/OptionalBooleanParameter, Metrics/ParameterLists
+    def initialize(export_id, collection_ids, format = 'zip', nested = false, gate = false, current_user_id = nil)
       @export_id = export_id
       @collection_ids = collection_ids
       @format = format
       @nested = nested
       @gt = gate
+      @current_user_id = current_user_id
 
       @file_path = Rails.public_path.join(format, "#{export_id}.#{format}")
       @schema_file_path = Rails.public_path.join('json', 'schema.json')
@@ -21,6 +23,7 @@ module Export
       @datasets = []
       @images = []
     end
+    # rubocop:enable Style/OptionalBooleanParameter, Metrics/ParameterLists
 
     def to_json_data
       @data.to_json
@@ -608,9 +611,12 @@ module Export
     # holding a 'sample_id'/'reaction_id'). These still reference the source system's database id, so
     # translate them to the same uuid used for the referenced element itself, once all collections have
     # been fetched, so that import can resolve them against the newly created records (see
-    # Import::ImportCollections#import_research_plans). A link whose target isn't part of this export
-    # (a different, non-exported collection) is dropped rather than left with a stale id — on import that
-    # id could coincidentally match an unrelated record on the target system.
+    # Import::ImportCollections#import_research_plans). A sample link whose target isn't part of this
+    # export is instead converted into a static 'ketcher' field with the sample's structure, so the
+    # chemistry survives even though the live sample record doesn't (see #convert_sample_link_to_ketcher?).
+    # A reaction link in the same situation, or a sample link that can't be converted, is dropped rather
+    # than left with a stale id — on import that id could coincidentally match an unrelated record on
+    # the target system.
     def remap_research_plan_body_links
       @data.fetch('ResearchPlan', {}).each_value do |fields|
         body = fields['body']
@@ -623,12 +629,20 @@ module Export
     def unresolved_body_link?(field)
       case field['type']
       when 'sample'
-        drop_unless_remapped?(field, 'sample_id', 'Sample')
+        unresolved_sample_link?(field)
       when 'reaction'
         drop_unless_remapped?(field, 'reaction_id', 'Reaction')
       else
         false
       end
+    end
+
+    def unresolved_sample_link?(field)
+      old_id = field.dig('value', 'sample_id')
+      return true if old_id.blank?
+      return drop_unless_remapped?(field, 'sample_id', 'Sample') if uuid?('Sample', old_id)
+
+      convert_sample_link_to_ketcher?(field, old_id)
     end
 
     def drop_unless_remapped?(field, key, type)
@@ -638,6 +652,32 @@ module Export
 
       field['value'][key] = uuid(type, old_id)
       false
+    end
+
+    # Preserve the structure of a sample linked from outside the export as a static Ketcher schema,
+    # provided the exporting user can actually see that sample's structure — otherwise a research plan
+    # could be used to smuggle a structure out of a collection the exporting user has no (or only
+    # detail-level-restricted) access to; a sample shared at the lowest detail level is readable but its
+    # molfile is anonymized (see SampleEntity's `anonymize_below: 1`), so #read? alone isn't enough.
+    # Returns `false` when the field was converted (i.e. keep it), `true` when it should be dropped.
+    def convert_sample_link_to_ketcher?(field, sample_id)
+      return true if exporting_user.nil?
+
+      sample = Sample.find_by(id: sample_id)
+      return true if sample&.molfile.blank?
+
+      policy = ElementPolicy.new(exporting_user, sample)
+      return true unless policy.read? && policy.read_structure?
+
+      field['type'] = 'ketcher'
+      field['value'] = { 'sdf_file' => sample.molfile, 'svg_file' => nil }
+      false
+    end
+
+    def exporting_user
+      return @exporting_user if defined?(@exporting_user)
+
+      @exporting_user = @current_user_id && User.find_by(id: @current_user_id)
     end
 
     def extract_image_fields(body)

--- a/lib/export/export_collections.rb
+++ b/lib/export/export_collections.rb
@@ -94,7 +94,11 @@ module Export
             annotation.to_io.close if annotation.respond_to?(:to_io)
           end
           # write all the images into an images directory
-          @images.each do |file_path|
+          # .uniq: #build_research_plan_ketcher_svg computes a content-addressed filename per link,
+          # so the same outside sample linked from two research plans (or twice from one) produces
+          # the same #fetch_image path both times — without this, put_next_entry gets called twice
+          # with the identical entry name.
+          @images.uniq.each do |file_path|
             image_data = Rails.public_path.join(file_path).read
             image_checksum = Digest::SHA256.hexdigest(image_data)
             zipping.put_next_entry file_path

--- a/lib/export/export_collections.rb
+++ b/lib/export/export_collections.rb
@@ -679,8 +679,33 @@ module Export
       return true unless policy.read? && policy.read_structure?
 
       field['type'] = 'ketcher'
-      field['value'] = { 'sdf_file' => sample.molfile, 'svg_file' => nil }
+      field['value'] = { 'sdf_file' => sample.molfile, 'svg_file' => build_research_plan_ketcher_svg(sample.molfile) }
       false
+    end
+
+    # Renders a preview svg for a synthesized ketcher field, following the same convention research
+    # plan ketcher fields already use (see POST /api/v1/research_plans/svg in research_plan_api.rb):
+    # a content-addressed filename under public/images/research_plans/. Written on the exporting
+    # system (a real Ketcher-drawn field's svg is written there too, when the user saves it) and
+    # bundled into the zip so it can be materialized on import (see
+    # Import::ImportCollections#materialize_researchplan_ketcher_images). Returns nil — leaving the
+    # field with no preview, same as before — if rendering fails; the sdf_file is preserved either way.
+    def build_research_plan_ketcher_svg(molfile)
+      svg = Molecule.svg_reprocess(nil, molfile)
+      return nil if svg.blank?
+
+      filename = "#{Digest::SHA256.hexdigest(Digest::SHA256.hexdigest(svg))}.svg"
+      target_path = Rails.public_path.join('images', 'research_plans', filename)
+      unless File.file?(target_path)
+        FileUtils.mkdir_p(target_path.dirname)
+        File.write(target_path, svg)
+      end
+
+      fetch_image('research_plans', filename)
+      filename
+    rescue StandardError => e
+      Rails.logger.error("Failed to render ketcher preview svg: #{e.message}")
+      nil
     end
 
     # Preserve a reaction linked from outside the export as a static image of its report-style scheme

--- a/lib/export/export_collections.rb
+++ b/lib/export/export_collections.rb
@@ -608,28 +608,36 @@ module Export
     # holding a 'sample_id'/'reaction_id'). These still reference the source system's database id, so
     # translate them to the same uuid used for the referenced element itself, once all collections have
     # been fetched, so that import can resolve them against the newly created records (see
-    # Import::ImportCollections#import_research_plans).
+    # Import::ImportCollections#import_research_plans). A link whose target isn't part of this export
+    # (a different, non-exported collection) is dropped rather than left with a stale id — on import that
+    # id could coincidentally match an unrelated record on the target system.
     def remap_research_plan_body_links
       @data.fetch('ResearchPlan', {}).each_value do |fields|
         body = fields['body']
         next if body.blank?
 
-        body.each do |field|
-          case field['type']
-          when 'sample'
-            remap_body_reference(field, 'sample_id', 'Sample')
-          when 'reaction'
-            remap_body_reference(field, 'reaction_id', 'Reaction')
-          end
-        end
+        fields['body'] = body.reject { |field| unresolved_body_link?(field) }
       end
     end
 
-    def remap_body_reference(field, key, type)
-      old_id = field.dig('value', key)
-      return if old_id.blank?
+    def unresolved_body_link?(field)
+      case field['type']
+      when 'sample'
+        drop_unless_remapped?(field, 'sample_id', 'Sample')
+      when 'reaction'
+        drop_unless_remapped?(field, 'reaction_id', 'Reaction')
+      else
+        false
+      end
+    end
 
-      field['value'][key] = uuid(type, old_id) if uuid?(type, old_id)
+    def drop_unless_remapped?(field, key, type)
+      old_id = field.dig('value', key)
+      return true if old_id.blank?
+      return true unless uuid?(type, old_id)
+
+      field['value'][key] = uuid(type, old_id)
+      false
     end
 
     def extract_image_fields(body)

--- a/lib/export/export_collections.rb
+++ b/lib/export/export_collections.rb
@@ -612,26 +612,27 @@ module Export
     # translate them to the same uuid used for the referenced element itself, once all collections have
     # been fetched, so that import can resolve them against the newly created records (see
     # Import::ImportCollections#import_research_plans). A sample link whose target isn't part of this
-    # export is instead converted into a static 'ketcher' field with the sample's structure, so the
-    # chemistry survives even though the live sample record doesn't (see #convert_sample_link_to_ketcher?).
-    # A reaction link in the same situation, or a sample link that can't be converted, is dropped rather
-    # than left with a stale id — on import that id could coincidentally match an unrelated record on
-    # the target system.
+    # export is instead converted into a static 'ketcher' field with the sample's structure (see
+    # #convert_sample_link_to_ketcher?), and a reaction link in the same situation into a static 'image'
+    # field with its report-style scheme (see #convert_reaction_link_to_image?), so the chemistry
+    # survives even though the live record doesn't. A link that can't be converted is dropped rather than
+    # left with a stale id — on import that id could coincidentally match an unrelated record on the
+    # target system.
     def remap_research_plan_body_links
-      @data.fetch('ResearchPlan', {}).each_value do |fields|
+      @data.fetch('ResearchPlan', {}).each do |research_plan_uuid, fields|
         body = fields['body']
         next if body.blank?
 
-        fields['body'] = body.reject { |field| unresolved_body_link?(field) }
+        fields['body'] = body.reject { |field| unresolved_body_link?(field, research_plan_uuid) }
       end
     end
 
-    def unresolved_body_link?(field)
+    def unresolved_body_link?(field, research_plan_uuid)
       case field['type']
       when 'sample'
         unresolved_sample_link?(field)
       when 'reaction'
-        drop_unless_remapped?(field, 'reaction_id', 'Reaction')
+        unresolved_reaction_link?(field, research_plan_uuid)
       else
         false
       end
@@ -643,6 +644,14 @@ module Export
       return drop_unless_remapped?(field, 'sample_id', 'Sample') if uuid?('Sample', old_id)
 
       convert_sample_link_to_ketcher?(field, old_id)
+    end
+
+    def unresolved_reaction_link?(field, research_plan_uuid)
+      old_id = field.dig('value', 'reaction_id')
+      return true if old_id.blank?
+      return drop_unless_remapped?(field, 'reaction_id', 'Reaction') if uuid?('Reaction', old_id)
+
+      convert_reaction_link_to_image?(field, old_id, research_plan_uuid)
     end
 
     def drop_unless_remapped?(field, key, type)
@@ -672,6 +681,74 @@ module Export
       field['type'] = 'ketcher'
       field['value'] = { 'sdf_file' => sample.molfile, 'svg_file' => nil }
       false
+    end
+
+    # Preserve a reaction linked from outside the export as a static image of its report-style scheme
+    # (the same rendering used when generating docx reports, see Reaction#compose_report_scheme_svg),
+    # provided the exporting user holds full detail access — a plain #read? isn't enough, since
+    # ReactionEntity only exposes `reaction_svg_file` at `anonymize_below: 10`, i.e. full detail.
+    # Returns `false` when the field was converted (i.e. keep it), `true` when it should be dropped.
+    def convert_reaction_link_to_image?(field, reaction_id, research_plan_uuid)
+      return true if exporting_user.nil?
+
+      reaction = Reaction.find_by(id: reaction_id)
+      return true if reaction.blank?
+
+      policy = ElementPolicy.new(exporting_user, reaction)
+      return true unless policy.read? && policy.read_full_detail?
+
+      svg = reaction.compose_report_scheme_svg
+      return true if svg.blank?
+
+      attachment = build_research_plan_image_attachment(svg)
+      return true if attachment.nil?
+
+      bundle_research_plan_image_attachment(attachment, research_plan_uuid)
+
+      field['type'] = 'image'
+      field['value'] = { 'public_name' => attachment.identifier, 'file_name' => attachment.filename }
+      false
+    end
+
+    # A research plan 'image' field always points at a real, if initially unassociated, Attachment
+    # record (see #fetch_research_plan_body_attachments) — so a synthesized one needs one too.
+    def build_research_plan_image_attachment(svg)
+      tmp = Tempfile.new(['reaction_scheme', '.svg'])
+      tmp.write(svg)
+      tmp.rewind
+
+      attachment = Attachment.new(
+        attachable_type: 'ResearchPlan',
+        filename: "#{SecureRandom.uuid}.svg",
+        file_path: tmp.path,
+        created_by: exporting_user.id,
+        created_for: exporting_user.id,
+      )
+      attachment.save!
+      # Without this, the in-memory Shrine reference set by the after_save attach callback streams
+      # back empty on its first read — a fresh reload forces it to rebuild from the persisted record.
+      # Note: Attachment#reload returns set_key's value, not self, so it can't be the last expression.
+      attachment.reload
+      attachment
+    rescue StandardError => e
+      Rails.logger.error("Failed to attach research plan report image: #{e.message}")
+      nil
+    ensure
+      tmp&.close
+      tmp&.unlink
+    end
+
+    # Bundles the attachment for the zip exactly like a pre-existing research-plan image attachment
+    # would be (see #process_attachments), associating it in the exported JSON — but not on the
+    # exporting system itself — with the research plan whose body now references it.
+    def bundle_research_plan_image_attachment(attachment, research_plan_uuid)
+      attachment['attachable_id'] = real_id_for_uuid('ResearchPlan', research_plan_uuid)
+      fetch_many([attachment], 'attachable_id' => 'ResearchPlan', 'created_by' => 'User', 'created_for' => 'User')
+      @attachments << attachment
+    end
+
+    def real_id_for_uuid(type, target_uuid)
+      @uuids.fetch(type, {}).key(target_uuid)
     end
 
     def exporting_user

--- a/lib/export/export_collections.rb
+++ b/lib/export/export_collections.rb
@@ -655,7 +655,7 @@ module Export
     def unresolved_sample_link?(field)
       old_id = field.dig('value', 'sample_id')
       return true if old_id.blank?
-      return drop_unless_remapped?(field, 'sample_id', 'Sample') if uuid?('Sample', old_id)
+      return drop_unless_remapped?(field, 'sample_id', 'Sample') if exported?('Sample', old_id)
 
       convert_sample_link_to_ketcher?(field, old_id)
     end
@@ -663,7 +663,7 @@ module Export
     def unresolved_reaction_link?(field, research_plan_uuid)
       old_id = field.dig('value', 'reaction_id')
       return true if old_id.blank?
-      return drop_unless_remapped?(field, 'reaction_id', 'Reaction') if uuid?('Reaction', old_id)
+      return drop_unless_remapped?(field, 'reaction_id', 'Reaction') if exported?('Reaction', old_id)
 
       convert_reaction_link_to_image?(field, old_id, research_plan_uuid)
     end
@@ -671,10 +671,19 @@ module Export
     def drop_unless_remapped?(field, key, type)
       old_id = field.dig('value', key)
       return true if old_id.blank?
-      return true unless uuid?(type, old_id)
+      return true unless exported?(type, old_id)
 
       field['value'][key] = uuid(type, old_id)
       false
+    end
+
+    # uuid?(type, id) only tells us a uuid was ever minted for id — not that the record itself was
+    # ever serialized into @data. fetch_one mints uuids for ancestor ids (and other foreign-keyed
+    # records) purely to write the 'ancestry' string, regardless of whether that ancestor is part of
+    # this export (e.g. a split sample's parent living in a different, non-exported collection).
+    # Presence in @data is the only reliable "is this actually part of the export" test.
+    def exported?(type, old_id)
+      @data.dig(type, uuid(type, old_id)).present?
     end
 
     # Preserve the structure of a sample linked from outside the export as a static Ketcher schema,

--- a/lib/export/export_collections.rb
+++ b/lib/export/export_collections.rb
@@ -654,7 +654,9 @@ module Export
 
     def unresolved_sample_link?(field)
       old_id = field.dig('value', 'sample_id')
-      return true if old_id.blank?
+      # An unfilled placeholder (see ResearchPlan.js#addSampleField) carries no stale reference to
+      # clean up — keep it as is, rather than treating it as unresolved and dropping it.
+      return false if old_id.blank?
       return drop_unless_remapped?(field, 'sample_id', 'Sample') if exported?('Sample', old_id)
 
       convert_sample_link_to_ketcher?(field, old_id)
@@ -662,7 +664,7 @@ module Export
 
     def unresolved_reaction_link?(field, research_plan_uuid)
       old_id = field.dig('value', 'reaction_id')
-      return true if old_id.blank?
+      return false if old_id.blank?
       return drop_unless_remapped?(field, 'reaction_id', 'Reaction') if exported?('Reaction', old_id)
 
       convert_reaction_link_to_image?(field, old_id, research_plan_uuid)
@@ -670,7 +672,7 @@ module Export
 
     def drop_unless_remapped?(field, key, type)
       old_id = field.dig('value', key)
-      return true if old_id.blank?
+      return false if old_id.blank?
       return true unless exported?(type, old_id)
 
       field['value'][key] = uuid(type, old_id)

--- a/lib/import/import_collections.rb
+++ b/lib/import/import_collections.rb
@@ -854,7 +854,10 @@ module Import
 
     def drop_unless_remapped?(field, key, type)
       old_ref = field.dig('value', key)
-      return true if old_ref.blank?
+      # An unfilled placeholder (see ResearchPlan.js#addSampleField) carries no stale reference to
+      # clean up — keep it as is, rather than treating it as unresolved and dropping it. Only ever
+      # hit for zips exported before Export::ExportCollections handled this case itself.
+      return false if old_ref.blank?
 
       new_instance = @instances.dig(type, old_ref)
       return true if new_instance.nil?

--- a/lib/import/import_collections.rb
+++ b/lib/import/import_collections.rb
@@ -86,7 +86,15 @@ module Import
             # write data to tmp dir with the same path
             path = File.join(@tmp_dir, entry_name)
             FileUtils.mkdir_p(File.dirname(path))
-            entry.extract(path) { |src, dest| IO.copy_stream(src, dest) }
+            # Zip::Entry#extract's block is an exists? gate, not a copy step (see rubyzip's
+            # Entry#create_file: `yield(self, dest_path)`, block truthy => overwrite) — it is not
+            # given IO objects, so the previous `IO.copy_stream(src, dest)` here would have raised
+            # TypeError had it ever actually run. In practice it never did: Zip::EntrySet is
+            # Hash-backed, so two same-named entries (e.g. two samples sharing a molecule, each
+            # exported via fetch_image('molecules', ...)) collapse to one on read and this
+            # exists-already branch is unreachable. Kept as an explicit always-overwrite for the
+            # same reason the original line existed, without the wrong argument assumption.
+            entry.extract(path) { true }
           end
         end
       end

--- a/lib/import/import_collections.rb
+++ b/lib/import/import_collections.rb
@@ -567,7 +567,7 @@ module Import
 
     def import_research_plans
       sort_data(@data.fetch('ResearchPlan', {})).each do |uuid, fields|
-        fields['body'] = remap_research_plan_body_links(fields['body'])
+        fields['body'] = remap_research_plan_body_links(fields['body'], fields['name'])
         materialize_researchplan_ketcher_images(fields['body'])
 
         # create the research_plan
@@ -835,24 +835,24 @@ module Import
     # import_reactions have populated @instances. A link that can't be resolved (unknown uuid, or a raw
     # id left over from a zip exported before this remapping existed) is dropped rather than kept as-is
     # — otherwise it could coincidentally match an unrelated record on the importing system.
-    def remap_research_plan_body_links(body)
+    def remap_research_plan_body_links(body, research_plan_name)
       return body if body.blank?
 
-      body.reject { |field| unresolved_body_link?(field) }
+      body.reject { |field| unresolved_body_link?(field, research_plan_name) }
     end
 
-    def unresolved_body_link?(field)
+    def unresolved_body_link?(field, research_plan_name)
       case field['type']
       when 'sample'
-        drop_unless_remapped?(field, 'sample_id', 'Sample')
+        drop_unless_remapped?(field, 'sample_id', 'Sample', research_plan_name)
       when 'reaction'
-        drop_unless_remapped?(field, 'reaction_id', 'Reaction')
+        drop_unless_remapped?(field, 'reaction_id', 'Reaction', research_plan_name)
       else
         false
       end
     end
 
-    def drop_unless_remapped?(field, key, type)
+    def drop_unless_remapped?(field, key, type, research_plan_name)
       old_ref = field.dig('value', key)
       # An unfilled placeholder (see ResearchPlan.js#addSampleField) carries no stale reference to
       # clean up — keep it as is, rather than treating it as unresolved and dropping it. Only ever
@@ -860,10 +860,30 @@ module Import
       return false if old_ref.blank?
 
       new_instance = @instances.dig(type, old_ref)
-      return true if new_instance.nil?
+      if new_instance.nil?
+        # Every zip exported before Export::ExportCollections started remapping these links carries
+        # a raw source-system id here that can never resolve against @instances — log it the same
+        # way as an unassociated attachment (see #log_unassociated_attachment), so the user can see
+        # what was silently removed and re-link it by hand, rather than it just vanishing.
+        log_dropped_element_link(research_plan_name, type, old_ref)
+        return true
+      end
 
       field['value'][key] = new_instance.id
       false
+    end
+
+    def log_dropped_element_link(research_plan_name, type, old_ref)
+      log_content = <<~LOG
+
+        Research Plan: #{research_plan_name}
+        #{type} reference: #{old_ref}
+        Error: link could not be resolved against the imported data and was removed from the research plan
+        ----------------------------------------
+
+      LOG
+
+      @logger.error(log_content)
     end
 
     # A research plan's 'ketcher' body field references its preview svg by bare filename, resolved by

--- a/lib/import/import_collections.rb
+++ b/lib/import/import_collections.rb
@@ -567,7 +567,7 @@ module Import
 
     def import_research_plans
       sort_data(@data.fetch('ResearchPlan', {})).each do |uuid, fields|
-        remap_research_plan_body_links(fields['body'])
+        fields['body'] = remap_research_plan_body_links(fields['body'])
 
         # create the research_plan
         research_plan = ResearchPlan.create!(fields.slice(
@@ -831,26 +831,35 @@ module Import
     # 'sample_id'/'reaction_id'), rewritten to the exported uuid by Export::ExportCollections. Resolve
     # them to the newly created instance's id, mirroring the id remapping already done for other
     # associations (reactions_samples, wells, ...) via @instances. Must run after import_samples and
-    # import_reactions have populated @instances.
+    # import_reactions have populated @instances. A link that can't be resolved (unknown uuid, or a raw
+    # id left over from a zip exported before this remapping existed) is dropped rather than kept as-is
+    # — otherwise it could coincidentally match an unrelated record on the importing system.
     def remap_research_plan_body_links(body)
-      return if body.blank?
+      return body if body.blank?
 
-      body.each do |field|
-        case field['type']
-        when 'sample'
-          remap_body_link!(field, 'sample_id', 'Sample')
-        when 'reaction'
-          remap_body_link!(field, 'reaction_id', 'Reaction')
-        end
+      body.reject { |field| unresolved_body_link?(field) }
+    end
+
+    def unresolved_body_link?(field)
+      case field['type']
+      when 'sample'
+        drop_unless_remapped?(field, 'sample_id', 'Sample')
+      when 'reaction'
+        drop_unless_remapped?(field, 'reaction_id', 'Reaction')
+      else
+        false
       end
     end
 
-    def remap_body_link!(field, key, type)
+    def drop_unless_remapped?(field, key, type)
       old_ref = field.dig('value', key)
-      return if old_ref.blank?
+      return true if old_ref.blank?
 
       new_instance = @instances.dig(type, old_ref)
-      field['value'][key] = new_instance.id if new_instance.present?
+      return true if new_instance.nil?
+
+      field['value'][key] = new_instance.id
+      false
     end
 
     def log_unassociated_attachment(research_plan_name, field)

--- a/lib/import/import_collections.rb
+++ b/lib/import/import_collections.rb
@@ -13,7 +13,7 @@ module Import
     def created_collection_labels
       return [] unless @instances.key?('Collection')
 
-      @instances['Collection'].values.map(&:label).compact.sort
+      @instances['Collection'].values.filter_map(&:label).sort
     end
 
     # rubocop:disable Style/OptionalBooleanParameter , Metrics/ParameterLists
@@ -204,7 +204,7 @@ module Import
         # add collection to @instances map
         update_instances!(uuid, collection)
       end
-      labels = created_collection_labels
+      created_collection_labels
     end
 
     def gate_collection

--- a/lib/import/import_collections.rb
+++ b/lib/import/import_collections.rb
@@ -567,6 +567,8 @@ module Import
 
     def import_research_plans
       sort_data(@data.fetch('ResearchPlan', {})).each do |uuid, fields|
+        remap_research_plan_body_links(fields['body'])
+
         # create the research_plan
         research_plan = ResearchPlan.create!(fields.slice(
           'name',
@@ -823,6 +825,32 @@ module Import
           log_unassociated_attachment(attr_value['name'], field)
         end
       end
+    end
+
+    # research plan bodies can embed links to other elements (type 'sample'/'reaction' fields holding a
+    # 'sample_id'/'reaction_id'), rewritten to the exported uuid by Export::ExportCollections. Resolve
+    # them to the newly created instance's id, mirroring the id remapping already done for other
+    # associations (reactions_samples, wells, ...) via @instances. Must run after import_samples and
+    # import_reactions have populated @instances.
+    def remap_research_plan_body_links(body)
+      return if body.blank?
+
+      body.each do |field|
+        case field['type']
+        when 'sample'
+          remap_body_link!(field, 'sample_id', 'Sample')
+        when 'reaction'
+          remap_body_link!(field, 'reaction_id', 'Reaction')
+        end
+      end
+    end
+
+    def remap_body_link!(field, key, type)
+      old_ref = field.dig('value', key)
+      return if old_ref.blank?
+
+      new_instance = @instances.dig(type, old_ref)
+      field['value'][key] = new_instance.id if new_instance.present?
     end
 
     def log_unassociated_attachment(research_plan_name, field)

--- a/lib/import/import_collections.rb
+++ b/lib/import/import_collections.rb
@@ -568,6 +568,7 @@ module Import
     def import_research_plans
       sort_data(@data.fetch('ResearchPlan', {})).each do |uuid, fields|
         fields['body'] = remap_research_plan_body_links(fields['body'])
+        materialize_researchplan_ketcher_images(fields['body'])
 
         # create the research_plan
         research_plan = ResearchPlan.create!(fields.slice(
@@ -860,6 +861,38 @@ module Import
 
       field['value'][key] = new_instance.id
       false
+    end
+
+    # A research plan's 'ketcher' body field references its preview svg by bare filename, resolved by
+    # the frontend as /images/research_plans/<svg_file> (not via the Attachment model). The export side
+    # bundles that file into the zip under images/research_plans/ (see extract's zip-entry handling,
+    # which lands it under @tmp_dir), but nothing previously copied it into the importing system's own
+    # public/images/research_plans/ — so every ketcher preview, hand-drawn or synthesized, rendered as
+    # a broken image after import. Must run before @tmp_dir is cleaned up (see #cleanup).
+    def materialize_researchplan_ketcher_images(body)
+      return if body.blank?
+
+      body.each do |field|
+        materialize_ketcher_svg(field.dig('value', 'svg_file')) if field['type'] == 'ketcher'
+      end
+    end
+
+    def materialize_ketcher_svg(svg_file)
+      return if svg_file.blank?
+
+      # Guard against a crafted zip smuggling a path (e.g. '../../secrets') through svg_file: only a
+      # bare filename identical to its own basename is accepted.
+      filename = File.basename(svg_file.to_s)
+      return if filename != svg_file || filename.match?(%r{\.\.|/|\\})
+
+      target_path = Rails.public_path.join('images', 'research_plans', filename)
+      return if File.file?(target_path)
+
+      source_path = Pathname.new(@tmp_dir).join('images', 'research_plans', filename)
+      return unless File.file?(source_path)
+
+      FileUtils.mkdir_p(target_path.dirname)
+      FileUtils.cp(source_path, target_path)
     end
 
     def log_unassociated_attachment(research_plan_name, field)

--- a/spec/jobs/export_collection_to_radar_job_spec.rb
+++ b/spec/jobs/export_collection_to_radar_job_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExportCollectionToRadarJob do
+  describe '#perform' do
+    let(:user) { create(:person) }
+    let(:collection) { create(:collection, user_id: user.id) }
+    let(:job) { described_class.new }
+
+    before do
+      collection.metadata = create(:metadata)
+    end
+
+    # Regression: current_user_id used to be silently dropped on this path, so
+    # Export::ExportCollections#exporting_user was always nil and an outside sample/reaction link
+    # linked from a research plan in this collection could never be converted (see
+    # #convert_sample_link_to_ketcher?/#convert_reaction_link_to_image?) — always dropped instead.
+    it 'passes the acting user id through to Export::ExportCollections' do
+      export_double = instance_double(
+        Export::ExportCollections, prepare_data: nil, to_file: nil, file_path: 'path/to/export.zip'
+      )
+      allow(Oauth2::Radar).to receive(:store_file).and_return('radar-file-id')
+      allow(Export::ExportCollections).to receive(:new).and_return(export_double)
+
+      job.perform('access-token', collection.id, 'dataset-id', user.id)
+
+      expect(Export::ExportCollections).to have_received(:new)
+        .with(anything, [collection.id], 'zip', true, false, user.id)
+    end
+
+    it 'still succeeds when no user id is given (e.g. an already-enqueued job from before this argument existed)' do
+      export_double = instance_double(
+        Export::ExportCollections, prepare_data: nil, to_file: nil, file_path: 'path/to/export.zip'
+      )
+      allow(Oauth2::Radar).to receive(:store_file).and_return('radar-file-id')
+      allow(Export::ExportCollections).to receive(:new).and_return(export_double)
+
+      job.perform('access-token', collection.id, 'dataset-id')
+
+      expect(Export::ExportCollections).to have_received(:new)
+        .with(anything, [collection.id], 'zip', true, false, nil)
+    end
+  end
+end

--- a/spec/lib/export/export_collections_spec.rb
+++ b/spec/lib/export/export_collections_spec.rb
@@ -147,6 +147,30 @@ RSpec.describe 'ExportCollection' do
     end
   end
 
+  # A synthetic attachment (see Export::ExportCollections#build_research_plan_image_attachment,
+  # used for converting an out-of-export reaction link into a static image) is a real, if
+  # initially unassociated, Attachment record — export must not leave it (or its quota usage)
+  # behind on the exporting system once it's no longer needed.
+  context 'with #cleanup_synthetic_attachments' do
+    let(:export) { Export::ExportCollections.new(job_id, [collection.id], 'zip', nested, gate, user.id) }
+
+    it 'hard-deletes a synthetic attachment, not just soft-deletes it' do
+      attachment = export.send(:build_research_plan_image_attachment, '<svg>x</svg>')
+      expect(attachment).to be_present
+
+      export.send(:cleanup_synthetic_attachments)
+
+      expect { Attachment.with_deleted.find(attachment.id) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'clears the tracked list so a later cleanup is a no-op' do
+      export.send(:build_research_plan_image_attachment, '<svg>x</svg>')
+      export.send(:cleanup_synthetic_attachments)
+
+      expect { export.send(:cleanup_synthetic_attachments) }.not_to raise_error
+    end
+  end
+
   context 'with a reaction' do # rubocop:disable RSpec/MultipleMemoizedHelpers
     let(:sample1) { create(:sample) }
     let(:sample2) { create(:sample) }

--- a/spec/lib/export/export_collections_spec.rb
+++ b/spec/lib/export/export_collections_spec.rb
@@ -171,6 +171,54 @@ RSpec.describe 'ExportCollection' do
     end
   end
 
+  # #build_research_plan_ketcher_svg computes a content-addressed filename per converted link, so
+  # linking the very same outside sample from two research plans renders (and #fetch_image-s) the
+  # identical path twice. #fetch_image has no dedup guard, so @images ends up with a duplicate
+  # entry — without deduping before writing the zip, put_next_entry is called twice with the same
+  # entry name.
+  context 'with two research plans linking the same outside sample' do
+    let(:other_collection) { create(:collection, user_id: user.id, label: 'other-owned-collection') }
+    let(:outside_sample) do
+      create(:sample, created_by: user.id, name: 'Outside Sample', molfile: molfile, collections: [other_collection])
+    end
+    let(:research_plan1) do
+      create(
+        :research_plan,
+        collections: [collection],
+        body: [{ 'id' => SecureRandom.uuid, 'type' => 'sample', 'value' => { 'sample_id' => outside_sample.id } }],
+      )
+    end
+    let(:research_plan2) do
+      create(
+        :research_plan,
+        collections: [collection],
+        body: [{ 'id' => SecureRandom.uuid, 'type' => 'sample', 'value' => { 'sample_id' => outside_sample.id } }],
+      )
+    end
+
+    before do
+      research_plan1
+      research_plan2
+      export = Export::ExportCollections.new(job_id, [collection.id], 'zip', nested, gate, user.id)
+      export.prepare_data
+      export.to_file
+    end
+
+    # Zip::File#each silently coalesces two entries written with the identical name, so it can't
+    # tell a real fix apart from the bug — description.txt is built up by the same loop that calls
+    # put_next_entry, so a line appearing twice there reliably means the loop ran twice for it.
+    it 'lists the shared ketcher preview svg in description.txt only once' do
+      svg_path = file_names.find { |name| name.start_with?('images/research_plans/') }
+
+      description = ''
+      Zip::File.open(file_path) do |files|
+        files.each { |file| description = file.get_input_stream.read if file.name == 'description.txt' }
+      end
+
+      expect(description.scan(svg_path).length).to eq(1)
+    end
+  end
+
   context 'with a reaction' do # rubocop:disable RSpec/MultipleMemoizedHelpers
     let(:sample1) { create(:sample) }
     let(:sample2) { create(:sample) }

--- a/spec/lib/import/import_collections_research_plan_links_spec.rb
+++ b/spec/lib/import/import_collections_research_plan_links_spec.rb
@@ -2,53 +2,63 @@
 
 require 'rails_helper'
 
-# Regression test for: after importing a collection whose research plan links to a sample
-# in the same collection, opening the sample via the research plan raised "Sample is not
-# accessible!" because the embedded sample_id still pointed at the exporting system's id.
-RSpec.describe 'ImportCollection with a research plan sample/reaction link' do
-  let(:exporting_user) { create(:person, first_name: 'Ex', last_name: 'Porter', name_abbreviation: 'EP') }
-  let(:importing_user) { create(:person, first_name: 'Im', last_name: 'Porter', name_abbreviation: 'IP') }
-  let(:collection) { create(:collection, user_id: exporting_user.id, label: 'collection-with-rp-sample-link') }
-  let(:sample) { create(:sample, created_by: exporting_user.id, name: 'Linked Sample', collections: [collection]) }
-  let(:reaction) { create(:reaction, name: 'Linked Reaction', collections: [collection]) }
-  let(:job_id) { SecureRandom.uuid }
-  let(:zip_path) { Rails.public_path.join('zip', "#{job_id}.zip") }
+# rubocop:disable RSpec/MultipleMemoizedHelpers
+RSpec.describe 'ImportCollection' do
+  # Regression test for: after importing a collection whose research plan links to a sample
+  # in the same collection, opening the sample via the research plan raised "Sample is not
+  # accessible!" because the embedded sample_id still pointed at the exporting system's id.
+  describe 'import a collection with a researchplan linking a sample and a reaction' do
+    let(:exporting_user) { create(:person, first_name: 'Ex', last_name: 'Porter', name_abbreviation: 'EP') }
+    let(:importing_user) { create(:person, first_name: 'Im', last_name: 'Porter', name_abbreviation: 'IP') }
+    let(:collection) { create(:collection, user_id: exporting_user.id, label: 'collection-with-rp-sample-link') }
+    let(:sample) { create(:sample, created_by: exporting_user.id, name: 'Linked Sample', collections: [collection]) }
+    let(:reaction) { create(:reaction, name: 'Linked Reaction', collections: [collection]) }
+    let(:job_id) { SecureRandom.uuid }
+    let(:zip_path) { Rails.public_path.join('zip', "#{job_id}.zip") }
 
-  let(:research_plan) do
-    create(
-      :research_plan,
-      collections: [collection],
-      body: [
-        { 'id' => SecureRandom.uuid, 'type' => 'sample', 'value' => { 'sample_id' => sample.id } },
-        { 'id' => SecureRandom.uuid, 'type' => 'reaction', 'value' => { 'reaction_id' => reaction.id } },
-      ],
-    )
-  end
+    let(:research_plan) do
+      create(
+        :research_plan,
+        collections: [collection],
+        body: [
+          { 'id' => SecureRandom.uuid, 'type' => 'sample', 'value' => { 'sample_id' => sample.id } },
+          { 'id' => SecureRandom.uuid, 'type' => 'reaction', 'value' => { 'reaction_id' => reaction.id } },
+        ],
+      )
+    end
 
-  before do
-    research_plan
-    export = Export::ExportCollections.new(job_id, [collection.id], 'zip', false, false)
-    export.prepare_data
-    export.to_file
-  end
+    let(:imported_collection) do
+      Collection.find_by(label: 'collection-with-rp-sample-link', user_id: importing_user.id)
+    end
+    let(:imported_sample) { imported_collection.samples.find_by(name: 'Linked Sample') }
+    let(:imported_reaction) { imported_collection.reactions.find_by(name: 'Linked Reaction') }
+    let(:imported_research_plan) { imported_collection.research_plans.first }
+    let(:sample_field) { imported_research_plan.body.find { |field| field['type'] == 'sample' } }
+    let(:reaction_field) { imported_research_plan.body.find { |field| field['type'] == 'reaction' } }
 
-  it 'rewrites the sample/reaction link to the newly imported instances' do
-    attachment = create(:attachment, file_path: zip_path)
-    Import::ImportCollections.new(attachment, importing_user.id).execute
+    before do
+      research_plan
+      export = Export::ExportCollections.new(job_id, [collection.id], 'zip', false, false)
+      export.prepare_data
+      export.to_file
 
-    imported_collection = Collection.find_by(label: 'collection-with-rp-sample-link', user_id: importing_user.id)
-    expect(imported_collection).to be_present
+      attachment = create(:attachment, file_path: zip_path)
+      Import::ImportCollections.new(attachment, importing_user.id).execute
+    end
 
-    imported_sample = imported_collection.samples.find_by(name: 'Linked Sample')
-    imported_reaction = imported_collection.reactions.find_by(name: 'Linked Reaction')
-    imported_research_plan = imported_collection.research_plans.first
+    it 'imports the collection' do
+      expect(imported_collection).to be_present
+    end
 
-    sample_field = imported_research_plan.body.find { |field| field['type'] == 'sample' }
-    reaction_field = imported_research_plan.body.find { |field| field['type'] == 'reaction' }
+    it 'rewrites the sample link to the newly imported sample' do
+      expect(sample_field['value']['sample_id']).to eq(imported_sample.id)
+      expect(sample_field['value']['sample_id']).not_to eq(sample.id)
+    end
 
-    expect(sample_field['value']['sample_id']).to eq(imported_sample.id)
-    expect(sample_field['value']['sample_id']).not_to eq(sample.id)
-    expect(reaction_field['value']['reaction_id']).to eq(imported_reaction.id)
-    expect(reaction_field['value']['reaction_id']).not_to eq(reaction.id)
+    it 'rewrites the reaction link to the newly imported reaction' do
+      expect(reaction_field['value']['reaction_id']).to eq(imported_reaction.id)
+      expect(reaction_field['value']['reaction_id']).not_to eq(reaction.id)
+    end
   end
 end
+# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/lib/import/import_collections_research_plan_links_spec.rb
+++ b/spec/lib/import/import_collections_research_plan_links_spec.rb
@@ -142,5 +142,165 @@ RSpec.describe 'ImportCollection' do
       expect(reaction_field).to be_nil
     end
   end
+
+  # When the exporting user can actually read the outside sample, its structure is preserved as a
+  # static Ketcher schema instead of being dropped outright — the live sample record still isn't part
+  # of the export, but the chemistry survives.
+  describe 'import a collection with a researchplan linking an accessible sample outside the export' do
+    let(:exporting_user) { create(:person, first_name: 'Ex', last_name: 'Porter', name_abbreviation: 'EP') }
+    let(:importing_user) { create(:person, first_name: 'Im', last_name: 'Porter', name_abbreviation: 'IP') }
+    let(:collection) { create(:collection, user_id: exporting_user.id, label: 'collection-with-accessible-link') }
+    let(:other_collection) { create(:collection, user_id: exporting_user.id, label: 'other-owned-collection') }
+    let(:molfile) { build(:molfile, type: 'test_2') }
+    let(:outside_sample) do
+      create(:sample, created_by: exporting_user.id, name: 'Outside Sample', molfile: molfile,
+                      collections: [other_collection])
+    end
+    let(:job_id) { SecureRandom.uuid }
+    let(:zip_path) { Rails.public_path.join('zip', "#{job_id}.zip") }
+
+    let(:research_plan) do
+      create(
+        :research_plan,
+        collections: [collection],
+        body: [
+          { 'id' => SecureRandom.uuid, 'type' => 'sample', 'value' => { 'sample_id' => outside_sample.id } },
+        ],
+      )
+    end
+
+    let(:imported_collection) do
+      Collection.find_by(label: 'collection-with-accessible-link', user_id: importing_user.id)
+    end
+    let(:imported_research_plan) { imported_collection.research_plans.first }
+    let(:sample_field) { imported_research_plan.body.find { |field| field['type'] == 'sample' } }
+    let(:ketcher_field) { imported_research_plan.body.find { |field| field['type'] == 'ketcher' } }
+
+    before do
+      research_plan
+      # other_collection is owned by the exporting user but not part of the export
+      export = Export::ExportCollections.new(job_id, [collection.id], 'zip', false, false, exporting_user.id)
+      export.prepare_data
+      export.to_file
+
+      attachment = create(:attachment, file_path: zip_path)
+      Import::ImportCollections.new(attachment, importing_user.id).execute
+    end
+
+    it 'does not import the outside sample record itself' do
+      expect(imported_collection.samples).to be_empty
+    end
+
+    it 'replaces the sample field with a ketcher field' do
+      expect(sample_field).to be_nil
+      expect(ketcher_field).to be_present
+    end
+
+    it 'embeds the sample structure and no pre-rendered svg' do
+      expect(ketcher_field['value']['sdf_file']).to eq(outside_sample.molfile)
+      expect(ketcher_field['value']['svg_file']).to be_nil
+    end
+  end
+
+  # The exporting user does not have read access to the outside sample (it lives in someone else's,
+  # unshared collection). The link must still be dropped, never converted — otherwise a research plan
+  # could be used to exfiltrate a structure the exporting user isn't allowed to see.
+  describe 'import a collection with a researchplan linking an inaccessible sample outside the export' do
+    let(:exporting_user) { create(:person, first_name: 'Ex', last_name: 'Porter', name_abbreviation: 'EP') }
+    let(:importing_user) { create(:person, first_name: 'Im', last_name: 'Porter', name_abbreviation: 'IP') }
+    let(:stranger) { create(:person, first_name: 'Str', last_name: 'Anger', name_abbreviation: 'SA') }
+    let(:collection) { create(:collection, user_id: exporting_user.id, label: 'collection-with-inaccessible-link') }
+    let(:strangers_collection) { create(:collection, user_id: stranger.id, label: 'strangers-collection') }
+    let(:molfile) { build(:molfile, type: 'test_2') }
+    let(:inaccessible_sample) do
+      create(:sample, created_by: stranger.id, name: 'Inaccessible Sample', molfile: molfile,
+                      collections: [strangers_collection])
+    end
+    let(:job_id) { SecureRandom.uuid }
+    let(:zip_path) { Rails.public_path.join('zip', "#{job_id}.zip") }
+
+    let(:research_plan) do
+      create(
+        :research_plan,
+        collections: [collection],
+        body: [
+          { 'id' => SecureRandom.uuid, 'type' => 'sample', 'value' => { 'sample_id' => inaccessible_sample.id } },
+        ],
+      )
+    end
+
+    let(:imported_collection) do
+      Collection.find_by(label: 'collection-with-inaccessible-link', user_id: importing_user.id)
+    end
+    let(:imported_research_plan) { imported_collection.research_plans.first }
+
+    before do
+      research_plan
+      export = Export::ExportCollections.new(job_id, [collection.id], 'zip', false, false, exporting_user.id)
+      export.prepare_data
+      export.to_file
+
+      attachment = create(:attachment, file_path: zip_path)
+      Import::ImportCollections.new(attachment, importing_user.id).execute
+    end
+
+    it 'drops the link instead of converting or keeping it' do
+      expect(imported_research_plan.body).to be_empty
+    end
+  end
+
+  # The exporting user has general read access to the outside sample via a share, but that share caps
+  # the sample detail level at the lowest tier, where SampleEntity anonymizes the molfile (see
+  # `anonymize_below: 1`). ElementPolicy#read? alone would pass here — #read_structure? is what must
+  # block the conversion, since the exporting user isn't actually allowed to see the structure.
+  describe 'import a collection with a researchplan linking a sample shared at the lowest detail level' do
+    let(:exporting_user) { create(:person, first_name: 'Ex', last_name: 'Porter', name_abbreviation: 'EP') }
+    let(:importing_user) { create(:person, first_name: 'Im', last_name: 'Porter', name_abbreviation: 'IP') }
+    let(:sample_owner) { create(:person, first_name: 'Ow', last_name: 'Ner', name_abbreviation: 'ON') }
+    let(:collection) { create(:collection, user_id: exporting_user.id, label: 'collection-with-low-detail-link') }
+    let(:owners_collection) do
+      create(:collection, user_id: sample_owner.id, label: 'owners-collection').tap do |shared_collection|
+        create(:collection_share, collection: shared_collection, shared_with: exporting_user,
+                                  permission_level: CollectionShare.permission_level(:read_elements),
+                                  sample_detail_level: 0)
+      end
+    end
+    let(:molfile) { build(:molfile, type: 'test_2') }
+    let(:low_detail_sample) do
+      create(:sample, created_by: sample_owner.id, name: 'Low Detail Sample', molfile: molfile,
+                      collections: [owners_collection])
+    end
+    let(:job_id) { SecureRandom.uuid }
+    let(:zip_path) { Rails.public_path.join('zip', "#{job_id}.zip") }
+
+    let(:research_plan) do
+      create(
+        :research_plan,
+        collections: [collection],
+        body: [
+          { 'id' => SecureRandom.uuid, 'type' => 'sample', 'value' => { 'sample_id' => low_detail_sample.id } },
+        ],
+      )
+    end
+
+    let(:imported_collection) do
+      Collection.find_by(label: 'collection-with-low-detail-link', user_id: importing_user.id)
+    end
+    let(:imported_research_plan) { imported_collection.research_plans.first }
+
+    before do
+      research_plan
+      export = Export::ExportCollections.new(job_id, [collection.id], 'zip', false, false, exporting_user.id)
+      export.prepare_data
+      export.to_file
+
+      attachment = create(:attachment, file_path: zip_path)
+      Import::ImportCollections.new(attachment, importing_user.id).execute
+    end
+
+    it 'drops the link instead of converting it, since the molfile is not visible at this detail level' do
+      expect(imported_research_plan.body).to be_empty
+    end
+  end
 end
 # rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/lib/import/import_collections_research_plan_links_spec.rb
+++ b/spec/lib/import/import_collections_research_plan_links_spec.rb
@@ -248,6 +248,69 @@ RSpec.describe 'ImportCollection' do
     end
   end
 
+  # Regression: fetch_one mints a uuid for every ancestor id while writing a split sample's
+  # 'ancestry' string, whether or not that ancestor is ever itself fetched into @data — so a plain
+  # @uuids lookup ("has a uuid ever been minted for this id") is not a valid "is this sample part of
+  # the export" test. A parent sample split into a child that lives in the exported collection is
+  # exactly this case: the parent's own collection is never exported, but its uuid gets minted as a
+  # side effect of exporting the child.
+  describe "import a collection with a researchplan linking a split sample's unexported parent" do
+    let(:exporting_user) { create(:person, first_name: 'Ex', last_name: 'Porter', name_abbreviation: 'EP') }
+    let(:importing_user) { create(:person, first_name: 'Im', last_name: 'Porter', name_abbreviation: 'IP') }
+    let(:collection) { create(:collection, user_id: exporting_user.id, label: 'collection-with-split-sample') }
+    let(:parent_collection) { create(:collection, user_id: exporting_user.id, label: 'parent-collection') }
+    let(:molfile) { build(:molfile, type: 'test_2') }
+    let(:parent_sample) do
+      create(:sample, created_by: exporting_user.id, name: 'Parent Sample', molfile: molfile,
+                      collections: [parent_collection])
+    end
+    let(:child_sample) do
+      create(:sample, created_by: exporting_user.id, name: 'Child Sample', parent: parent_sample,
+                      collections: [collection])
+    end
+    let(:job_id) { SecureRandom.uuid }
+    let(:zip_path) { Rails.public_path.join('zip', "#{job_id}.zip") }
+
+    let(:research_plan) do
+      create(
+        :research_plan,
+        collections: [collection],
+        body: [
+          { 'id' => SecureRandom.uuid, 'type' => 'sample', 'value' => { 'sample_id' => parent_sample.id } },
+        ],
+      )
+    end
+
+    let(:imported_collection) do
+      Collection.find_by(label: 'collection-with-split-sample', user_id: importing_user.id)
+    end
+    let(:imported_research_plan) { imported_collection.research_plans.first }
+    let(:sample_field) { imported_research_plan.body.find { |field| field['type'] == 'sample' } }
+    let(:ketcher_field) { imported_research_plan.body.find { |field| field['type'] == 'ketcher' } }
+
+    before do
+      child_sample
+      research_plan
+      # only `collection` (holding the child) is exported; parent_collection (holding the parent) is not
+      export = Export::ExportCollections.new(job_id, [collection.id], 'zip', false, false, exporting_user.id)
+      export.prepare_data
+      export.to_file
+
+      attachment = create(:attachment, file_path: zip_path)
+      Import::ImportCollections.new(attachment, importing_user.id).execute
+    end
+
+    it 'imports the child sample but not the parent' do
+      expect(imported_collection.samples.pluck(:name)).to eq(['Child Sample'])
+    end
+
+    it 'converts the parent link into a ketcher field instead of silently dropping it' do
+      expect(sample_field).to be_nil
+      expect(ketcher_field).to be_present
+      expect(ketcher_field['value']['sdf_file']).to eq(parent_sample.molfile)
+    end
+  end
+
   # The exporting user does not have read access to the outside sample (it lives in someone else's,
   # unshared collection). The link must still be dropped, never converted — otherwise a research plan
   # could be used to exfiltrate a structure the exporting user isn't allowed to see.

--- a/spec/lib/import/import_collections_research_plan_links_spec.rb
+++ b/spec/lib/import/import_collections_research_plan_links_spec.rb
@@ -60,5 +60,87 @@ RSpec.describe 'ImportCollection' do
       expect(reaction_field['value']['reaction_id']).not_to eq(reaction.id)
     end
   end
+
+  # Defense in depth for zips exported before this remapping existed: their research plan bodies still
+  # hold the raw source-system sample_id/reaction_id (not a uuid), which would never resolve against
+  # @instances. Such a link must be dropped rather than kept, since the leftover numeric id could
+  # coincidentally match an unrelated record on the importing system.
+  describe '#remap_research_plan_body_links' do
+    let(:user) { create(:person) }
+    let(:attachment) { build(:attachment) }
+    let(:importer) { Import::ImportCollections.new(attachment, user.id) }
+
+    after { importer.cleanup }
+
+    it 'drops sample/reaction fields whose id cannot be resolved to an imported instance' do
+      body = [
+        { 'id' => 'a', 'type' => 'sample', 'value' => { 'sample_id' => 999_999 } },
+        { 'id' => 'b', 'type' => 'reaction', 'value' => { 'reaction_id' => 888_888 } },
+      ]
+
+      expect(importer.send(:remap_research_plan_body_links, body)).to be_empty
+    end
+  end
+
+  # Negative case: the linked sample/reaction is not part of the exported collection (e.g. it lives in
+  # a collection the exporting user didn't select), so it's never assigned an export uuid. The link
+  # must be dropped rather than kept with its stale id, which could otherwise coincidentally match an
+  # unrelated record on the importing system.
+  describe 'import a collection with a researchplan linking a sample/reaction outside the export' do
+    let(:exporting_user) { create(:person, first_name: 'Ex', last_name: 'Porter', name_abbreviation: 'EP') }
+    let(:importing_user) { create(:person, first_name: 'Im', last_name: 'Porter', name_abbreviation: 'IP') }
+    let(:collection) { create(:collection, user_id: exporting_user.id, label: 'collection-without-linked-sample') }
+    let(:other_collection) { create(:collection, user_id: exporting_user.id, label: 'other-collection') }
+    let(:outside_sample) do
+      create(:sample, created_by: exporting_user.id, name: 'Outside Sample', collections: [other_collection])
+    end
+    let(:outside_reaction) { create(:reaction, name: 'Outside Reaction', collections: [other_collection]) }
+    let(:job_id) { SecureRandom.uuid }
+    let(:zip_path) { Rails.public_path.join('zip', "#{job_id}.zip") }
+
+    let(:research_plan) do
+      create(
+        :research_plan,
+        collections: [collection],
+        body: [
+          { 'id' => SecureRandom.uuid, 'type' => 'sample', 'value' => { 'sample_id' => outside_sample.id } },
+          { 'id' => SecureRandom.uuid, 'type' => 'reaction', 'value' => { 'reaction_id' => outside_reaction.id } },
+        ],
+      )
+    end
+
+    let(:imported_collection) do
+      Collection.find_by(label: 'collection-without-linked-sample', user_id: importing_user.id)
+    end
+    let(:imported_research_plan) { imported_collection.research_plans.first }
+    let(:sample_field) { imported_research_plan.body.find { |field| field['type'] == 'sample' } }
+    let(:reaction_field) { imported_research_plan.body.find { |field| field['type'] == 'reaction' } }
+
+    before do
+      research_plan
+      # only `collection` is exported, not `other_collection`, so the linked sample/reaction never
+      # gets an export uuid assigned
+      export = Export::ExportCollections.new(job_id, [collection.id], 'zip', false, false)
+      export.prepare_data
+      export.to_file
+
+      attachment = create(:attachment, file_path: zip_path)
+      Import::ImportCollections.new(attachment, importing_user.id).execute
+    end
+
+    it 'imports the collection without the outside sample/reaction' do
+      expect(imported_collection).to be_present
+      expect(imported_collection.samples).to be_empty
+      expect(imported_collection.reactions).to be_empty
+    end
+
+    it 'drops the unresolved sample link instead of keeping a stale id' do
+      expect(sample_field).to be_nil
+    end
+
+    it 'drops the unresolved reaction link instead of keeping a stale id' do
+      expect(reaction_field).to be_nil
+    end
+  end
 end
 # rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/lib/import/import_collections_research_plan_links_spec.rb
+++ b/spec/lib/import/import_collections_research_plan_links_spec.rb
@@ -82,6 +82,44 @@ RSpec.describe 'ImportCollection' do
     end
   end
 
+  # Ketcher preview svgs are bundled into the zip under images/research_plans/ but extracted only to a
+  # temp dir (see extract's zip-entry handling) — this materializes them into
+  # public/images/research_plans/ so the frontend's <img src="/images/research_plans/...svg"> actually
+  # resolves after import, for hand-drawn structures and synthesized ones alike.
+  describe '#materialize_researchplan_ketcher_images' do
+    let(:user) { create(:person) }
+    let(:attachment) { build(:attachment) }
+    let(:importer) { Import::ImportCollections.new(attachment, user.id) }
+    let(:tmp_dir) { importer.instance_variable_get(:@tmp_dir) }
+
+    after { importer.cleanup }
+
+    it 'copies a bundled preview svg into public/images/research_plans' do
+      svg_file = "#{SecureRandom.hex(16)}.svg"
+      source_dir = Pathname.new(tmp_dir).join('images', 'research_plans')
+      FileUtils.mkdir_p(source_dir)
+      File.write(source_dir.join(svg_file), '<svg>materialized</svg>')
+      target_path = Rails.public_path.join('images', 'research_plans', svg_file)
+
+      begin
+        body = [{ 'id' => 'a', 'type' => 'ketcher', 'value' => { 'svg_file' => svg_file } }]
+        importer.send(:materialize_researchplan_ketcher_images, body)
+
+        expect(File.file?(target_path)).to be true
+        expect(File.read(target_path)).to eq('<svg>materialized</svg>')
+      ensure
+        FileUtils.rm_f(target_path)
+      end
+    end
+
+    it 'ignores a svg_file value that is not a bare filename, rather than writing outside the target folder' do
+      body = [{ 'id' => 'a', 'type' => 'ketcher', 'value' => { 'svg_file' => '../../evil.svg' } }]
+
+      expect { importer.send(:materialize_researchplan_ketcher_images, body) }.not_to raise_error
+      expect(Rails.public_path.join('images', 'research_plans', 'evil.svg')).not_to exist
+    end
+  end
+
   # Negative case: the linked sample/reaction is not part of the exported collection (e.g. it lives in
   # a collection the exporting user didn't select), so it's never assigned an export uuid. The link
   # must be dropped rather than kept with its stale id, which could otherwise coincidentally match an
@@ -196,9 +234,17 @@ RSpec.describe 'ImportCollection' do
       expect(ketcher_field).to be_present
     end
 
-    it 'embeds the sample structure and no pre-rendered svg' do
+    it 'embeds the sample structure' do
       expect(ketcher_field['value']['sdf_file']).to eq(outside_sample.molfile)
-      expect(ketcher_field['value']['svg_file']).to be_nil
+    end
+
+    it 'materializes a rendered preview svg under public/images/research_plans' do
+      svg_file = ketcher_field['value']['svg_file']
+      expect(svg_file).to be_present
+
+      svg_path = Rails.public_path.join('images', 'research_plans', svg_file)
+      expect(File.file?(svg_path)).to be true
+      expect(File.read(svg_path)).to include('</svg>')
     end
   end
 

--- a/spec/lib/import/import_collections_research_plan_links_spec.rb
+++ b/spec/lib/import/import_collections_research_plan_links_spec.rb
@@ -4,6 +4,55 @@ require 'rails_helper'
 
 # rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe 'ImportCollection' do
+  # Not research-plan specific — this covers the shared images/(samples|reactions|molecules|
+  # research_plans)/... case branch in Import::ImportCollections#extract, which every image kind
+  # goes through. Kept here rather than import_collections_spec.rb, whose file-level `before`
+  # requires a fixture zip this test doesn't use.
+  describe 'extracting a zip entry whose destination path already exists' do
+    let(:tmp_dir) { Dir.mktmpdir }
+    let(:zip_path) { File.join(tmp_dir, 'test.zip') }
+    let(:dest_path) { File.join(tmp_dir, 'extracted.svg') }
+
+    after { FileUtils.rm_rf(tmp_dir) }
+
+    before do
+      Zip::OutputStream.open(zip_path) do |zipping|
+        zipping.put_next_entry('images/molecules/test.svg')
+        zipping.write('<svg>first</svg>')
+      end
+    end
+
+    # Two samples sharing a molecule (routine — the same compound imported/used more than once)
+    # both call fetch_image('molecules', ...) on export with the identical path, so this
+    # exists-already branch is reachable in principle. In practice it is never hit via the normal
+    # each-based extraction loop, because Zip::EntrySet is Hash-backed and collapses two same-named
+    # entries to one on read — this exercises Zip::Entry#extract directly to verify the fix on its
+    # own terms, independent of that.
+    it 'overwrites silently instead of erroring on a misused on-exists block' do
+      Zip::File.open(zip_path) do |zip_file|
+        entry = zip_file.first
+        entry.extract(dest_path) { true } # first extraction: destination does not exist yet
+
+        expect { entry.extract(dest_path) { true } }.not_to raise_error
+        expect(File.read(dest_path)).to eq('<svg>first</svg>')
+      end
+    end
+
+    # Entry#create_file yields (self, dest_path) to decide whether to overwrite — not IO objects —
+    # so the previous `{ |src, dest| IO.copy_stream(src, dest) }` block would have blown up had
+    # this branch ever been reached.
+    it 'documents that the previous block would have raised, had this branch ever been reached' do
+      Zip::File.open(zip_path) do |zip_file|
+        entry = zip_file.first
+        entry.extract(dest_path) { true }
+
+        expect do
+          entry.extract(dest_path) { |src, dest| IO.copy_stream(src, dest) }
+        end.to raise_error(NoMethodError, /undefined method [`']read'? for/)
+      end
+    end
+  end
+
   # Regression test for: after importing a collection whose research plan links to a sample
   # in the same collection, opening the sample via the research plan raised "Sample is not
   # accessible!" because the embedded sample_id still pointed at the exporting system's id.

--- a/spec/lib/import/import_collections_research_plan_links_spec.rb
+++ b/spec/lib/import/import_collections_research_plan_links_spec.rb
@@ -78,7 +78,28 @@ RSpec.describe 'ImportCollection' do
         { 'id' => 'b', 'type' => 'reaction', 'value' => { 'reaction_id' => 888_888 } },
       ]
 
-      expect(importer.send(:remap_research_plan_body_links, body)).to be_empty
+      expect(importer.send(:remap_research_plan_body_links, body, 'Test Plan')).to be_empty
+    end
+
+    # The importer already logs an unassociated image attachment (see #log_unassociated_attachment)
+    # so the user can see what was silently dropped — a dropped sample/reaction link deserves the
+    # same visibility, since every zip exported before Export::ExportCollections started remapping
+    # these links carries a raw id here that will always hit this path.
+    it 'logs each dropped sample/reaction link so the user can see what was removed' do
+      logger = importer.instance_variable_get(:@logger)
+      allow(logger).to receive(:error)
+
+      body = [
+        { 'id' => 'a', 'type' => 'sample', 'value' => { 'sample_id' => 999_999 } },
+        { 'id' => 'b', 'type' => 'reaction', 'value' => { 'reaction_id' => 888_888 } },
+      ]
+
+      importer.send(:remap_research_plan_body_links, body, 'Test Plan')
+
+      expect(logger).to have_received(:error)
+        .with(a_string_including('Research Plan: Test Plan', 'Sample reference: 999999')).once
+      expect(logger).to have_received(:error)
+        .with(a_string_including('Research Plan: Test Plan', 'Reaction reference: 888888')).once
     end
 
     # ResearchPlan.js#addSampleField/#addReactionField create exactly this shape when a user adds
@@ -90,7 +111,7 @@ RSpec.describe 'ImportCollection' do
         { 'id' => 'b', 'type' => 'reaction', 'value' => { 'reaction_id' => nil } },
       ]
 
-      expect(importer.send(:remap_research_plan_body_links, body)).to eq(body)
+      expect(importer.send(:remap_research_plan_body_links, body, 'Test Plan')).to eq(body)
     end
   end
 

--- a/spec/lib/import/import_collections_research_plan_links_spec.rb
+++ b/spec/lib/import/import_collections_research_plan_links_spec.rb
@@ -80,6 +80,59 @@ RSpec.describe 'ImportCollection' do
 
       expect(importer.send(:remap_research_plan_body_links, body)).to be_empty
     end
+
+    # ResearchPlan.js#addSampleField/#addReactionField create exactly this shape when a user adds
+    # a field before dragging an element onto it. A nil id carries no stale reference, so unlike an
+    # unresolvable one, it must survive untouched rather than being dropped.
+    it 'keeps a placeholder field whose sample_id/reaction_id was never filled in' do
+      body = [
+        { 'id' => 'a', 'type' => 'sample', 'value' => { 'sample_id' => nil } },
+        { 'id' => 'b', 'type' => 'reaction', 'value' => { 'reaction_id' => nil } },
+      ]
+
+      expect(importer.send(:remap_research_plan_body_links, body)).to eq(body)
+    end
+  end
+
+  # End-to-end version of the same case: ResearchPlan.js#addSampleField/#addReactionField create a
+  # placeholder field with a nil id before the user drags a sample/reaction onto it. Round-tripping
+  # a research plan with such an unfilled field through export+import must not silently remove it.
+  describe 'import a collection with a researchplan containing unfilled sample/reaction placeholders' do
+    let(:exporting_user) { create(:person, first_name: 'Ex', last_name: 'Porter', name_abbreviation: 'EP') }
+    let(:importing_user) { create(:person, first_name: 'Im', last_name: 'Porter', name_abbreviation: 'IP') }
+    let(:collection) { create(:collection, user_id: exporting_user.id, label: 'collection-with-placeholders') }
+    let(:job_id) { SecureRandom.uuid }
+    let(:zip_path) { Rails.public_path.join('zip', "#{job_id}.zip") }
+
+    let(:research_plan) do
+      create(
+        :research_plan,
+        collections: [collection],
+        body: [
+          { 'id' => SecureRandom.uuid, 'type' => 'sample', 'value' => { 'sample_id' => nil } },
+          { 'id' => SecureRandom.uuid, 'type' => 'reaction', 'value' => { 'reaction_id' => nil } },
+        ],
+      )
+    end
+
+    let(:imported_collection) do
+      Collection.find_by(label: 'collection-with-placeholders', user_id: importing_user.id)
+    end
+    let(:imported_research_plan) { imported_collection.research_plans.first }
+
+    before do
+      research_plan
+      export = Export::ExportCollections.new(job_id, [collection.id], 'zip', false, false, exporting_user.id)
+      export.prepare_data
+      export.to_file
+
+      attachment = create(:attachment, file_path: zip_path)
+      Import::ImportCollections.new(attachment, importing_user.id).execute
+    end
+
+    it 'keeps both unfilled placeholder fields, unchanged' do
+      expect(imported_research_plan.body).to eq(research_plan.body)
+    end
   end
 
   # Ketcher preview svgs are bundled into the zip under images/research_plans/ but extracted only to a

--- a/spec/lib/import/import_collections_research_plan_links_spec.rb
+++ b/spec/lib/import/import_collections_research_plan_links_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression test for: after importing a collection whose research plan links to a sample
+# in the same collection, opening the sample via the research plan raised "Sample is not
+# accessible!" because the embedded sample_id still pointed at the exporting system's id.
+RSpec.describe 'ImportCollection with a research plan sample/reaction link' do
+  let(:exporting_user) { create(:person, first_name: 'Ex', last_name: 'Porter', name_abbreviation: 'EP') }
+  let(:importing_user) { create(:person, first_name: 'Im', last_name: 'Porter', name_abbreviation: 'IP') }
+  let(:collection) { create(:collection, user_id: exporting_user.id, label: 'collection-with-rp-sample-link') }
+  let(:sample) { create(:sample, created_by: exporting_user.id, name: 'Linked Sample', collections: [collection]) }
+  let(:reaction) { create(:reaction, name: 'Linked Reaction', collections: [collection]) }
+  let(:job_id) { SecureRandom.uuid }
+  let(:zip_path) { Rails.public_path.join('zip', "#{job_id}.zip") }
+
+  let(:research_plan) do
+    create(
+      :research_plan,
+      collections: [collection],
+      body: [
+        { 'id' => SecureRandom.uuid, 'type' => 'sample', 'value' => { 'sample_id' => sample.id } },
+        { 'id' => SecureRandom.uuid, 'type' => 'reaction', 'value' => { 'reaction_id' => reaction.id } },
+      ],
+    )
+  end
+
+  before do
+    research_plan
+    export = Export::ExportCollections.new(job_id, [collection.id], 'zip', false, false)
+    export.prepare_data
+    export.to_file
+  end
+
+  it 'rewrites the sample/reaction link to the newly imported instances' do
+    attachment = create(:attachment, file_path: zip_path)
+    Import::ImportCollections.new(attachment, importing_user.id).execute
+
+    imported_collection = Collection.find_by(label: 'collection-with-rp-sample-link', user_id: importing_user.id)
+    expect(imported_collection).to be_present
+
+    imported_sample = imported_collection.samples.find_by(name: 'Linked Sample')
+    imported_reaction = imported_collection.reactions.find_by(name: 'Linked Reaction')
+    imported_research_plan = imported_collection.research_plans.first
+
+    sample_field = imported_research_plan.body.find { |field| field['type'] == 'sample' }
+    reaction_field = imported_research_plan.body.find { |field| field['type'] == 'reaction' }
+
+    expect(sample_field['value']['sample_id']).to eq(imported_sample.id)
+    expect(sample_field['value']['sample_id']).not_to eq(sample.id)
+    expect(reaction_field['value']['reaction_id']).to eq(imported_reaction.id)
+    expect(reaction_field['value']['reaction_id']).not_to eq(reaction.id)
+  end
+end

--- a/spec/lib/import/import_collections_research_plan_links_spec.rb
+++ b/spec/lib/import/import_collections_research_plan_links_spec.rb
@@ -381,10 +381,10 @@ RSpec.describe 'ImportCollection' do
     let(:reaction_field) { imported_research_plan.body.find { |field| field['type'] == 'reaction' } }
     let(:image_field) { imported_research_plan.body.find { |field| field['type'] == 'image' } }
     let(:image_attachment) { Attachment.find_by(identifier: image_field['value']['public_name']) }
+    let(:export) { Export::ExportCollections.new(job_id, [collection.id], 'zip', false, false, exporting_user.id) }
 
     before do
       research_plan
-      export = Export::ExportCollections.new(job_id, [collection.id], 'zip', false, false, exporting_user.id)
       export.prepare_data
       export.to_file
 
@@ -409,6 +409,10 @@ RSpec.describe 'ImportCollection' do
     it 'embeds the report-style reaction scheme as svg content' do
       svg_content = image_attachment.attachment.open(&:read)
       expect(svg_content).to include('</svg>')
+    end
+
+    it 'does not leave the synthetic attachment (even soft-deleted) on the exporting system' do
+      expect(Attachment.with_deleted.where(created_by: exporting_user.id, attachable_type: 'ResearchPlan')).to be_empty
     end
   end
 

--- a/spec/lib/import/import_collections_research_plan_links_spec.rb
+++ b/spec/lib/import/import_collections_research_plan_links_spec.rb
@@ -302,5 +302,173 @@ RSpec.describe 'ImportCollection' do
       expect(imported_research_plan.body).to be_empty
     end
   end
+
+  # When the exporting user holds full detail access to the outside reaction, its report-style scheme
+  # (see Reaction#compose_report_scheme_svg) is preserved as a static image instead of being dropped
+  # outright — the live reaction record still isn't part of the export, but the chemistry survives.
+  describe 'import a collection with a researchplan linking an accessible reaction outside the export' do
+    let(:exporting_user) { create(:person, first_name: 'Ex', last_name: 'Porter', name_abbreviation: 'EP') }
+    let(:importing_user) { create(:person, first_name: 'Im', last_name: 'Porter', name_abbreviation: 'IP') }
+    let(:collection) { create(:collection, user_id: exporting_user.id, label: 'collection-with-accessible-rxn') }
+    let(:other_collection) { create(:collection, user_id: exporting_user.id, label: 'other-owned-collection-rxn') }
+    let(:product) { create(:sample, molfile: build(:molfile, type: 'test_2')) }
+    let(:outside_reaction) do
+      create(:reaction, name: 'Outside Reaction', products: [product], collections: [other_collection])
+    end
+    let(:job_id) { SecureRandom.uuid }
+    let(:zip_path) { Rails.public_path.join('zip', "#{job_id}.zip") }
+
+    let(:research_plan) do
+      create(
+        :research_plan,
+        collections: [collection],
+        body: [
+          { 'id' => SecureRandom.uuid, 'type' => 'reaction', 'value' => { 'reaction_id' => outside_reaction.id } },
+        ],
+      )
+    end
+
+    let(:imported_collection) do
+      Collection.find_by(label: 'collection-with-accessible-rxn', user_id: importing_user.id)
+    end
+    let(:imported_research_plan) { imported_collection.research_plans.first }
+    let(:reaction_field) { imported_research_plan.body.find { |field| field['type'] == 'reaction' } }
+    let(:image_field) { imported_research_plan.body.find { |field| field['type'] == 'image' } }
+    let(:image_attachment) { Attachment.find_by(identifier: image_field['value']['public_name']) }
+
+    before do
+      research_plan
+      export = Export::ExportCollections.new(job_id, [collection.id], 'zip', false, false, exporting_user.id)
+      export.prepare_data
+      export.to_file
+
+      attachment = create(:attachment, file_path: zip_path)
+      Import::ImportCollections.new(attachment, importing_user.id).execute
+    end
+
+    it 'does not import the outside reaction record itself' do
+      expect(imported_collection.reactions).to be_empty
+    end
+
+    it 'replaces the reaction field with an image field' do
+      expect(reaction_field).to be_nil
+      expect(image_field).to be_present
+    end
+
+    it 'backs the image field with a real attachment associated to the research plan' do
+      expect(image_attachment).to be_present
+      expect(image_attachment.attachable).to eq(imported_research_plan)
+    end
+
+    it 'embeds the report-style reaction scheme as svg content' do
+      svg_content = image_attachment.attachment.open(&:read)
+      expect(svg_content).to include('</svg>')
+    end
+  end
+
+  # The exporting user does not have read access to the outside reaction. The link must still be
+  # dropped, never converted.
+  describe 'import a collection with a researchplan linking an inaccessible reaction outside the export' do
+    let(:exporting_user) { create(:person, first_name: 'Ex', last_name: 'Porter', name_abbreviation: 'EP') }
+    let(:importing_user) { create(:person, first_name: 'Im', last_name: 'Porter', name_abbreviation: 'IP') }
+    let(:stranger) { create(:person, first_name: 'Str', last_name: 'Anger', name_abbreviation: 'SA') }
+    let(:collection) { create(:collection, user_id: exporting_user.id, label: 'collection-with-inaccessible-rxn') }
+    let(:strangers_collection) { create(:collection, user_id: stranger.id, label: 'strangers-collection-rxn') }
+    let(:product) { create(:sample, molfile: build(:molfile, type: 'test_2')) }
+    let(:inaccessible_reaction) do
+      create(:reaction, name: 'Inaccessible Reaction', products: [product], collections: [strangers_collection])
+    end
+    let(:job_id) { SecureRandom.uuid }
+    let(:zip_path) { Rails.public_path.join('zip', "#{job_id}.zip") }
+
+    let(:research_plan) do
+      create(
+        :research_plan,
+        collections: [collection],
+        body: [
+          {
+            'id' => SecureRandom.uuid, 'type' => 'reaction',
+            'value' => { 'reaction_id' => inaccessible_reaction.id }
+          },
+        ],
+      )
+    end
+
+    let(:imported_collection) do
+      Collection.find_by(label: 'collection-with-inaccessible-rxn', user_id: importing_user.id)
+    end
+    let(:imported_research_plan) { imported_collection.research_plans.first }
+
+    before do
+      research_plan
+      export = Export::ExportCollections.new(job_id, [collection.id], 'zip', false, false, exporting_user.id)
+      export.prepare_data
+      export.to_file
+
+      attachment = create(:attachment, file_path: zip_path)
+      Import::ImportCollections.new(attachment, importing_user.id).execute
+    end
+
+    it 'drops the link instead of converting or keeping it' do
+      expect(imported_research_plan.body).to be_empty
+    end
+  end
+
+  # The exporting user has general read access to the outside reaction via a share, but that share
+  # caps the reaction detail level below full — where ReactionEntity anonymizes reaction_svg_file (see
+  # `anonymize_below: 10`). #read? alone would pass here — #read_full_detail? is what must block the
+  # conversion.
+  describe 'import a collection with a researchplan linking a reaction shared below full detail' do
+    let(:exporting_user) { create(:person, first_name: 'Ex', last_name: 'Porter', name_abbreviation: 'EP') }
+    let(:importing_user) { create(:person, first_name: 'Im', last_name: 'Porter', name_abbreviation: 'IP') }
+    let(:reaction_owner) { create(:person, first_name: 'Ow', last_name: 'Ner', name_abbreviation: 'ON') }
+    let(:collection) { create(:collection, user_id: exporting_user.id, label: 'collection-with-low-detail-rxn') }
+    let(:owners_collection) do
+      create(:collection, user_id: reaction_owner.id, label: 'owners-collection-rxn').tap do |shared_collection|
+        create(:collection_share, collection: shared_collection, shared_with: exporting_user,
+                                  permission_level: CollectionShare.permission_level(:read_elements),
+                                  reaction_detail_level: 9)
+      end
+    end
+    let(:product) { create(:sample, molfile: build(:molfile, type: 'test_2')) }
+    let(:low_detail_reaction) do
+      create(:reaction, created_by: reaction_owner.id, name: 'Low Detail Reaction', products: [product],
+                        collections: [owners_collection])
+    end
+    let(:job_id) { SecureRandom.uuid }
+    let(:zip_path) { Rails.public_path.join('zip', "#{job_id}.zip") }
+
+    let(:research_plan) do
+      create(
+        :research_plan,
+        collections: [collection],
+        body: [
+          {
+            'id' => SecureRandom.uuid, 'type' => 'reaction',
+            'value' => { 'reaction_id' => low_detail_reaction.id }
+          },
+        ],
+      )
+    end
+
+    let(:imported_collection) do
+      Collection.find_by(label: 'collection-with-low-detail-rxn', user_id: importing_user.id)
+    end
+    let(:imported_research_plan) { imported_collection.research_plans.first }
+
+    before do
+      research_plan
+      export = Export::ExportCollections.new(job_id, [collection.id], 'zip', false, false, exporting_user.id)
+      export.prepare_data
+      export.to_file
+
+      attachment = create(:attachment, file_path: zip_path)
+      Import::ImportCollections.new(attachment, importing_user.id).execute
+    end
+
+    it 'drops the link instead of converting it, since full detail access is required' do
+      expect(imported_research_plan.body).to be_empty
+    end
+  end
 end
 # rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/policies/element_policy_spec.rb
+++ b/spec/policies/element_policy_spec.rb
@@ -242,6 +242,57 @@ describe ElementPolicy do
     end
   end
 
+  describe '#read_structure?' do
+    let(:sample) { create(:sample) }
+    let(:element_policy) { described_class.new(user, sample) }
+
+    context 'when the record is in an own collection' do
+      before { own_collection_of_user.samples << sample }
+
+      it 'returns true' do
+        expect(element_policy.read_structure?).to be true
+      end
+    end
+
+    context 'when the record is in a collection shared to me with a sample detail level of 0' do
+      let(:shared_collection_of_other_user) do
+        create(:collection, user: other_user, label: "Shared collection of #{other_user.name}").tap do |collection|
+          create(:collection_share, collection: collection, shared_with: user, sample_detail_level: 0)
+        end
+      end
+
+      before { shared_collection_of_other_user.samples << sample }
+
+      it 'returns false' do
+        expect(element_policy.read_structure?).to be false
+      end
+    end
+
+    context 'when the record is in a collection shared to me with a sample detail level of 1 or higher' do
+      let(:shared_collection_of_other_user) do
+        create(:collection, user: other_user, label: "Shared collection of #{other_user.name}").tap do |collection|
+          create(:collection_share, collection: collection, shared_with: user, sample_detail_level: 1)
+        end
+      end
+
+      before { shared_collection_of_other_user.samples << sample }
+
+      it 'returns true' do
+        expect(element_policy.read_structure?).to be true
+      end
+    end
+
+    context 'when the record is neither in a collection of mine or shared to me' do
+      let(:owner) { other_user }
+
+      before { own_collection_of_other_user.samples << sample }
+
+      it 'returns false' do
+        expect(element_policy.read_structure?).to be false
+      end
+    end
+  end
+
   describe '#pass_ownership?' do
     context 'when the record is in an own collection' do
       before { own_collection_of_user.screens << screen }

--- a/spec/policies/element_policy_spec.rb
+++ b/spec/policies/element_policy_spec.rb
@@ -293,6 +293,58 @@ describe ElementPolicy do
     end
   end
 
+  describe '#read_full_detail?' do
+    let(:reaction) { create(:reaction) }
+    let(:element_policy) { described_class.new(user, reaction) }
+
+    context 'when the record is in an own collection' do
+      before { own_collection_of_user.reactions << reaction }
+
+      it 'returns true' do
+        expect(element_policy.read_full_detail?).to be true
+      end
+    end
+
+    context 'when the record is in a collection shared to me below full detail' do
+      let(:shared_collection_of_other_user) do
+        create(:collection, user: other_user, label: "Shared collection of #{other_user.name}").tap do |collection|
+          create(:collection_share, collection: collection, shared_with: user, reaction_detail_level: 9)
+        end
+      end
+
+      before { shared_collection_of_other_user.reactions << reaction }
+
+      it 'returns false' do
+        expect(element_policy.read_full_detail?).to be false
+      end
+    end
+
+    context 'when the record is in a collection shared to me with full detail' do
+      let(:shared_collection_of_other_user) do
+        create(:collection, user: other_user, label: "Shared collection of #{other_user.name}").tap do |collection|
+          create(:collection_share, collection: collection, shared_with: user,
+                                    reaction_detail_level: Collection::OWNER_LEVEL)
+        end
+      end
+
+      before { shared_collection_of_other_user.reactions << reaction }
+
+      it 'returns true' do
+        expect(element_policy.read_full_detail?).to be true
+      end
+    end
+
+    context 'when the record is neither in a collection of mine or shared to me' do
+      let(:owner) { other_user }
+
+      before { own_collection_of_other_user.reactions << reaction }
+
+      it 'returns false' do
+        expect(element_policy.read_full_detail?).to be false
+      end
+    end
+  end
+
   describe '#pass_ownership?' do
     context 'when the record is in an own collection' do
       before { own_collection_of_user.screens << screen }


### PR DESCRIPTION
Research plans with linked samples or reactions now export and import correctly. On import, a linked sample/reaction now points at the newly created element instead of a stale id from the source system.

When the linked element isn't part of the export (e.g. it lives in a collection that wasn't selected), the link is preserved as static chemistry instead of silently breaking, provided the exporting user has permission to see that level of detail: a sample becomes a Ketcher structure field, a reaction becomes an image of its report-style scheme. If the exporting user can't see it, the link is dropped instead — and the drop is now recorded in the import log so it's visible, not silent.

Also fixed: an unfilled sample/reaction placeholder field (added but never linked to anything) survived the round trip untouched instead of being dropped, and the RADAR export path now carries the acting user through so this fallback works there too.