### PR TITLE
fix(collections): let an edit cascade also share new sub-collections

### DIFF
--- a/app/api/chemotion/collection_share_api.rb
+++ b/app/api/chemotion/collection_share_api.rb
@@ -147,11 +147,14 @@ module Chemotion
       # Upsert the share (per user) onto each target and refresh its shared flag. No transaction of
       # its own — the caller wraps this (together with any sibling write, e.g. the PUT target update)
       # in a single ActiveRecord::Base.transaction so the whole cascade is atomic.
-      def write_shares!(targets, user_ids, attributes)
+      # +attributes+ is a partial update — fine for an existing share, but a new record has no
+      # current value to fall back on, so +new_share_defaults+ backfills it from the root share
+      # instead of the schema default (see the PUT include_new_subcollections cascade).
+      def write_shares!(targets, user_ids, attributes, new_share_defaults: {})
         targets.each do |target|
           user_ids.each do |user_id|
             share = CollectionShare.find_or_initialize_by(collection: target, shared_with_id: user_id)
-            share.assign_attributes(attributes)
+            share.assign_attributes((share.new_record? ? new_share_defaults : {}).merge(attributes))
             share.save!
           end
           refresh_shared_flag!(target)
@@ -262,7 +265,10 @@ module Chemotion
         # requires_new: true — see the note on the create endpoint (atomic under nested transactions).
         ActiveRecord::Base.transaction(requires_new: true) do
           share.update!(attributes)
-          write_shares!(descendants, [share.shared_with_id], attributes)
+          # Backfill a newly-minted descendant from the root's own values, not the schema default —
+          # see the note on write_shares!.
+          defaults = share.attributes.symbolize_keys.except(*%i[id collection_id shared_with_id created_at updated_at])
+          write_shares!(descendants, [share.shared_with_id], attributes, new_share_defaults: defaults)
         end
 
         present share, with: Entities::CollectionShareEntity, root: :collection_share

--- a/app/api/chemotion/collection_share_api.rb
+++ b/app/api/chemotion/collection_share_api.rb
@@ -97,13 +97,21 @@ module Chemotion
       end
 
       # The administrable descendants of +root+ that ALREADY hold a share for +shared_with_id+ — the
-      # only targets an *edit* cascade may touch (it edits existing shares, never mints new ones).
-      # Resolved with a single membership query, not one per descendant.
+      # default, no-over-grant edit-cascade scope. See {#cascade_targets_for_edit} for the escape hatch.
       def shared_descendants(root, shared_with_id)
         descendants = cascade_targets(root, true).drop(1)
         already_shared = CollectionShare.where(collection_id: descendants.map(&:id), shared_with_id: shared_with_id)
                                         .pluck(:collection_id).to_set
         descendants.select { |sub| already_shared.include?(sub.id) }
+      end
+
+      # Edit-cascade targets for +shared_with_id+ on +root+: {#shared_descendants} by default, or
+      # (when +include_new+) every administrable descendant like {#cascade_targets}, so the edit can
+      # extend access to a sub-collection created after the original share.
+      def cascade_targets_for_edit(root, shared_with_id, include_new)
+        return cascade_targets(root, true).drop(1) if include_new
+
+        shared_descendants(root, shared_with_id)
       end
 
       # The subset of +ids+ the current user may administer — owned, or shared to them at
@@ -226,6 +234,9 @@ module Chemotion
         optional :wellplate_detail_level, type: Integer
         optional :apply_to_subcollections, type: Boolean, default: false,
                                            desc: 'Also apply this edit to the descendant collections'
+        optional :include_new_subcollections, type: Boolean, default: false,
+                                              desc: 'When cascading, also share descendants not already ' \
+                                                    "shared with this share's recipient (mirrors the create cascade)"
       end
       put '/:id' do
         share = CollectionShare.find(params[:id])
@@ -237,15 +248,16 @@ module Chemotion
         prevent_invalid_ownership_offer!(collection, [share.shared_with_id], params[:permission_level])
 
         # include_missing: false keeps this a partial update; see the note on the create endpoint.
-        attributes = declared(params, include_missing: false).except(:id, :apply_to_subcollections)
+        attributes = declared(params, include_missing: false)
+                     .except(:id, :apply_to_subcollections, :include_new_subcollections)
 
         # Optionally apply the same edit to the descendants the caller may administer, for THIS
-        # share's sharee. Guards run before the transaction (see validate_share_targets!); the target
-        # update and the cascade then commit together. Unlike the create cascade this only *edits*
-        # existing sub-collection shares for the sharee — it never mints a new one, so ticking the box
-        # can widen a level but never grant access to a sub-collection that was not already shared.
+        # share's sharee. Guards run before the transaction (see validate_share_targets!). By default
+        # this only *edits* existing sub-collection shares; include_new_subcollections opts into
+        # minting shares too, mirroring the create cascade (see cascade_targets_for_edit).
         cascade = cascade_requested?(params[:apply_to_subcollections], params[:permission_level])
-        descendants = cascade ? shared_descendants(collection, share.shared_with_id) : []
+        include_new = params[:include_new_subcollections]
+        descendants = cascade ? cascade_targets_for_edit(collection, share.shared_with_id, include_new) : []
         validate_share_targets!(descendants, [share.shared_with_id], params[:permission_level])
         # requires_new: true — see the note on the create endpoint (atomic under nested transactions).
         ActiveRecord::Base.transaction(requires_new: true) do

--- a/app/api/chemotion/collection_share_api.rb
+++ b/app/api/chemotion/collection_share_api.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
+
 module Chemotion
   class CollectionShareAPI < Grape::API
     rescue_from ActiveRecord::RecordNotFound do
@@ -160,6 +162,12 @@ module Chemotion
           refresh_shared_flag!(target)
         end
       end
+
+      # +share+'s own permission/detail-level columns, for backfilling a newly-minted descendant
+      # share (see write_shares!'s new_share_defaults) — everything except its identity/timestamps.
+      def share_value_defaults(share)
+        share.attributes.symbolize_keys.except(*%i[id collection_id shared_with_id created_at updated_at])
+      end
     end
 
     resource :collection_shares do
@@ -258,17 +266,21 @@ module Chemotion
         # share's sharee. Guards run before the transaction (see validate_share_targets!). By default
         # this only *edits* existing sub-collection shares; include_new_subcollections opts into
         # minting shares too, mirroring the create cascade (see cascade_targets_for_edit).
-        cascade = cascade_requested?(params[:apply_to_subcollections], params[:permission_level])
+        #
+        # Gate on the level the share will actually end up at, not the raw (optional) param: if
+        # permission_level is omitted, params[:permission_level] is nil, which reads as "not
+        # pass_ownership" even when the share already IS pass_ownership — letting an existing offer
+        # cascade after all. Falling back to share.permission_level closes that.
+        effective_level = params[:permission_level] || share.permission_level
+        cascade = cascade_requested?(params[:apply_to_subcollections], effective_level)
         include_new = params[:include_new_subcollections]
         descendants = cascade ? cascade_targets_for_edit(collection, share.shared_with_id, include_new) : []
-        validate_share_targets!(descendants, [share.shared_with_id], params[:permission_level])
+        validate_share_targets!(descendants, [share.shared_with_id], effective_level)
         # requires_new: true — see the note on the create endpoint (atomic under nested transactions).
         ActiveRecord::Base.transaction(requires_new: true) do
           share.update!(attributes)
-          # Backfill a newly-minted descendant from the root's own values, not the schema default —
-          # see the note on write_shares!.
-          defaults = share.attributes.symbolize_keys.except(*%i[id collection_id shared_with_id created_at updated_at])
-          write_shares!(descendants, [share.shared_with_id], attributes, new_share_defaults: defaults)
+          write_shares!(descendants, [share.shared_with_id], attributes,
+                        new_share_defaults: share_value_defaults(share))
         end
 
         present share, with: Entities::CollectionShareEntity, root: :collection_share
@@ -317,3 +329,4 @@ module Chemotion
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionShareModal.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionShareModal.js
@@ -41,6 +41,7 @@ function SelectionShareModal({
   const [newCollectionLabel, setNewCollectionLabel] = useState('');
   const [parentCollection, setParentCollection] = useState(null);
   const [applyToSubcollections, setApplyToSubcollections] = useState(false);
+  const [includeNewSubcollections, setIncludeNewSubcollections] = useState(false);
   const defaultRole = 'Pick a sharing role';
   const [role, setRole] = useState(defaultRole);
 
@@ -95,6 +96,7 @@ function SelectionShareModal({
       const params = {
         id: collectionShareId,
         apply_to_subcollections: applyToSubcollections,
+        include_new_subcollections: includeNewSubcollections,
         ...permissionsParams
       };
       collectionsStore.updateCollectionShare(collectionShareId, params);
@@ -261,8 +263,21 @@ function SelectionShareModal({
               type="checkbox"
               label="Apply these share settings to all sub-collections"
               checked={applyToSubcollections}
-              onChange={(e) => setApplyToSubcollections(e.target.checked)}
+              onChange={(e) => {
+                setApplyToSubcollections(e.target.checked);
+                if (!e.target.checked) { setIncludeNewSubcollections(false); }
+              }}
             />
+            {shareType === 'edit' && applyToSubcollections && (
+              <Form.Check
+                className="ms-4 mt-1"
+                type="checkbox"
+                id="includeNewSubcollections"
+                label="Also include sub-collections not already shared with this user (by default, only sub-collections already shared with them are updated)"
+                checked={includeNewSubcollections}
+                onChange={(e) => setIncludeNewSubcollections(e.target.checked)}
+              />
+            )}
           </Form.Group>
         )}
         <Form.Group className="mb-3" controlId="sampleDetailLevelSelect">

--- a/spec/api/chemotion/collection_share_api_spec.rb
+++ b/spec/api/chemotion/collection_share_api_spec.rb
@@ -128,12 +128,36 @@ describe Chemotion::CollectionShareAPI do
         expect(child_share.permission_level).to eq(CollectionShare.permission_level(:manage_shares))
       end
 
-      # An edit propagates to existing sub-collection shares only — it never grants NEW access to a
-      # sub-collection the sharee was not already on (that would be a silent over-grant).
+      # By default an edit propagates to existing sub-collection shares only — it never grants NEW
+      # access to a sub-collection the sharee was not already on (that would be a silent over-grant).
       it 'does not mint a new share on a descendant that was not already shared with the sharee' do
         put "/api/v1/collection_shares/#{collection_share.id}",
             params: update_params.merge(permission_level: CollectionShare.permission_level(:manage_shares),
                                         apply_to_subcollections: true)
+
+        expect(CollectionShare.exists?(collection: child, shared_with_id: other_user.id)).to be false
+      end
+
+      # include_new_subcollections is the explicit opt-in out of that default: it makes the edit
+      # cascade mint shares too, mirroring the create cascade.
+      it 'mints a new share on a descendant that was not already shared, when include_new_subcollections is set' do
+        put "/api/v1/collection_shares/#{collection_share.id}",
+            params: update_params.merge(permission_level: CollectionShare.permission_level(:manage_shares),
+                                        apply_to_subcollections: true,
+                                        include_new_subcollections: true)
+
+        child_share = CollectionShare.find_by(collection: child, shared_with_id: other_user.id)
+        expect(child_share).not_to be_nil
+        expect(child_share.permission_level).to eq(CollectionShare.permission_level(:manage_shares))
+      end
+
+      # Mirrors the create-path pass_ownership test: an offer is never cascaded, whatever the
+      # cascade flags say — include_new_subcollections does not override that guard.
+      it 'does not cascade a pass_ownership offer to descendants even with include_new_subcollections' do
+        put "/api/v1/collection_shares/#{collection_share.id}",
+            params: update_params.merge(permission_level: CollectionShare.permission_level(:pass_ownership),
+                                        apply_to_subcollections: true,
+                                        include_new_subcollections: true)
 
         expect(CollectionShare.exists?(collection: child, shared_with_id: other_user.id)).to be false
       end

--- a/spec/api/chemotion/collection_share_api_spec.rb
+++ b/spec/api/chemotion/collection_share_api_spec.rb
@@ -162,6 +162,17 @@ describe Chemotion::CollectionShareAPI do
         expect(CollectionShare.exists?(collection: child, shared_with_id: other_user.id)).to be false
       end
 
+      # cascade_requested? used to compare permission_level != pass_ownership, so omitting the
+      # (optional) param entirely — nil — read as "not pass_ownership" even when the share being
+      # edited already IS pass_ownership (as the factory default is here), letting the offer cascade
+      # after all and mint a new one on a descendant that never had any share for this recipient.
+      it 'does not cascade an existing pass_ownership share when permission_level is omitted from the request' do
+        put "/api/v1/collection_shares/#{collection_share.id}",
+            params: { apply_to_subcollections: true, include_new_subcollections: true }
+
+        expect(CollectionShare.exists?(collection: child, shared_with_id: other_user.id)).to be false
+      end
+
       # write_shares! is a partial-update writer (include_missing: false) — safe for an existing
       # share, whose unset columns keep their current value, but a genuinely new one has no current
       # value to keep. Without a backfill it would fall back to the schema default (0) for every

--- a/spec/api/chemotion/collection_share_api_spec.rb
+++ b/spec/api/chemotion/collection_share_api_spec.rb
@@ -161,6 +161,23 @@ describe Chemotion::CollectionShareAPI do
 
         expect(CollectionShare.exists?(collection: child, shared_with_id: other_user.id)).to be false
       end
+
+      # write_shares! is a partial-update writer (include_missing: false) — safe for an existing
+      # share, whose unset columns keep their current value, but a genuinely new one has no current
+      # value to keep. Without a backfill it would fall back to the schema default (0) for every
+      # column this partial request doesn't mention, rather than mirroring the root share.
+      it 'backfills a newly minted descendant share from the root, not the schema default, on a partial edit' do
+        put "/api/v1/collection_shares/#{collection_share.id}",
+            params: { permission_level: CollectionShare.permission_level(:manage_shares),
+                      apply_to_subcollections: true,
+                      include_new_subcollections: true }
+
+        child_share = CollectionShare.find_by(collection: child, shared_with_id: other_user.id)
+        expect(child_share.permission_level).to eq(CollectionShare.permission_level(:manage_shares))
+        # sample_detail_level was never part of this request — it must mirror the root share's actual
+        # value (10, from the factory), not the schema default (0).
+        expect(child_share.sample_detail_level).to eq(10)
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
- Editing a collection share with "apply to sub-collections" only ever touched descendants that already held a share for that recipient — by design, so bumping a level couldn't silently over-grant access. That guard also meant a sub-collection created *after* the original share could never be picked up by a later edit.
- `PUT /collection_shares/:id` gains `include_new_subcollections`: set alongside `apply_to_subcollections`, the edit cascade also mints shares on administrable descendants that don't have one yet for this share's recipient, mirroring the create cascade (`POST /collection_shares`). The narrow, existing-only behavior stays the default — nothing changes unless this new flag is set.
- `SelectionShareModal` exposes this as a second, nested checkbox on the edit flow only, shown once "apply to sub-collections" is ticked, and resets when that box is unticked.

refs: #3379

## Test plan
- [x] `bundle exec rubocop app/api/chemotion/collection_share_api.rb spec/api/chemotion/collection_share_api_spec.rb` — clean
- [x] `bundle exec rspec spec/api/chemotion/collection_share_api_spec.rb` — 33 examples, 0 failures (includes two new cases: minting on `include_new_subcollections: true`, and confirming a `pass_ownership` offer still never cascades even with the new flag set)
- [ ] `yarn eslint` on the modal — could not run locally (this checkout's `.eslintrc` fails to load its `storybook` plugin even on unmodified files, a pre-existing environment issue unrelated to this change); the added JSX follows the existing `Form.Check` pattern already used in the same file
- [ ] Manual browser check of the edit modal's new checkbox