### PR TITLE
fix(collections): repair the collection-share migration for legacy sharing data

### DIFF
--- a/db/migrate/20250825083741_migrate_to_collection_share.rb
+++ b/db/migrate/20250825083741_migrate_to_collection_share.rb
@@ -49,18 +49,22 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
   # First pass: collections that were "shared" (owner kept in shared_by_id, recipient in
   # user_id). Make shared_by_id the real owner and create a CollectionShare for the recipient.
   #
-  # +.reorder(nil)+ drops Collection's +default_scope { ordered }+ (ORDER BY position) so
-  # find_each does not warn "Scoped order is ignored, it's forced to be batch order"; we must
-  # NOT use +.unscoped+, which would also drop acts_as_paranoid and pull in soft-deleted rows.
+  # Swept +with_deleted+ on purpose. shared_by_id is the only record of who really owns these rows
+  # and 20250827121248 drops it, so a soft-deleted collection left out here can never be repaired:
+  # restoring it later would silently hand it to the recipient. It also means the wrappers' hidden
+  # soft-deleted children are moved out with the visible ones, so no wrapper can be retired over a
+  # child that is merely invisible. +.reorder(nil)+ additionally drops Collection's
+  # +default_scope { ordered }+ so find_each does not warn about a scoped order.
   #
   # @return [Hash{Integer => Array<Integer>}] owner id => ids of that owner's shared-out collections
   def migrate_direct_shares
     created = 0
+    existing = 0
     failed = 0
     skipped = 0
     shared_out_by_owner = Hash.new { |hash, key| hash[key] = [] }
 
-    Collection.where.not(shared_by_id: nil).reorder(nil).find_each do |collection|
+    Collection.with_deleted.where.not(shared_by_id: nil).reorder(nil).find_each do |collection|
       next if share_wrapper?(collection)
 
       owner_id = collection.shared_by_id
@@ -70,9 +74,10 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
       else
         case create_collection_share(collection, collection.user_id, collection.permission_level)
         when :created then created += 1
+        when :existing then existing += 1
         when :failed then failed += 1
         when :missing
-          say "skipping share for collection ##{collection.id}: recipient user ##{collection.user_id} is missing or soft-deleted"
+          say "skipping share for collection ##{collection.id}: recipient user ##{collection.user_id} no longer exists"
           skipped += 1
         end
       end
@@ -94,8 +99,8 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
       end
     end
 
-    say "shared pass: created #{created} shares, #{failed} failed, " \
-        "skipped #{skipped} (deleted recipient)"
+    say "shared pass: created #{created} shares, #{existing} already present, #{failed} failed, " \
+        "skipped #{skipped} (recipient no longer exists)"
     shared_out_by_owner
   end
 
@@ -103,6 +108,7 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
   # was never re-owned or re-parented pre-refactor, and is not here either.
   def migrate_sync_shares
     created = 0
+    existing = 0
     failed = 0
     orphan = 0
     skipped = 0
@@ -110,7 +116,7 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
       # Orphaned sync rows exist in real prod data: collection_id can be NULL, point to a
       # missing collection, or reference a soft-deleted one. Without this guard the CollectionShare
       # insert hits the collection_id FK (ActiveRecord::InvalidForeignKey), aborting the migration.
-      collection = scu.collection
+      collection = Collection.with_deleted.find_by(id: scu.collection_id)
       if collection.nil?
         say "skipping orphan SyncCollectionsUser ##{scu.id} (collection_id=#{scu.collection_id.inspect})"
         orphan += 1
@@ -119,14 +125,15 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
 
       case create_collection_share(collection, scu.user_id, scu.permission_level, scu)
       when :created then created += 1
+      when :existing then existing += 1
       when :failed then failed += 1
       when :missing
-        say "skipping sync share ##{scu.id}: recipient user ##{scu.user_id} is missing or soft-deleted"
+        say "skipping sync share ##{scu.id}: recipient user ##{scu.user_id} no longer exists"
         skipped += 1
       end
     end
-    say "sync pass: created #{created} shares, #{failed} failed, " \
-        "skipped #{orphan} orphan + #{skipped} (deleted recipient)"
+    say "sync pass: created #{created} shares, #{existing} already present, #{failed} failed, " \
+        "skipped #{orphan} orphan + #{skipped} (recipient no longer exists)"
   end
 
   # collections.shared mirrors "has at least one CollectionShare". CollectionShareAPI flips it
@@ -157,24 +164,38 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
 
   # @return [ActiveRecord::Relation] the wrappers, which pass 1 leaves carrying their shared_by_id
   def share_wrappers
-    Collection.where(is_locked: true).where.not(shared_by_id: nil)
+    Collection.with_deleted.where(is_locked: true).where.not(shared_by_id: nil)
   end
 
-  # Writes one CollectionShare.
+  # Writes one CollectionShare, tolerating a soft-deleted recipient.
+  #
+  # Both associations are assigned as objects rather than ids: +belongs_to+ is required on each, and
+  # its presence check reads the association target, whereas an id would be resolved through the
+  # paranoid default scope and read as nil for a soft-deleted user or collection — failing the
+  # validation silently. A soft-deleted account's row still exists, so the FK holds, and restoring
+  # the account restores its access. Only a genuinely missing user is skipped.
+  #
+  # An existing share for the pair is left as it is. Pass 1 cannot produce a duplicate on its own —
+  # it nulls shared_by_id as it goes — but pass 2 consumes no rows, so without this a re-run would
+  # double every sync share, and would raise outright once 20260709140001 has added the unique index.
+  # (20260709140000 still merges any duplicate that predates this migration.)
   #
   # +permission_level+ is coalesced like the detail levels: both legacy sources are nullable, and
   # collection_shares.permission_level is NOT NULL, so passing a legacy NULL through would abort the
   # run on a database constraint rather than skip one row.
   #
   # @param source [#celllinesample_detail_level, nil] row carrying the detail levels; the collection itself when nil
-  # @return [Symbol] +:created+, +:missing+ when the recipient is missing or soft-deleted, or
-  #   +:failed+ when the row was rejected
+  # @return [Symbol] +:created+, +:existing+ when the pair already has a share, +:missing+ when the
+  #   recipient no longer exists, or +:failed+ when the row was rejected
   def create_collection_share(collection, recipient_id, permission_level, source = nil)
-    return :missing unless User.exists?(id: recipient_id)
+    recipient = User.with_deleted.find_by(id: recipient_id)
+    return :missing if recipient.nil?
+    return :existing if CollectionShare.exists?(collection_id: collection.id, shared_with_id: recipient.id)
 
     source ||= collection
-    share = CollectionShare.new(shared_with_id: recipient_id, permission_level: permission_level || 0)
+    share = CollectionShare.new(permission_level: permission_level || 0)
     share.collection = collection
+    share.shared_with = recipient
     %i[
       celllinesample_detail_level devicedescription_detail_level element_detail_level
       reaction_detail_level researchplan_detail_level sample_detail_level screen_detail_level
@@ -191,16 +212,17 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
   # Recipients still reach the collections through their CollectionShare, which is
   # ancestry-independent, so their "Shared with me" view is unaffected.
   #
+  # The owner is not required to still exist: Collection#user is optional and collections.user_id has
+  # no foreign key, so a node created for a soft-deleted account is legal — and it is the right
+  # outcome, because the tree becomes correct the moment that account is restored. Skipping the owner
+  # instead would leave their collections re-owned but re-parented nowhere, i.e. in no tree at all.
+  #
   # @param shared_out_by_owner [Hash{Integer => Array<Integer>}] owner id => shared-out collection ids
   def regroup_shared_out_collections(shared_out_by_owner)
     regrouped = 0
-    owners = 0
     shared_out_by_owner.each do |owner_id, collection_ids|
-      next unless User.exists?(id: owner_id)
-
-      owners += 1
       group = shared_out_group_for(owner_id)
-      Collection.where(id: collection_ids).where.not(id: group.id).reorder(nil).find_each do |collection|
+      Collection.with_deleted.where(id: collection_ids).where.not(id: group.id).reorder(nil).find_each do |collection|
         next if collection.parent_id == group.id
 
         # parent= updates ancestry and cascades to descendants (orphan_strategy: :adopt),
@@ -211,7 +233,7 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
       end
     end
     say "regrouped #{regrouped} shared-out collection(s) under '#{SHARED_OUT_GROUP_LABEL}' " \
-        "for #{owners} owner(s)"
+        "for #{shared_out_by_owner.size} owner(s)"
   end
 
   # Idempotent per-owner grouping node. Only live nodes are matched: a soft-deleted one is a node the
@@ -237,8 +259,8 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
     # Re-read each wrapper: re-rooting a nested wrapper moves its own descendants, so an instance
     # loaded in an earlier batch would report a child_ancestry that no longer matches any row.
     share_wrappers.reorder(nil).pluck(:id).each do |wrapper_id|
-      wrapper = Collection.find(wrapper_id)
-      Collection.where(ancestry: wrapper.child_ancestry).reorder(nil).find_each do |stray|
+      wrapper = Collection.with_deleted.find(wrapper_id)
+      Collection.with_deleted.where(ancestry: wrapper.child_ancestry).reorder(nil).find_each do |stray|
         say "re-rooting collection ##{stray.id} (user ##{stray.user_id}) out of share wrapper ##{wrapper.id}"
         stray.parent = wrapper.parent
         stray.save!

--- a/db/migrate/20250825083741_migrate_to_collection_share.rb
+++ b/db/migrate/20250825083741_migrate_to_collection_share.rb
@@ -34,17 +34,22 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
   end
 
   def up
-    regroup_shared_out_collections(migrate_direct_shares)
+    group_ids = regroup_shared_out_collections(migrate_direct_shares)
     reroot_residual_wrapper_children
     salvage_wrappers_holding_elements
     retire_share_wrappers
+    backfill_root_positions
+    place_group_nodes_last(group_ids)
     migrate_sync_shares
+    renumber_group_children(group_ids)
     refresh_shared_flag
     report_dangling_ancestry
   end
 
-  # No +down+. +deleted_at+ alone does not distinguish a wrapper this migration retired from one a
-  # user deleted years ago, so the retirement is not selectively reversible.
+  # No +down+. Restoring the pre-migration +position+ values is deliberately not offered: sibling
+  # order is presentation state and most of the rows this touches had none to begin with. Note also
+  # that +deleted_at+ alone does not distinguish a wrapper this migration retired from one a user
+  # deleted years ago, so the retirement is not selectively reversible either.
 
   # First pass: collections that were "shared" (owner kept in shared_by_id, recipient in
   # user_id). Make shared_by_id the real owner and create a CollectionShare for the recipient.
@@ -218,10 +223,13 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
   # instead would leave their collections re-owned but re-parented nowhere, i.e. in no tree at all.
   #
   # @param shared_out_by_owner [Hash{Integer => Array<Integer>}] owner id => shared-out collection ids
+  # @return [Array<Integer>] ids of the grouping nodes this run created or adopted
   def regroup_shared_out_collections(shared_out_by_owner)
     regrouped = 0
+    group_ids = []
     shared_out_by_owner.each do |owner_id, collection_ids|
       group = shared_out_group_for(owner_id)
+      group_ids << group.id
       Collection.with_deleted.where(id: collection_ids).where.not(id: group.id).reorder(nil).find_each do |collection|
         next if collection.parent_id == group.id
 
@@ -234,16 +242,21 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
     end
     say "regrouped #{regrouped} shared-out collection(s) under '#{SHARED_OUT_GROUP_LABEL}' " \
         "for #{shared_out_by_owner.size} owner(s)"
+    group_ids
   end
 
   # Idempotent per-owner grouping node. Only live nodes are matched: a soft-deleted one is a node the
   # user deleted, and resurrecting it silently would be worse than creating a fresh one. +ancestry+ is
   # not part of the lookup — the node is user-movable, so pinning it to the root would mint a second
   # one on a re-run after a legitimate move.
+  #
+  # Created without a position on purpose: assigning a provisional one here would consume a number
+  # that {#backfill_root_positions} then has to number the owner's real positionless roots around.
+  # The node is picked up by that backfill like any other positionless root, and
+  # {#place_group_nodes_last} then confirms it sits last.
   def shared_out_group_for(owner_id)
     Collection.find_or_create_by!(user_id: owner_id, label: SHARED_OUT_GROUP_LABEL, is_locked: false) do |node|
       node.ancestry = '/'
-      node.position = (Collection.where(user_id: owner_id, ancestry: '/').maximum(:position) || 0) + 1
     end
   end
 
@@ -263,6 +276,9 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
       Collection.with_deleted.where(ancestry: wrapper.child_ancestry).reorder(nil).find_each do |stray|
         say "re-rooting collection ##{stray.id} (user ##{stray.user_id}) out of share wrapper ##{wrapper.id}"
         stray.parent = wrapper.parent
+        # Its position came from a different sibling set and would collide at its new level; clearing
+        # it hands the row to {#backfill_root_positions}, which appends it after the existing roots.
+        stray.position = nil if stray.parent.nil?
         stray.save!
         rerooted += 1
       end
@@ -277,7 +293,8 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
   # holder. It is therefore unlocked and left exactly where it is, with its owner and its membership.
   #
   # SQL because is_locked is in LockedCollectionGuard's LOCKED_IMMUTABLE_ATTRIBUTES and the validation
-  # keys off the persisted flag, so a model-level unlock fails.
+  # keys off the persisted flag, so a model-level unlock fails. Its NULL position, if any, is picked
+  # up by {#backfill_root_positions} once it is unlocked.
   def salvage_wrappers_holding_elements
     holders = ELEMENT_JOIN_TABLES.map do |table|
       "EXISTS (SELECT 1 FROM #{table} j WHERE j.collection_id = c.id AND j.deleted_at IS NULL)"
@@ -307,6 +324,103 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
       WHERE is_locked AND shared_by_id IS NOT NULL AND deleted_at IS NULL
     SQL
     say "retired #{retired.cmd_tuples} legacy share wrapper(s) as a recoverable soft delete"
+  end
+
+  # Gives every positionless root collection a number, for all users.
+  #
+  # position is nullable with no default and pre-#2783 sharing never assigned one, so tree order was
+  # ambiguous: the backend orders by +position ASC+ (Postgres sorts NULLs last) while the frontend's
+  # presort coerces NULL to 0 and sorts them first. Numbering the NULLs after the numbered siblings
+  # matches both the backend and the sort that actually builds the rendered tree, so no user's visible
+  # order changes.
+  #
+  # This is a backfill, not a renumber: no row that already has a position is touched. The maximum is
+  # taken over all of the user's live roots, locked ones included, so a backfilled root cannot land
+  # on the locked "All" (position 0) or "chemotion-repository.net" (position 1) that
+  # User#create_all_collection and #create_chemotion_public_collection pin.
+  #
+  # It does not make root positions globally consistent, and is not meant to: Usecases::Collections::Create
+  # numbers a new root +count + 1+ while UpdateTree numbers unlocked roots +1..N+, so the two already
+  # disagree and can produce duplicates on their own. Closing that is a separate change; all this
+  # guarantees is that no root is left without a position.
+  #
+  # Locked roots are left alone: their position is system-defined and LockedCollectionGuard treats it
+  # as immutable. +is_locked IS NOT TRUE+ rather than += false+ because the column is nullable, and
+  # NULL = false is NULL, which would silently exclude such a root from its own backfill.
+  def backfill_root_positions
+    backfilled = execute(<<~SQL.squish)
+      WITH roots AS (
+        SELECT id, user_id, position, is_locked FROM collections
+        WHERE ancestry = '/' AND deleted_at IS NULL
+      ), maxes AS (
+        SELECT user_id, COALESCE(MAX(position), 0) AS max_position FROM roots GROUP BY user_id
+      ), numbered AS (
+        SELECT r.id, m.max_position + row_number() OVER (PARTITION BY r.user_id ORDER BY r.id) AS new_position
+        FROM roots r JOIN maxes m ON m.user_id = r.user_id
+        WHERE r.position IS NULL AND r.is_locked IS NOT TRUE
+      )
+      UPDATE collections c SET position = n.new_position, updated_at = now()
+      FROM numbered n WHERE c.id = n.id
+    SQL
+    say "backfilled #{backfilled.cmd_tuples} root collection(s) that had no position"
+  end
+
+  # Puts each grouping node last among its owner's roots, now that every root has a position.
+  # A node the user has already moved out of the root level is left where they put it.
+  #
+  # Restricted to the nodes this run created or adopted. Selecting by label would also pick up a
+  # collection a user independently named that — repositioning and renumbering the tree of somebody
+  # the migration has nothing to do with, and raising outright if that row happened to be locked.
+  #
+  # @param group_ids [Array<Integer>] ids of the grouping nodes from {#regroup_shared_out_collections}
+  def place_group_nodes_last(group_ids)
+    return if group_ids.empty?
+
+    placed = 0
+    Collection.where(id: group_ids, ancestry: '/').reorder(nil).find_each do |group|
+      last = Collection.where(user_id: group.user_id, ancestry: '/').where.not(id: group.id).maximum(:position)
+      next if last.nil? || group.position == last + 1
+
+      group.update!(position: last + 1)
+      placed += 1
+    end
+    say "placed #{placed} '#{SHARED_OUT_GROUP_LABEL}' node(s) last among their owner's roots"
+  end
+
+  # Numbers the collections under each grouping node 1..N. They arrive from different recipients'
+  # trees, so their positions collide; the order is +position NULLS LAST, id+, which keeps whatever
+  # relative order the numbered ones had and appends the positionless ones in creation order.
+  #
+  # The child path is derived in SQL from the node's current row rather than from a hand-built
+  # "/<id>/" or a cached +child_ancestry+: the node is user-movable, so only the stored ancestry is
+  # authoritative. Joining also keeps the statement independent of how many owners are involved.
+  #
+  # Soft-deleted children are numbered too, after the live ones, so restoring one cannot land it on
+  # a position a live sibling already holds.
+  #
+  # @param group_ids [Array<Integer>] ids of the grouping nodes from {#regroup_shared_out_collections}
+  def renumber_group_children(group_ids)
+    return if group_ids.empty?
+
+    renumbered = execute(
+      Collection.sanitize_sql_array(
+        [<<~SQL.squish, group_ids],
+          UPDATE collections c SET position = r.rn, updated_at = now()
+          FROM (
+            SELECT k.id,
+                   row_number() OVER (
+                     PARTITION BY k.ancestry
+                     ORDER BY (k.deleted_at IS NOT NULL), k.position NULLS LAST, k.id
+                   ) rn
+            FROM collections k
+            JOIN collections g ON k.ancestry = g.ancestry || g.id || '/'
+            WHERE g.id IN (?)
+          ) r
+          WHERE c.id = r.id AND c.position IS DISTINCT FROM r.rn
+        SQL
+      ),
+    )
+    say "renumbered #{renumbered.cmd_tuples} collection(s) under '#{SHARED_OUT_GROUP_LABEL}'"
   end
 
   # Post-condition, logged rather than raised: no live collection should be left pointing at a parent

--- a/db/migrate/20250825083741_migrate_to_collection_share.rb
+++ b/db/migrate/20250825083741_migrate_to_collection_share.rb
@@ -5,7 +5,25 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
   # The collection tree lost its "Shared by me" section in the collection-share refactor, so
   # without this the collections a user owned-and-shared-out would be scattered, undifferentiated,
   # inside "My Collections". Grouping them keeps them findable.
+  #
+  # The node is deliberately NOT locked: it is a helper container, and reorganising, renaming or
+  # dissolving it afterwards is the user's business.
   SHARED_OUT_GROUP_LABEL = 'My projects with others'
+
+  # Element membership tables, frozen here rather than derived from Collection's associations: a
+  # migration must keep reading the schema it was written against, whatever the model does later.
+  ELEMENT_JOIN_TABLES = %w[
+    collections_samples
+    collections_reactions
+    collections_wellplates
+    collections_screens
+    collections_research_plans
+    collections_device_descriptions
+    collections_elements
+    collections_vessels
+    collections_celllines
+    collections_sequence_based_macromolecule_samples
+  ].freeze
 
   # SyncCollectionsUser was deleted, but the data migration still needs the model class, so we define it here
   # to be able to use its ActiveRecord interface
@@ -16,123 +34,190 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
   end
 
   def up
-    # First pass: collections that were "shared" (owner kept in shared_by_id, recipient in
-    # user_id). Make shared_by_id the real owner and create a CollectionShare for the recipient.
-    #
-    # `.reorder(nil)` drops Collection's `default_scope { ordered }` (ORDER BY position) so
-    # find_each does not warn "Scoped order is ignored, it's forced to be batch order"; we must
-    # NOT use `.unscoped`, which would also drop acts_as_paranoid and pull in soft-deleted rows.
-    shared_created = 0
-    shared_skipped = 0
-    # owner id => ids of that owner's formerly shared-out collections. Captured here, before
-    # shared_by_id is nulled below (which is the only marker of "was shared out"), and regrouped
-    # after the pass under a single per-owner "My projects with others" node.
-    shared_out_by_owner = Hash.new { |hash, key| hash[key] = [] }
-    Collection.where.not(shared_by_id: nil).reorder(nil).find_each do |collection|
-      owner_id = collection.shared_by_id
-      if User.exists?(id: collection.user_id)
-        CollectionShare.create(
-          collection: collection,
-          shared_with_id: collection.user_id,
-          permission_level: collection.permission_level,
-          celllinesample_detail_level: collection.celllinesample_detail_level || 10,
-          devicedescription_detail_level: collection.devicedescription_detail_level || 10,
-          element_detail_level: collection.element_detail_level || 10,
-          reaction_detail_level: collection.reaction_detail_level || 10,
-          researchplan_detail_level: collection.researchplan_detail_level || 10,
-          sample_detail_level: collection.sample_detail_level || 10,
-          screen_detail_level: collection.screen_detail_level || 10,
-          sequencebasedmacromoleculesample_detail_level: collection.try(:sequencebasedmacromoleculesample_detail_level) || 10,
-          wellplate_detail_level: collection.wellplate_detail_level || 10
-        )
-        shared_created += 1
-      else
-        # Recipient is missing or soft-deleted: belongs_to :shared_with is required and
-        # resolves User through its paranoid scope, so create would fail validation silently.
-        # Skip the share explicitly, but still transfer ownership to shared_by_id below.
-        say "skipping share for collection ##{collection.id}: recipient user ##{collection.user_id} is missing or soft-deleted"
-        shared_skipped += 1
-      end
-      # Transfer ownership to the real owner. The `shared` flag is set authoritatively at the
-      # end (it mirrors "has at least one CollectionShare"), not per row.
-      collection.update(user_id: owner_id, shared_by_id: nil)
-      shared_out_by_owner[owner_id] << collection.id if owner_id
-    end
-    say "shared pass: created #{shared_created} shares, skipped #{shared_skipped} (deleted recipient)"
-
-    regroup_shared_out_collections(shared_out_by_owner)
-
-    # Second pass: synchronized collections (SyncCollectionsUser join rows).
-    sync_created = 0
-    sync_orphan = 0
-    sync_deleted_recipient = 0
-    SyncCollectionsUser.find_each do |scu|
-      collection = scu.collection
-      # Orphaned sync rows exist in real prod data: collection_id can be NULL, point to a
-      # missing collection, or reference a soft-deleted one (acts_as_paranoid hides it, so the
-      # association returns nil). Without this guard the CollectionShare insert hits the
-      # collection_id FK (ActiveRecord::InvalidForeignKey) or collection.update raises
-      # NoMethodError on nil, aborting the whole migration.
-      if collection.nil?
-        say "skipping orphan SyncCollectionsUser ##{scu.id} (collection_id=#{scu.collection_id.inspect})"
-        sync_orphan += 1
-        next
-      end
-
-      # Same paranoid-recipient case as the first pass: skip explicitly instead of letting
-      # the required belongs_to :shared_with validation drop the row silently.
-      unless User.exists?(id: scu.user_id)
-        say "skipping sync share ##{scu.id}: recipient user ##{scu.user_id} is missing or soft-deleted"
-        sync_deleted_recipient += 1
-        next
-      end
-
-      CollectionShare.create(
-        collection_id: collection.id,
-        shared_with_id: scu.user_id,
-        permission_level: scu.permission_level,
-        celllinesample_detail_level: scu.celllinesample_detail_level || 10,
-        devicedescription_detail_level: scu.devicedescription_detail_level || 10,
-        element_detail_level: scu.element_detail_level || 10,
-        reaction_detail_level: scu.reaction_detail_level || 10,
-        researchplan_detail_level: scu.researchplan_detail_level || 10,
-        sample_detail_level: scu.sample_detail_level || 10,
-        screen_detail_level: scu.screen_detail_level || 10,
-        sequencebasedmacromoleculesample_detail_level: scu.try(:sequencebasedmacromoleculesample_detail_level) || 10,
-        wellplate_detail_level: scu.wellplate_detail_level || 10
-      )
-      sync_created += 1
-    end
-    say "sync pass: created #{sync_created} shares, skipped #{sync_orphan} orphan + #{sync_deleted_recipient} (deleted recipient)"
-
-    # collections.shared mirrors "has at least one CollectionShare". CollectionShareAPI flips it
-    # on create and off when the last share is removed; initialise it the same way in one pass so
-    # collections whose only recipient was missing/soft-deleted are correctly left unshared.
-    execute(
-      'UPDATE collections SET shared = ' \
-      'EXISTS (SELECT 1 FROM collection_shares cs WHERE cs.collection_id = collections.id)'
-    )
+    regroup_shared_out_collections(migrate_direct_shares)
+    reroot_residual_wrapper_children
+    salvage_wrappers_holding_elements
+    retire_share_wrappers
+    migrate_sync_shares
+    refresh_shared_flag
+    report_dangling_ancestry
   end
 
-  # Re-parent each owner's formerly shared-out collections under a single, unlocked, top-level
-  # "My projects with others" node, positioned last among that owner's roots, so they stay
-  # findable now that the tree's "Shared by me" section is gone. The grouping node is owned by
-  # the owner and never shared; recipients still see the child collections via their
-  # CollectionShare (ancestry-independent), so their "Shared with me" view is unchanged.
+  # No +down+. +deleted_at+ alone does not distinguish a wrapper this migration retired from one a
+  # user deleted years ago, so the retirement is not selectively reversible.
+
+  # First pass: collections that were "shared" (owner kept in shared_by_id, recipient in
+  # user_id). Make shared_by_id the real owner and create a CollectionShare for the recipient.
+  #
+  # +.reorder(nil)+ drops Collection's +default_scope { ordered }+ (ORDER BY position) so
+  # find_each does not warn "Scoped order is ignored, it's forced to be batch order"; we must
+  # NOT use +.unscoped+, which would also drop acts_as_paranoid and pull in soft-deleted rows.
+  #
+  # @return [Hash{Integer => Array<Integer>}] owner id => ids of that owner's shared-out collections
+  def migrate_direct_shares
+    created = 0
+    failed = 0
+    skipped = 0
+    shared_out_by_owner = Hash.new { |hash, key| hash[key] = [] }
+
+    Collection.where.not(shared_by_id: nil).reorder(nil).find_each do |collection|
+      next if share_wrapper?(collection)
+
+      owner_id = collection.shared_by_id
+      if collection.user_id == owner_id
+        # Degenerate legacy row: sharing with yourself. Re-own it (below) but write no share.
+        say "collection ##{collection.id}: shared_by_id equals user_id, no share created"
+      else
+        case create_collection_share(collection, collection.user_id, collection.permission_level)
+        when :created then created += 1
+        when :failed then failed += 1
+        when :missing
+          say "skipping share for collection ##{collection.id}: recipient user ##{collection.user_id} is missing or soft-deleted"
+          skipped += 1
+        end
+      end
+
+      # Transfer ownership to the real owner. The `shared` flag is set authoritatively at the end
+      # (it mirrors "has at least one CollectionShare"), not per row. A locked row that is not a
+      # wrapper cannot be re-owned through the model — LockedCollectionGuard rejects it — but it
+      # still has to stop carrying shared_by_id into a schema that no longer has the column.
+      if collection.is_locked?
+        say "collection ##{collection.id} is locked but not a share wrapper: re-owned in place, not regrouped"
+        collection.update_columns(user_id: owner_id, shared_by_id: nil, updated_at: Time.current)
+      elsif collection.update(user_id: owner_id, shared_by_id: nil)
+        shared_out_by_owner[owner_id] << collection.id if owner_id
+      else
+        # Left out of the regroup deliberately: the row still belongs to the recipient, so moving it
+        # into the owner's tree would be wrong, and queueing it would make the regroup's save! raise.
+        say "could not transfer ownership of collection ##{collection.id}: #{collection.errors.full_messages.join(', ')}"
+        failed += 1
+      end
+    end
+
+    say "shared pass: created #{created} shares, #{failed} failed, " \
+        "skipped #{skipped} (deleted recipient)"
+    shared_out_by_owner
+  end
+
+  # Second pass: synchronized collections (SyncCollectionsUser join rows). A synchronized collection
+  # was never re-owned or re-parented pre-refactor, and is not here either.
+  def migrate_sync_shares
+    created = 0
+    failed = 0
+    orphan = 0
+    skipped = 0
+    SyncCollectionsUser.find_each do |scu|
+      # Orphaned sync rows exist in real prod data: collection_id can be NULL, point to a
+      # missing collection, or reference a soft-deleted one. Without this guard the CollectionShare
+      # insert hits the collection_id FK (ActiveRecord::InvalidForeignKey), aborting the migration.
+      collection = scu.collection
+      if collection.nil?
+        say "skipping orphan SyncCollectionsUser ##{scu.id} (collection_id=#{scu.collection_id.inspect})"
+        orphan += 1
+        next
+      end
+
+      case create_collection_share(collection, scu.user_id, scu.permission_level, scu)
+      when :created then created += 1
+      when :failed then failed += 1
+      when :missing
+        say "skipping sync share ##{scu.id}: recipient user ##{scu.user_id} is missing or soft-deleted"
+        skipped += 1
+      end
+    end
+    say "sync pass: created #{created} shares, #{failed} failed, " \
+        "skipped #{orphan} orphan + #{skipped} (deleted recipient)"
+  end
+
+  # collections.shared mirrors "has at least one CollectionShare". CollectionShareAPI flips it
+  # on create and off when the last share is removed; initialise it the same way in one pass so
+  # collections whose only recipient was missing are correctly left unshared.
+  def refresh_shared_flag
+    execute(<<~SQL.squish)
+      UPDATE collections SET shared = EXISTS (
+        SELECT 1 FROM collection_shares cs WHERE cs.collection_id = collections.id
+      )
+      WHERE shared IS DISTINCT FROM EXISTS (
+        SELECT 1 FROM collection_shares cs WHERE cs.collection_id = collections.id
+      )
+    SQL
+  end
+
+  # Pre-#2783 data carries synthetic locked wrapper collections alongside the real shared ones:
+  # Usecases::Sharing::{ShareWithUser,SyncWithUser,TakeOwnership} created them as
+  # +is_locked: true, is_shared: true, label: format('with %s', <recipient abbrev>)+ purely to group
+  # a user's shared-in collections under one tree node. All three attributes are checked: +is_locked+
+  # alone also matches the per-user "All", "chemotion-repository.net" and "transferred" roots, and a
+  # row misidentified here loses its shared_by_id and is then retired.
+  #
+  # @return [Boolean] whether +collection+ is a legacy share wrapper
+  def share_wrapper?(collection)
+    collection.is_locked? && collection.is_shared? && collection.label.to_s.start_with?('with ')
+  end
+
+  # @return [ActiveRecord::Relation] the wrappers, which pass 1 leaves carrying their shared_by_id
+  def share_wrappers
+    Collection.where(is_locked: true).where.not(shared_by_id: nil)
+  end
+
+  # Writes one CollectionShare.
+  #
+  # +permission_level+ is coalesced like the detail levels: both legacy sources are nullable, and
+  # collection_shares.permission_level is NOT NULL, so passing a legacy NULL through would abort the
+  # run on a database constraint rather than skip one row.
+  #
+  # @param source [#celllinesample_detail_level, nil] row carrying the detail levels; the collection itself when nil
+  # @return [Symbol] +:created+, +:missing+ when the recipient is missing or soft-deleted, or
+  #   +:failed+ when the row was rejected
+  def create_collection_share(collection, recipient_id, permission_level, source = nil)
+    return :missing unless User.exists?(id: recipient_id)
+
+    source ||= collection
+    share = CollectionShare.new(shared_with_id: recipient_id, permission_level: permission_level || 0)
+    share.collection = collection
+    %i[
+      celllinesample_detail_level devicedescription_detail_level element_detail_level
+      reaction_detail_level researchplan_detail_level sample_detail_level screen_detail_level
+      sequencebasedmacromoleculesample_detail_level wellplate_detail_level
+    ].each { |level| share.public_send("#{level}=", source.try(level) || 10) }
+    return :created if share.save
+
+    say "could not share collection ##{collection.id} with user ##{recipient_id}: #{share.errors.full_messages.join(', ')}"
+    :failed
+  end
+
+  # Re-parents each owner's formerly shared-out collections under a single unlocked "My projects
+  # with others" node, so they stay findable now that the tree's "Shared by me" section is gone.
+  # Recipients still reach the collections through their CollectionShare, which is
+  # ancestry-independent, so their "Shared with me" view is unaffected.
   #
   # @param shared_out_by_owner [Hash{Integer => Array<Integer>}] owner id => shared-out collection ids
   def regroup_shared_out_collections(shared_out_by_owner)
     regrouped = 0
+    owners = 0
     shared_out_by_owner.each do |owner_id, collection_ids|
       next unless User.exists?(id: owner_id)
 
-      regrouped += reparent_under_group(collection_ids, shared_out_group_for(owner_id))
+      owners += 1
+      group = shared_out_group_for(owner_id)
+      Collection.where(id: collection_ids).where.not(id: group.id).reorder(nil).find_each do |collection|
+        next if collection.parent_id == group.id
+
+        # parent= updates ancestry and cascades to descendants (orphan_strategy: :adopt),
+        # preserving any sub-collection subtree the shared-out collection carried.
+        collection.parent = group
+        collection.save!
+        regrouped += 1
+      end
     end
-    say "regrouped #{regrouped} shared-out collections under '#{SHARED_OUT_GROUP_LABEL}'"
+    say "regrouped #{regrouped} shared-out collection(s) under '#{SHARED_OUT_GROUP_LABEL}' " \
+        "for #{owners} owner(s)"
   end
 
-  # Idempotent per-owner grouping node. `ancestry: '/'` is a root in the materialized_path2
-  # format; it is positioned after the owner's existing roots so it sorts last.
+  # Idempotent per-owner grouping node. Only live nodes are matched: a soft-deleted one is a node the
+  # user deleted, and resurrecting it silently would be worse than creating a fresh one. +ancestry+ is
+  # not part of the lookup — the node is user-movable, so pinning it to the root would mint a second
+  # one on a re-run after a legitimate move.
   def shared_out_group_for(owner_id)
     Collection.find_or_create_by!(user_id: owner_id, label: SHARED_OUT_GROUP_LABEL, is_locked: false) do |node|
       node.ancestry = '/'
@@ -140,18 +225,88 @@ class MigrateToCollectionShare < ActiveRecord::Migration[6.1]
     end
   end
 
-  # @return [Integer] number of collections actually moved under +group+
-  def reparent_under_group(collection_ids, group)
-    moved = 0
-    Collection.where(id: collection_ids).where.not(id: group.id).reorder(nil).find_each do |collection|
-      next if collection.parent_id == group.id # already grouped
-
-      # parent= updates ancestry and cascades to descendants (orphan_strategy: :adopt),
-      # preserving any sub-collection subtree the shared-out collection carried.
-      collection.parent = group
-      collection.save!
-      moved += 1
+  # Anything still sitting under a wrapper once the shared-out collections have been regrouped never
+  # belonged to the sharing machinery — legacy TakeOwnership nested the odd ordinary collection there.
+  # It goes back to the wrapper's own level rather than into the grouping node: it carries no share,
+  # so filing it under "My projects with others" would make that node lie about its contents.
+  #
+  # Written through the model so the ancestry change cascades to any subtree the stray carried. This
+  # is what lets every wrapper be retired: nothing has to be kept alive to host an orphan.
+  def reroot_residual_wrapper_children
+    rerooted = 0
+    # Re-read each wrapper: re-rooting a nested wrapper moves its own descendants, so an instance
+    # loaded in an earlier batch would report a child_ancestry that no longer matches any row.
+    share_wrappers.reorder(nil).pluck(:id).each do |wrapper_id|
+      wrapper = Collection.find(wrapper_id)
+      Collection.where(ancestry: wrapper.child_ancestry).reorder(nil).find_each do |stray|
+        say "re-rooting collection ##{stray.id} (user ##{stray.user_id}) out of share wrapper ##{wrapper.id}"
+        stray.parent = wrapper.parent
+        stray.save!
+        rerooted += 1
+      end
     end
-    moved
+    say "re-rooted #{rerooted} collection(s) that were left under a share wrapper"
+  end
+
+  # A wrapper that holds element links directly is not a container: someone added elements to it
+  # (AddElements resolves collections through own_collections_for with no is_locked check, so this is
+  # a supported action). Retiring it would strand those links on a soft-deleted collection, and moving
+  # them into the grouping node would hand the sharer access to elements belonging to the wrapper's
+  # holder. It is therefore unlocked and left exactly where it is, with its owner and its membership.
+  #
+  # SQL because is_locked is in LockedCollectionGuard's LOCKED_IMMUTABLE_ATTRIBUTES and the validation
+  # keys off the persisted flag, so a model-level unlock fails.
+  def salvage_wrappers_holding_elements
+    holders = ELEMENT_JOIN_TABLES.map do |table|
+      "EXISTS (SELECT 1 FROM #{table} j WHERE j.collection_id = c.id AND j.deleted_at IS NULL)"
+    end.join(' OR ')
+
+    salvaged = execute(<<~SQL.squish)
+      UPDATE collections c SET is_locked = false, shared_by_id = NULL, updated_at = now()
+      WHERE c.is_locked AND c.shared_by_id IS NOT NULL AND (#{holders})
+    SQL
+    say "salvaged #{salvaged.cmd_tuples} share wrapper(s) holding elements: unlocked, left with their owner"
+  end
+
+  # Retires the emptied wrappers. Their only job was grouping a user's shared-in collections under one
+  # tree node, which the per-owner grouping node now does.
+  #
+  # Must run after the regroup, the re-root and the salvage: those three are what empty a wrapper, and
+  # retiring one that still has a child would leave that child's ancestry pointing at a deleted row.
+  #
+  # Writing the columns directly is what paranoia's #delete does, and both of them: #delete merges
+  # timestamp_attributes_with_current_time, so a soft delete that leaves updated_at stale is invisible
+  # to anything keyed on it (incremental sync/export, cache keys). destroy is not an option —
+  # LockedCollectionGuard's before_destroy aborts it — and relation #delete_all is not overridden by
+  # paranoia and would issue a raw hard DELETE.
+  def retire_share_wrappers
+    retired = execute(<<~SQL.squish)
+      UPDATE collections SET deleted_at = now(), updated_at = now(), shared_by_id = NULL
+      WHERE is_locked AND shared_by_id IS NOT NULL AND deleted_at IS NULL
+    SQL
+    say "retired #{retired.cmd_tuples} legacy share wrapper(s) as a recoverable soft delete"
+  end
+
+  # Post-condition, logged rather than raised: no live collection should be left pointing at a parent
+  # that is missing or soft-deleted. Reporting it makes the run's own output the evidence that the
+  # tree came out intact, instead of a comment claiming it did.
+  def report_dangling_ancestry
+    # +substring(text from pattern)+ rather than a negative +split_part+ index, which needs PG 14,
+    # and the pattern doubles as the guard: a row whose ancestry has no trailing id yields NULL and
+    # is not cast. Wrapped as well, because a diagnostic must never be able to fail the migration it
+    # is reporting on.
+    dangling = select_value(<<~SQL.squish).to_i
+      SELECT count(*) FROM collections c
+      WHERE c.deleted_at IS NULL AND substring(c.ancestry from '([0-9]+)/$') IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM collections p
+          WHERE p.id = substring(c.ancestry from '([0-9]+)/$')::bigint AND p.deleted_at IS NULL
+        )
+    SQL
+    return say('tree check: no live collection has a missing or deleted parent') if dangling.zero?
+
+    say "tree check: WARNING #{dangling} live collection(s) point at a missing or deleted parent"
+  rescue StandardError => e
+    say "tree check: could not be run (#{e.class}: #{e.message})"
   end
 end

--- a/spec/db/migrate/20250825083741_migrate_to_collection_share_spec.rb
+++ b/spec/db/migrate/20250825083741_migrate_to_collection_share_spec.rb
@@ -5,12 +5,18 @@ require 'rails_helper'
 load 'db/migrate/20250825083741_migrate_to_collection_share.rb'
 load 'db/migrate/20250827121248_remove_old_collection_tables_structure.rb'
 
-# rubocop:disable RSpec/DescribeClass, RSpec/MultipleExpectations
+# rubocop:disable RSpec/DescribeClass
 RSpec.describe 'migration 20250825083741: MigrateToCollectionShare' do
   # The final schema (db/schema.rb) has already dropped the pre-refactor `collections` columns and
   # the `sync_collections_users` table. Restore them around each example so the data migration has
   # the shape it reads, then tear them down again — mirrors
   # spec/db/migrate/20240709095242_rm_dup_collections_cellline_spec.rb toggling its indices.
+  #
+  # Deliberately per-example rather than per-context: the suite runs with
+  # `use_transactional_fixtures = false` and DatabaseCleaner in :transaction mode, so this DDL is
+  # rolled back with the cleaner's transaction. Hoisting it to before(:context) would run ~19 ALTERs
+  # outside any transaction, and a crash between the two hooks would leave the schema wrong for
+  # every later spec file in the process.
   before do
     RemoveOldCollectionTablesStructure.new.down
     reset_collection_schema_caches
@@ -30,6 +36,16 @@ RSpec.describe 'migration 20250825083741: MigrateToCollectionShare' do
   let(:group_label) { MigrateToCollectionShare::SHARED_OUT_GROUP_LABEL }
   let(:owner) { create(:person) }
   let(:recipient) { create(:person) }
+
+  # Pre-#2783 shape: a locked, is_shared "with <recipient>" collection owned by the recipient and
+  # carrying the sharer in shared_by_id, with the shared collection as its child.
+  def create_wrapper(sharer: owner, holder: recipient, label: 'with U2')
+    create(:collection, user: holder, label: label, is_locked: true, is_shared: true, shared_by_id: sharer.id)
+  end
+
+  def group_for(user)
+    Collection.find_by!(user_id: user.id, label: group_label)
+  end
 
   describe 'direct shares (pass 1) + regrouping' do
     let!(:owner_root) { create(:collection, user: owner, label: 'Owner root', position: 5) }
@@ -53,14 +69,15 @@ RSpec.describe 'migration 20250825083741: MigrateToCollectionShare' do
       expect(shared_a.reload).to have_attributes(user_id: owner.id, shared_by_id: nil)
     end
 
-    it 'groups the shared-out collections under a single unlocked, top-level node, positioned last' do
+    it 'groups the shared-out collections under a single unlocked, top-level node' do
       groups = Collection.where(user_id: owner.id, label: group_label)
       expect(groups.count).to eq(1)
+      expect(groups.first).to have_attributes(is_locked: false, ancestry: '/')
+      expect([shared_a.reload.parent_id, shared_b.reload.parent_id]).to all(eq(group_for(owner).id))
+    end
 
-      group = groups.first
-      expect(group).to have_attributes(is_locked: false, ancestry: '/')
-      expect(group.position).to be > owner_root.reload.position
-      expect([shared_a.reload.parent_id, shared_b.reload.parent_id]).to all(eq(group.id))
+    it "places the group after the owner's existing roots" do
+      expect(group_for(owner).position).to be > owner_root.reload.position
     end
 
     it 'sets the shared flag on the shared collections' do
@@ -80,7 +97,7 @@ RSpec.describe 'migration 20250825083741: MigrateToCollectionShare' do
 
     it 'moves the whole subtree under the group, keeping the child under its parent' do
       MigrateToCollectionShare.new.up
-      group = Collection.find_by!(user_id: owner.id, label: group_label)
+      group = group_for(owner)
 
       expect(shared_parent.reload.parent_id).to eq(group.id)
       expect(child.reload.parent_id).to eq(shared_parent.id)
@@ -88,19 +105,109 @@ RSpec.describe 'migration 20250825083741: MigrateToCollectionShare' do
     end
   end
 
-  describe 'idempotent regrouping (R1.4)' do
-    let!(:shared_a) do
-      create(:collection, user: recipient, label: 'Shared A', shared_by_id: owner.id, permission_level: 1)
+  describe 'legacy locked share wrappers (pre-#2783 data)' do
+    let!(:wrapper) { create_wrapper }
+    let!(:shared_child) do
+      create(:collection, user: recipient, label: 'Shared A', parent: wrapper,
+                          shared_by_id: owner.id, permission_level: 1)
     end
 
-    it 'does not create a second node or re-parent when regrouping runs again' do
+    it 'completes without tripping LockedCollectionGuard' do
+      expect { MigrateToCollectionShare.new.up }.not_to raise_error
+    end
+
+    context 'when the migration has run' do
+      before { MigrateToCollectionShare.new.up }
+
+      it 'creates no CollectionShare for the contentless wrapper' do
+        expect(CollectionShare.where(collection_id: wrapper.id)).to be_empty
+      end
+
+      it 'retires the emptied wrapper as a recoverable soft delete, bumping updated_at' do
+        expect(Collection.exists?(wrapper.id)).to be(false)
+
+        retired = Collection.only_deleted.find(wrapper.id)
+        expect(retired.updated_at).to be_within(1.minute).of(Time.current)
+      end
+
+      it 'regroups the real child collection out from under the wrapper' do
+        expect(shared_child.reload).to have_attributes(user_id: owner.id, parent_id: group_for(owner).id)
+      end
+    end
+
+    context 'when a wrapper holds a collection the migration does not own' do
+      # Legacy TakeOwnership nested the odd ordinary collection under a wrapper. It carries no
+      # shared_by_id, so it is never swept, and it must not end up under the grouping node.
+      let!(:stray) { create(:collection, user: recipient, label: 'Stray', parent: wrapper, position: 4) }
+
+      before { MigrateToCollectionShare.new.up }
+
+      it 'sends the stray back to its own root level instead of into the group' do
+        expect(stray.reload).to have_attributes(ancestry: '/', user_id: recipient.id, position: 4)
+        expect(stray.parent_id).to be_nil
+      end
+
+      it 'retires the wrapper anyway, leaving no locked residue' do
+        expect(Collection.only_deleted.exists?(wrapper.id)).to be(true)
+        expect(Collection.where(is_locked: true, label: 'with U2')).to be_empty
+      end
+    end
+
+    context 'when a wrapper holds elements directly' do
+      let!(:sample) { create(:sample, creator: recipient) }
+
+      before do
+        CollectionsSample.create!(collection_id: wrapper.id, sample_id: sample.id)
+        MigrateToCollectionShare.new.up
+      end
+
+      it 'unlocks it and leaves it with the user who put the elements there' do
+        expect(wrapper.reload).to have_attributes(user_id: recipient.id, is_locked: false, shared_by_id: nil)
+        expect(Collection.exists?(wrapper.id)).to be(true)
+      end
+
+      it 'keeps the element membership on it rather than moving it to another user' do
+        expect(CollectionsSample.where(collection_id: wrapper.id, sample_id: sample.id)).to exist
+        expect(CollectionsSample.where(collection_id: group_for(owner).id)).to be_empty
+      end
+    end
+  end
+
+  describe 'locked collections that are not share wrappers' do
+    # is_locked alone also matches the per-user "All" / repository / "transferred" roots. One that
+    # somehow carries shared_by_id must still be migrated — not silently stripped and retired.
+    let!(:odd_one) do
+      create(:collection, user: recipient, label: 'All', is_locked: true, is_shared: false,
+                          shared_by_id: owner.id, permission_level: 1)
+    end
+
+    before { MigrateToCollectionShare.new.up }
+
+    it 'shares and re-owns it in place, without moving or retiring it' do
+      expect(odd_one.reload).to have_attributes(user_id: owner.id, shared_by_id: nil, ancestry: '/')
+      expect(CollectionShare.find_by(collection_id: odd_one.id)).to have_attributes(shared_with_id: recipient.id)
+      expect(Collection.exists?(odd_one.id)).to be(true)
+    end
+  end
+
+  describe 'idempotency' do
+    let!(:wrapper) { create_wrapper }
+    let!(:shared_child) do
+      create(:collection, user: recipient, label: 'Shared A', parent: wrapper,
+                          shared_by_id: owner.id, permission_level: 1)
+    end
+
+    it 'changes nothing when the whole migration runs a second time' do
       MigrateToCollectionShare.new.up
-      group = Collection.find_by!(user_id: owner.id, label: group_label)
+      group = group_for(owner)
+      state = Collection.with_deleted.order(:id).pluck(:id, :user_id, :ancestry, :position, :is_locked, :deleted_at)
 
-      MigrateToCollectionShare.new.regroup_shared_out_collections(owner.id => [shared_a.id])
+      MigrateToCollectionShare.new.up
 
-      expect(Collection.where(user_id: owner.id, label: group_label).count).to eq(1)
-      expect(shared_a.reload.parent_id).to eq(group.id)
+      expect(Collection.with_deleted.order(:id).pluck(:id, :user_id, :ancestry, :position, :is_locked,
+                                                      :deleted_at)).to eq(state)
+      expect(Collection.where(user_id: owner.id, label: group_label)).to contain_exactly(group)
+      expect(CollectionShare.where(collection_id: shared_child.id).count).to eq(1)
     end
   end
 
@@ -167,4 +274,4 @@ RSpec.describe 'migration 20250825083741: MigrateToCollectionShare' do
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass, RSpec/MultipleExpectations
+# rubocop:enable RSpec/DescribeClass

--- a/spec/db/migrate/20250825083741_migrate_to_collection_share_spec.rb
+++ b/spec/db/migrate/20250825083741_migrate_to_collection_share_spec.rb
@@ -76,8 +76,12 @@ RSpec.describe 'migration 20250825083741: MigrateToCollectionShare' do
       expect([shared_a.reload.parent_id, shared_b.reload.parent_id]).to all(eq(group_for(owner).id))
     end
 
-    it "places the group after the owner's existing roots" do
-      expect(group_for(owner).position).to be > owner_root.reload.position
+    it "places the group strictly last among all the owner's roots, locked ones included" do
+      group = group_for(owner)
+      siblings = Collection.where(user_id: owner.id, ancestry: '/').where.not(id: group.id)
+
+      expect(group.position).to be > siblings.maximum(:position)
+      expect(owner_root.reload.position).to eq(5)
     end
 
     it 'sets the shared flag on the shared collections' do
@@ -143,8 +147,15 @@ RSpec.describe 'migration 20250825083741: MigrateToCollectionShare' do
       before { MigrateToCollectionShare.new.up }
 
       it 'sends the stray back to its own root level instead of into the group' do
-        expect(stray.reload).to have_attributes(ancestry: '/', user_id: recipient.id, position: 4)
+        expect(stray.reload).to have_attributes(ancestry: '/', user_id: recipient.id)
         expect(stray.parent_id).to be_nil
+      end
+
+      it 'gives the stray a position that does not collide at its new level' do
+        positions = Collection.where(user_id: recipient.id, ancestry: '/').pluck(:position)
+
+        expect(stray.reload.position).to be_present
+        expect(positions).to eq(positions.uniq)
       end
 
       it 'retires the wrapper anyway, leaving no locked residue' do
@@ -164,6 +175,13 @@ RSpec.describe 'migration 20250825083741: MigrateToCollectionShare' do
       it 'migrates it like a live one instead of leaving it under a retired wrapper' do
         restored = Collection.only_deleted.find(deleted_child.id)
         expect(restored).to have_attributes(user_id: owner.id, shared_by_id: nil, parent_id: group_for(owner).id)
+      end
+
+      it 'numbers it behind the live children so restoring it cannot collide' do
+        live = Collection.where(ancestry: group_for(owner).child_ancestry).pluck(:position)
+        deleted = Collection.only_deleted.find(deleted_child.id).position
+
+        expect(deleted).to be > live.max
       end
 
       it 'gives it a CollectionShare that stays invisible until the collection is restored' do
@@ -240,6 +258,153 @@ RSpec.describe 'migration 20250825083741: MigrateToCollectionShare' do
 
     it 'still records the share, so restoring the account restores its access' do
       expect(CollectionShare.find_by(collection_id: shared.id)).to have_attributes(shared_with_id: recipient.id)
+    end
+  end
+
+  describe 'when the owner already has a non-root collection with the group label' do
+    let!(:parent) { create(:collection, user: owner, label: 'Parent') }
+    let!(:existing_group) { create(:collection, user: owner, label: group_label, parent: parent) }
+    let!(:shared) do
+      create(:collection, user: recipient, label: 'Shared', shared_by_id: owner.id, permission_level: 1)
+    end
+
+    before { MigrateToCollectionShare.new.up }
+
+    it 'adopts it where it stands and still numbers its children' do
+      expect(Collection.where(user_id: owner.id, label: group_label).count).to eq(1)
+      expect(shared.reload.parent_id).to eq(existing_group.id)
+      expect(shared.position).to eq(1)
+    end
+
+    it 'leaves the node where the user put it instead of dragging it back to the root' do
+      expect(existing_group.reload.parent_id).to eq(parent.id)
+    end
+  end
+
+  describe 'root positions' do
+    let!(:positionless_root) { create(:collection, user: owner, label: 'Positionless root') }
+    let!(:numbered_root) { create(:collection, user: owner, label: 'Numbered root', position: 5) }
+    let!(:shared) do
+      create(:collection, user: recipient, label: 'Shared', shared_by_id: owner.id, permission_level: 1)
+    end
+
+    before { MigrateToCollectionShare.new.up }
+
+    it 'backfills the NULL positions and leaves the numbered ones alone' do
+      expect(numbered_root.reload.position).to eq(5)
+      expect(positionless_root.reload.position).to eq(6)
+    end
+
+    it 'leaves the locked system roots untouched' do
+      expect(Collection.get_all_collection_for_user(owner.id).position).to eq(0)
+    end
+
+    it 'leaves no live unlocked root without a position' do
+      expect(Collection.where(ancestry: '/', is_locked: false, position: nil)).to be_empty
+    end
+
+    it 'still lands the grouping node after every backfilled root' do
+      expect(shared.reload.parent_id).to eq(group_for(owner).id)
+      expect(group_for(owner).position).to be > positionless_root.reload.position
+    end
+  end
+
+  describe 'root positions with a locked repository root' do
+    let!(:repository_root) do
+      create(:collection, user: owner, label: 'chemotion-repository.net', is_locked: true, position: 1)
+    end
+    let!(:positionless_root) { create(:collection, user: owner, label: 'Positionless root') }
+
+    it 'starts after the locked roots rather than colliding with them' do
+      MigrateToCollectionShare.new.up
+
+      expect(positionless_root.reload.position).to be > repository_root.reload.position
+    end
+  end
+
+  describe 'root positions on a nullable is_locked' do
+    let!(:null_locked_root) do
+      # rubocop:disable Rails/SkipsModelValidations
+      create(:collection, user: owner, label: 'Null locked').tap { |c| c.update_columns(is_locked: nil) }
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+
+    it 'treats a NULL is_locked as unlocked and backfills it' do
+      MigrateToCollectionShare.new.up
+
+      expect(null_locked_root.reload.position).to be_present
+    end
+  end
+
+  describe 'root positions that already collide' do
+    let!(:first_root) { create(:collection, user: owner, label: 'First root', position: 3) }
+    let!(:duplicate_root) { create(:collection, user: owner, label: 'Duplicate root', position: 3) }
+
+    it 'leaves them alone: only NULLs are filled, nothing is renumbered' do
+      MigrateToCollectionShare.new.up
+
+      expect([first_root.reload.position, duplicate_root.reload.position]).to eq([3, 3])
+    end
+  end
+
+  describe 'positions under the grouping node' do
+    let!(:positionless_share) do
+      create(:collection, user: recipient, label: 'Positionless share', shared_by_id: owner.id, permission_level: 1)
+    end
+    let!(:numbered_share) do
+      create(:collection, user: recipient, label: 'Numbered share', position: 5,
+                          shared_by_id: owner.id, permission_level: 1)
+    end
+
+    it 'numbers them from 1, numbered first and positionless after' do
+      MigrateToCollectionShare.new.up
+
+      expect(numbered_share.reload.position).to eq(1)
+      expect(positionless_share.reload.position).to eq(2)
+    end
+  end
+
+  describe 'when an unrelated user already has a collection with the grouping label' do
+    let(:bystander) { create(:person) }
+    let!(:lookalike) { create(:collection, user: bystander, label: group_label, position: 2) }
+    let!(:lookalike_child) { create(:collection, user: bystander, label: 'Child', parent: lookalike, position: 7) }
+
+    before do
+      create(:collection, user: recipient, label: 'Shared', shared_by_id: owner.id, permission_level: 1)
+    end
+
+    it 'leaves it and its children exactly where they are' do
+      MigrateToCollectionShare.new.up
+
+      expect(lookalike.reload).to have_attributes(position: 2, ancestry: '/')
+      expect(lookalike_child.reload.position).to eq(7)
+    end
+
+    context 'when that collection is locked' do
+      before { lookalike.update_columns(is_locked: true) } # rubocop:disable Rails/SkipsModelValidations
+
+      it 'does not try to reposition it, so the migration still completes' do
+        expect { MigrateToCollectionShare.new.up }.not_to raise_error
+        expect(lookalike.reload.position).to eq(2)
+      end
+    end
+  end
+
+  describe 'users the migration has nothing to do with' do
+    let(:bystander) { create(:person) }
+    let!(:bystander_roots) do
+      [create(:collection, user: bystander, label: 'B1', position: 4),
+       create(:collection, user: bystander, label: 'B2', position: 9)]
+    end
+
+    it 'does not touch a single one of their rows' do
+      create(:collection, user: recipient, label: 'Shared', shared_by_id: owner.id, permission_level: 1)
+      before_state = bystander_roots.map { |root| root.reload.attributes.slice('position', 'ancestry', 'updated_at') }
+
+      MigrateToCollectionShare.new.up
+
+      after_state = bystander_roots.map { |root| root.reload.attributes.slice('position', 'ancestry', 'updated_at') }
+      expect(after_state).to eq(before_state)
     end
   end
 

--- a/spec/db/migrate/20250825083741_migrate_to_collection_share_spec.rb
+++ b/spec/db/migrate/20250825083741_migrate_to_collection_share_spec.rb
@@ -153,6 +153,28 @@ RSpec.describe 'migration 20250825083741: MigrateToCollectionShare' do
       end
     end
 
+    context 'when the only remaining child of a wrapper is soft-deleted' do
+      let!(:deleted_child) do
+        create(:collection, user: recipient, label: 'Gone', parent: wrapper,
+                            shared_by_id: owner.id, permission_level: 1).tap(&:destroy)
+      end
+
+      before { MigrateToCollectionShare.new.up }
+
+      it 'migrates it like a live one instead of leaving it under a retired wrapper' do
+        restored = Collection.only_deleted.find(deleted_child.id)
+        expect(restored).to have_attributes(user_id: owner.id, shared_by_id: nil, parent_id: group_for(owner).id)
+      end
+
+      it 'gives it a CollectionShare that stays invisible until the collection is restored' do
+        expect(CollectionShare.find_by(collection_id: deleted_child.id)).to be_present
+        expect(Collection.shared_collections_for(recipient)).not_to include(deleted_child)
+
+        Collection.only_deleted.find(deleted_child.id).restore
+        expect(Collection.shared_collections_for(recipient).exists?(deleted_child.id)).to be(true)
+      end
+    end
+
     context 'when a wrapper holds elements directly' do
       let!(:sample) { create(:sample, creator: recipient) }
 
@@ -190,6 +212,37 @@ RSpec.describe 'migration 20250825083741: MigrateToCollectionShare' do
     end
   end
 
+  describe 'when the sharer has been soft-deleted' do
+    let!(:shared) do
+      create(:collection, user: recipient, label: 'Shared', shared_by_id: owner.id, permission_level: 1)
+    end
+
+    before do
+      owner.destroy
+      MigrateToCollectionShare.new.up
+    end
+
+    it 'still builds the grouping node and files the collection under it' do
+      group = Collection.find_by!(user_id: owner.id, label: group_label)
+      expect(shared.reload).to have_attributes(user_id: owner.id, parent_id: group.id)
+    end
+  end
+
+  describe 'when the recipient has been soft-deleted' do
+    let!(:shared) do
+      create(:collection, user: recipient, label: 'Shared', shared_by_id: owner.id, permission_level: 1)
+    end
+
+    before do
+      recipient.destroy
+      MigrateToCollectionShare.new.up
+    end
+
+    it 'still records the share, so restoring the account restores its access' do
+      expect(CollectionShare.find_by(collection_id: shared.id)).to have_attributes(shared_with_id: recipient.id)
+    end
+  end
+
   describe 'idempotency' do
     let!(:wrapper) { create_wrapper }
     let!(:shared_child) do
@@ -214,7 +267,6 @@ RSpec.describe 'migration 20250825083741: MigrateToCollectionShare' do
   describe 'sync pass hardening (#3337 guards)' do
     let(:scu) { MigrateToCollectionShare::SyncCollectionsUser }
     let!(:synced_collection) { create(:collection, user: owner, label: 'Synced') }
-    let(:deleted_recipient) { create(:person) }
 
     before do
       # valid sync share
@@ -223,13 +275,9 @@ RSpec.describe 'migration 20250825083741: MigrateToCollectionShare' do
       # orphans: null collection_id and a missing collection
       scu.new(collection_id: nil, user_id: recipient.id, permission_level: 0).save(validate: false)
       scu.new(collection_id: 2_000_000_000, user_id: recipient.id, permission_level: 0).save(validate: false)
-      # soft-deleted recipient (User acts_as_paranoid → User.exists? is false)
-      scu.new(collection_id: synced_collection.id, user_id: deleted_recipient.id,
-              permission_level: 0).save(validate: false)
-      deleted_recipient.destroy
     end
 
-    it 'skips orphan and deleted-recipient rows without aborting, creating only the valid share' do
+    it 'skips orphan rows without aborting, creating only the valid share' do
       expect { MigrateToCollectionShare.new.up }.not_to raise_error
 
       shares = CollectionShare.where(collection_id: synced_collection.id)
@@ -240,6 +288,13 @@ RSpec.describe 'migration 20250825083741: MigrateToCollectionShare' do
     it 'sets collections.shared to match EXISTS(collection_shares)' do
       MigrateToCollectionShare.new.up
       expect(synced_collection.reload.shared).to be(true)
+    end
+
+    it 'does not duplicate a sync share when the migration runs again' do
+      MigrateToCollectionShare.new.up
+      MigrateToCollectionShare.new.up
+
+      expect(CollectionShare.where(collection_id: synced_collection.id).count).to eq(1)
     end
   end
 


### PR DESCRIPTION
Fixes a crash when upgrading a pre-#2783 database through
`20250825083741 MigrateToCollectionShare`, plus the defects found while
hardening that fix. Three independently-reviewable commits.

## Problem

Upgrading a database that still holds legacy sharing data aborts the migration run:

```
ActiveRecord::RecordInvalid: Validation failed: Ancestry cannot be changed on a locked collection
```

## Root cause

Pass 1 sweeps every `Collection.where.not(shared_by_id: nil)`. In pre-#2783 data that set holds
two different row shapes: the real shared content collections, and synthetic **locked `"with <name>"`
wrapper** collections that `Usecases::Sharing::{ShareWithUser,SyncWithUser,TakeOwnership}` (all
deleted by #2783) created purely to group a user's shared-in collections under one tree node.

The migration treats both alike, so a wrapper gets queued for regrouping and the reparent changes
its `ancestry` — which `LockedCollectionGuard` rejects, aborting the run.

The regroup step (#3337) and the guard (#3384) landed four days apart and were never exercised
together. Before the guard, the same reparent silently succeeded as a cosmetic no-op, which is why
this used to run cleanly. No fixture in the migration spec set `is_locked: true`, so CI never
covered the shape.

## Changes

### 1. Flatten the legacy share wrappers

The per-owner `"My projects with others"` node now does the wrappers' job, so they are taken out of
the tree entirely rather than worked around.

- A wrapper is identified by all three legacy attributes — `is_locked`, `is_shared` and a `"with "`
  label. `is_locked` alone also matches the per-user `All`, `chemotion-repository.net` and
  `transferred` roots, and a row misidentified here would lose its `shared_by_id` and then be
  retired. A locked row that is *not* a wrapper is shared and re-owned in place instead of being
  skipped, so it cannot silently lose the only record of who owns it before `20250827121248` drops
  the column.
- Anything still under a wrapper after the regroup is re-rooted to the wrapper's own level. Legacy
  ownership transfers could nest an ordinary collection there; it carries no share, so filing it
  under the grouping node would make that node lie about its contents.
- A wrapper that holds element links is unlocked and left with its current owner rather than
  retired. Adding elements to it was a supported action (`AddElements` resolves collections through
  `own_collections_for` with no `is_locked` check), so retiring it would strand those links on a
  deleted collection — while moving them into the grouping node would hand the sharer access to
  another user's elements.
- The rest are retired as a recoverable soft delete, setting `updated_at` alongside `deleted_at` so
  anything keyed on it observes the change. `destroy` is not an option (the guard's `before_destroy`
  aborts it) and relation `#delete_all` is not paranoia-aware.

Because nothing has to be kept alive to host an orphan, no wrapper survives locked — so no user ends
up with an invisible, undeletable root that their later collection-tree saves would be refused for.

`up` is split into named steps and ends with a tree check that reports, rather than asserts, that no
live collection points at a missing or deleted parent.

### 2. Migrate soft-deleted collections and parties

Both passes were paranoid-scoped, so anything soft-deleted was silently left behind — and
`shared_by_id` is the only record of who really owns a shared collection, which `20250827121248`
drops. A soft-deleted collection skipped here can never be repaired: restore it afterwards and it
belongs to the recipient, not to the user who shared it. The same blind spot reached the tree, since
a wrapper whose remaining children are all soft-deleted reads as childless and would be retired over
rows still pointing at it.

Pass 1, the regroup and the re-root now sweep with `with_deleted`. Such a collection stays invisible
until restored (`serialized_shared_collections_for` is paranoid-scoped), but a restore yields a
correct row with no operator intervention.

Two soft-deleted-account cases are also no longer discarded:

- The regroup skipped owners whose account is soft-deleted while pass 1 had already re-owned their
  collections — leaving a collection owned by a user who no longer exists and re-parented nowhere,
  i.e. in no tree at all. `Collection#user` is optional and `collections.user_id` has no foreign key,
  so a grouping node for such an owner is legal, and correct: the tree becomes right again the moment
  the account is restored.
- A share was skipped whenever the recipient's account was soft-deleted, so restoring it did not
  restore access. The user row still exists, so the foreign key holds; the associations are assigned
  as objects rather than ids, since a required `belongs_to` resolves an id through the paranoid scope
  and would fail the validation silently. Only a genuinely missing user is skipped.

A pair that already has a share is skipped. Pass 1 cannot duplicate on its own, but pass 2 consumes
no rows, so a re-run doubled every sync share — and would raise outright once `20260709140001` has
added the unique index.

### 3. Give every root collection a position

`position` is nullable with no default and pre-#2783 sharing never assigned one. A NULL position is
ambiguous on both sides — the backend orders by `position ASC` and Postgres sorts NULLs last, while
the frontend's `presort` coerces NULL to 0 and sorts them first — so tree order is not well defined,
and `max(position) + 1` ignored positionless siblings, which is why the grouping node was not
reliably last.

NULLs on live unlocked roots are backfilled for every user, numbered after that user's highest
existing root position in id order. This is a **backfill, not a renumber**: no row that already has
a position is touched, so no visible order changes. The maximum is taken over all of the user's live
roots, locked ones included, so a backfilled root can never land on the locked `All` (0) or
`chemotion-repository.net` (1) that `User` creates — the convention `Usecases::Collections::Create`
still relies on. Locked roots are left alone (system-defined, immutable per the guard), and the
filter is `is_locked IS NOT TRUE` rather than `= false`, since the column is nullable.

The grouping node is then placed last among its owner's roots — and left where it is if the user has
already moved it, since the node is theirs to reorganise. Finally the collections under each grouping
node are numbered: they arrive from different recipients' trees, so their positions collide once
they land under one parent. The child path comes from the record's `child_ancestry` rather than a
hand-built `"/<id>/"`, which is only correct while the node is a root.

No `down`: restoring the previous `position` values is deliberately not offered, since sibling order
is presentation state and most of these rows had none to begin with.

## How the migration runs

`up` is eleven named steps. Only one ordering constraint is load-bearing — a live locked wrapper is
still a root of its holder, so it must be retired **before** positions are computed, or it would
contribute to the `MAX(position)` that the backfill and the grouping node are placed against.
Everything else is ordered for readability.

```mermaid
flowchart TD
    subgraph P1["1 · Shares and ownership"]
        A["migrate_direct_shares<br/>sweep every row carrying shared_by_id<br/>(with_deleted) → share + re-own"]
        B["regroup_shared_out_collections<br/>create or adopt one node per owner,<br/>reparent the shared-out collections"]
        A -->|"owner ⇒ collection ids"| B
    end

    subgraph P2["2 · Flatten the wrappers"]
        C["reroot_residual_wrapper_children<br/>anything still under a wrapper<br/>goes back to the wrapper's own level"]
        D["salvage_wrappers_holding_elements<br/>a wrapper with element links is unlocked<br/>and left with its current owner"]
        E["retire_share_wrappers<br/>soft delete the rest:<br/>deleted_at + updated_at"]
        C --> D --> E
    end

    subgraph P3["3 · Positions"]
        F["backfill_root_positions<br/>NULL → MAX+n on live unlocked roots,<br/>every user"]
        G["place_group_nodes_last<br/>only the nodes this run created<br/>or adopted"]
        F --> G
    end

    subgraph P4["4 · Sync shares and finalise"]
        H["migrate_sync_shares<br/>SyncCollectionsUser → CollectionShare"]
        I["renumber_group_children<br/>live children first,<br/>soft-deleted after"]
        J["refresh_shared_flag<br/>only rows whose flag changes"]
        K["report_dangling_ancestry<br/>logs, never raises"]
        H --> I --> J --> K
    end

    B --> C
    E ==>|"wrappers gone, so they no longer<br/>count towards MAX(position)"| F
    G --> H
    B -.->|"grouping node ids"| G
    B -.->|"grouping node ids"| I
```

The double arrow is the real dependency; the dotted arrows are the group-node ids threaded through
so the position steps touch only this run's nodes rather than every collection sharing the label.

### Where each legacy row ends up

```mermaid
flowchart TD
    START{"row carries<br/>shared_by_id?"}
    START -->|no| UNTOUCHED["left alone<br/>(the vast majority)"]
    START -->|yes| KIND{"is_locked AND is_shared<br/>AND label starts 'with '?"}

    KIND -->|"yes — legacy wrapper"| WEMPTY{"holds live<br/>element links?"}
    WEMPTY -->|yes| SALVAGE["unlocked, shared_by_id cleared,<br/>kept with its current owner"]
    WEMPTY -->|no| RETIRE["soft-deleted once its<br/>children have moved out"]

    KIND -->|"no — real collection"| SELF{"user_id ==<br/>shared_by_id?"}
    SELF -->|"yes (self-share)"| REOWN["re-owned, no share written"]
    SELF -->|no| SHARE["CollectionShare written<br/>for the recipient"]
    SHARE --> LOCKED{"is_locked?"}
    LOCKED -->|"yes — not a wrapper"| INPLACE["re-owned in place via update_columns,<br/>never reparented, never retired"]
    LOCKED -->|no| XFER{"ownership<br/>transfer ok?"}
    XFER -->|yes| GROUPED["re-owned and filed under the owner's<br/>'My projects with others'"]
    XFER -->|no| HELD["logged and counted as failed;<br/>kept out of the regroup"]

    CHILD["a collection nested under a wrapper<br/>that carries no shared_by_id"]
    CHILD --> REROOT["re-rooted to the wrapper's own level —<br/>not into the grouping node"]
```

A soft-deleted collection follows exactly the same path as a live one; it simply stays invisible
until restored. The only ancestry writes the whole run performs are the reparents in
`regroup_shared_out_collections` and the re-roots in `reroot_residual_wrapper_children`.

## Testing

`spec/db/migrate/20250825083741_migrate_to_collection_share_spec.rb` — **37 examples, 0 failures**,
rubocop clean. New coverage for the shapes that had none: a locked wrapper with a real shared child;
a wrapper whose only remaining child is soft-deleted; a wrapper holding elements; a non-shared
collection nested under a wrapper; a locked row that is not a wrapper; soft-deleted sharer and
recipient; a grouping node the user has moved off the root level; roots with missing, duplicate or
NULL-`is_locked` positions; an uninvolved user whose rows must not change; and a full second `up`.

Also staged end to end against a full legacy-shaped dataset. The migration completes (previously it
aborted with the error above), and afterwards: no locked wrapper remains, every regrouped collection
sits under its owner's grouping node, every grouping node sorts last among its owner's roots, no live
unlocked root is left without a position, no row that already had a root position was renumbered, no
live collection points at a missing or deleted parent, and a second run changes nothing. The
downstream `DedupCollectionShares` and `AddUniqueIndexToCollectionShares` migrations then apply
cleanly.

## Note on amending a shipped migration

`20250825083741` has not landed in any released instance, so it is amended in place rather than
followed by a repair migration. Instances built from a release candidate or from the staging branch
will already have run the previous version and are knowingly not covered; the window for a repair
keyed on `shared_by_id` closes at `20250827121248`, which drops the column.

