### PR TITLE
fix(ui): sidebar, notifications, and detail-header UX papercuts

### DIFF
--- a/app/assets/stylesheets/components/CollectionTree.scss
+++ b/app/assets/stylesheets/components/CollectionTree.scss
@@ -53,9 +53,17 @@
   &__title {
     @extend .flex-grow-1;
     min-width: 0;
-    overflow-x: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+    // Wrap normally (so a multi-word long label still shows in full across a
+    // couple of lines, as it did before long-label overflow was clipped) but
+    // allow breaking mid-word so a single unbroken word can't force the row
+    // wider than the sidebar. Capped at 2 lines so one extreme label can't
+    // stretch the row indefinitely; anything beyond that gets an ellipsis on
+    // the second line.
+    overflow-wrap: anywhere;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
 }
 

--- a/app/assets/stylesheets/components/CollectionTree.scss
+++ b/app/assets/stylesheets/components/CollectionTree.scss
@@ -1,12 +1,22 @@
 .tree-view {
   @extend .d-flex;
   @extend .flex-column;
+  // Every row is wrapped in a plain div (see TreeViewItem.js) that becomes a flex
+  // item here (and in each nested .tree-view for sub-collections). Without
+  // min-width:0 it hugs its content's natural width instead of shrinking to the
+  // sidebar's available width, which is what let long labels balloon past the
+  // sidebar and get hard-clipped (no ellipsis) by an ancestor's overflow-x:hidden.
+  > div {
+    @extend .min-w-0;
+  }
   &__frame {
     min-height: 0;
+    @extend .min-w-0;
   }
   &__container {
     @extend .tree-view;
     @extend .overflow-y-auto;
+    @extend .min-w-0;
     // Load-bearing with the kebab dropdown (see .collection-subtree-functions below):
     // Popper pre-positions every `renderOnMount` menu at (0,0) before it is shown;
     // this clip stops those off-screen menus from stacking into view. Remove it
@@ -21,6 +31,7 @@
     cursor: pointer;
     font-size: 14px;
     min-height: 36px;
+    min-width: 0;
     @extend .py-1;
     @extend .pe-2;
     @extend .gap-2;
@@ -41,7 +52,9 @@
   }
   &__title {
     @extend .flex-grow-1;
+    min-width: 0;
     overflow-x: hidden;
+    white-space: nowrap;
     text-overflow: ellipsis;
   }
 }

--- a/app/assets/stylesheets/components/SelectionActions.scss
+++ b/app/assets/stylesheets/components/SelectionActions.scss
@@ -1,10 +1,12 @@
 .selection-actions {
   container-name: selection-actions;
   container-type: inline-size;
+  flex-wrap: wrap;
 }
 
 .selection-action-text-label {
   display: none;
+  white-space: nowrap;
 }
 
 @container selection-actions (width > 43rem) {

--- a/app/assets/stylesheets/components/Sidebar_Topbar.scss
+++ b/app/assets/stylesheets/components/Sidebar_Topbar.scss
@@ -9,7 +9,6 @@ $topbar-height: 35px;
   @extend .flex-shrink-0;
   @extend .surface-lighten4;
   width: 260px;
-  overflow-x: hidden;
   &.sidebar--collapsed {
     width: 44px;
     .sidebar-logo {

--- a/app/assets/stylesheets/components/Sidebar_Topbar.scss
+++ b/app/assets/stylesheets/components/Sidebar_Topbar.scss
@@ -9,6 +9,7 @@ $topbar-height: 35px;
   @extend .flex-shrink-0;
   @extend .surface-lighten4;
   width: 260px;
+  overflow-x: hidden;
   &.sidebar--collapsed {
     width: 44px;
     .sidebar-logo {
@@ -27,6 +28,7 @@ $topbar-height: 35px;
     @extend .d-flex;
     @extend .flex-column;
     @extend .flex-grow-1;
+    @extend .min-w-0;
     @extend .pb-4;
     @extend .align-items-stretch;
   }

--- a/app/assets/stylesheets/global-styles/utilities/sizing.scss
+++ b/app/assets/stylesheets/global-styles/utilities/sizing.scss
@@ -6,6 +6,10 @@
   height: 0;
 }
 
+.min-w-0 {
+  min-width: 0;
+}
+
 .vw-90 {
   width: 90vw;
 }

--- a/app/javascript/src/apps/mydb/elements/Elements.js
+++ b/app/javascript/src/apps/mydb/elements/Elements.js
@@ -73,7 +73,7 @@ function Elements() {
         defaultSize={showDetailView ? defaultLayout[0] : 100}
         className="w-0"
       >
-        <div className="h-100 pt-4 px-4 overflow-x-auto">
+        <div className="h-100 pt-4 px-4 overflow-x-auto min-w-0">
           <ElementsList overview={!showDetailView} />
         </div>
       </Panel>

--- a/app/javascript/src/apps/mydb/elements/details/DetailCard.js
+++ b/app/javascript/src/apps/mydb/elements/details/DetailCard.js
@@ -14,6 +14,7 @@ export default function DetailCard({
   titleTooltip,
   titleAppendix,
   headerToolbar,
+  headerBanner,
   footerToolbar,
   onClose,
   className,
@@ -53,6 +54,11 @@ export default function DetailCard({
           </div>
           <CloseButton onClick={handleClose} />
         </div>
+        {headerBanner && (
+          <div className="detail-card__header-banner mt-2">
+            {headerBanner}
+          </div>
+        )}
       </Card.Header>
       <div className="detail-card__scroll-container">
         <Card.Body>
@@ -75,6 +81,7 @@ DetailCard.propTypes = {
   titleTooltip: PropTypes.string,
   titleAppendix: PropTypes.node,
   headerToolbar: PropTypes.node,
+  headerBanner: PropTypes.node,
   footerToolbar: PropTypes.node,
   onClose: PropTypes.func,
   className: PropTypes.string,
@@ -85,6 +92,7 @@ DetailCard.defaultProps = {
   titleTooltip: null,
   titleAppendix: null,
   headerToolbar: null,
+  headerBanner: null,
   footerToolbar: null,
   onClose: null,
   className: null,

--- a/app/javascript/src/apps/mydb/elements/details/ElementDetailCard.js
+++ b/app/javascript/src/apps/mydb/elements/details/ElementDetailCard.js
@@ -26,6 +26,7 @@ export default function ElementDetailCard({
   titleTooltip,
   titleAppendix,
   headerToolbar,
+  headerBanner,
   footerToolbar,
   onClose,
   onSave,
@@ -197,6 +198,7 @@ export default function ElementDetailCard({
       titleTooltip={titleTooltip}
       titleAppendix={elementTitleAppendix}
       headerToolbar={elementHeaderToolbar}
+      headerBanner={headerBanner}
       footerToolbar={elementFooterToolbar}
       onClose={(event) => requestClose(event, false, 'bottom')}
       className={pendingToSave ? 'detail-card--unsaved' : ''}
@@ -232,6 +234,7 @@ ElementDetailCard.propTypes = {
   titleTooltip: PropTypes.string,
   titleAppendix: PropTypes.node,
   headerToolbar: PropTypes.node,
+  headerBanner: PropTypes.node,
   footerToolbar: PropTypes.node,
   onClose: PropTypes.func,
   onSave: PropTypes.func.isRequired,
@@ -248,6 +251,7 @@ ElementDetailCard.defaultProps = {
   titleTooltip: null,
   titleAppendix: null,
   headerToolbar: null,
+  headerBanner: null,
   footerToolbar: null,
   onClose: null,
   onSaveClose: null,

--- a/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetails.js
@@ -69,20 +69,33 @@ const formatReactionTypeOption = (option, { context }) => (
     : option.label
 );
 
-const productLink = (product, active) => (
-  <span>
-    {active && "Sample Analysis:"}
-    <span
-      aria-hidden="true"
-      className="pseudo-link"
-      onClick={() => aviatorNavigation('sample', product.id, true, true)}
-      title="Open sample window"
-    >
-      <i className="icon-sample mx-1" />
-      {product.title()}
+const productLink = (product, active) => {
+  const icon = <i className="icon-sample mx-1" />;
+
+  if (!active) {
+    return (
+      <span>
+        {icon}
+        {product.title()}
+      </span>
+    );
+  }
+
+  return (
+    <span>
+      Sample Analysis:
+      <span
+        aria-hidden="true"
+        className="pseudo-link"
+        onClick={() => aviatorNavigation('sample', product.id, true, true)}
+        title="Open sample window"
+      >
+        {icon}
+        {product.title()}
+      </span>
     </span>
-  </span>
-);
+  );
+};
 
 export default class ReactionDetails extends Component {
   constructor(props) {

--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -1073,10 +1073,25 @@ export default class SampleDetails extends React.Component {
       />
     ) : null;
 
+    return (
+      <>
+        {decoupleCb}
+        {inventorySample}
+      </>
+    );
+  }
+
+  // Full-width banner content for the panel header (structure/redirect alerts).
+  // Kept out of sampleHeader()'s icon-button toolbar row: an Alert is a tall,
+  // multi-line block, and rendering it as a flex item alongside small icon
+  // buttons (see DetailCard.js's headerToolbar row) stretched the whole header
+  // row to the alert's height and squeezed the alert's own width down to
+  // whatever was left over next to the buttons.
+  sampleHeaderBanner() {
     const { pageMessage } = this.state;
     const messageBlock = (pageMessage
       && (pageMessage.error.length > 0 || pageMessage.warning.length > 0)) ? (
-        <Alert variant="warning" style={{ marginBottom: 'unset', padding: '5px', marginTop: '10px' }}>
+        <Alert variant="warning" style={{ marginBottom: 'unset', padding: '5px' }}>
           <strong>Structure Alert</strong>
           <Button
             size="sm"
@@ -1101,7 +1116,7 @@ export default class SampleDetails extends React.Component {
 
     // warning message for redirection
     const redirectWarningBlock = this.state.showRedirectWarning ? (
-      <Alert variant="warning" className="d-flex flex-column gap-2 mt-2 mb-0 p-2">
+      <Alert variant="warning" className={`d-flex flex-column gap-2 mb-0 p-2${messageBlock ? ' mt-2' : ''}`}>
         <div>
           <strong>Notice:</strong>
           <p className="mb-1">
@@ -1125,10 +1140,10 @@ export default class SampleDetails extends React.Component {
       </Alert>
     ) : null;
 
+    if (!messageBlock && !redirectWarningBlock) return null;
+
     return (
       <>
-        {decoupleCb}
-        {inventorySample}
         {messageBlock}
         {redirectWarningBlock}
       </>
@@ -1582,6 +1597,7 @@ export default class SampleDetails extends React.Component {
         element={sample}
         isPendingToSave={pendingToSave}
         headerToolbar={this.sampleHeader(sample)}
+        headerBanner={this.sampleHeaderBanner()}
         footerToolbar={this.sampleFooter()}
         title={sampleTitle(sample)}
         titleTooltip={formatTimeStampsOfElement(sample || {})}

--- a/app/javascript/src/apps/mydb/elements/list/ElementsList.js
+++ b/app/javascript/src/apps/mydb/elements/list/ElementsList.js
@@ -144,6 +144,30 @@ export default class ElementsList extends React.Component {
         currentCollection: state.currentCollection
       });
     }
+    if (currentCollection !== state.currentCollection) {
+      this.prefetchShareInfo(state.currentCollection);
+    }
+  }
+
+  // The header's share icon shows UserInfosTooltip/SharedToMeInfosTooltip on hover, which
+  // otherwise fetch their share list lazily on first mount and resize once it arrives. That
+  // resize can shift the icon out from under the pointer, triggering a hide/show/hide flicker
+  // (mouseleave -> hide -> layout settles back -> mouseenter -> show -> resize -> repeat).
+  // Fetching as soon as the collection is known to be shared means the tooltip's first render
+  // already has the real content, so it never resizes while visible.
+  prefetchShareInfo(collection) {
+    const collectionsStore = this.context?.collections;
+    if (!collectionsStore || collection?.id == null) return;
+
+    if (collection.shared) {
+      if (collectionsStore.sharedWithUsers(collection.id) === undefined) {
+        collectionsStore.getSharedWithUsers(collection.id);
+      }
+    } else if (collectionsStore.isSharedCollection?.(collection.id)) {
+      if (collectionsStore.mySharesFor(collection.id) === undefined) {
+        collectionsStore.getMySharesFor(collection.id);
+      }
+    }
   }
 
   handleRemoveSearchResult(searchStore) {
@@ -230,20 +254,20 @@ export default class ElementsList extends React.Component {
 
     return (
       <div className="elements-list h-100 d-flex flex-column" style={{ minWidth: '400px' }}>
-        <div className="d-flex align-items-center justify-content-between mb-3 flex-wrap column-gap-4 row-gap-2">
-          <h1 className="m-0 text-capitalize d-flex align-items-center gap-2">
-            {currentCollection?.label || ''}
+        <div className="d-flex align-items-center justify-content-between mb-3 flex-wrap column-gap-4 row-gap-2 min-w-0">
+          <h1 className="m-0 text-capitalize d-flex align-items-center gap-2 min-w-0">
+            <span className="text-truncate flex-grow-1 min-w-0">{currentCollection?.label || ''}</span>
             {/* Own vs shared-with-me are mutually exclusive: if the current user owns
                 the collection (`shared` is set when they've shared it with others), don't
                 also render the shared-with-me indicator even if the store reports it. */}
             {currentCollection?.shared ? (
-              <OverlayTrigger placement="right" overlay={<UserInfosTooltip collectionId={currentCollection.id} />}>
+              <OverlayTrigger placement="auto" overlay={<UserInfosTooltip collectionId={currentCollection.id} />}>
                 <i className="fa fa-share-alt fs-5" aria-label="Shared collection" />
               </OverlayTrigger>
             ) : (currentCollection?.id != null
               && this.context?.collections?.isSharedCollection?.(currentCollection.id) && (
               <OverlayTrigger
-                placement="right"
+                placement="auto"
                 overlay={(
                   <SharedToMeInfosTooltip
                     collectionId={currentCollection.id}

--- a/app/javascript/src/apps/mydb/mainNavigation/sidebar/Sidebar.js
+++ b/app/javascript/src/apps/mydb/mainNavigation/sidebar/Sidebar.js
@@ -20,7 +20,7 @@ export default function Sidebar() {
   return (
     <div className={classnames('sidebar', { 'sidebar--collapsed': isCollapsed })}>
       <div className="sidebar-content">
-        <div className="flex-grow-1 h-0 pb-4">
+        <div className="flex-grow-1 min-w-0 h-0 pb-4">
           <CollectionTree isCollapsed={isCollapsed} />
         </div>
         <div className={classnames(

--- a/app/javascript/src/apps/mydb/mainNavigation/topbar/NoticeButton.js
+++ b/app/javascript/src/apps/mydb/mainNavigation/topbar/NoticeButton.js
@@ -19,6 +19,22 @@ import UIStore from 'src/stores/alt/stores/UIStore';
 
 import NotificationButton from 'src/apps/mydb/mainNavigation/topbar/NotificationButton';
 
+const MAX_VISIBLE_PAGES = 5;
+
+const getPaginationRange = (currentPage, totalPages, maxVisible) => {
+  if (totalPages <= maxVisible) {
+    return Array.from({ length: totalPages }, (unused, i) => i + 1);
+  }
+  const half = Math.floor(maxVisible / 2);
+  let start = Math.max(currentPage - half, 1);
+  let end = start + maxVisible - 1;
+  if (end > totalPages) {
+    end = totalPages;
+    start = end - maxVisible + 1;
+  }
+  return Array.from({ length: end - start + 1 }, (unused, i) => start + i);
+};
+
 const changeUrl = (url, urlTitle) => (url ? (
   <a href={url} target="_blank" rel="noopener noreferrer">
     {urlTitle || url}
@@ -435,27 +451,40 @@ const NoticeButton = () => {
             </Card>
           );
         })}
-        {totalPages > 1 && (
-          <Pagination className="justify-content-center mt-3">
-            <Pagination.Prev
-              disabled={effectivePage === 1}
-              onClick={() => setCurrentPage(effectivePage - 1)}
-            />
-            {[...Array(totalPages).keys()].map((key, i) => (
-              <Pagination.Item
-                key={`page_${key}`}
-                active={i + 1 === effectivePage}
-                onClick={() => setCurrentPage(i + 1)}
-              >
-                {i + 1}
-              </Pagination.Item>
-            ))}
-            <Pagination.Next
-              disabled={effectivePage === totalPages}
-              onClick={() => setCurrentPage(effectivePage + 1)}
-            />
-          </Pagination>
-        )}
+        {totalPages > 1 && (() => {
+          const pageRange = getPaginationRange(effectivePage, totalPages, MAX_VISIBLE_PAGES);
+          return (
+            <Pagination className="justify-content-center mt-3">
+              <Pagination.First
+                disabled={effectivePage === 1}
+                onClick={() => setCurrentPage(1)}
+              />
+              <Pagination.Prev
+                disabled={effectivePage === 1}
+                onClick={() => setCurrentPage(effectivePage - 1)}
+              />
+              {pageRange[0] > 1 && <Pagination.Ellipsis disabled />}
+              {pageRange.map((page) => (
+                <Pagination.Item
+                  key={`page_${page}`}
+                  active={page === effectivePage}
+                  onClick={() => setCurrentPage(page)}
+                >
+                  {page}
+                </Pagination.Item>
+              ))}
+              {pageRange[pageRange.length - 1] < totalPages && <Pagination.Ellipsis disabled />}
+              <Pagination.Next
+                disabled={effectivePage === totalPages}
+                onClick={() => setCurrentPage(effectivePage + 1)}
+              />
+              <Pagination.Last
+                disabled={effectivePage === totalPages}
+                onClick={() => setCurrentPage(totalPages)}
+              />
+            </Pagination>
+          );
+        })()}
       </>
     );
   };


### PR DESCRIPTION
Started as a fix for unbounded notification pagination and grew to cover a batch of related minor UX/UI issues found along the way, all in the same low-risk "layout/CSS + small behavior fix" category:

- **Notification pagination** — the notification list's pagination is now windowed to a fixed number of visible pages (with First/Prev/…/Next/Last), instead of rendering one page button per page.
- **Reaction → Analyses tab misclick** — a product's sub-tab header (icon + title) is now only clickable to open the Sample view when that tab is already active; clicking a non-active tab just switches tabs instead of navigating away.
- **Long collection names overflow the sidebar** — labels with a very long word no longer overflow the sidebar into the element list panel; they wrap (up to 2 lines) and stay readable instead of being clipped or blowing out the layout.
- **Sidebar collapse/expand button clipping** — fixed a regression introduced while fixing the above: the sidebar's own collapse/expand toggle was being clipped by the new overflow handling.
- **Element-detail header alert layout** — the "Structure Alert" and "you are viewing the original sample" notices no longer distort the panel header's height or get squeezed between the header buttons; they render as a full-width banner below the header row.
- **Element-list action-button wrapping** — in the narrow width range between icon-only and icon+text display, action buttons (Share, References, My labels, …) no longer wrap their label onto a second line and blow up out of alignment with the rest of the row; a button that doesn't fit now drops to a full second row instead.

---

Ruby testscript to generate test notifications (for testing the pagination fix):
```ruby
user_email = "complat.user1@eln.edu"
count = 40

receiver = User.find_by!(email: user_email)
sender = receiver

channel = Channel.find_by!(subject: Channel::SEND_INDIVIDUAL_USERS)

count.times do |i|
  Message.create_msg_notification(
    channel_id: channel.id,
    message_content: { data: "Test notification ##{i + 1}" },
    message_from: sender.id,
    message_to: [receiver.id],
  )
end

puts "Created #{count} notifications for #{receiver.email}"
```