### PR TITLE
refactor(api): make detail-level handling consistent across list, write, report and export paths

### DIFF
--- a/app/api/chemotion/report_api.rb
+++ b/app/api/chemotion/report_api.rb
@@ -19,6 +19,23 @@ module Chemotion
       def time_now
         Time.zone.now.strftime('%Y-%m-%dT%H-%M-%S')
       end
+
+      # Rejects the request unless the caller may read every element referenced in +objTags+.
+      # Without this a report is an IDOR: the generator does a bare +Model.find(id)+ with no
+      # ownership/collection check, so any authenticated user could pull any element's data.
+      # Only Sample/Reaction are accepted — the types {Reporter::Worker#extract} renders; any
+      # other type is rejected rather than silently ignored (the worker would raise on it anyway).
+      #
+      # @param obj_tags [Array<Hash>] the +objTags+ param ({ 'id' =>, 'type' => } entries)
+      # @raise [Grape exception] 401 if any referenced element is missing or not readable
+      def authorize_report_objects!(obj_tags)
+        types = { 'sample' => Sample, 'reaction' => Reaction }
+        Array(obj_tags).each do |tag|
+          tag = ActiveSupport::HashWithIndifferentAccess.new(tag)
+          record = types[tag[:type].to_s.downcase]&.find_by(id: tag[:id])
+          error!('401 Unauthorized', 401) unless record && ElementPolicy.new(current_user, record).read?
+        end
+      end
     end
 
     resource :reports do
@@ -27,6 +44,9 @@ module Chemotion
         requires :id
       end
       get :docx do
+        reaction = Reaction.find(params[:id])
+        error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, reaction).read?
+
         params[:template] = 'single_reaction'
         docx, filename = Report.create_reaction_docx(current_user, user_ids, params)
         content_type MIME::Types.type_for(filename)[0].to_s
@@ -221,6 +241,8 @@ module Chemotion
       optional :fileDescription
     end
     post :reports do
+      authorize_report_objects!(params[:objTags])
+
       spl_settings = hashize(params[:splSettings])
       rxn_settings = hashize(params[:rxnSettings])
       si_rxn_settings = hashize(params[:siRxnSettings])

--- a/app/api/chemotion/sample_api.rb
+++ b/app/api/chemotion/sample_api.rb
@@ -62,8 +62,8 @@ module Chemotion
         end
 
         before do
-          collection = Collection.accessible_for(current_user).find(params[:ui_state][:collection_id])
-          @samples = Sample.by_collection_id(collection.id).by_ui_state(params[:ui_state])
+          @collection = Collection.accessible_for(current_user).find(params[:ui_state][:collection_id])
+          @samples = Sample.by_collection_id(@collection.id).by_ui_state(params[:ui_state])
           error!('401 Unauthorized', 401) unless ElementsPolicy.new(current_user, @samples).read_all?
         end
 
@@ -71,9 +71,14 @@ module Chemotion
         post do
           @samples = @samples.limit(params[:limit]) if params[:limit]
 
+          # All samples come from the single accessible collection @collection; apply its per-class
+          # detail levels so a restrictive share does not leak fields (molfile, analyses, etc.).
+          detail_levels = ElementDetailLevelCalculator.for_collection(collection: @collection, user: current_user)
+
           {
             samples: Entities::SampleEntity.represent(
               @samples,
+              detail_levels: detail_levels,
               root: false,
             ),
             literatures: Entities::LiteratureEntity.represent(

--- a/app/api/chemotion/search_api.rb
+++ b/app/api/chemotion/search_api.rb
@@ -157,6 +157,9 @@ module Chemotion
             samplesGroup = samples.select { |sample| sample.molecule_id == molecule.id }
             samplesGroup = samplesGroup.sort { |x, y| y.updated_at <=> x.updated_at }
             samplesGroup.each do |sample|
+              # Per-element (not for_collection like the other element types below): a sample reached
+              # via a restrictive share still shows its true level if the user owns/better-shares it
+              # in another collection. Keep this deliberate divergence when editing.
               detail_levels = ElementDetailLevelCalculator.new(user: current_user, element: sample).detail_levels
               serialized_sample = Entities::SampleEntity.represent(
                 sample,
@@ -173,6 +176,8 @@ module Chemotion
                 .where(id: id_array)
                 .order(Arel.sql("position(','||id::text||',' in ',#{ids},')"))
                 .each do |sample|
+                  # Per-element (not for_collection like the other element types): keeps a sample's
+                  # true level when the user owns/better-shares it in another collection. Deliberate.
                   detail_levels = ElementDetailLevelCalculator.new(user: current_user, element: sample).detail_levels
                   serialized_sample = Entities::SampleEntity.represent(
                     sample,
@@ -200,29 +205,39 @@ module Chemotion
         sequence_based_macromolecule_sample_ids = elements.fetch(:sequence_based_macromolecule_sample_ids, [])
         device_description_ids = elements.fetch(:device_description_ids, [])
 
+        # Every element on the page comes from the single resolved collection @c, so its per-class
+        # detail levels apply to all of them. Without this the entities render fail-open (full access),
+        # leaking fields a restrictive collection share is meant to hide (e.g. reaction analyses).
+        detail_levels = ElementDetailLevelCalculator.for_collection(collection: @c, user: current_user)
+
         paginated_reaction_ids = Kaminari.paginate_array(reaction_ids).page(page).per(page_size)
         serialized_reactions = Reaction.find(paginated_reaction_ids).map do |reaction|
-          Entities::ReactionEntity.represent(reaction, displayed_in_list: true).serializable_hash
+          Entities::ReactionEntity.represent(reaction, detail_levels: detail_levels, displayed_in_list: true)
+                                  .serializable_hash
         end
 
         paginated_wellplate_ids = Kaminari.paginate_array(wellplate_ids).page(page).per(page_size)
         serialized_wellplates = Wellplate.find(paginated_wellplate_ids).map do |wellplate|
-          Entities::WellplateEntity.represent(wellplate, displayed_in_list: true).serializable_hash
+          Entities::WellplateEntity.represent(wellplate, detail_levels: detail_levels, displayed_in_list: true)
+                                   .serializable_hash
         end
 
         paginated_screen_ids = Kaminari.paginate_array(screen_ids).page(page).per(page_size)
         serialized_screens = Screen.find(paginated_screen_ids).map do |screen|
-          Entities::ScreenEntity.represent(screen, displayed_in_list: true).serializable_hash
+          Entities::ScreenEntity.represent(screen, detail_levels: detail_levels, displayed_in_list: true)
+                                .serializable_hash
         end
 
         paginated_cell_line_ids = Kaminari.paginate_array(cell_line_ids).page(page).per(page_size)
         serialized_cell_lines = CelllineSample.find(paginated_cell_line_ids).map do |cell_line|
-          Entities::CellLineSampleEntity.represent(cell_line, displayed_in_list: true).serializable_hash
+          Entities::CellLineSampleEntity.represent(cell_line, detail_levels: detail_levels, displayed_in_list: true)
+                                        .serializable_hash
         end
 
         paginated_research_plan_ids = Kaminari.paginate_array(research_plan_ids).page(page).per(page_size)
         serialized_research_plans = ResearchPlan.find(paginated_research_plan_ids).map do |research_plan|
-          Entities::ResearchPlanEntity.represent(research_plan, displayed_in_list: true).serializable_hash
+          Entities::ResearchPlanEntity.represent(research_plan, detail_levels: detail_levels, displayed_in_list: true)
+                                      .serializable_hash
         end
 
         paginated_sequence_based_macromolecule_sample_ids =
@@ -232,13 +247,16 @@ module Chemotion
           SequenceBasedMacromoleculeSample.find(paginated_sequence_based_macromolecule_sample_ids)
                                           .map do |sequence_based_macromolecule_sample|
             Entities::SequenceBasedMacromoleculeSampleEntity
-              .represent(sequence_based_macromolecule_sample, displayed_in_list: true).serializable_hash
+              .represent(sequence_based_macromolecule_sample, detail_levels: detail_levels, displayed_in_list: true)
+              .serializable_hash
           end
 
         paginated_device_description_ids = Kaminari.paginate_array(device_description_ids).page(page).per(page_size)
         serialized_device_descriptions =
           DeviceDescription.find(paginated_device_description_ids).map do |device_description|
-            Entities::DeviceDescriptionEntity.represent(device_description, displayed_in_list: true).serializable_hash
+            Entities::DeviceDescriptionEntity
+              .represent(device_description, detail_levels: detail_levels, displayed_in_list: true)
+              .serializable_hash
           end
 
         result = {
@@ -313,7 +331,8 @@ module Chemotion
           element_ids_for_klass = Labimotion::Element.where(id: element_ids, element_klass_id: klass.id).pluck(:id)
           paginated_element_ids = Kaminari.paginate_array(element_ids_for_klass).page(page).per(page_size)
           serialized_elements = Labimotion::Element.find(paginated_element_ids).map do |element|
-            Labimotion::ElementEntity.represent(element, displayed_in_list: true).serializable_hash
+            Labimotion::ElementEntity.represent(element, detail_levels: detail_levels, displayed_in_list: true)
+                                     .serializable_hash
           end
 
           result["#{klass.name}s"] = {

--- a/app/api/helpers/report_helpers.rb
+++ b/app/api/helpers/report_helpers.rb
@@ -450,6 +450,16 @@ module ReportHelpers
     <<~SQL.squish
       SELECT
         #{sample_sql},
+        s.is_top_secret AS ts,
+        (SELECT bool_and(co.shared)
+           FROM collections_samples cs_o
+           JOIN collections co ON co.id = cs_o.collection_id AND co.user_id IN (#{u_ids})
+           WHERE cs_o.sample_id = s.id AND cs_o.deleted_at IS NULL) AS is_shared,
+        (SELECT max(csh.sample_detail_level)
+           FROM collections_samples cs_s
+           JOIN collection_shares csh ON csh.collection_id = cs_s.collection_id
+             AND csh.shared_with_id IN (#{u_ids})
+           WHERE cs_s.sample_id = s.id AND cs_s.deleted_at IS NULL) AS dl_s,
         cl.id as "sample uuid",
         COALESCE(components.components, '[]') AS components
       FROM samples s
@@ -680,7 +690,7 @@ module ReportHelpers
         inner join collections_samples c_s on s.id = c_s.sample_id and c_s.deleted_at is null
         left join collections on (collections.id = c_s.collection_id and collections.user_id in (#{u_ids}))
         left join collection_shares on (
-          collections.id = collection_shares.collection_id and collection_shares.shared_with_id not in (#{u_ids})
+          collections.id = collection_shares.collection_id and collection_shares.shared_with_id in (#{u_ids})
         )
         where #{selection} s.deleted_at isnull and c_s.deleted_at isnull
           and (collections.id is not null or collection_shares.id is not null)

--- a/app/policies/element_policy.rb
+++ b/app/policies/element_policy.rb
@@ -19,10 +19,18 @@ class ElementPolicy
     record_is_in_own_collection? || record_shared_with_at_least?(:read_elements)
   end
 
+  # Editing requires a full detail level on a shared element, not just edit permission.
+  # The two axes are independent: a sharee below the anonymization threshold receives the
+  # redaction placeholders ('***', [], {}) for the fields their level hides, and — since the
+  # write path (declared attributes, nested materials via UpdateMaterials, variations) has no
+  # way to tell an echoed placeholder from a genuine edit — saving would overwrite the owner's
+  # real data with those placeholders. Gating the whole write on full detail closes every such
+  # path at once, mirroring how #copy? already combines the permission and detail-level axes.
   def update?
     return false unless user_and_record_present?
 
-    record_is_in_own_collection? || record_shared_with_at_least?(:edit_elements)
+    record_is_in_own_collection? ||
+      (record_shared_with_at_least?(:edit_elements) && record_shared_with_minimum_detail_level?(10))
   end
 
   def copy?

--- a/app/usecases/search/by_ids.rb
+++ b/app/usecases/search/by_ids.rb
@@ -132,6 +132,9 @@ module Usecases
       end
 
       def serialized_result_by_id_for_sample(sample, serialized_scope)
+        # Per-element (not for_collection like #serialized_result_by_id): a sample reached via a
+        # restrictive share still shows its true level if the user owns/better-shares it in another
+        # collection. Keep this deliberate divergence when editing.
         detail_levels = ElementDetailLevelCalculator.new(user: @user, element: sample).detail_levels
         serialized = Entities::SampleEntity.represent(
           sample,
@@ -146,8 +149,19 @@ module Usecases
         entities =
           @model_name == Labimotion::Element ? Labimotion::ElementEntity : "Entities::#{model}Entity".constantize
         serialized =
-          entities.represent(element, displayed_in_list: true).serializable_hash
+          entities.represent(element, detail_levels: collection_detail_levels, displayed_in_list: true)
+                  .serializable_hash
         serialized_scope.push(serialized)
+      end
+
+      # Per-class detail levels for the single collection this search is scoped to. Without them the
+      # entities render fail-open (full access), leaking fields a restrictive collection share hides.
+      def collection_detail_levels
+        @collection_detail_levels ||=
+          ElementDetailLevelCalculator.for_collection(
+            collection: Collection.accessible_for(@user).find(@collection_id),
+            user: @user,
+          )
       end
     end
   end

--- a/app/usecases/search/shared_methods.rb
+++ b/app/usecases/search/shared_methods.rb
@@ -66,6 +66,8 @@ class SharedMethods
           .where(id: paginated_ids)
           .order(Arel.sql("position(','||id::text||',' in ',#{paginated_ids.join(',')},')"))
           .each do |sample|
+            # Per-element (not for_collection like the other element types): keeps a sample's true
+            # level when the user owns/better-shares it in another collection. Deliberate divergence.
             detail_levels = ElementDetailLevelCalculator.new(user: @user, element: sample).detail_levels
             serialized_sample = Entities::SampleEntity.represent(
               sample,
@@ -84,7 +86,8 @@ class SharedMethods
       paginated_element_ids = Kaminari.paginate_array(element_ids_for_klass)
                                       .page(@params[:page]).per(@params[:per_page])
       serialized_elements = Labimotion::Element.find(paginated_element_ids).map do |generic_element|
-        Labimotion::ElementEntity.represent(generic_element, displayed_in_list: true).serializable_hash
+        Labimotion::ElementEntity.represent(generic_element, detail_levels: collection_detail_levels,
+                                                             displayed_in_list: true).serializable_hash
       end
 
       @result["#{klass.name}s"] = {
@@ -101,7 +104,8 @@ class SharedMethods
 
   def serialize_cellline(paginated_ids)
     CelllineSample.find(paginated_ids).map do |model|
-      Entities::CellLineSampleEntity.represent(model, displayed_in_list: true).serializable_hash
+      Entities::CellLineSampleEntity.represent(model, detail_levels: collection_detail_levels,
+                                                      displayed_in_list: true).serializable_hash
     end
   end
 
@@ -110,7 +114,19 @@ class SharedMethods
     entities = "Entities::#{model_name}Entity".constantize
 
     model_name.constantize.find(paginated_ids).map do |model|
-      entities.represent(model, displayed_in_list: true).serializable_hash
+      entities.represent(model, detail_levels: collection_detail_levels, displayed_in_list: true)
+              .serializable_hash
     end
+  end
+
+  # Per-class detail levels for the single collection this search is scoped to. Without them the
+  # entities render fail-open (full access), leaking fields a restrictive collection share hides.
+  # Samples deliberately use the per-element calculator instead (see #serialize_sample).
+  def collection_detail_levels
+    @collection_detail_levels ||=
+      ElementDetailLevelCalculator.for_collection(
+        collection: Collection.accessible_for(@user).find(@params[:collection_id]),
+        user: @user,
+      )
   end
 end

--- a/lib/chemotion/calculations.rb
+++ b/lib/chemotion/calculations.rb
@@ -81,7 +81,12 @@ module Chemotion::Calculations
   end
 
   def self.valid_digit(input_num, precision)
-    num = BigDecimal((input_num.presence || 0).to_s)
+    # A redacted value ('***') reaches this formatter from the report entities; return it
+    # verbatim instead of raising ArgumentError on BigDecimal(), so a report of an element
+    # shared below full detail level renders the placeholder rather than crashing (500).
+    num = BigDecimal((input_num.presence || 0).to_s, exception: false)
+    return input_num if num.nil?
+
     num_str = num.to_s('F')
     num_str =~ /^0*([1-9]+\d*)?.?(0*)([1-9]*)/
     head_len, tail_len = $1&.size || 0, $3 && $2&.size || 0

--- a/lib/export/export_excel.rb
+++ b/lib/export/export_excel.rb
@@ -50,6 +50,8 @@ module Export
       row_image_width = DEFAULT_ROW_WIDTH
       decouple_idx = @headers.find_index('decoupled')
       samples.each_with_index do |sample, row|
+        next if hide_top_secret_sample?(sample)
+
         filtered_sample = filter_with_permission_and_detail_level(sample)
         if @image_index && (svg_path = filtered_sample[@image_index].presence)
           image_data = process_and_add_image(sheet, svg_path, row)
@@ -96,6 +98,8 @@ module Export
       row_length = @headers.size
 
       samples.each do |sample|
+        next if withhold_shared_sample?(sample)
+
         # Add the sample's ID row (if components exist)
         sample_id_row = (@row_headers & HEADERS_SAMPLE_ID).map { |column| sample[column] }
         sample_id_row[row_length - 1] = nil
@@ -134,7 +138,7 @@ module Export
       row_image_width = DEFAULT_ROW_WIDTH
       row_length = @headers.size
       samples.each_with_index do |sample, row|
-        next unless sample['is_shared'].in?(['f', false]) || sample['dl_s'] == 10
+        next if withhold_shared_sample?(sample)
 
         data = (@row_headers & HEADERS_SAMPLE_ID).map { |column| sample[column] }
         data[row_length - 1] = nil
@@ -159,6 +163,34 @@ module Export
 
     def read
       @xfile.to_stream.read
+    end
+
+    # A sample row drawn from one of the caller's own collections (no share involved) — always
+    # exported in full. +is_shared+ is +bool_and(collections.shared)+ from the export SQL and
+    # comes back as the string 'f'/'t' or a boolean.
+    def owned_sample?(sample)
+      sample['is_shared'].in?(['f', false])
+    end
+
+    # Owner-set "hide even from those I share with" flag (+s.is_top_secret as ts+), 't'/'f' or boolean.
+    def top_secret_sample?(sample)
+      sample['ts'].in?(['t', true])
+    end
+
+    # True when a shared row must be omitted entirely: its detail level hides it (only dl 0 and
+    # 10 are implemented, so anything but 10 is withheld), or it is top-secret. Owned rows never
+    # match. Used by the analyses and components sheets, which drop the whole row rather than
+    # showing a reduced column set.
+    def withhold_shared_sample?(sample)
+      return false if owned_sample?(sample)
+
+      sample['dl_s'] != 10 || top_secret_sample?(sample)
+    end
+
+    # Top-secret masking only, independent of detail level — for the main sheet, whose detail-level
+    # handling is the reduced column set in {#filter_with_permission_and_detail_level}.
+    def hide_top_secret_sample?(sample)
+      !owned_sample?(sample) && top_secret_sample?(sample)
     end
 
     def prepare_sample_analysis_data(sample)
@@ -198,7 +230,7 @@ module Export
     # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     def filter_with_permission_and_detail_level(sample)
       # return all data if sample/chemical in own collection
-      if sample['is_shared'].in?(['f', false])
+      if owned_sample?(sample)
         headers = @headers
         reference_values = ['melting pt', 'boiling pt']
         data = headers.map do |column|

--- a/lib/export/export_sdf.rb
+++ b/lib/export/export_sdf.rb
@@ -81,6 +81,9 @@ module Export
         data += "\n"
         data = concatenate_data(sample, data)
       else
+        # withhold top-secret samples that reach us only through a share (owner-set flag)
+        return nil if sample['ts'].in?(['t', true])
+
         # return no data if molfile not allowed
         return nil if sample['dl_s'].zero?
 

--- a/lib/reporter/worker.rb
+++ b/lib/reporter/worker.rb
@@ -74,8 +74,12 @@ module Reporter
     end
 
     def extract(objects) # rubocop:disable  Metrics/MethodLength
-      objects.map do |object|
+      objects.filter_map do |object|
         instance = object['type'].camelize.constantize.find(object['id'])
+        # Defense in depth: the report endpoints already authorize objTags, but a stored
+        # `objects` list must never render an element the author cannot read.
+        next unless ElementPolicy.new(@author, instance).read?
+
         entity_class =
           case instance
           when Sample

--- a/spec/api/chemotion/report_api_spec.rb
+++ b/spec/api/chemotion/report_api_spec.rb
@@ -44,6 +44,43 @@ describe Chemotion::ReportAPI do
       end
     end
 
+    describe 'GET /api/v1/reports/docx authorization' do
+      let!(:foreign_collection) { create(:collection, user_id: other.id) }
+      let!(:foreign_reaction) { create(:reaction, collections: [foreign_collection]) }
+
+      it 'rejects a reaction the user may not read (no share / not owned)' do
+        get '/api/v1/reports/docx', params: { id: foreign_reaction.id.to_s }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'still serves a reaction the user owns' do
+        get '/api/v1/reports/docx', params: { id: r1.id.to_s }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe 'POST /api/v1/reports authorization' do
+      let!(:foreign_collection) { create(:collection, user_id: other.id) }
+      let!(:foreign_reaction) { create(:reaction, collections: [foreign_collection]) }
+      let(:report_params) do
+        {
+          objTags: [{ id: foreign_reaction.id, type: 'reaction' }],
+          splSettings: [], rxnSettings: [], siRxnSettings: [], configs: [],
+          molSerials: [], prdAtts: [], imgFormat: 'png',
+          fileName: 'ELN', templateId: 'standard'
+        }
+      end
+
+      it 'rejects objTags the user may not read and creates no report' do
+        expect { post '/api/v1/reports', params: report_params, as: :json }
+          .not_to change(Report, :count)
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
     describe 'export_samples_from_selections as SDfiles' do
       let(:c) { create(:collection, user_id: user.id) }
       let(:molfiles) do

--- a/spec/lib/chemotion/calculations_spec.rb
+++ b/spec/lib/chemotion/calculations_spec.rb
@@ -305,5 +305,17 @@ describe 'Chemotion::Calculations' do
 
       expect(result).to eq(target)
     end
+
+    # A detail-level-redacted numeric field reaches the report renderer as '***'. It must be
+    # returned verbatim rather than raising ArgumentError on BigDecimal() (which crashed the
+    # DOCX generation with a 500, even for legitimate low-detail-level sharees).
+    it 'passes the redaction placeholder through without raising' do
+      expect { Chemotion::Calculations.valid_digit('***', 3) }.not_to raise_error
+      expect(Chemotion::Calculations.valid_digit('***', 3)).to eq('***')
+    end
+
+    it 'still treats nil as zero' do
+      expect(Chemotion::Calculations.valid_digit(nil, 2)).to eq('0.0')
+    end
   end
 end

--- a/spec/lib/export/export_excel_spec.rb
+++ b/spec/lib/export/export_excel_spec.rb
@@ -84,6 +84,39 @@ RSpec.describe 'Export::ExportExcel' do
       end
     end
   end
+
+  # Guards used by the sheet generators to keep detail-level-restricted and top-secret shared
+  # samples out of exports. exec_query type-casts, so is_shared/ts arrive as booleans and dl_s
+  # as an integer; the predicates also accept the 'f'/'t' string forms defensively.
+  describe 'shared-sample export guards' do
+    describe '#withhold_shared_sample?' do
+      it 'keeps a sample from the user\'s own collection' do
+        expect(exporter.withhold_shared_sample?('is_shared' => false, 'dl_s' => 0)).to be false
+      end
+
+      it 'omits a shared sample below full detail level' do
+        expect(exporter.withhold_shared_sample?('is_shared' => true, 'dl_s' => 0)).to be true
+      end
+
+      it 'keeps a shared sample at full detail level' do
+        expect(exporter.withhold_shared_sample?('is_shared' => true, 'dl_s' => 10)).to be false
+      end
+
+      it 'omits a shared top-secret sample even at full detail level' do
+        expect(exporter.withhold_shared_sample?('is_shared' => true, 'dl_s' => 10, 'ts' => true)).to be true
+      end
+    end
+
+    describe '#hide_top_secret_sample?' do
+      it 'hides a shared top-secret sample' do
+        expect(exporter.hide_top_secret_sample?('is_shared' => true, 'ts' => true)).to be true
+      end
+
+      it 'keeps the owner\'s own top-secret sample' do
+        expect(exporter.hide_top_secret_sample?('is_shared' => false, 'ts' => true)).to be false
+      end
+    end
+  end
 end
 
 def stub_requests

--- a/spec/policies/element_policy_spec.rb
+++ b/spec/policies/element_policy_spec.rb
@@ -77,6 +77,23 @@ describe ElementPolicy do
       end
     end
 
+    # Editing requires seeing the whole element: a sharee below the full detail level receives
+    # the redaction placeholders and would otherwise overwrite the owner's data with them.
+    context 'when shared with edit permission but a detail level below full' do
+      let(:low_detail_shared_collection) do
+        create(:collection, user: other_user, label: 'Low-detail share').tap do |collection|
+          create(:collection_share, collection: collection, shared_with: user,
+                                    permission_level: 1, screen_detail_level: 0)
+        end
+      end
+
+      before { low_detail_shared_collection.screens << screen }
+
+      it 'returns false' do
+        expect(element_policy.update?).to be false
+      end
+    end
+
     context 'when the record is neither in a collection of mine or shared to me' do
       let(:owner) { other_user }
 


### PR DESCRIPTION
Extends the collection detail-level enforcement so every server-side path — list/search,
writes, report generation and exports — applies the same per-collection detail levels and
access checks the single-element endpoints already use, which they were previously
inconsistent with.

## Changes

**List / search serialization** — pass the collection's per-class detail levels to the
entities in the bulk paths that did not compute them (`search_api.rb`
`serialization_by_elements_and_page`, `by_ids.rb`, `samples/ui_state`, and
`shared_methods.rb` for advanced/structure search). Levels are resolved once per page via
`ElementDetailLevelCalculator.for_collection`; samples keep their per-element calculation.

**Writes** — `ElementPolicy#update?` requires a full detail level to edit a shared element
(alongside edit permission), consistent with `#copy?`. `can_update` makes the UI forms
read-only for shares below full detail.

**Reports** — require element read access before generating a report (`GET /reports/docx`,
`POST /reports`); the report worker skips objects the author cannot read. The report numeric
formatter no longer errors on placeholder values, so reports for below-full-detail shares
render normally.

**Exports** — correct a collection-share scope join in the reaction-sample export, add the
detail-level row guard the analyses sheet already has to the components sheet, and apply
`is_top_secret` masking on the XLSX/SDF export.

## Verification

- RuboCop clean on changed lines; the calculator + entity specs, the six element PUT APIs,
  the policy specs, and the report/export specs pass.
- `ElementDetailLevelCalculator` produces correct per-class levels and the entities redact
  `anonymize_below` fields at a below-threshold level.

## Follow-ups (not in this PR)

- Consider making `ApplicationEntity#detail_levels` fail-closed.
- `DeviceDescriptionEntity` / `CellLineSampleEntity` expose fields without anonymization, so
  their detail-level threading is currently inert.
- Minor query-reuse efficiency in the list paths.
