### PR TITLE
fix(navigation): correct broken docs search link

### DIFF
--- a/app/javascript/src/components/navigation/NavHead.js
+++ b/app/javascript/src/components/navigation/NavHead.js
@@ -12,7 +12,7 @@ function NavHead() {
           Documentation
           <i className="fa fa-external-link float-end" aria-hidden="true" />
         </NavDropdown.Item>
-        <NavDropdown.Item as="a" eventKey="14" href="https://chemotion.net/search" target="_blank">
+        <NavDropdown.Item as="a" eventKey="14" href="https://chemotion.net/docs/search" target="_blank">
           Search documentation
           <i className="fa fa-external-link float-end" aria-hidden="true" />
         </NavDropdown.Item>

--- a/app/javascript/src/components/navigation/SupportMenuButton.js
+++ b/app/javascript/src/components/navigation/SupportMenuButton.js
@@ -45,7 +45,7 @@ export default function SupportMenuButton({ linkToEln, variant }) {
         <ExternalItem title="Chemotion.net" href="https://www.chemotion.net" />
         <ExternalItem title="Chemotion-Repository.net" href="https://www.chemotion-repository.net" />
         <Dropdown.Divider />
-        <ExternalItem title="Search documentation" href="https://chemotion.net/search" />
+        <ExternalItem title="Search documentation" href="https://chemotion.net/docs/search" />
         <ExternalItem title="Helpdesk - Contact Us" href="https://chemotion.net/helpdesk" />
         <ExternalItem title="Report an issue on Github" href="https://github.com/ComPlat/chemotion_ELN/issues" />
 


### PR DESCRIPTION
## Summary
- "Search documentation" in the Info & Support / Chemotion navbar menus linked to `https://chemotion.net/search`, which 404s.
- The docs site serves its search page under its configured `baseUrl`, so the working URL is `https://chemotion.net/docs/search` — matching every other in-app link into the docs site (`.../docs/eln/ui`, etc.).
- Verified live: `chemotion.net/search` → 404, `chemotion.net/docs/search` → 200 with a working search page.

## Test plan
- [x] `eslint` on both changed files — no new errors introduced (two pre-existing, unrelated `react/function-component-definition` warnings on untouched lines)
- [ ] Manually click Info & Support → Search documentation and confirm it lands on a working search page

Closes #3430