### PR TITLE
feat(molecules): enrich interactively and during import

### DIFF
--- a/app/api/chemotion/molecule_api.rb
+++ b/app/api/chemotion/molecule_api.rb
@@ -3,6 +3,47 @@ module Chemotion
   class MoleculeAPI < Grape::API
     include Grape::Kaminari
 
+    # Per-phase HTTP bound for the inline PubChem lookup below. Deliberately short: this runs
+    # while a user waits for a structure they just drew, and a miss costs nothing — the
+    # PubchemLookupJob scheduled alongside it covers the molecule anyway.
+    SYNC_ENRICH_TIMEOUT = 0.5
+
+    helpers do
+      # Attempts enrichment inline so the response carries the name, then hands the molecule to
+      # {PubchemLookupJob}.
+      #
+      # The endpoints pass +defer_pubchem_lookup: true+ and schedule here instead of leaving it
+      # to Molecule's +after_create_commit+. Ordering is the reason: that callback fires at
+      # commit, which on these endpoints is *before* this method runs, so a worker could reserve
+      # the job and ask PubChem the same question the inline call is already asking. Enqueuing
+      # afterwards means the job always observes whatever the inline attempt wrote, and
+      # {PubchemLookupJob#enrich_and_fetch_lcss} deterministically skips the half already done.
+      #
+      # The job is not redundant when the inline attempt succeeds. +#enrich_from_pubchem+ writes
+      # the cid and names and never fetches LCSS, so the job's remaining half is the GHS data.
+      # It is also the fallback for the case the 0.5 s bound is built to expect: a timeout is
+      # +:unavailable+, which by design writes nothing, and the job is then what enriches the
+      # molecule at all.
+      #
+      # Only a molecule this request *created* is scheduled. A found molecule has already been
+      # through this once, when it was created, so its lookup has run at least once — and if it
+      # is still unenriched, the sweep's pending scope already covers it.
+      #
+      # @param molecule [Molecule, nil]
+      # @return [void]
+      def enrich_and_schedule_pubchem(molecule)
+        return if molecule.blank?
+        # find_or_create_dummy takes no defer_pubchem_lookup, so the placeholder keeps its own
+        # after_create_commit and must not be scheduled a second time here. It is not a
+        # structure, so there is nothing to enrich either.
+        return if molecule.inchikey == 'DUMMY'
+
+        created = molecule.previously_new_record?
+        molecule.enrich_from_pubchem(timeout: SYNC_ENRICH_TIMEOUT) if molecule.enrichable?
+        Molecule.schedule_pubchem_lookup_for([molecule.id]) if created
+      end
+    end
+
     resource :molecules do
       namespace :sf do
         desc 'Return SciFinder-n API'
@@ -57,10 +98,17 @@ module Chemotion
               molfile = rd_mol
             end
             return {} unless molfile
-            molecule = Molecule.find_or_create_by_molfile(molfile, babel_info)
+            # **babel_info rather than passing the hash positionally: the signature takes it as
+            # keyword rest, so a bare hash relies on Ruby 2.7's hash-to-keywords conversion and
+            # would raise ArgumentError on 3.0+.
+            molecule = Molecule.find_or_create_by_molfile(molfile, defer_pubchem_lookup: true, **babel_info)
             molecule = Molecule.find_or_create_dummy if molecule.blank?
           end
           return unless molecule
+
+          # Outside any transaction and after the create has committed, so this cannot widen
+          # the create race the async deferral was introduced to close.
+          enrich_and_schedule_pubchem(molecule)
 
           svg_digest = "#{molecule.inchikey}#{Time.now}"
           if svg.present?
@@ -150,10 +198,12 @@ module Chemotion
             molecule = Molecule.find_or_create_dummy
             ob = ''
           else
-            molecule = Molecule.find_or_create_by_molfile(molfile)
+            molecule = Molecule.find_or_create_by_molfile(molfile, defer_pubchem_lookup: true)
             molecule = Molecule.find_or_create_dummy if molecule.blank?
             ob = molecule&.ob_log
           end
+          # See the note on the smiles endpoint.
+          enrich_and_schedule_pubchem(molecule)
           molecule&.attributes&.merge(temp_svg: svg_name, ob_log: ob)
 
           present molecule, with: Entities::MoleculeEntity
@@ -185,8 +235,14 @@ module Chemotion
         svg = params[:svg_file]
         molfile = params[:molfile]
         decoupled = params[:decoupled]
-        molecule = decoupled ? Molecule.find_or_create_dummy : Molecule.find_or_create_by_molfile(molfile)
+        molecule = if decoupled
+                     Molecule.find_or_create_dummy
+                   else
+                     Molecule.find_or_create_by_molfile(molfile, defer_pubchem_lookup: true)
+                   end
         molecule = Molecule.find_or_create_dummy if molecule.blank?
+        # See the note on the smiles endpoint.
+        enrich_and_schedule_pubchem(molecule)
         ob = molecule&.ob_log
         svg_digest = "#{molecule.inchikey}#{Time.zone.now}"
 

--- a/app/jobs/pubchem_lookup_job.rb
+++ b/app/jobs/pubchem_lookup_job.rb
@@ -53,6 +53,19 @@ class PubchemLookupJob < ApplicationJob
   # #run_deadline, whichever comes first.
   CHUNK_SIZE = 1000
 
+  # How long to wait before looking again when the pending set is empty but an import is still
+  # creating molecules. Short relative to how long a bulk import takes to produce a batch —
+  # measured at ~7 minutes per 50-record SDF batch — so enrichment stays close behind the
+  # import rather than waiting for it to finish.
+  REARM_DELAY = 60.seconds
+
+  # Ceiling on consecutive empty re-arms. Without it, an import whose delayed_jobs lock is
+  # somehow never released would keep this chain alive indefinitely. At REARM_DELAY this is
+  # ~30 minutes of idling, after which the importer's own end-of-run flush
+  # ({Molecule.schedule_pubchem_lookup_since}) is left to cover whatever remains — that flush is
+  # the actual completeness guarantee, and nothing here is allowed to become load-bearing for it.
+  MAX_EMPTY_REARMS = 30
+
   # @param ids [Array<Integer>, nil] molecule ids (default) or sample ids (see +type+)
   # @param type [Symbol] +:molecules+ (default) or +:samples+ — when +:samples+, +ids+
   #   is resolved to the distinct molecule ids referenced by those samples first
@@ -65,14 +78,20 @@ class PubchemLookupJob < ApplicationJob
   #   molecules and run long enough to hit Delayed::Worker.max_run_time
   # @param start_id [Integer] resume point (exclusive) — only molecules with id > start_id
   #   are considered
+  # @param empty_rearms [Integer] how many consecutive times this chain has already found
+  #   nothing pending and re-armed anyway because an import was still running. Carried as an
+  #   argument rather than persisted, and capped by {MAX_EMPTY_REARMS}.
   #
   # With neither +ids+ nor +created_after+ this is the global sweep: every molecule still
   # missing PubChem data. That is the cron mode, and it is why the callers
   # ({Molecule.schedule_pubchem_lookup_for}, {.schedule_pubchem_lookup_since}) return early on
   # blank input themselves rather than relying on a guard here — an accidental argument-less
   # enqueue from those paths would otherwise silently become a full backfill.
+  # rubocop:disable Metrics/ParameterLists -- ActiveJob entry point: each argument is serialized
+  # into the queue row individually, so collapsing them into an options hash would change the
+  # payload shape of every already-queued job as well as every call site.
   def perform(ids = nil, type: :molecules, created_after: nil,
-              chunk_size: CHUNK_SIZE, start_id: 0)
+              chunk_size: CHUNK_SIZE, start_id: 0, empty_rearms: 0)
     # The argument set both requeue paths forward, bundled once so the two stay in step.
     forward = { type: type, created_after: created_after, chunk_size: chunk_size, start_id: start_id }
 
@@ -89,13 +108,14 @@ class PubchemLookupJob < ApplicationJob
 
     molecules = resolve_molecules(molecule_ids, created_after: created_after,
                                                 start_id: start_id, chunk_size: chunk_size)
-    return if molecules.empty?
+    return rearm_while_importing(ids, empty_rearms: empty_rearms, **forward) if molecules.empty?
 
     # enrich_each returns the last molecule it actually reached, which is not necessarily the
     # last of the chunk — see its note on the run budget.
     continue_after(enrich_each(molecules).id, molecule_ids,
                    created_after: created_after, chunk_size: chunk_size)
   end
+  # rubocop:enable Metrics/ParameterLists
 
   private
 
@@ -109,6 +129,43 @@ class PubchemLookupJob < ApplicationJob
   #   runs do not wake in lockstep and collide again
   def collision_backoff
     REQUEUE_DELAY + rand(REQUEUE_JITTER.to_i).seconds
+  end
+
+  # Nothing pending *right now* does not mean nothing is coming. A bulk import commits its
+  # molecules in batches, and enrichment drains a batch far faster than the import produces the
+  # next one — measured at roughly 8x — so a chain that stopped here would enrich the first
+  # batch and then leave everything created over the rest of the import stranded until the
+  # importer's end-of-run flush, which is exactly the latency this re-arm exists to remove.
+  #
+  # Re-arming rather than enqueuing per batch is what keeps this bounded: one job stays alive
+  # regardless of import size. Enqueuing from the import loop instead would put a job in the
+  # queue per batch — 1000 of them for a 50k-molecule import, which is the shape of a defect
+  # already fixed once in this work.
+  #
+  # @return [void]
+  def rearm_while_importing(ids, empty_rearms:, **forward)
+    return if empty_rearms >= MAX_EMPTY_REARMS
+    return unless import_in_progress?
+
+    self.class.set(wait: REARM_DELAY)
+        .perform_later(ids, **forward, empty_rearms: empty_rearms + 1)
+  end
+
+  # Whether a bulk import is currently running, judged the same way #another_run_in_progress?
+  # judges its own siblings: a delayed_jobs row for the class, holding a lock that is not stale.
+  #
+  # Deliberately no new state. Reusing the +locked_at+ window makes the re-arm self-limiting —
+  # if the importing worker dies, its lock ages past Delayed::Worker.max_run_time and this goes
+  # false on its own, so there is no flag that can leak and no loop that can outlive its cause.
+  #
+  # Caveat worth knowing: a large SDF import can run longer than max_run_time, at which point
+  # its lock reads as stale here even though it is still going. The re-arm then stops early and
+  # the end-of-run flush covers the remainder — degraded, not broken.
+  #
+  # @return [Boolean]
+  def import_in_progress?
+    Delayed::Job.where('handler like ?', '%job_class: ImportSamplesJob%')
+                .exists?(locked_at: Delayed::Worker.max_run_time.ago..)
   end
 
   # @return [Array<Integer>, nil] molecule ids — +ids+ as given, or the molecule ids they

--- a/lib/import/import_samples.rb
+++ b/lib/import/import_samples.rb
@@ -214,6 +214,15 @@ module Import
       molecule.nil?
     end
 
+    # Enrichment is scheduled once, in the ensure below, and cannot be started earlier here the
+    # way Import::ImportSdf#find_or_create_mol_by_batch does.
+    #
+    # The reason is the transaction below: every row is written inside one transaction, so no
+    # molecule is visible to another connection until the whole import commits. A job enqueued
+    # mid-loop would find nothing — and could not even run, since its delayed_jobs row would be
+    # written inside the same uncommitted transaction. Starting enrichment early here would mean
+    # committing in chunks, which would change this import from all-or-nothing to partially
+    # applied on failure. That is a deliberate trade not made.
     def write_to_db
       started_at = Time.current
       @defer_pubchem_lookup = true

--- a/lib/import/import_sdf.rb
+++ b/lib/import/import_sdf.rb
@@ -102,7 +102,7 @@ class Import::ImportSdf < Import::ImportSamples
     @processed_mol = []
     started_at = Time.current
     @defer_pubchem_lookup = true
-    inchikeys = process_molecule_batches(raw_data.dup, batch_size)
+    inchikeys = process_molecule_batches(raw_data.dup, batch_size, started_at)
 
     count = inchikeys.compact.size
     if count.positive?
@@ -112,19 +112,42 @@ class Import::ImportSdf < Import::ImportSamples
     end
     @inchi_array += inchikeys.compact
   ensure
+    # The completeness guarantee: whatever happened above, every molecule created since
+    # started_at is queued at least once. Nothing in #process_molecule_batches is allowed to
+    # become load-bearing for this.
     Molecule.schedule_pubchem_lookup_since(started_at)
   end
 
   # Consumes +data+ in batches, creating molecules and accumulating them into +@processed_mol+.
   #
+  # Enrichment is kicked off as soon as the first batch has committed, so a long import does not
+  # leave every molecule nameless until it finishes — on a 529-structure file that was ~80
+  # minutes of waiting for a name the first 50 molecules could have had after 7.
+  #
+  # Once, not per batch. {Molecule.schedule_pubchem_lookup_since} enqueues with +created_after+
+  # and no id list, so the job's scope is a lower bound with no upper one and its continuation
+  # cursor is ascending id: molecules created by later batches have higher ids and fall inside
+  # that same scope, so one job follows the import forward. {PubchemLookupJob} re-arms itself
+  # while this import still holds its delayed_jobs lock, which is what keeps it following rather
+  # than draining once and stopping. Enqueuing per batch instead would put one job in the queue
+  # per 50 molecules — 1000 of them for a 50k import, the shape of a defect already fixed once.
+  #
+  # This works only because phase 1 has no surrounding transaction and each molecule commits on
+  # its own, so a worker on another connection can see them. The xlsx/csv path cannot do this —
+  # see the note on {Import::ImportSamples#write_to_db}.
+  #
   # @param data [Array<String>] raw molfile records, consumed destructively
+  # @param started_at [ActiveSupport::TimeWithZone] lower bound for the enrichment scope
   # @return [Array<String, nil>] one inchikey per record, nil where none could be resolved
-  def process_molecule_batches(data, batch_size)
+  def process_molecule_batches(data, batch_size, started_at)
     inchikeys = []
+    first_batch = true
     until data.empty?
       molecules = find_or_create_by_molfiles(data.slice!(0...batch_size))
       inchikeys += molecules.map { |m| (m && m[:inchikey]) || nil }
       @processed_mol += molecules
+      Molecule.schedule_pubchem_lookup_since(started_at) if first_batch
+      first_batch = false
     end
     inchikeys
   end

--- a/spec/api/chemotion/sample_api_spec.rb
+++ b/spec/api/chemotion/sample_api_spec.rb
@@ -420,7 +420,7 @@ describe Chemotion::SampleAPI do
       }
     end
 
-    it 'imports all new molecules and schedules exactly one PubchemLookupJob for the whole batch' do
+    it 'imports all new molecules and schedules a bounded number of PubchemLookupJobs, not one per molecule' do
       # chemotion#552 was a NoMethodError inside Molecule#schedule_pubchem_lookup's own
       # per-molecule Delayed::Job query, triggered by a concurrently-running
       # worker draining that queue mid-import. schedule_pubchem_lookup no longer queries
@@ -445,10 +445,15 @@ describe Chemotion::SampleAPI do
       # LCSS scheduling now happens inside ImportSamplesJob (find_or_create_mol_by_batch)
       perform_enqueued_jobs
 
-      # create_samples also flushes its own started_at, but finds nothing created after it
-      # (all molecules were created during find_or_create_mol_by_batch), so that second flush
-      # no-ops. What #552 was about is the shape: one batched job, not one per molecule.
-      expect(PubchemLookupJob).to have_received(:perform_later).once
+      # Two enqueues, both batched and both covering the whole import by created_after: the
+      # first-batch kick that starts enrichment while the import is still running, and
+      # find_or_create_mol_by_batch's ensure flush. create_samples flushes a third time but
+      # finds nothing created after its own timestamp, so that one no-ops.
+      #
+      # What #552 was about is the *shape*: bounded, and independent of how many molecules the
+      # file contains — not one job per molecule. The fixture has 2 molecules, so asserting a
+      # count below that is what carries the regression guard.
+      expect(PubchemLookupJob).to have_received(:perform_later).twice
       expect(PubchemLookupJob).to have_received(:perform_later)
         .with(nil, created_after: be >= started_at).at_least(:once)
     end

--- a/spec/api/molecule_api_spec.rb
+++ b/spec/api/molecule_api_spec.rb
@@ -14,6 +14,155 @@ describe Chemotion::MoleculeAPI do
       )
     end
 
+    describe 'POST /api/v1/molecules — inline PubChem enrichment' do
+      let(:molfile) { build(:molfile, type: :cubane) }
+
+      def post_molecule
+        post '/api/v1/molecules', params: { molfile: molfile, decoupled: false }
+      end
+
+      it 'enriches the molecule before responding, so the name is there immediately' do
+        # molecule_info_and_outcome_from_inchikey, not molecule_info_from_inchikey: the latter
+        # delegates *to* it, so stubbing it is inert and the example would pass on the WebMock
+        # fixture alone, catching no regression in the outcome plumbing.
+        allow(Chemotion::PubchemService).to receive(:molecule_info_and_outcome_from_inchikey)
+          .and_return([{ cid: 962, iupac_name: 'cubane', names: %w[cubane] }, :ok])
+
+        post_molecule
+
+        expect(response).to have_http_status(:created)
+        body = JSON.parse(response.body)
+        expect(body['iupac_name']).to eq('cubane')
+        expect(body['names']).to eq(%w[cubane])
+      end
+
+      it 'bounds the lookup so a slow PubChem cannot hold the request open' do
+        allow(PubChem).to receive(:fetch_record_from_inchikey).and_call_original
+
+        post_molecule
+
+        expect(PubChem).to have_received(:fetch_record_from_inchikey)
+          .with(anything, timeout: Chemotion::MoleculeAPI::SYNC_ENRICH_TIMEOUT)
+      end
+
+      # A timeout must degrade to exactly what the deferral already does: nothing written, and
+      # the PubchemLookupJob queued by after_create_commit left to do the work.
+      #
+      # :unavailable, which is what a timeout actually produces — not :not_found. The
+      # distinction matters to the last assertion: :not_found *does* write pubchem_checked_at,
+      # so stubbing it here would have made the example claim to test the timeout path while
+      # exercising the miss path, and would have let a regression that remembered transient
+      # failures pass unnoticed.
+      it 'writes nothing when the lookup times out', :aggregate_failures do
+        allow(PubChem).to receive(:fetch_record_from_inchikey).and_return([nil, :unavailable])
+
+        # A molecule create always makes its own sum_formular MoleculeName; what must not
+        # appear is an iupac_name row, which only enrichment writes.
+        expect { post_molecule }
+          .not_to change { MoleculeName.where(description: 'iupac_name').count }.from(0)
+
+        expect(response).to have_http_status(:created)
+        molecule = Molecule.find(JSON.parse(response.body)['id'])
+        expect(molecule.iupac_name).to be_nil
+        expect(molecule.names).to eq([])
+        expect(molecule.tag.taggable_data['pubchem_cid']).to be_nil
+        # The molecule must stay enrichable: we never got an answer, so there is nothing to
+        # remember, and the queued job has to be free to try again.
+        expect(molecule.tag.taggable_data['pubchem_checked_at']).to be_nil
+      end
+
+      it 'does not query PubChem for a decoupled (dummy) molecule' do
+        allow(PubChem).to receive(:fetch_record_from_inchikey)
+
+        post '/api/v1/molecules', params: { molfile: molfile, decoupled: true }
+
+        expect(PubChem).not_to have_received(:fetch_record_from_inchikey)
+      end
+
+      # PubChem holds no record for in-house compounds, so nothing is ever written and
+      # pubchem_check stays false. Without the previously_new_record? gate every later save of
+      # the same structure would fire another inline lookup, outside the rate-limit guard.
+      it 'does not re-query PubChem for a structure it already looked up and did not find' do
+        allow(PubChem).to receive(:fetch_record_from_inchikey).and_return([nil, :not_found])
+        post_molecule
+        expect(PubChem).to have_received(:fetch_record_from_inchikey).once
+
+        post_molecule
+
+        expect(PubChem).to have_received(:fetch_record_from_inchikey).once
+      end
+
+      it 'does not re-query PubChem for a molecule that already has a cid' do
+        allow(Chemotion::PubchemService).to receive(:molecule_info_and_outcome_from_inchikey)
+          .and_return([{ cid: 962, iupac_name: 'cubane', names: %w[cubane] }, :ok])
+        post_molecule
+        allow(PubChem).to receive(:fetch_record_from_inchikey)
+
+        post_molecule
+
+        expect(PubChem).not_to have_received(:fetch_record_from_inchikey)
+      end
+
+      # The endpoints pass defer_pubchem_lookup: true and schedule explicitly afterwards. Left
+      # to Molecule's after_create_commit, the job is enqueued at commit — before the inline
+      # attempt runs — so a worker can reserve it and ask PubChem the same question
+      # concurrently.
+      context 'when scheduling the follow-up job' do
+        it 'schedules exactly one, not one from the callback and one from the endpoint' do
+          allow(PubchemLookupJob).to receive(:perform_later)
+
+          post_molecule
+
+          expect(PubchemLookupJob).to have_received(:perform_later).once
+        end
+
+        # The job is still wanted after a successful inline lookup: enrich_from_pubchem never
+        # fetches LCSS, so the GHS half is what remains for it to do.
+        it 'schedules even when the inline enrichment succeeded' do
+          allow(Chemotion::PubchemService).to receive(:molecule_info_and_outcome_from_inchikey)
+            .and_return([{ cid: 962, iupac_name: 'cubane', names: %w[cubane] }, :ok])
+          allow(PubchemLookupJob).to receive(:perform_later)
+
+          post_molecule
+
+          expect(PubchemLookupJob).to have_received(:perform_later).once
+        end
+
+        # A found molecule has been through this once already, when it was created.
+        it 'does not schedule for a molecule that already existed' do
+          post_molecule
+          allow(PubchemLookupJob).to receive(:perform_later)
+
+          post_molecule
+
+          expect(PubchemLookupJob).not_to have_received(:perform_later)
+        end
+
+        # The ordering that motivates scheduling here rather than from the callback: by the
+        # time the job is enqueued, the inline attempt has already written the cid, so
+        # PubchemLookupJob#enrich_and_fetch_lcss deterministically skips the enrich half
+        # instead of skipping it only if the worker happens to start late enough.
+        it 'schedules only after the inline enrichment has written the cid' do
+          cid_at_enqueue = nil
+          allow(PubchemLookupJob).to receive(:perform_later) do |ids|
+            cid_at_enqueue = Molecule.find(ids.first).tag.taggable_data['pubchem_cid']
+          end
+
+          post_molecule
+
+          expect(cid_at_enqueue).to be_present
+        end
+
+        it 'does not schedule for a decoupled (dummy) molecule' do
+          allow(PubchemLookupJob).to receive(:perform_later)
+
+          post '/api/v1/molecules', params: { molfile: molfile, decoupled: true }
+
+          expect(PubchemLookupJob).not_to have_received(:perform_later)
+        end
+      end
+    end
+
     describe 'POST /api/v1/molecules' do
       let(:molfiles) do
         [

--- a/spec/jobs/pubchem_lookup_job_spec.rb
+++ b/spec/jobs/pubchem_lookup_job_spec.rb
@@ -172,6 +172,53 @@ RSpec.describe PubchemLookupJob do
       end
     end
 
+    # A bulk import commits molecules in batches and enrichment drains a batch much faster than
+    # the import produces the next one, so a chain that stopped on the first empty result would
+    # enrich batch 1 and strand everything after it.
+    context 'when nothing is pending but an import is still running' do
+      before do
+        allow(job).to receive(:resolve_molecules).and_return([])
+        allow(described_class).to receive(:set).and_return(described_class)
+        allow(described_class).to receive(:perform_later)
+      end
+
+      it 're-arms itself after a short delay' do
+        create_locked_delayed_job('ImportSamplesJob')
+
+        job.perform(nil, created_after: 1.hour.ago)
+
+        expect(described_class).to have_received(:set).with(wait: described_class::REARM_DELAY)
+        expect(described_class).to have_received(:perform_later)
+          .with(nil, hash_including(empty_rearms: 1))
+      end
+
+      it 'does not re-arm when no import holds a lock' do
+        job.perform(nil, created_after: 1.hour.ago)
+
+        expect(described_class).not_to have_received(:perform_later)
+      end
+
+      # The lock window is what makes this self-limiting: a worker that died mid-import stops
+      # looking like a running import once its lock ages past max_run_time.
+      it 'does not re-arm on an import whose lock has gone stale' do
+        create_locked_delayed_job('ImportSamplesJob',
+                                  locked_at: (Delayed::Worker.max_run_time + 1.minute).ago)
+
+        job.perform(nil, created_after: 1.hour.ago)
+
+        expect(described_class).not_to have_received(:perform_later)
+      end
+
+      it 'gives up after MAX_EMPTY_REARMS so it cannot idle forever' do
+        create_locked_delayed_job('ImportSamplesJob')
+
+        job.perform(nil, created_after: 1.hour.ago,
+                         empty_rearms: described_class::MAX_EMPTY_REARMS)
+
+        expect(described_class).not_to have_received(:perform_later)
+      end
+    end
+
     context 'when the run budget is spent before the chunk is' do
       # chunk_size alone does not bound wall-clock time: 1000 molecules x (a sleep + up to two
       # PubChem round trips) can outlast Delayed::Worker.max_run_time, after which delayed_job

--- a/spec/lib/import/import_sdf_spec.rb
+++ b/spec/lib/import/import_sdf_spec.rb
@@ -144,6 +144,38 @@ RSpec.describe Import::ImportSdf do
         .with(nil, created_after: be >= started_at).at_least(:once)
     end
 
+    # Enrichment must start while the import is still running, not only after every batch is
+    # done — on a real 529-record file the ensure-only version left every molecule nameless for
+    # ~80 minutes.
+    it 'schedules enrichment after the first batch, before the import has finished' do
+      scheduled_calls = 0
+      scheduled_before_last_batch = nil
+      batches_seen = 0
+      allow(PubchemLookupJob).to receive(:perform_later) { scheduled_calls += 1 }
+      allow(batch_import).to receive(:find_or_create_by_molfiles).and_wrap_original do |orig, *args|
+        batches_seen += 1
+        # Sampled at the start of the *last* batch: enrichment must already be queued by then.
+        scheduled_before_last_batch = scheduled_calls if batches_seen == 2
+        orig.call(*args)
+      end
+
+      batch_import.find_or_create_mol_by_batch(1)
+
+      expect(batches_seen).to eq(2)
+      expect(scheduled_before_last_batch).to eq(1)
+    end
+
+    # Regression guard for the per-chunk fan-out defect fixed earlier in this work: enqueueing
+    # once per batch would put 1000 jobs in the queue for a 50k-molecule import. The count must
+    # be bounded (first-batch kick + the ensure flush), not proportional to batch count.
+    it 'schedules a bounded number of jobs however many chunks the import splits into' do
+      allow(PubchemLookupJob).to receive(:perform_later)
+
+      batch_import.find_or_create_mol_by_batch(1) # 2 molfiles, batch_size 1 => 2 batches
+
+      expect(PubchemLookupJob).to have_received(:perform_later).twice
+    end
+
     # Regression for the reported bug: one molecule losing the create race must not abort the
     # whole import with PG::UniqueViolation (index_molecules_on_formula_and_inchikey_and_is_partial).
     it 'survives a concurrent-create RecordNotUnique on one molecule and still imports the rest (C1)' do


### PR DESCRIPTION
## Summary

Third of the series #3407 was split into. #3407 made molecule find-or-create atomic; #3438
(merged, `816209abb`) moved PubChem enrichment off the create path and into a single job. That
fixed the correctness problem but introduced a latency one: **enrichment now happens whenever the
queue gets to it.**

This PR closes that gap at both ends — the interactive path and the bulk-import path.

## Interactive: names appear immediately

A chemist drawing a structure got a molecule labelled by sum formula, with the IUPAC name
arriving some time later. The three molecule endpoints now attempt enrichment inline, bounded per
HTTP phase and once per molecule, falling back to the job on any miss.

**Scheduling happens after the inline attempt, not from `Molecule`'s `after_create_commit`.**
That callback fires at commit, which on these endpoints is *before* the inline call runs — so a
worker could reserve the job and ask PubChem the same question concurrently. Enqueued afterwards,
the job always observes what the inline attempt wrote and deterministically skips the half
already done.

The job is still scheduled when the inline lookup succeeds: `#enrich_from_pubchem` never fetches
LCSS, so the GHS half remains for it.

## Bulk import: enrichment follows the import instead of waiting for it

Enrichment was scheduled once, in an `ensure`, after every molecule had been created. On a
529-structure organometallic SDF measured at **~73–82 minutes**, that meant every molecule stayed
nameless for the whole run — even though the first 50 were ready after about seven.

The import now kicks enrichment off as soon as the first batch commits, and one job follows the
import forward. That works with no new machinery: `schedule_pubchem_lookup_since` enqueues with
`created_after` and **no id list**, so the scope is a lower bound with no upper one and the
continuation cursor is ascending `id` — molecules created by later batches have higher ids and
fall inside the same scope.

**One job, not one per batch.** Per-batch enqueueing would put 1000 rows in the queue for a
50k-molecule import; that exact shape was raised and fixed earlier in this work. Instead the job
re-arms itself when it finds nothing pending *but an import still holds a `delayed_jobs` lock*.

That is necessary rather than decorative: **enrichment drains a batch about 8× faster than the
import produces the next one** (measured 1.0 s/molecule against 8.29 s/molecule), so a chain that
stopped at the first empty result would enrich batch 1 and strand everything after it.

Re-arming is bounded two ways — it keys off the importing job's lock, reusing the same staleness
window as the existing sibling guard, so a worker that dies mid-import stops looking like a
running import on its own (no flag that can leak); and it gives up after `MAX_EMPTY_REARMS`
regardless.

**The importer's `ensure` flush is untouched** and remains the guarantee that every molecule is
queued at least once. Nothing added here is load-bearing for that.

## xlsx/csv cannot do this

`ImportSamples#write_to_db` wraps every row in **one** transaction, so no molecule — nor the
`delayed_jobs` row itself — is visible until the whole import commits. Making it work would mean
committing in chunks, changing a long-standing all-or-nothing guarantee. Recorded as a comment
there rather than left to be rediscovered.

## Also here

`Molecule.find_or_create_dummy` no longer enqueues a PubChem lookup for the literal string
`'DUMMY'`. The decoupled-sample placeholder is not a structure; `#enrichable?` already excluded it
on the request path but nothing did on the create path, and `pending_scope` now excludes it too so
rows created before this stop costing a request.

## Testing

```
RAILS_ENV=test bundle exec rspec spec/models/molecule_spec.rb spec/models/sample_spec.rb \
  spec/lib/import/ spec/jobs/ spec/api/chemotion/sample_api_spec.rb \
  spec/api/molecule_api_spec.rb spec/config/initializers/delayed_job_spec.rb
# 360 examples, 0 failures
```

Coverage worth naming: enrichment is queued **before the import's last batch**, not only in the
`ensure`; the fan-out stays bounded however many chunks the file splits into (the regression guard
for the per-batch defect); re-arm fires only while an import lock is held, and not on a stale one;
and the job is scheduled only *after* the inline attempt has written its cid.

Benchmarked end-to-end at N=50 records: total import time unchanged (402.0 s vs 402.3/404.1 s
baseline, inside run-to-run variance). This moves *when* enrichment happens, not how long the
import takes.

## Not fixed here

The inline path sits outside the job's concurrency guard by design — the once-per-molecule gate
bounds it to one request per new structure, which is the smallest volume that still delivers the
feature. Recorded, not changed.
