### PR TITLE
refactor(collections): enhance CollectionSelect and collectionOptions

### DIFF
--- a/app/javascript/src/components/common/CollectionSelect.js
+++ b/app/javascript/src/components/common/CollectionSelect.js
@@ -7,8 +7,10 @@ const CollectionSelect = ({ value, withShared, onChange }) => {
   const collectionsStore = useContext(StoreContext).collections;
   const [selectedCollection, setSelectedCollection] = useState(value || null);
 
-  const optionLabel = ({ label, depth }) => (
-    <span style={{ paddingLeft: `${depth * 10}px` }}>
+  // Indent by nesting depth only inside the menu; the selected value shown in the control should
+  // sit flush-left. `depth` defaults to 0 so a stray option without it never yields `NaNpx`.
+  const optionLabel = ({ label, depth = 0 }, { context } = {}) => (
+    <span style={{ paddingLeft: context === 'menu' ? `${depth * 10}px` : 0 }}>
       {label}
     </span>
   );

--- a/app/javascript/src/utilities/collectionUtilities.js
+++ b/app/javascript/src/utilities/collectionUtilities.js
@@ -34,35 +34,48 @@ const filterParamsFromUIState = (uiState) => {
   return filterParams;
 };
 
+// Flatten the collection tree into a pre-order list (parent immediately followed by its
+// descendants). The nesting depth is stamped onto each pushed option so the dropdown can indent
+// child collections. react-select passes the option object straight to `formatOptionLabel`, so a
+// depth that only lived in this closure could never reach the renderer.
 const makeList = (collections, tree = [], depth = 0) => {
   if (!Array.isArray(collections)) return tree;
 
-  collections.forEach((collection) => {
-    tree.push(collection);
-    makeList(collection.children, tree, depth + 1);
+  collections.forEach(({ children, ...rest }) => {
+    tree.push({ ...rest, depth });
+    makeList(children, tree, depth + 1);
   });
 
   return tree;
 };
 
 const collectionOptions = (store, showSharedCollections) => {
-  const ownCollections = store.own_collections;
-  let shared = [];
-  if (showSharedCollections) {
-    const sharedWithMeCollections = store.shared_with_me_collections;
-    // Only offer shared collections the user may actually assign elements into.
-    shared = sharedWithMeCollections
-      .flatMap((c) => c.children)
-      .filter((c) => c.permission_level >= PermissionConst.AddElements);
-  }
-
-  return [
-    ...makeList(ownCollections),
+  // Label the owned collections as their own react-select group so it sits parallel to the shared
+  // groups below, rather than as an unlabelled block of top-level options.
+  const groups = [
     {
-      label: 'Shared with me collections',
-      options: makeList(shared),
+      label: 'My Collections',
+      options: makeList(store.own_collections),
     },
   ];
+
+  if (showSharedCollections) {
+    // Keep one group per owner (the "shared by <user>" level) so a user with shares from several
+    // people can tell them apart, instead of flattening every owner's collections together.
+    store.shared_with_me_collections.forEach((owner) => {
+      // Only offer shared collections the user may actually assign elements into.
+      const assignable = owner.children
+        .filter((c) => c.permission_level >= PermissionConst.AddElements);
+      if (assignable.length === 0) return;
+
+      groups.push({
+        label: `Shared by ${owner.label}`,
+        options: makeList(assignable),
+      });
+    });
+  }
+
+  return groups;
 };
 
 const collectionHasPermission = (collection, permissionLevel) => {

--- a/spec/javascripts/packs/src/utilities/collectionUtilities.spec.js
+++ b/spec/javascripts/packs/src/utilities/collectionUtilities.spec.js
@@ -1,5 +1,7 @@
 // eslint-disable-next-line import/no-unresolved
-import { collectionHasPermission, filterParamsFromUIState } from 'src/utilities/collectionUtilities';
+import { collectionHasPermission, collectionOptions, filterParamsFromUIState } from 'src/utilities/collectionUtilities';
+// eslint-disable-next-line import/no-unresolved
+import { PermissionConst } from 'src/utilities/PermissionConst';
 import { List } from 'immutable';
 import expect from 'expect';
 function createCollectionDummy(collectionShareId = undefined, permissionLevel = 0) {
@@ -22,6 +24,55 @@ describe('collectionUtilities', () => {
       it('has no permissions', () => {
         expect(collectionHasPermission(createCollectionDummy(2, 0), 1)).toBe(false);
       });
+    });
+  });
+
+  describe('.collectionOptions', () => {
+    const store = () => ({
+      own_collections: [
+        {
+          id: 1,
+          label: 'Project',
+          children: [{ id: 2, label: 'Sub', children: [] }],
+        },
+      ],
+      shared_with_me_collections: [
+        {
+          id: 0,
+          label: 'Alice',
+          children: [
+            { id: 3, label: 'Editable', permission_level: PermissionConst.AddElements, children: [] },
+            { id: 4, label: 'ReadOnly', permission_level: 0, children: [] },
+          ],
+        },
+      ],
+    });
+
+    it('groups owned collections under a "My Collections" label', () => {
+      const [owned] = collectionOptions(store(), false);
+
+      expect(owned.label).toBe('My Collections');
+      expect(owned.options.map((o) => o.id)).toEqual([1, 2]);
+    });
+
+    it('stamps nesting depth so child collections can be indented', () => {
+      const [owned] = collectionOptions(store(), false);
+
+      expect(owned.options.map((o) => o.depth)).toEqual([0, 1]);
+    });
+
+    it('omits shared collections when not requested', () => {
+      const groups = collectionOptions(store(), false);
+
+      expect(groups).toHaveLength(1);
+    });
+
+    it('keeps a per-owner "Shared by" group and drops unassignable collections', () => {
+      const groups = collectionOptions(store(), true);
+
+      expect(groups.map((g) => g.label)).toEqual(['My Collections', 'Shared by Alice']);
+      // Only the collection the user may add elements into is offered.
+      expect(groups[1].options.map((o) => o.id)).toEqual([3]);
     });
   });
 


### PR DESCRIPTION
- Updated CollectionSelect to conditionally indent options based on their context, ensuring a cleaner UI.
- Modified collectionOptions to group owned collections under a "My Collections" label and to maintain distinct "Shared by" groups for shared collections, while also stamping nesting depth for proper indentation in dropdowns.
- Added tests to verify these changes and ensure correct behavior for owned and shared collections.

Resolves https://github.com/ComPlat/chemotion/issues/589