### PR TITLE
perf(import): stop rendering an OpenBabel SVG that is always discarded

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -81,5 +81,13 @@ SENTRY_FRONTEND_SAMPLE_RATE=1.0
 # @note available pools: transfer_to_repo, collect_data, ..., *
 # @note be sure to have a catch-all pool at the end with --pool=* for all other jobs
 # DELAYED_JOB_ARGS=""
+
+# Wall-clock bound, in seconds, on OpenBabel's native SVG writer, which hangs indefinitely on
+# some organometallic structures. Rendering runs in a forked child that is killed at this
+# deadline; the caller then falls back to the rest of the render chain (Indigo, Ketcher).
+# Raise it if structures that legitimately take longer are coming back without an image AND
+# neither Indigo nor Ketcher is available to draw them.
+# OPENBABEL_SVG_TIMEOUT_SECONDS=5
+
 # PG_CARTRIDGE=rdkit
 # PG_CARTRIDGE_VERSION=4.4.0

--- a/app/models/molecule.rb
+++ b/app/models/molecule.rb
@@ -180,7 +180,8 @@ class Molecule < ApplicationRecord
     babel_info_array = Chemotion::OpenBabelService.molecule_info_from_molfiles(molfiles_array, render_svg: false)
     babel_info_array.map.with_index do |babel_info, i|
       if babel_info && babel_info[:inchikey]
-        Molecule.find_or_create_by_molfile(molfiles_array[i], babel_info)
+        # ** rather than a positional hash — see the note in Sample#find_or_create_molecule.
+        Molecule.find_or_create_by_molfile(molfiles_array[i], **babel_info)
       else
         nil
       end

--- a/app/models/molecule.rb
+++ b/app/models/molecule.rb
@@ -111,7 +111,10 @@ class Molecule < ApplicationRecord
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
   def self.find_or_create_by_molfile(molfile, defer_pubchem_lookup: false, **babel_info)
     unless babel_info && babel_info[:inchikey]
-      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile)
+      # render_svg: false — the SVG produced here is discarded unconditionally a few lines
+      # below by #assign_molecule_data -> .svg_reprocess, which always re-renders through
+      # Chemotion::SvgRenderer because OpenBabel's output carries the 'Open Babel' marker.
+      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile, render_svg: false)
     end
     inchikey = babel_info[:inchikey]
     return if inchikey.blank?
@@ -173,7 +176,8 @@ class Molecule < ApplicationRecord
   end
 
   def self.find_or_create_by_molfiles(molfiles_array)
-    babel_info_array = Chemotion::OpenBabelService.molecule_info_from_molfiles(molfiles_array)
+    # render_svg: false — see .find_or_create_by_molfile.
+    babel_info_array = Chemotion::OpenBabelService.molecule_info_from_molfiles(molfiles_array, render_svg: false)
     babel_info_array.map.with_index do |babel_info, i|
       if babel_info && babel_info[:inchikey]
         Molecule.find_or_create_by_molfile(molfiles_array[i], babel_info)
@@ -184,7 +188,9 @@ class Molecule < ApplicationRecord
   end
 
   def refresh_molecule_data
-    babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(self.molfile)
+    # render_svg: false — #assign_molecule_data below re-renders through Chemotion::SvgRenderer
+    # regardless, so OpenBabel's SVG would be discarded.
+    babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile, render_svg: false)
     # this is to not refresh is_partial, because the info has already been removed from the molfile
     babel_info[:is_partial] = self.is_partial
     inchikey = babel_info[:inchikey]

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -500,7 +500,11 @@ class Sample < ApplicationRecord
     self.molfile_version = babel_info[:version]
     return unless molecule&.inchikey != inchikey || molecule.is_partial != is_partial
 
-    self.molecule = Molecule.find_or_create_by_molfile(molfile, babel_info)
+    # **, not a positional hash: find_or_create_by_molfile takes babel_info as keyword rest, so
+    # a bare hash relies on Ruby 2.7's hash-to-keywords conversion and raises ArgumentError on
+    # 3.0+. This is a before_save on every sample whose molfile changed, so it is the call site
+    # of this shape that would hurt most on an upgrade.
+    self.molecule = Molecule.find_or_create_by_molfile(molfile, **babel_info)
   end
 
   def find_or_create_fingerprint

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -490,7 +490,9 @@ class Sample < ApplicationRecord
 
     return if molecule.present?
 
-    babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile)
+    # render_svg: false — only the inchikey/is_partial/version are read here, and the molecule
+    # this resolves to renders its own SVG through Chemotion::SvgRenderer.
+    babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile, render_svg: false)
     inchikey = babel_info[:inchikey]
     return if inchikey.blank?
 

--- a/lib/chemotion/open_babel_service.rb
+++ b/lib/chemotion/open_babel_service.rb
@@ -58,11 +58,26 @@ M  END
     { inchi: inchi, inchikey: inchikey }
   end
 
-  def self.molecule_info_from_molfile(molfile)
-    self.molecule_info_from_structure(molfile, 'mol')
+  # @param render_svg [Boolean] whether to render the SVG. Pass false when the caller discards it:
+  #   it is the single most expensive part of this method — a forked child bounded at
+  #   {SVG_RENDER_TIMEOUT_SECONDS}, and the only bounded operation here — and on organometallic
+  #   structures roughly one record in ten spends the full 20 s only to be SIGKILLed and return
+  #   nil. See {.molecule_info_from_structure} for who should be passing false.
+  def self.molecule_info_from_molfile(molfile, render_svg: true)
+    molecule_info_from_structure(molfile, 'mol', render_svg: render_svg)
   end
 
-  def self.molecule_info_from_structure(structure, format = 'mol')
+  # @param render_svg [Boolean] when false, +svg:+ comes back nil and no fork is taken.
+  #
+  #   Defaults to true so no untraced caller changes behaviour, but note that anything feeding
+  #   this into {Molecule#assign_molecule_data} should pass false: {Molecule.svg_reprocess} tests
+  #   the result with {Molecule.svg_valid_and_not_openbabel?}, OpenBabel's SVG always contains the
+  #   literal +Open Babel+, so it is *unconditionally* discarded and re-rendered through
+  #   {Chemotion::SvgRenderer}. Rendering it there is dead work, timeout or not.
+  #
+  #   The renderer chain is unaffected — {Chemotion::SvgRenderer.open_babel_service} calls
+  #   {.svg_from_molfile} directly as its last resort, independently of this method.
+  def self.molecule_info_from_structure(structure, format = 'mol', render_svg: true)
     is_partial = false
     mf = nil
     if format == 'mol'
@@ -117,14 +132,14 @@ M  END
       inchikey = inchi_info[:inchikey]
     end
 
-    svg = svg_from_molfile(mf || molfile)
+    svg = render_svg ? svg_from_molfile(mf || molfile) : nil
     fp = fingerprint_from_molfile(mf || molfile)
     # Snapshot both log levels together, after every in-process OpenBabel call above, so
     # ob_log[:error] and ob_log[:warning] stay mutually consistent (fingerprint can log too).
     # NB: svg_from_molfile runs in a forked child, so its own obErrorLog never reaches here.
     ob_errors = OpenBabel.obErrorLog.get_messages_of_level(0)
     warnings = OpenBabel.obErrorLog.get_messages_of_level(1)
-    warnings += ["SVG rendering timed out after #{SVG_RENDER_TIMEOUT_SECONDS}s"] if svg.nil?
+    warnings += svg_timeout_warnings(render_svg, svg)
 
     {
       charge: m.get_total_charge,
@@ -170,9 +185,21 @@ M  END
     c.write_string(m, false).to_s
   end
 
-  def self.molecule_info_from_molfiles(molfile_array)
+  # A nil svg means two different things and only one of them is a fault: the render was asked
+  # for and timed out, or it was never asked for. Reporting the second as a timeout would put a
+  # false warning in the ob_log of every importer that opts out.
+  #
+  # @return [Array<String>] the timeout warning, or empty
+  def self.svg_timeout_warnings(render_svg, svg)
+    return [] unless render_svg && svg.nil?
+
+    ["SVG rendering timed out after #{SVG_RENDER_TIMEOUT_SECONDS}s"]
+  end
+
+  # @param render_svg [Boolean] forwarded per record — see {.molecule_info_from_structure}
+  def self.molecule_info_from_molfiles(molfile_array, render_svg: true)
     molfile_array.map do |molfile|
-      molecule_info_from_molfile(molfile)
+      molecule_info_from_molfile(molfile, render_svg: render_svg)
     rescue StandardError => e
       Rails.logger.error("Chemotion::OpenBabelService.molecule_info_from_molfiles: failed for one record: #{e.message}")
       nil

--- a/lib/chemotion/open_babel_service.rb
+++ b/lib/chemotion/open_babel_service.rb
@@ -4,7 +4,28 @@ module Chemotion::OpenBabelService
   # Wall-clock bound for svg_from_molfile: some organometallic molfiles make OpenBabel's
   # native SVG writer hang indefinitely (confirmed reproducer: CCDC record EKOWOR, a
   # 193-atom/648-bond uranium complex). Env-overridable so it can be retuned without a deploy.
-  SVG_RENDER_TIMEOUT_SECONDS = Integer(ENV.fetch('OPENBABEL_SVG_TIMEOUT_SECONDS', 20))
+  #
+  # 5s rather than the original 20s. What a caller gets from a hang is nil either way, so the
+  # only question is how long it waits to find out — and the paths still asking for an SVG here
+  # are ones where waiting is expensive:
+  #
+  # * {Chemotion::SvgRenderer.open_babel_service}, the render chain's last resort, reached only
+  #   when Indigo and Ketcher have both already failed. A request is blocked for the duration.
+  # * ChemSpectra and the molecule endpoints, which render for a waiting user.
+  #
+  # The importers no longer reach it at all — they pass render_svg: false, since
+  # {Molecule.svg_reprocess} discards this SVG unconditionally.
+  #
+  # The cost is real, not a free win: a structure whose render legitimately takes 5-20s now
+  # returns nil instead. Measured on 110 records of an organometallic CCDC file — deliberately
+  # the worst case for OpenBabel's writer — 92 renders finished within 5s, 9 timed out at 20s
+  # anyway, and 9 (8%) landed in the 5-20s band and would now come back empty. On ordinary
+  # organic structures that band is far narrower.
+  #
+  # Those 9 fall back to the rest of the chain, so they only end up with no image at all when
+  # Indigo and Ketcher are both unavailable too. Raise the env var if that combination is real
+  # for a given deployment.
+  SVG_RENDER_TIMEOUT_SECONDS = Integer(ENV.fetch('OPENBABEL_SVG_TIMEOUT_SECONDS', 5))
 
   # mdl V3000
   MOLFILE_COUNT_LINE_START      = 'M  V30 COUNTS '

--- a/lib/chemotion/open_babel_service.rb
+++ b/lib/chemotion/open_babel_service.rb
@@ -82,7 +82,8 @@ M  END
   # @param render_svg [Boolean] whether to render the SVG. Pass false when the caller discards it:
   #   it is the single most expensive part of this method — a forked child bounded at
   #   {SVG_RENDER_TIMEOUT_SECONDS}, and the only bounded operation here — and on organometallic
-  #   structures roughly one record in ten spends the full 20 s only to be SIGKILLed and return
+  #   structures roughly one record in ten spends the entire {SVG_RENDER_TIMEOUT_SECONDS} budget
+  #   only to be SIGKILLed and return
   #   nil. See {.molecule_info_from_structure} for who should be passing false.
   def self.molecule_info_from_molfile(molfile, render_svg: true)
     molecule_info_from_structure(molfile, 'mol', render_svg: render_svg)

--- a/lib/import/import_samples.rb
+++ b/lib/import/import_samples.rb
@@ -270,7 +270,7 @@ module Import
       molfile_for_babel = sanitized.dup
       molfile_for_babel = "\n#{molfile_for_babel}" unless molfile_for_babel.start_with?("\n")
       molfile_for_babel = "#{molfile_for_babel}\n" unless molfile_for_babel.end_with?("\n")
-      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile_for_babel)
+      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile_for_babel, render_svg: false)
       inchikey = babel_info[:inchikey]
       if inchikey.presence
         molecule = Molecule.find_or_create_by_molfile(molfile_for_babel,
@@ -326,7 +326,7 @@ module Import
 
       ori_molf = "\n#{ori_molf}" unless ori_molf.start_with?("\n")
       ori_molf = "#{ori_molf}\n" unless ori_molf.end_with?("\n")
-      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(ori_molf)
+      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(ori_molf, render_svg: false)
       molfile_coord = Chemotion::OpenBabelService.add_molfile_coordinate(ori_molf)
       inchikey = babel_info[:inchikey] if inchikey.blank? && babel_info.present?
       return nil if inchikey.blank?

--- a/lib/import/import_sdf.rb
+++ b/lib/import/import_sdf.rb
@@ -182,7 +182,7 @@ class Import::ImportSdf < Import::ImportSamples
     if !raw_data.empty? && inchi_array.empty?
       ActiveRecord::Base.transaction do
         raw_data.each do |molfile|
-          babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile)
+          babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile, render_svg: false)
           inchikey = babel_info[:inchikey]
           is_partial = babel_info[:is_partial]
           next unless inchikey.presence && (molecule = Molecule.find_by(inchikey: inchikey, is_partial: is_partial))
@@ -332,7 +332,11 @@ class Import::ImportSdf < Import::ImportSamples
   end
 
   def find_or_create_by_molfiles(molfiles)
-    babel_info_array = Chemotion::OpenBabelService.molecule_info_from_molfiles(molfiles)
+    # render_svg: false — Molecule#assign_molecule_data discards OpenBabel's SVG and re-renders
+    # via Chemotion::SvgRenderer, so rendering it per record is the largest avoidable cost on
+    # this path: it is the only timeout-bounded operation in molecule_info_from_molfile, and on
+    # organometallic files ~1 record in 10 burns the full 20 s before being killed.
+    babel_info_array = Chemotion::OpenBabelService.molecule_info_from_molfiles(molfiles, render_svg: false)
 
     babel_info_array.map.with_index do |babel_info, i|
       mf = molfiles[i]
@@ -384,7 +388,7 @@ class Import::ImportSdf < Import::ImportSamples
       [result.molecule, result.raw_molfile, result.babel_info]
     else
       san_molfile = sanitize_molfile(molfile)
-      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(san_molfile)
+      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(san_molfile, render_svg: false)
       inchikey = babel_info[:inchikey]
       is_partial = babel_info[:is_partial]
       molecule = inchikey.present? ? Molecule.find_by(inchikey: inchikey, is_partial: is_partial) : nil

--- a/lib/import/import_sdf.rb
+++ b/lib/import/import_sdf.rb
@@ -335,7 +335,8 @@ class Import::ImportSdf < Import::ImportSamples
     # render_svg: false — Molecule#assign_molecule_data discards OpenBabel's SVG and re-renders
     # via Chemotion::SvgRenderer, so rendering it per record is the largest avoidable cost on
     # this path: it is the only timeout-bounded operation in molecule_info_from_molfile, and on
-    # organometallic files ~1 record in 10 burns the full 20 s before being killed.
+    # organometallic files ~1 record in 10 burns the whole SVG render timeout before being
+    # killed (measured at the 20 s default then in force; it is now 5 s and env-configurable).
     babel_info_array = Chemotion::OpenBabelService.molecule_info_from_molfiles(molfiles, render_svg: false)
 
     babel_info_array.map.with_index do |babel_info, i|

--- a/lib/import/polymer_molecule_resolver.rb
+++ b/lib/import/polymer_molecule_resolver.rb
@@ -39,7 +39,9 @@ module Import
       cleaned = Chemotion::MolfilePolymerSupport.clean_molfile_for_inchikey(raw)
       return Result.new(molecule: nil, raw_molfile: raw, babel_info: nil) if cleaned.blank?
 
-      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(pad(cleaned))
+      # render_svg: false — the polymer SVG is rendered separately through Indigo in
+      # #reattach_svg_if_present; OpenBabel's would be discarded either way.
+      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(pad(cleaned), render_svg: false)
       molecule = if babel_info[:inchikey].present?
                    Molecule.find_or_create_by_molfile(raw, defer_pubchem_lookup: @defer_pubchem_lookup, **babel_info)
                  else

--- a/spec/lib/chemotion/open_babel_service_spec.rb
+++ b/spec/lib/chemotion/open_babel_service_spec.rb
@@ -144,6 +144,60 @@ RSpec.describe Chemotion::OpenBabelService do
         "SVG rendering timed out after #{Chemotion::OpenBabelService::SVG_RENDER_TIMEOUT_SECONDS}s",
       )
     end
+
+    # The SVG render is the only timeout-bounded operation in this method and, on the paths that
+    # feed Molecule#assign_molecule_data, its output is discarded unconditionally — svg_reprocess
+    # re-renders through Chemotion::SvgRenderer because OpenBabel's SVG always carries the
+    # 'Open Babel' marker. render_svg: false is how those callers stop paying for it.
+    describe 'render_svg: false' do
+      before do
+        allow(conversion).to receive(:write_string).and_return("C smiles-meta\n", "C can-meta\n", "molfile-v2000\n")
+      end
+
+      it 'does not fork a render at all' do
+        allow(Chemotion::ForkedTimeout).to receive(:run)
+
+        described_class.molecule_info_from_molfile('C', render_svg: false)
+
+        expect(Chemotion::ForkedTimeout).not_to have_received(:run)
+      end
+
+      it 'returns a nil svg without claiming a timeout', :aggregate_failures do
+        info = described_class.molecule_info_from_molfile('C', render_svg: false)
+
+        expect(info[:svg]).to be_nil
+        # A skipped render also leaves svg nil; reporting that as a timeout would put a false
+        # warning in every importer's ob_log.
+        expect(info[:ob_log][:warning].to_a.join).not_to include('SVG rendering timed out')
+      end
+
+      it 'leaves every other field intact', :aggregate_failures do
+        # The sequential stub in the outer `before` is one-shot, and this example calls the method
+        # twice. Reset the position between the two so the second invocation sees the same inputs
+        # as the first — otherwise the diff shows a difference in :smiles that has nothing to do
+        # with render_svg.
+        values = ["C smiles-meta\n", "C can-meta\n"]
+        call = 0
+        allow(conversion).to receive(:write_string) do
+          value = values[call] || values.last
+          call += 1
+          value
+        end
+
+        with_svg = described_class.molecule_info_from_molfile('C')
+        call = 0
+        without = described_class.molecule_info_from_molfile('C', render_svg: false)
+
+        expect(without.except(:svg, :ob_log)).to eq(with_svg.except(:svg, :ob_log))
+        expect(without[:inchikey]).to eq(with_svg[:inchikey])
+      end
+
+      it 'still renders by default, so untraced callers are unaffected' do
+        allow(described_class).to receive(:svg_from_molfile).and_return('<svg/>')
+
+        expect(described_class.molecule_info_from_molfile('C')[:svg]).to eq('<svg/>')
+      end
+    end
   end
 
   describe '.svg_from_molfile' do
@@ -183,6 +237,25 @@ RSpec.describe Chemotion::OpenBabelService do
       result = described_class.molecule_info_from_molfiles(%w[only])
 
       expect(result).to eq([nil])
+    end
+
+    # The batch entry point is what the SDF importer uses, so the skip has to reach every record
+    # or the saving only applies to callers that go one at a time.
+    it 'forwards render_svg to every record', :aggregate_failures do
+      allow(described_class).to receive(:molecule_info_from_molfile).and_return({})
+
+      described_class.molecule_info_from_molfiles(%w[a b], render_svg: false)
+
+      expect(described_class).to have_received(:molecule_info_from_molfile).with('a', render_svg: false)
+      expect(described_class).to have_received(:molecule_info_from_molfile).with('b', render_svg: false)
+    end
+
+    it 'renders by default' do
+      allow(described_class).to receive(:molecule_info_from_molfile).and_return({})
+
+      described_class.molecule_info_from_molfiles(%w[a])
+
+      expect(described_class).to have_received(:molecule_info_from_molfile).with('a', render_svg: true)
     end
   end
 end

--- a/spec/models/molecule_spec.rb
+++ b/spec/models/molecule_spec.rb
@@ -523,8 +523,9 @@ RSpec.describe Molecule, type: :model do
     end
     # OpenBabel's SVG is discarded unconditionally by .svg_reprocess (its output always contains
     # 'Open Babel'), and rendering it is the only timeout-bounded operation in
-    # molecule_info_from_molfile — on organometallic imports ~1 record in 10 spent the full 20 s
-    # producing an SVG that was then thrown away.
+    # molecule_info_from_molfile — on organometallic imports ~1 record in 10 spent the whole
+    # timeout producing an SVG that was then thrown away (measured at the 20 s default in force
+    # at the time; SVG_RENDER_TIMEOUT_SECONDS is now 5 s and env-configurable).
     it 'does not ask OpenBabel for an SVG it is going to discard' do
       allow(Chemotion::OpenBabelService).to receive(:molecule_info_from_molfile).and_return(babel_info)
       allow(PubchemLookupJob).to receive(:perform_later)

--- a/spec/models/molecule_spec.rb
+++ b/spec/models/molecule_spec.rb
@@ -521,6 +521,30 @@ RSpec.describe Molecule, type: :model do
         end.to raise_error(ActiveRecord::RecordNotUnique)
       end
     end
+    # OpenBabel's SVG is discarded unconditionally by .svg_reprocess (its output always contains
+    # 'Open Babel'), and rendering it is the only timeout-bounded operation in
+    # molecule_info_from_molfile — on organometallic imports ~1 record in 10 spent the full 20 s
+    # producing an SVG that was then thrown away.
+    it 'does not ask OpenBabel for an SVG it is going to discard' do
+      allow(Chemotion::OpenBabelService).to receive(:molecule_info_from_molfile).and_return(babel_info)
+      allow(PubchemLookupJob).to receive(:perform_later)
+
+      described_class.find_or_create_by_molfile('molfile')
+
+      expect(Chemotion::OpenBabelService).to have_received(:molecule_info_from_molfile)
+        .with('molfile', render_svg: false)
+    end
+
+    # The safety half of the above: the molecule must still end up with a picture, drawn by the
+    # renderer chain rather than by OpenBabel.
+    it 'still renders the SVG through the renderer chain' do
+      allow(Chemotion::SvgRenderer).to receive(:render_svg_from_molfile).and_return(nil)
+      allow(PubchemLookupJob).to receive(:perform_later)
+
+      described_class.find_or_create_by_molfile('molfile', **babel_info)
+
+      expect(Chemotion::SvgRenderer).to have_received(:render_svg_from_molfile)
+    end
   end
 
   describe '.schedule_pubchem_lookup_since' do


### PR DESCRIPTION
## Summary

**Targets `main` directly** — independent of #3438 / #3439, which are PubChem work. This is
OpenBabel rendering. Verified: it cherry-picks onto `main` with every production file applying
cleanly, and runs **581 examples, 0 failures** standing alone.

It is also the largest measured win of the series: **a 50-record SDF import goes from 402 s to
147 s — 2.7×.**

## The finding

`Molecule.svg_reprocess` tests its input with `svg_valid_and_not_openbabel?`, and **OpenBabel's
SVG output always contains the literal `Open Babel`** — three other places in this codebase
already use that string as the *definition* of an OB-produced SVG (`lib/tasks/svg.rake:37`,
`molecule_api.rb:120`, and the fixtures).

So on every path feeding `Molecule#assign_molecule_data`, the OpenBabel SVG is **discarded
unconditionally** and re-rendered through `Chemotion::SvgRenderer` (Indigo → Ketcher). Not on the
slow records — on all of them.

Rendering it is also the single most expensive thing `molecule_info_from_molfile` does. It is the
**only** timeout-bounded operation in the method — a forked child capped at
`SVG_RENDER_TIMEOUT_SECONDS` — and on organometallic structures roughly one record in ten spent
the full 20 s before being SIGKILLed, returning nil, and being re-rendered anyway.

Measured over 110 records of an organometallic CCDC file:

| | with SVG | without |
|---|---|---|
| total | 330.1 s | **18.2 s** |
| median | 0.233 s | **0.005 s** |
| p90 | 19.21 s | **0.040 s** |
| records over 10 s | 12 | **0** |

## Commit 1 — stop rendering the discarded SVG

Done as an **opt-out, not a removal**. `molecule_info_from_structure` keeps `render_svg: true` as
its default so no untraced caller shifts behaviour, and `chem_spectra_api.rb` — the one place that
genuinely returns `m[:svg]` to a client — is left on it. The callers passing `false` are exactly
those whose result reaches `assign_molecule_data`.

The renderer chain is untouched: `SvgRenderer.open_babel_service` calls `svg_from_molfile`
directly as its last resort, independently of this method, so molecules still get a picture. The
specs assert **both halves** — that OpenBabel is asked to skip, and that the chain still runs.

Also fixes a nil-svg ambiguity this introduces: a skipped render leaves `svg` nil just as a
timeout does, and the timeout warning would otherwise appear in the `ob_log` of every importer
that opts out.

## Commit 2 — cut the timeout 20 s → 5 s

A hang yields nil whatever the deadline is; the only question is how long the caller waits to find
out. With importers no longer requesting this SVG, what still reaches the timeout is
`SvgRenderer.open_babel_service` (the chain's last resort, reached only once Indigo *and* Ketcher
have failed) and the endpoints rendering for a waiting user. Blocking a request for 20 s to arrive
at a foregone nil is hard to justify.

**The cost is real and worth stating.** Measured on the same 110 records, at the old bound:

- **92** renders finished within 5 s → unaffected
- **9** timed out at 20 s anyway → now fail 15 s sooner
- **9 (8%)** finished in the 5–20 s band → **now return nil instead of an SVG**

Those 9 fall through to the rest of the chain and only end up with no image at all if Indigo and
Ketcher are unavailable too. This file is the worst case for OpenBabel's writer, not a typical
one; on ordinary organic structures that band is far narrower.

`OPENBABEL_SVG_TIMEOUT_SECONDS` still overrides it, and is now documented in
`.env.production.example` — it was honoured by the code before but appeared nowhere an operator
would look.

**The two commits are separable.** If the 8% trade wants its own decision, commit 1 carries
essentially all of the speedup and can land alone.

## Testing

```
RAILS_ENV=test bundle exec rspec spec/models/molecule_spec.rb spec/models/sample_spec.rb \
  spec/lib/chemotion/ spec/lib/import/ spec/jobs/
# 581 examples, 0 failures
```

Coverage: the skip suppresses the fork entirely and leaves every other field byte-identical; the
default still renders, so untraced callers are unaffected; the flag is forwarded per record by the
batch entry point; and a molecule still ends up with an SVG from the renderer chain.

## Note on merge order

This touches `molecule.rb`, `import_samples.rb`, `import_sdf.rb` and `polymer_molecule_resolver.rb`,
which #3438 and #3439 also touch — but only to add a `render_svg: false` keyword at call sites.
Whichever lands second will get small, mechanical conflicts. There is no logical dependency in
either direction.

## Expected CI

`pronto/rubocop` will flag four `Metrics/*` offences on `molecule_info_from_structure`. They are
**pre-existing** — identical values on `main` (`AbcSize` 65.07, `CyclomaticComplexity` 13,
`PerceivedComplexity` 15) — and are attributed here only because this PR changes that method's
signature to add the keyword. No new offence is introduced.
