### PR TITLE
fix(collections): keep the repository subtree nested, and make collection ownership personal

### DIFF
--- a/app/api/chemotion/collection_api.rb
+++ b/app/api/chemotion/collection_api.rb
@@ -10,6 +10,10 @@ module Chemotion
       error!(e.message, 403)
     end
 
+    rescue_from Usecases::Collections::Errors::CreateForbidden do |e|
+      error!(e.message, 403)
+    end
+
     resource :collections do
       get '/' do
         own_collections =

--- a/app/api/chemotion/reaction_api.rb
+++ b/app/api/chemotion/reaction_api.rb
@@ -290,7 +290,8 @@ module Chemotion
         # (reaction_id, collection_id) index when the chosen collection is the
         # user's "All" collection (both inserts would otherwise be identical).
         CollectionsReaction.find_or_create_by(reaction: reaction, collection: collection) if collection
-        CollectionsReaction.find_or_create_by(reaction: reaction, collection: all_collection)
+        # nil when the owning account has no "All" collection — a Group never gets one.
+        CollectionsReaction.find_or_create_by(reaction: reaction, collection: all_collection) if all_collection
         CollectionsReaction.update_tag_by_element_ids(reaction.id)
 
         if reaction

--- a/app/javascript/src/apps/mydb/collections/CollectionSubtree.js
+++ b/app/javascript/src/apps/mydb/collections/CollectionSubtree.js
@@ -92,12 +92,24 @@ function CollectionSubtree({
       UIActions.toggleCollectionManagement();
     }
 
+    // A locked node still toggles, since the locked containers are the ones worth folding away,
+    // but it must navigate too: "transferred" is locked and has no sub-collections, so toggling
+    // alone would leave the elements a gate transfer moved there unreachable. Expand on the way in
+    // and never collapse — folding the subtree shut on the node being selected reads as a failed
+    // click, and the chevron already has its own handler.
     if (node.is_locked) {
-      toggleExpansion(e, node);
+      if (!visible) toggleExpansion(e, node);
     } else {
       setVisible(visible || isVisible(node, uiState.currentCollection));
-      aviatorNavigationWithCollectionId(node.id, element?.type, (element?.isNew ? 'new' : element?.id), true, true);
     }
+
+    // The shared-with-me tree's owner rows are synthetic grouping nodes with no collection behind
+    // them (CollectionsStore.setSharedWithMeCollections gives them id 0). Keyed on the id rather
+    // than on is_locked, which is only incidentally true of them: navigating one would request
+    // /collections/0, 404, and clear the current collection.
+    if (!node.id) return;
+
+    aviatorNavigationWithCollectionId(node.id, element?.type, (element?.isNew ? 'new' : element?.id), true, true);
   };
 
   const handleTakeOwnershipKeyDown = (e) => {

--- a/app/javascript/src/apps/mydb/collections/ModalExportCollection.js
+++ b/app/javascript/src/apps/mydb/collections/ModalExportCollection.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import AppModal from 'src/components/common/AppModal';
 
 import { StoreContext } from 'src/stores/mobx/RootStore';
+import { SYSTEM_LABELS } from 'src/stores/mobx/CollectionsStore';
 import UserStore from 'src/stores/alt/stores/UserStore';
 
 function ModalExportCollection({ onHide }) {
@@ -61,7 +62,7 @@ function ModalExportCollection({ onHide }) {
     const nodes = collections.map((collection) => {
       const nodeKey = `${collection.id}-${collection.label}`;
 
-      if (collection.is_locked && !['All', 'chemotion-repository.net', 'transferred'].includes(collection.label)) {
+      if (collection.is_locked && !SYSTEM_LABELS.includes(collection.label)) {
         return (
           <li key={nodeKey}>
             <h6>{collection.label}</h6>

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -14,6 +14,15 @@ import {
   sampleAssociationMoveNotification
 } from 'src/utilities/notificationMessages';
 
+// The system collections every user has: created by the application, never by a user, and shown
+// outside the ordinary collection tree. Their labels are NOT reserved - a user can name a
+// collection "transferred", and a collection archive can carry one called "chemotion-repository.net"
+// - so a label match alone never identifies one; it always has to be paired with is_locked.
+export const ALL_LABEL = 'All';
+export const REPOSITORY_LABEL = 'chemotion-repository.net';
+export const TRANSFERRED_LABEL = 'transferred';
+export const SYSTEM_LABELS = [ALL_LABEL, REPOSITORY_LABEL, TRANSFERRED_LABEL];
+
 export const Collection = types.model({
   ancestry: types.string,
   children: types.array(types.late(() => Collection)),
@@ -470,29 +479,46 @@ export const CollectionsStore = types
       return { children, inserted }
     },
     setOwnCollections(collections) {
+      // Rebuilt from scratch on every pass, alongside the own_collections its callers clear, so
+      // neither the repository node's children nor the locked bucket accumulate across reloads.
+      self.chemotion_repository_collection = null;
+      self.locked_collection.clear();
       // basic presorting, so we can assume that parent objects are encountered before child objects when iterating the collection array
       collections.sort(presort);
       collections.forEach((collection) => {
-        if (collection.is_locked && ['All', 'chemotion-repository.net', 'transferred'].includes(collection.label)
+        if (collection.is_locked && SYSTEM_LABELS.includes(collection.label)
           && self.locked_collection.findIndex((c) => c.label === collection.label) === -1) {
-          self.locked_collection.push(Collection.create(collection))
+          self.locked_collection.push(Collection.create(collection));
         }
 
-        if (collection.is_locked && (collection.label == 'All' || (collection.label !== 'chemotion-repository.net'
-          && collection.label !== 'transferred'))) {
-          // do nothing and skip this collection
-        } else if (collection.label == 'chemotion-repository.net') {
-          self.chemotion_repository_collection = Collection.create(collection)
-        } else {
-          const collectionItem = Collection.create(collection)
-
-          const collectionTree =
-            (self.chemotion_repository_collection && collectionItem.ancestorIds.includes(self.chemotion_repository_collection.id))
-              ? self.chemotion_repository_collection.children
-              : self.own_collections
-
-          self.addCollectionToTree(collectionItem, collectionTree)
+        // Locked collections are system containers rendered outside the tree, except the repository
+        // root (its own sidebar section) and "transferred" (inside that section).
+        if (collection.is_locked && collection.label !== REPOSITORY_LABEL
+          && collection.label !== TRANSFERRED_LABEL) {
+          return;
         }
+        // Matched on is_locked as well as the label: the repository root is system-created and
+        // locked, but the label is not reserved, and a collection archive containing a collection
+        // of that name is recreated as an ordinary unlocked root on import. Keeping the first match
+        // makes a payload that somehow carries two resolve predictably rather than last-one-wins.
+        if (collection.label === REPOSITORY_LABEL && collection.is_locked) {
+          if (!self.chemotion_repository_collection) {
+            self.chemotion_repository_collection = Collection.create(collection);
+          }
+          return;
+        }
+
+        const collectionItem = Collection.create(collection);
+        // The repository node is held on its own field and never pushed into a node array, so its
+        // children cannot find it as a parent; the sidebar renders that array under a group header
+        // instead. Route them there rather than into own_collections, where a tree save would
+        // re-root them.
+        const collectionTree = (self.chemotion_repository_collection
+          && collectionItem.ancestorIds.includes(self.chemotion_repository_collection.id))
+          ? self.chemotion_repository_collection.children
+          : self.own_collections;
+
+        self.addCollectionToTree(collectionItem, collectionTree);
       });
     },
     setSharedWithMeCollections(collections) {
@@ -540,9 +566,13 @@ export const CollectionsStore = types
     addCollectionToTree(collection, collectionTree) {
       const parentIndex = collectionTree.findIndex(element => element.isAncestorOf(collection))
 
+      // A collection whose parent is not in this array is shown at the top of it rather than
+      // dropped, but its `ancestry` is deliberately left untouched: that field is the persisted
+      // parent pointer this store hands back to the server, not display state. Rewriting it here
+      // would silently promote the collection to a root on the next tree save. Callers that
+      // genuinely want to truncate a branch reset the ancestry themselves before calling in — see
+      // setSharedWithMeCollections.
       if (collection.isRootCollection || parentIndex === -1) {
-        if (parentIndex === -1 && !collection.isRootCollection) { collection.resetAncestry() }
-
         collectionTree.push(collection)
         collectionTree.sort((a, b) => {
           if (a.position != null && b.position != null) { return a.position - b.position }

--- a/app/jobs/move_to_collection_job.rb
+++ b/app/jobs/move_to_collection_job.rb
@@ -9,7 +9,13 @@ class MoveToCollectionJob < ApplicationJob
 
   def perform(id, msg = nil)
     col = Collection.find(id)
-    tr_col = col.children.find_or_create_by(user_id: col.user_id, label: 'transferred')
+    # is_locked goes in the block, not in the argument hash: that hash doubles as the lookup
+    # criteria, so passing it there would miss the existing (pre-lock) row and create a second one.
+    # The "transferred" node is system-managed like the "All" and repository roots it sits beside,
+    # and locking it is what keeps a collection-tree update from moving it out of that subtree.
+    tr_col = col.children.find_or_create_by(user_id: col.user_id, label: 'transferred') do |collection|
+      collection.is_locked = true
+    end
     move_col(col, tr_col)
     send_message(col.user_id, "operation completed. #{msg}", 'success')
   rescue StandardError => e
@@ -18,7 +24,9 @@ class MoveToCollectionJob < ApplicationJob
       message:  #{e.message}
       --------- gate move collection FAIL error message.END ---------------
     TXT
-    send_message(col.user_id, e.message, 'error')
+    # col is nil when Collection.find above is what raised; dereferencing it there would replace the
+    # real error with a NoMethodError and, since max_attempts is 1, lose it entirely.
+    send_message(col.user_id, e.message, 'error') if col
   end
 
   def move_col(col, tr_col)

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -65,9 +65,12 @@ class Collection < ApplicationRecord
 
   delegate :prefix, :name, to: :inventory, allow_nil: true, prefix: :inventory
 
+  # +is_locked+ is nullable with no NOT NULL constraint, and a NULL there is as unlocked as a
+  # false, so the two scopes are written to partition every row between them: +where(is_locked:
+  # false)+ would silently drop the NULL rows from both.
   scope :locked, -> { where(is_locked: true) }
   scope :ordered, -> { order('position ASC') }
-  scope :unlocked, -> { where(is_locked: false) }
+  scope :unlocked, -> { where('collections.is_locked IS NOT TRUE') }
 
   scope(
     :shared_with_more_than_one_user,
@@ -85,11 +88,10 @@ class Collection < ApplicationRecord
   scope(
     :accessible_for,
     lambda do |user|
-      user_and_group_ids = [user.id, *user.group_ids]
       left_joins(:collection_shares)
       .left_joins(:inventory)
-      .where(user_id: user_and_group_ids)
-      .or(where(collection_shares: { shared_with_id: user_and_group_ids }))
+      .where(user_id: user.id)
+      .or(where(collection_shares: { shared_with_id: [user.id, *user.group_ids] }))
       .distinct
     end,
   )
@@ -101,14 +103,13 @@ class Collection < ApplicationRecord
   scope(
     :writable_by,
     lambda do |user|
-      user_and_group_ids = [user.id, *user.group_ids]
       left_joins(:collection_shares)
       .left_joins(:inventory)
-      .where(user_id: user_and_group_ids)
+      .where(user_id: user.id)
       .or(
         where(
           collection_shares: {
-            shared_with_id: user_and_group_ids,
+            shared_with_id: [user.id, *user.group_ids],
             permission_level: CollectionShare.permission_level(:add_elements)..,
           },
         ),
@@ -117,20 +118,25 @@ class Collection < ApplicationRecord
     end,
   )
 
-  # temp for labimotion
+  # temp for labimotion — no caller in this app or in the labimotion gem; kept in step with
+  # +accessible_for+ so it cannot become the one place where a group still counts as an owner.
   scope(
     :belongs_to_or_shared_by,
     lambda do |user_ids, group_ids|
-      user_and_group_ids = [user_ids, group_ids]
       left_joins(:collection_shares)
       .left_joins(:inventory)
-      .where(user_id: user_and_group_ids)
-      .or(where(collection_shares: { shared_with_id: user_and_group_ids }))
+      .where(user_id: user_ids)
+      .or(where(collection_shares: { shared_with_id: [user_ids, group_ids] }))
       .distinct
     end,
   )
 
-  scope :own_collections_for, ->(user) { left_joins(:inventory).where(user_id: [user.id, *user.group_ids]) }
+  # Ownership is personal. A collection owned by a *group* is not owned by its members: they reach
+  # it, like anyone else, through a CollectionShare addressed to them or to one of their groups
+  # (+shared_collections_for+, +CollectionShare.shared_with+). Widening this to the user's groups
+  # would make every member able to rename, delete, re-parent and re-share the group's collections,
+  # and would pull the group's system-locked rows into each member's tree payload.
+  scope :own_collections_for, ->(user) { left_joins(:inventory).where(user_id: user.id) }
   scope(
     :serialized_own_collections_for,
     lambda do |user|
@@ -290,10 +296,10 @@ class Collection < ApplicationRecord
   # The level granted to an owner. Above every real rung, so an owner passes any threshold.
   OWNER_LEVEL = 10
 
-  # A collection owned by a group belongs to each of its members, which is how +own_collections_for+,
-  # +accessible_for+ and +writable_by+ all read it.
+  # Owned means owned by this user personally, matching +own_collections_for+. A group's collection
+  # is the group's; a member reaches it through a share, not through membership.
   def owned_by?(user)
-    user_id.in?([user.id, *user.group_ids])
+    user_id == user.id
   end
 
   # What +user+ effectively gets on this collection.

--- a/app/models/collection_share.rb
+++ b/app/models/collection_share.rb
@@ -56,7 +56,9 @@ class CollectionShare < ApplicationRecord
   belongs_to :collection
   belongs_to :shared_with, class_name: 'User'
 
-  scope :shared_by, ->(user) { joins(:collection).where(collections: { user_id: [user.id, *user.group_ids] }) }
+  # Shares on the user's *own* collections. Personal, like Collection#owned_by?: a share a group
+  # made is the group's to enumerate or revoke, not each member's.
+  scope :shared_by, ->(user) { joins(:collection).where(collections: { user_id: user.id }) }
 
   # Every share that grants +user+ access, including the ones held by their groups. Use for
   # *authorization* — never to decide what a user may destroy: a group's share is not theirs.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -496,7 +496,15 @@ class User < ApplicationRecord
   # - add subcollections
   # - delete it
 
+  # Every account type except +Group+ gets one. The "All" collection backs the MyDB element paths,
+  # and config/routes.rb routes a +Group+ session to the command-and-control view for `/`, `/group`,
+  # `/mydb` and `/mydb/*any`, so a group can never use one. This is deliberately narrower than
+  # +create_chemotion_public_collection+'s Person-only guard: +Admin+ subclasses +User+, not
+  # +Person+, and admins do hold and use an "All" collection — the element and import paths
+  # dereference it without a nil check.
   def create_all_collection
+    return if type == 'Group'
+
     Collection.create(user: self, label: 'All', position: 0, is_locked: true)
   end
 

--- a/app/policies/elements_policy.rb
+++ b/app/policies/elements_policy.rb
@@ -65,12 +65,21 @@ class ElementsPolicy
     record_ids_from_shared_collections.none?
   end
 
-  # A collection owned by one of the user's groups counts as their own, matching Collection#owned_by?,
-  # writable_by and the group-aware WithdrawElements/RemoveElements use cases. Without the group ids
-  # here, a group member acting on a group-owned collection would see every record fall through to
-  # "inaccessible", so remove_all?/destroy_all? would wrongly deny an action the backend permits.
+  # Ownership is personal, matching Collection#owned_by? and own_collections_for. A group's
+  # collections are not the member's: they must come through +scope_for_shared_records+ so the
+  # share's permission_level is actually consulted. Widening this to the user's groups short-circuits
+  # that — the records land in +scope_for_own_records+, are excluded from the shared scope, and
+  # update_all?/destroy_all? return true for a member holding only :read_elements.
   def own_user_ids
-    @own_user_ids ||= [user.id, *user.group_ids]
+    @own_user_ids ||= [user.id]
+  end
+
+  # The other half: who a share can be addressed to. A share held by one of the user's groups grants
+  # them access, which is the whole of what group membership does here — see
+  # CollectionShare.shared_with. Kept apart from +own_user_ids+ because the two mean different
+  # things; using one for both is what let membership stand in for ownership.
+  def shared_with_ids
+    @shared_with_ids ||= [user.id, *user.group_ids]
   end
 
   def scope_for_own_records
@@ -81,7 +90,7 @@ class ElementsPolicy
     records_scope
       .joins(collections: [:collection_shares])
       .where.not(collections: { user_id: own_user_ids }) # to prevent looking at circular shares
-      .where(collection_shares: { shared_with_id: own_user_ids })
+      .where(collection_shares: { shared_with_id: shared_with_ids })
       .distinct
   end
 

--- a/app/services/element_detail_level_calculator.rb
+++ b/app/services/element_detail_level_calculator.rb
@@ -101,9 +101,10 @@ class ElementDetailLevelCalculator
     detail_levels
   end
 
-  # taken from API#group_ids
+  # Personal ownership only, matching Collection#detail_levels_for_user. A group-owned collection
+  # grants a member nothing by membership; the share path below is what gives them a level.
   def user_ids
-    @user_ids ||= user.group_ids + [user.id]
+    @user_ids ||= [user.id]
   end
 
   def detail_level_for(key)

--- a/app/usecases/collections/create.rb
+++ b/app/usecases/collections/create.rb
@@ -34,10 +34,19 @@ module Usecases
 
       private
 
+      # A locked collection is a system container ("All", the repository root, "transferred"): its
+      # contents are system-managed, and {UpdateTree} refuses to move anything out of one *at any
+      # depth*, so a collection created anywhere inside would be stuck there for good. Hence the
+      # whole path is checked, not just the immediate parent.
+      #
+      # @raise [Errors::CreateForbidden] if the requested parent is, or sits inside, a locked collection
       def find_parent(parent_id)
-        return unless parent_id
+        parent = current_user.collections.find(parent_id) # NOTE: own collections only
+        if parent.path.any?(&:is_locked?)
+          raise Errors::CreateForbidden, 'Cannot create a collection inside a locked collection'
+        end
 
-        current_user.collections.find(parent_id) if parent_id.present? # NOTE: own collections only
+        parent
       end
 
       # TODO: how are inventories access controlled?

--- a/app/usecases/collections/errors.rb
+++ b/app/usecases/collections/errors.rb
@@ -4,6 +4,7 @@ module Usecases
   module Collections
     module Errors
       class UpdateForbidden < StandardError; end
+      class CreateForbidden < StandardError; end
       class InsufficientPermissionError < StandardError; end
     end
   end

--- a/app/usecases/collections/update_tree.rb
+++ b/app/usecases/collections/update_tree.rb
@@ -25,8 +25,31 @@ module Usecases
       # tree position are system-defined, so a bulk tree update may neither move nor rename them.
       # The frontend already omits them from the payload; a request that includes one anyway is
       # rejected wholesale via {#add_collection_and_children_to_linear_tree}.
+      #
+      # Everything *inside* a locked collection is excluded for the same reason: a tree payload
+      # places a collection by nesting, so accepting one would let a save lift it out of the locked
+      # container it was put in. That is how the repository root's "transferred" child escaped to
+      # the top level. The whole subtree is excluded, not just the direct children — a grandchild
+      # listed at the top level of a payload would escape exactly the same way.
+      #
+      # Returns a Set: this is checked once per node of the submitted tree.
       def collections_permitted_to_update
-        @collections_permitted_to_update ||= Collection.own_collections_for(current_user).unlocked.ids
+        @collections_permitted_to_update ||=
+          (Collection.own_collections_for(current_user).unlocked.ids - collections_inside_locked_containers).to_set
+      end
+
+      # Descendants of the user's locked collections, at any depth. +child_ancestry+ is the ancestry
+      # value this collection's children carry, so every descendant's ancestry starts with it.
+      #
+      # @return [Array<Integer>] ids of the collections nested inside a locked collection
+      def collections_inside_locked_containers
+        prefixes = Collection.own_collections_for(current_user).locked.map(&:child_ancestry)
+        return [] if prefixes.empty?
+
+        Collection.own_collections_for(current_user)
+                  .where(prefixes.map { 'collections.ancestry LIKE ?' }.join(' OR '),
+                         *prefixes.map { |prefix| "#{prefix}%" })
+                  .ids
       end
 
       def add_collection_and_children_to_linear_tree(collection, position:, parent_ids: [])

--- a/app/usecases/collections/withdraw_elements.rb
+++ b/app/usecases/collections/withdraw_elements.rb
@@ -38,10 +38,12 @@ module Usecases
       #   of their collections, whether or not the record was destroyed), keyed by the model
       #   +param_key+ — the shape the endpoint needs to close the matching detail tabs.
       def perform!(source_collection:, ui_state:, options: {})
-        # The user's own collections, spanning the groups they belong to (a group member could
-        # already destroy group-collection elements, so withdrawal keeps that reach). Restricting
-        # group-owned withdrawal to group-admins is a deliberate future refinement, not done here.
-        @owned_collection_ids = Collection.where(user_id: [current_user.id, *current_user.group_ids]).pluck(:id)
+        # The user's own collections, and only those. This used to span the groups they belong to,
+        # on the grounds that a group member could already destroy group-collection elements — which
+        # was true only because +own_collections_for+ counted a group's collections as its members'.
+        # Ownership is personal now, and withdrawal is destructive, so it does not reach into a
+        # group's collections; a member who should act on one gets a share.
+        @owned_collection_ids = Collection.where(user_id: current_user.id).pluck(:id)
         @locked_sample_ids = []
         removed = Hash.new { |hash, key| hash[key] = [] }
 

--- a/app/usecases/device_descriptions/create.rb
+++ b/app/usecases/device_descriptions/create.rb
@@ -25,10 +25,14 @@ module Usecases
           # (device_description_id, collection_id) index when the chosen
           # collection is already the user's "All" collection.
           CollectionsDeviceDescription.find_or_create_by(device_description: device_description, collection: collection)
-          CollectionsDeviceDescription.find_or_create_by(
-            device_description: device_description,
-            collection: all_collection,
-          )
+          # all_collection is nil when the owning account has no "All" collection — a Group never
+          # gets one — so there is no owner-side membership to add.
+          if all_collection
+            CollectionsDeviceDescription.find_or_create_by(
+              device_description: device_description,
+              collection: all_collection,
+            )
+          end
 
           device_description
         end

--- a/app/usecases/sbmm/sample.rb
+++ b/app/usecases/sbmm/sample.rb
@@ -70,8 +70,9 @@ module Usecases
         collections << collection
         user_and_group_ids = [current_user.id, *current_user.group_ids]
         all_coll_owner_id = user_and_group_ids.include?(collection.user_id) ? current_user.id : collection.user_id
+        # nil when the owning account has no "All" collection — a Group never gets one.
         collections << Collection.get_all_collection_for_user(all_coll_owner_id)
-        collections.uniq(&:id)
+        collections.compact.uniq(&:id)
       end
 
       def raise_if_sbmm_is_not_writable!(sbmm)

--- a/app/usecases/wellplates/create.rb
+++ b/app/usecases/wellplates/create.rb
@@ -25,10 +25,10 @@ module Usecases
           # find_or_create_by avoids violating the unique
           # (wellplate_id, collection_id) index when the chosen collection is
           # already the relevant "All" collection (it is attached on create above).
-          if collection_is_owned_by_user?
-            CollectionsWellplate.find_or_create_by(wellplate: wellplate, collection: all_collection_of_current_user)
-          elsif collection_is_shared_to_user?
-            CollectionsWellplate.find_or_create_by(wellplate: wellplate, collection: all_collection_of_sharer)
+          # The sharer's "All" is nil when they are a Group, which never gets one.
+          owner_all = collection_is_owned_by_user? ? all_collection_of_current_user : all_collection_of_sharer
+          if owner_all && (collection_is_owned_by_user? || collection_is_shared_to_user?)
+            CollectionsWellplate.find_or_create_by(wellplate: wellplate, collection: owner_all)
           end
 
           WellplateUpdater

--- a/db/migrate/20260806120000_lock_transferred_collections.rb
+++ b/db/migrate/20260806120000_lock_transferred_collections.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class LockTransferredCollections < ActiveRecord::Migration[6.1]
+  # The "transferred" collection MoveToCollectionJob creates under a user's locked
+  # "chemotion-repository.net" root is system-managed like the roots it sits beside, but it was
+  # created unlocked. Every guard that should keep it in place keys off is_locked —
+  # LockedCollectionGuard treats ancestry as immutable on a locked row, and
+  # Usecases::Collections::UpdateTree only accepts unlocked ids in a tree payload — so an unlocked
+  # "transferred" could be re-rooted by a collection-tree save and leave the repository subtree.
+  #
+  # The lock is written through SQL: LockedCollectionGuard rejects changes to is_locked on a locked
+  # row, and this statement is what makes these rows locked.
+  #
+  # "transferred" is not a reserved label — a user can create their own collection with that name —
+  # so the lock is keyed on the parent being a locked repository root, never on the label alone. That
+  # narrows it but does not make it exact: a row a user placed directly under their repository root
+  # and named "transferred" is indistinguishable from the job's, and locking it makes it permanently
+  # un-renamable and un-deletable. Accepted here, unlike for the root-level case below, because no UI
+  # path offers that parent (the repository root is a sidebar header, not a node in the collection
+  # tree) and +Usecases::Collections::Create+ now refuses a locked parent outright, so the population
+  # is bounded to rows created through the API before this change.
+  # +is_locked IS NOT TRUE+ rather than += false+: the column is nullable with no NOT NULL
+  # constraint, and a NULL there is as unlocked as a false.
+
+  REPOSITORY_LABEL = 'chemotion-repository.net'
+  TRANSFERRED_LABEL = 'transferred'
+
+  def up
+    report_root_level_candidates
+
+    say_with_time 'locking "transferred" collections under a locked repository root' do
+      execute(<<~SQL.squish)
+        UPDATE collections c
+        SET is_locked = true
+        FROM collections repo
+        WHERE c.label = '#{TRANSFERRED_LABEL}'
+          AND c.is_locked IS NOT TRUE
+          AND c.deleted_at IS NULL
+          AND c.ancestry = '/' || repo.id || '/'
+          AND repo.label = '#{REPOSITORY_LABEL}'
+          AND repo.is_locked
+          AND repo.deleted_at IS NULL;
+      SQL
+    end
+  end
+
+  private
+
+  # Reported, never moved. A root-level collection labelled "transferred" is indistinguishable from
+  # one a user created themselves — the label is not reserved — and re-parenting somebody's own
+  # collection into the repository subtree and locking it there is worse than leaving an escaped one
+  # where it is, especially as #down cannot tell the two apart either.
+  def report_root_level_candidates
+    escaped = select_values(<<~SQL.squish)
+      SELECT c.id FROM collections c
+      WHERE c.label = '#{TRANSFERRED_LABEL}'
+        AND c.ancestry = '/'
+        AND c.is_locked IS NOT TRUE
+        AND c.deleted_at IS NULL
+        AND EXISTS (
+          SELECT 1 FROM collections repo
+          WHERE repo.user_id = c.user_id
+            AND repo.label = '#{REPOSITORY_LABEL}'
+            AND repo.is_locked
+            AND repo.deleted_at IS NULL
+        )
+    SQL
+    escaped.each do |id|
+      say "collection ##{id} is a root-level \"transferred\" collection: check by hand whether it " \
+          'escaped the repository subtree and belongs back under it'
+    end
+  end
+
+  def down
+    # Raised rather than logged: a `down` that returns normally reports success and drops the
+    # schema_migrations row while the data change stays applied.
+    raise ActiveRecord::IrreversibleMigration,
+          'LockTransferredCollections is not reversible (locked rows are indistinguishable).'
+  end
+end

--- a/db/migrate/20260810120000_remove_group_repository_collections.rb
+++ b/db/migrate/20260810120000_remove_group_repository_collections.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+class RemoveGroupRepositoryCollections < ActiveRecord::Migration[6.1]
+  # A "chemotion-repository.net" collection belongs to a person, not to a group account.
+  # User#create_chemotion_public_collection has returned early unless the user is a +Person+ for
+  # years, so no new one can appear; what is left are legacy rows from before that guard.
+  #
+  # They are not merely redundant. +Collection.own_collections_for+ resolves a user's collections as
+  # `user_id IN (self, *group_ids)`, so a member of such a group receives several collections
+  # labelled "chemotion-repository.net" in one payload, and the collection store keeps a single
+  # +chemotion_repository_collection+. The group-owned row could take that field over, and the
+  # member's own repository subtree — the "transferred" collection a gate transfer fills — was then
+  # routed into their ordinary collections, shown at the top level, and re-rooted by the next tree
+  # save.
+  #
+  # Soft-deleted rather than destroyed: +Collection+ is +acts_as_paranoid+, so writing +deleted_at+
+  # is what +#delete+ does, the row stays recoverable through +Collection.only_deleted+, and no
+  # callback runs (+LockedCollectionGuard+ aborts +destroy+ on a locked collection).
+  #
+  # Only rows that hold nothing are touched — no child collections and no elements — so a group row
+  # that unexpectedly has content is reported and left for a human rather than taking it out of
+  # reach. +is_locked+ is required as well: the label is not reserved, and an ordinary collection a
+  # user made or a collection archive recreated under that name is not this migration's business.
+
+  REPOSITORY_LABEL = 'chemotion-repository.net'
+
+  # Every join table an element can sit in; mirrors
+  # 20260713120000_backfill_missing_all_collection_memberships.
+  ELEMENT_JOIN_TABLES = %w[
+    collections_samples
+    collections_reactions
+    collections_wellplates
+    collections_screens
+    collections_research_plans
+    collections_celllines
+    collections_device_descriptions
+    collections_sequence_based_macromolecule_samples
+    collections_elements
+    collections_vessels
+  ].freeze
+
+  def up
+    kept = select_values(<<~SQL.squish)
+      SELECT c.id FROM collections c
+      JOIN users u ON u.id = c.user_id AND u.type = 'Group'
+      WHERE c.label = '#{REPOSITORY_LABEL}'
+        AND c.is_locked
+        AND c.deleted_at IS NULL
+        AND NOT (#{empty_predicate})
+    SQL
+    kept.each { |id| say "keeping group repository collection ##{id}: it still holds content" }
+
+    say_with_time 'soft-deleting the empty repository collections of group accounts' do
+      execute(<<~SQL.squish)
+        UPDATE collections c
+        SET deleted_at = NOW()
+        FROM users u
+        WHERE u.id = c.user_id
+          AND u.type = 'Group'
+          AND c.label = '#{REPOSITORY_LABEL}'
+          AND c.is_locked
+          AND c.deleted_at IS NULL
+          AND #{empty_predicate};
+      SQL
+    end
+  end
+
+  def down
+    # Raised rather than logged: a `down` that returns normally reports success and drops the
+    # schema_migrations row while the data change stays applied.
+    raise ActiveRecord::IrreversibleMigration,
+          'RemoveGroupRepositoryCollections is not reversible (its soft deletes are indistinguishable).'
+  end
+
+  private
+
+  # True for a collection that holds neither sub-collections nor elements.
+  def empty_predicate
+    <<~SQL.squish
+      NOT EXISTS (
+        SELECT 1 FROM collections k WHERE k.ancestry = '/' || c.id || '/' AND k.deleted_at IS NULL
+      )
+      #{ELEMENT_JOIN_TABLES.map do |table|
+        "AND NOT EXISTS (SELECT 1 FROM #{table} j WHERE j.collection_id = c.id AND j.deleted_at IS NULL)"
+      end.join(' ')}
+    SQL
+  end
+end

--- a/db/migrate/20260811120000_remove_group_all_collections.rb
+++ b/db/migrate/20260811120000_remove_group_all_collections.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+class RemoveGroupAllCollections < ActiveRecord::Migration[6.1]
+  # The "All" collection exists to back the MyDB element paths — every element its owner owns is a
+  # member of it. A group account never renders MyDB: config/routes.rb routes a +Group+ session to
+  # the command-and-control view for `/`, `/group`, `/mydb` and `/mydb/*any`. So a group's "All" has
+  # never been reachable by anybody, and +User#create_all_collection+ no longer makes one.
+  #
+  # It was not merely unused, either. Until ownership was narrowed to the user,
+  # +Collection.own_collections_for+ resolved a user's collections as `user_id IN (self, *group_ids)`,
+  # so a group's locked "All" arrived in every member's tree payload.
+  #
+  # Same shape and the same reasoning as 20260810120000_remove_group_repository_collections: a
+  # soft delete (+Collection+ is +acts_as_paranoid+, and +LockedCollectionGuard+ aborts +destroy+ on
+  # a locked row), only rows that hold nothing, anything with content reported and left alone, and
+  # an irreversible +down+ because nothing on the row distinguishes these soft deletes from anyone
+  # else's.
+
+  ALL_LABEL = 'All'
+
+  # Every join table an element can sit in; mirrors
+  # 20260713120000_backfill_missing_all_collection_memberships.
+  ELEMENT_JOIN_TABLES = %w[
+    collections_samples
+    collections_reactions
+    collections_wellplates
+    collections_screens
+    collections_research_plans
+    collections_celllines
+    collections_device_descriptions
+    collections_sequence_based_macromolecule_samples
+    collections_elements
+    collections_vessels
+  ].freeze
+
+  def up
+    kept = select_values(<<~SQL.squish)
+      SELECT c.id FROM collections c
+      JOIN users u ON u.id = c.user_id AND u.type = 'Group'
+      WHERE c.label = '#{ALL_LABEL}'
+        AND c.is_locked
+        AND c.deleted_at IS NULL
+        AND NOT (#{empty_predicate})
+    SQL
+    kept.each { |id| say "keeping group \"#{ALL_LABEL}\" collection ##{id}: it still holds content" }
+
+    say_with_time 'soft-deleting the empty "All" collections of group accounts' do
+      execute(<<~SQL.squish)
+        UPDATE collections c
+        SET deleted_at = NOW()
+        FROM users u
+        WHERE u.id = c.user_id
+          AND u.type = 'Group'
+          AND c.label = '#{ALL_LABEL}'
+          AND c.is_locked
+          AND c.deleted_at IS NULL
+          AND #{empty_predicate};
+      SQL
+    end
+  end
+
+  def down
+    # Raised rather than logged: a `down` that returns normally reports success and drops the
+    # schema_migrations row while the data change stays applied.
+    raise ActiveRecord::IrreversibleMigration,
+          'RemoveGroupAllCollections is not reversible (its soft deletes are indistinguishable).'
+  end
+
+  private
+
+  # True for a collection that holds neither sub-collections nor elements.
+  def empty_predicate
+    <<~SQL.squish
+      NOT EXISTS (
+        SELECT 1 FROM collections k WHERE k.ancestry = '/' || c.id || '/' AND k.deleted_at IS NULL
+      )
+      #{ELEMENT_JOIN_TABLES.map do |table|
+        "AND NOT EXISTS (SELECT 1 FROM #{table} j WHERE j.collection_id = c.id AND j.deleted_at IS NULL)"
+      end.join(' ')}
+    SQL
+  end
+end

--- a/spec/api/chemotion/element_api_spec.rb
+++ b/spec/api/chemotion/element_api_spec.rb
@@ -33,14 +33,27 @@ describe Chemotion::ElementAPI do
       end
     end
 
-    # own_collections_for spans group_ids, so a group's collection is its members'. The gate used to
-    # ask `current_user.collections`, miss it, and fall through to the share lookup.
+    # Membership is not ownership: a group's collection is the group's. This endpoint withdraws the
+    # selection from the user's *own* collections, so a member has nothing here to withdraw and
+    # falls through to the shared-collection branch, which refuses DELETE outright.
     context 'when the collection belongs to a group the user is a member of' do
       let(:collection) { create(:collection, user: group) }
 
-      it 'deletes the selected element' do
+      it 'does not resolve the collection at all when nothing is shared' do
         expect { delete '/api/v1/ui_state/', params: params, as: :json }
-          .to change(Sample, :count).by(-1)
+          .not_to change(Sample, :count)
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'refuses the delete when the collection is shared to the group' do
+        create(:collection_share, collection: collection, shared_with: group,
+                                  permission_level: CollectionShare.permission_level(:remove_elements))
+
+        expect { delete '/api/v1/ui_state/', params: params, as: :json }
+          .not_to change(Sample, :count)
+
+        expect(response).to have_http_status(:forbidden)
       end
     end
 

--- a/spec/db/migrate/20260806120000_lock_transferred_collections_spec.rb
+++ b/spec/db/migrate/20260806120000_lock_transferred_collections_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+load Rails.root.join('db/migrate/20260806120000_lock_transferred_collections.rb').to_s
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'migration 20260806120000: LockTransferredCollections' do
+  let(:user) { create(:person) }
+  # create_chemotion_public_collection already gives every Person a locked repository root; use it
+  # rather than building a second one, so the fixtures match real data.
+  let(:repository_root) do
+    Collection.find_by!(user_id: user.id, label: 'chemotion-repository.net', is_locked: true)
+  end
+
+  describe 'a "transferred" collection already nested under the repository root' do
+    let!(:transferred) do
+      create(:collection, user: user, label: 'transferred', parent: repository_root)
+    end
+
+    it 'is locked in place' do
+      LockTransferredCollections.new.up
+
+      expect(transferred.reload).to have_attributes(is_locked: true, parent_id: repository_root.id)
+    end
+  end
+
+  # A root-level collection with this label may be one that escaped the repository subtree or one
+  # the user created themselves - the label is not reserved and nothing in the row distinguishes
+  # them - so the migration reports it and touches nothing.
+  describe 'a root-level "transferred" collection' do
+    let!(:root_level) { create(:collection, user: user, label: 'transferred', position: 4) }
+
+    it 'is left exactly as it is' do
+      LockTransferredCollections.new.up
+
+      expect(root_level.reload).to have_attributes(ancestry: '/', is_locked: false)
+    end
+  end
+
+  describe 'a "transferred" collection whose is_locked is NULL' do
+    let!(:null_locked) do
+      create(:collection, user: user, label: 'transferred', parent: repository_root)
+                         .tap { |c| c.update_column(:is_locked, nil) }
+    end
+
+    it 'is locked too - a NULL flag is as unlocked as a false one' do
+      LockTransferredCollections.new.up
+
+      expect(null_locked.reload.is_locked).to be(true)
+    end
+  end
+
+  describe 'running twice' do
+    let!(:transferred) do
+      create(:collection, user: user, label: 'transferred', parent: repository_root)
+    end
+
+    it 'is idempotent' do
+      LockTransferredCollections.new.up
+      expect { LockTransferredCollections.new.up }.not_to raise_error
+
+      expect(transferred.reload).to have_attributes(is_locked: true, parent_id: repository_root.id)
+    end
+  end
+
+  describe 'a "transferred" collection outside the repository subtree' do
+    let!(:other_parent) { create(:collection, user: user, label: 'Some project') }
+    let!(:sub_collection) do
+      create(:collection, user: user, label: 'transferred', parent: other_parent)
+    end
+
+    it 'is not locked' do
+      LockTransferredCollections.new.up
+
+      expect(sub_collection.reload).to have_attributes(is_locked: false, parent_id: other_parent.id)
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/db/migrate/20260810120000_remove_group_repository_collections_spec.rb
+++ b/spec/db/migrate/20260810120000_remove_group_repository_collections_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+load Rails.root.join('db/migrate/20260810120000_remove_group_repository_collections.rb').to_s
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'migration 20260810120000: RemoveGroupRepositoryCollections' do
+  let(:group) { create(:group) }
+  let(:person) { create(:person) }
+  # User#create_chemotion_public_collection returns early for a Group, so a group's repository
+  # collection can only be a legacy row; build it the way the pre-guard code did.
+  let!(:group_repository) do
+    Collection.create!(user: group, label: 'chemotion-repository.net', position: 1, is_locked: true)
+  end
+
+  it "soft-deletes a group account's repository collection" do
+    RemoveGroupRepositoryCollections.new.up
+
+    expect(Collection.exists?(group_repository.id)).to be(false)
+    expect(Collection.only_deleted.exists?(group_repository.id)).to be(true)
+  end
+
+  it "leaves a person's repository collection alone" do
+    person_repository = Collection.find_by!(user_id: person.id, label: 'chemotion-repository.net')
+
+    RemoveGroupRepositoryCollections.new.up
+
+    expect(person_repository.reload.deleted_at).to be_nil
+  end
+
+  context 'when the group row unexpectedly has children' do
+    let!(:child) { create(:collection, user: group, label: 'Kept', parent: group_repository) }
+
+    it 'keeps it rather than putting the subtree out of reach' do
+      RemoveGroupRepositoryCollections.new.up
+
+      expect(Collection.exists?(group_repository.id)).to be(true)
+      expect(child.reload.parent_id).to eq(group_repository.id)
+    end
+  end
+
+  context 'when the group row is an ordinary unlocked collection with that label' do
+    # A collection archive recreates collections under their original labels and never locks them,
+    # so a group can own real user data called "chemotion-repository.net".
+    let!(:imported) { create(:collection, user: group, label: 'chemotion-repository.net') }
+
+    it 'is left alone' do
+      RemoveGroupRepositoryCollections.new.up
+
+      expect(imported.reload.deleted_at).to be_nil
+    end
+  end
+
+  context 'when the group row holds elements' do
+    let!(:sample) { create(:sample, collections: [group_repository]) }
+
+    it 'keeps it rather than orphaning the elements' do
+      RemoveGroupRepositoryCollections.new.up
+
+      expect(Collection.exists?(group_repository.id)).to be(true)
+      expect(sample.reload.collections).to include(group_repository)
+    end
+  end
+
+  it 'refuses to roll back rather than reporting a restore it cannot make' do
+    RemoveGroupRepositoryCollections.new.up
+
+    expect { RemoveGroupRepositoryCollections.new.down }.to raise_error(ActiveRecord::IrreversibleMigration)
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/db/migrate/20260811120000_remove_group_all_collections_spec.rb
+++ b/spec/db/migrate/20260811120000_remove_group_all_collections_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+load Rails.root.join('db/migrate/20260811120000_remove_group_all_collections.rb').to_s
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'migration 20260811120000: RemoveGroupAllCollections' do
+  let(:group) { create(:group) }
+  let(:person) { create(:person) }
+  # User#create_all_collection is Person-only now, so a group's "All" can only be a legacy row;
+  # build it the way the pre-guard code did.
+  let!(:group_all) do
+    Collection.create!(user: group, label: 'All', position: 0, is_locked: true)
+  end
+
+  it "soft-deletes a group account's empty All collection" do
+    RemoveGroupAllCollections.new.up
+
+    expect(Collection.exists?(group_all.id)).to be(false)
+    expect(Collection.only_deleted.exists?(group_all.id)).to be(true)
+  end
+
+  it "leaves a person's All collection alone" do
+    person_all = Collection.get_all_collection_for_user(person.id)
+
+    RemoveGroupAllCollections.new.up
+
+    expect(person_all.reload.deleted_at).to be_nil
+  end
+
+  context 'when the group row holds elements' do
+    let!(:sample) { create(:sample, collections: [group_all]) }
+
+    it 'keeps it rather than orphaning them' do
+      RemoveGroupAllCollections.new.up
+
+      expect(Collection.exists?(group_all.id)).to be(true)
+      expect(sample.reload.collections).to include(group_all)
+    end
+  end
+
+  context 'when the group row has a child collection' do
+    let!(:child) { create(:collection, user: group, label: 'Kept', parent: group_all) }
+
+    it 'keeps it rather than putting the subtree out of reach' do
+      RemoveGroupAllCollections.new.up
+
+      expect(Collection.exists?(group_all.id)).to be(true)
+      expect(child.reload.parent_id).to eq(group_all.id)
+    end
+  end
+
+  it 'refuses to roll back rather than reporting a restore it cannot make' do
+    RemoveGroupAllCollections.new.up
+
+    expect { RemoveGroupAllCollections.new.down }.to raise_error(ActiveRecord::IrreversibleMigration)
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/javascripts/stores/mobx/CollectionsStore.spec.js
+++ b/spec/javascripts/stores/mobx/CollectionsStore.spec.js
@@ -2,6 +2,7 @@
 import expect from 'expect';
 import sinon from 'sinon';
 import { RootStore } from 'src/stores/mobx/RootStore';
+import { Collection } from 'src/stores/mobx/CollectionsStore';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
 import CollectionElementsFetcher from 'src/fetchers/CollectionElementsFetcher';
 import CollectionsFetcher from 'src/fetchers/CollectionsFetcher';
@@ -240,6 +241,66 @@ describe('CollectionsStore', () => {
         [1, 'Original Label'],
       ]);
       expect(store.update_tree).toBe(false);
+    });
+  });
+
+  // The repository subtree is the one place where the array being built cannot contain the node's
+  // parent (the repository collection is held on its own store field, never pushed into its own
+  // `children`). Routing a `transferred` collection into `own_collections` instead is what put it
+  // into the collection-management payload, where UpdateTree persisted it as a root.
+  describe('.setOwnCollections', () => {
+    const repositoryRoot = {
+      id: 1, label: 'chemotion-repository.net', ancestry: '/', position: null, is_locked: true,
+    };
+    // an ordinary collection an archive import recreated under the same label
+    const importedDuplicate = {
+      id: 2, label: 'chemotion-repository.net', ancestry: '/', position: 3, is_locked: false,
+    };
+    const transferred = {
+      id: 3, label: 'transferred', ancestry: '/1/', position: null, is_locked: false,
+    };
+
+    it('keeps the repository subtree out of own_collections when a duplicate label exists', () => {
+      store.setOwnCollections([repositoryRoot, importedDuplicate, transferred]);
+
+      expect(store.chemotion_repository_collection.id).toEqual(1);
+      expect(store.chemotion_repository_collection.children.map((c) => c.id)).toEqual([3]);
+      expect(store.own_collections.map((c) => c.id)).not.toContain(3);
+    });
+
+    it('surfaces the unlocked duplicate as an ordinary collection', () => {
+      store.setOwnCollections([repositoryRoot, importedDuplicate, transferred]);
+
+      expect(store.own_collections.map((c) => c.id)).toEqual([2]);
+    });
+
+    // The state the lock migration leaves behind: is_locked takes a different arm of the skip
+    // condition, and the collection must still reach the repository subtree rather than vanish.
+    it('routes a locked "transferred" into the repository subtree', () => {
+      store.setOwnCollections([repositoryRoot, { ...transferred, is_locked: true }]);
+
+      expect(store.chemotion_repository_collection.children.map((c) => c.id)).toEqual([3]);
+      expect(store.own_collections.map((c) => c.id)).toEqual([]);
+    });
+
+    it('rebuilds the repository node on each pass instead of accumulating children', () => {
+      store.setOwnCollections([repositoryRoot, transferred]);
+      store.setOwnCollections([repositoryRoot, transferred]);
+
+      expect(store.chemotion_repository_collection.children.map((c) => c.id)).toEqual([3]);
+    });
+  });
+
+  describe('.addCollectionToTree', () => {
+    it('shows a collection whose parent is missing without rewriting its ancestry', () => {
+      const orphan = Collection.create({
+        id: 9, label: 'transferred', ancestry: '/1/', position: null, is_locked: false,
+      });
+
+      store.addCollectionToTree(orphan, store.own_collections);
+
+      expect(store.own_collections.map((c) => c.id)).toEqual([9]);
+      expect(store.own_collections[0].ancestry).toEqual('/1/');
     });
   });
 });

--- a/spec/jobs/move_to_collection_job_spec.rb
+++ b/spec/jobs/move_to_collection_job_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MoveToCollectionJob do
+  let(:user) { create(:person) }
+  # GatePushButton is rendered with the repository collection's id (CollectionTree.js), so the id
+  # this job receives is always the user's locked "chemotion-repository.net" root - the same shape
+  # the lock migration and LockedCollectionGuard both key on.
+  let(:source_collection) do
+    Collection.find_by!(user_id: user.id, label: 'chemotion-repository.net', is_locked: true)
+  end
+
+  describe '#perform' do
+    it 'creates the "transferred" collection locked, under the locked repository root' do
+      described_class.new.perform(source_collection.id)
+
+      transferred = source_collection.children.find_by(label: 'transferred')
+      expect(transferred).to have_attributes(is_locked: true, user_id: user.id)
+    end
+
+    it 'reuses an existing "transferred" collection instead of creating a second one' do
+      described_class.new.perform(source_collection.id)
+      described_class.new.perform(source_collection.id)
+
+      expect(source_collection.children.where(label: 'transferred').count).to eq(1)
+    end
+  end
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -221,6 +221,68 @@ RSpec.describe Collection do
     end
   end
 
+  # Ownership is personal; group membership reaches a collection only through a share. These pin
+  # the rule at the scope level, where every API path picks it up.
+  # `.reorder(nil)` on the .distinct scopes below: Collection's default_scope orders by position,
+  # and Postgres rejects SELECT DISTINCT with an ORDER BY column that is not selected. The API
+  # callers use find/find_by rather than .ids, so they never meet it.
+  describe 'ownership versus group membership' do
+    let(:user) { create(:person) }
+    let(:group) { create(:group, users: [user]) }
+    let!(:own_collection) { create(:collection, user: user) }
+    let!(:group_collection) { create(:collection, user: group) }
+
+    describe '.own_collections_for' do
+      it "returns the user's own collections" do
+        expect(described_class.own_collections_for(user).ids).to include(own_collection.id)
+      end
+
+      it "excludes a collection owned by the user's group" do
+        expect(described_class.own_collections_for(user).ids).not_to include(group_collection.id)
+      end
+    end
+
+    describe '.accessible_for' do
+      it 'excludes a group-owned collection that is not shared' do
+        expect(described_class.accessible_for(user).reorder(nil).ids).not_to include(group_collection.id)
+      end
+
+      it 'includes it once it is shared to the group' do
+        create(:collection_share, collection: group_collection, shared_with: group,
+                                  permission_level: CollectionShare.permission_level(:read_elements))
+
+        expect(described_class.accessible_for(user).reorder(nil).ids).to include(group_collection.id)
+      end
+    end
+
+    describe '.writable_by' do
+      it 'excludes a group-owned collection shared below add_elements' do
+        create(:collection_share, collection: group_collection, shared_with: group,
+                                  permission_level: CollectionShare.permission_level(:read_elements))
+
+        expect(described_class.writable_by(user).reorder(nil).ids).not_to include(group_collection.id)
+      end
+
+      it 'includes it when shared to the group at add_elements' do
+        create(:collection_share, collection: group_collection, shared_with: group,
+                                  permission_level: CollectionShare.permission_level(:add_elements))
+
+        expect(described_class.writable_by(user).reorder(nil).ids).to include(group_collection.id)
+      end
+    end
+
+    describe '.shared_collections_for' do
+      it 'still resolves a share addressed to the group' do
+        create(:collection_share, collection: own_collection, shared_with: group,
+                                  permission_level: CollectionShare.permission_level(:read_elements))
+        other_member = create(:person)
+        group.users << other_member
+
+        expect(described_class.shared_collections_for(other_member).reorder(nil).ids).to include(own_collection.id)
+      end
+    end
+  end
+
   describe '#detail_levels_for_user' do
     let(:owner) { create(:person) }
     let(:user) { create(:person) }
@@ -236,13 +298,22 @@ RSpec.describe Collection do
       expect(own_collection.detail_levels_for_user(user)).to eq(all_owner_levels)
     end
 
-    # own_collections_for / accessible_for / writable_by all treat a group's collection as its
-    # members'. This used to compare `collection.user != current_user` and fall through to zeros.
-    it 'grants a group member every level on a collection owned by that group' do
+    # A group's collection is the group's. Membership is not ownership: a member reaches it the way
+    # anyone else does, through a share addressed to them or to one of their groups.
+    it 'grants a group member nothing on a collection owned by that group' do
       group_collection = create(:collection, user: group)
 
-      expect(group_collection.detail_levels_for_user(user)).to eq(all_owner_levels)
-      expect(group_collection.owned_by?(user)).to be true
+      expect(group_collection.detail_levels_for_user(user)).to eq(all_zero)
+      expect(group_collection.owned_by?(user)).to be false
+    end
+
+    it 'grants a group member the shared levels once that collection is shared to the group' do
+      group_collection = create(:collection, user: group)
+      create(:collection_share, collection: group_collection, shared_with: group,
+                                permission_level: CollectionShare.permission_level(:read_elements),
+                                sample_detail_level: 3)
+
+      expect(group_collection.detail_levels_for_user(user)[:sample_detail_level]).to eq(3)
     end
 
     it 'returns zeros when the user has neither ownership nor a share' do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -66,8 +66,11 @@ RSpec.describe 'Group', type: :model do
       expect(group.type).to eq 'Group'
     end
 
-    it 'creates an All collection' do
-      expect(group.collections.pluck(:label)).to match_array ['All']
+    # A group gets no collections at all: the "All" collection backs the MyDB element paths, and
+    # config/routes.rb routes a Group session to the command-and-control view for /mydb, so it can
+    # never be used. Same reasoning as the repository collection, which has always been Person-only.
+    it 'creates no collections' do
+      expect(group.collections).to be_empty
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -139,6 +139,14 @@ RSpec.describe User do
       expect(user.collections.find_by(label: 'All', is_locked: true)).not_to be_nil
     end
 
+    # The All collection backs the MyDB element paths, and config/routes.rb sends a Group session to
+    # the command-and-control view for /mydb, so a group can never use one.
+    it 'creates no All collection for a group' do
+      group = create(:group)
+
+      expect(group.collections.find_by(label: 'All')).to be_nil
+    end
+
     it 'reset email after soft deletion' do
       user_deleted.destroy!
       expect(User.with_deleted.find_by(email: 'user_deleted@eln.edu')).to be_nil

--- a/spec/policies/elements_policy_spec.rb
+++ b/spec/policies/elements_policy_spec.rb
@@ -149,26 +149,32 @@ RSpec.describe ElementsPolicy do
     end
   end
 
-  # Regression: a collection owned by one of the user's groups is their own (Collection#owned_by?),
-  # so a group member may remove/destroy its elements. Without a group-aware own scope the policy
-  # denied it, and SelectionActions greyed out Move for every group collection.
+  # Membership is not ownership (Collection#owned_by?): a group's collection reaches its members
+  # through a share, so the share's permission_level decides. Counting it as own would skip that
+  # check entirely — the records land in the own scope, are excluded from the shared scope, and
+  # every bulk permission returns true regardless of the level granted.
   describe 'a group-owned collection' do
     let(:group) { create(:group, users: [user_1]) }
     let(:group_collection) { create(:collection, user: group) }
     let(:group_sample) { create(:sample, creator: user_1, collections: [group_collection]) }
+    let(:policy) { described_class.new(user_1, Sample.where(id: [group_sample.id])) }
 
     before { group_sample }
 
-    it 'counts as the member\'s own for #remove_all?' do
-      policy = described_class.new(user_1, Sample.where(id: [group_sample.id]))
-
-      expect(policy.remove_all?).to be true
+    it 'is not the member\'s own for #remove_all?' do
+      expect(policy.remove_all?).to be false
     end
 
-    it 'counts as the member\'s own for #destroy_all?' do
-      policy = described_class.new(user_1, Sample.where(id: [group_sample.id]))
+    it 'is not the member\'s own for #destroy_all?' do
+      expect(policy.destroy_all?).to be false
+    end
 
-      expect(policy.destroy_all?).to be true
+    it 'grants what the share to the group grants, and no more' do
+      create(:collection_share, collection: group_collection, shared_with: group,
+                                permission_level: CollectionShare.permission_level(:read_elements))
+
+      expect(policy.remove_all?).to be false
+      expect(policy.read_all?).to be true
     end
   end
 end

--- a/spec/usecases/collections/create_spec.rb
+++ b/spec/usecases/collections/create_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Usecases::Collections::Create do
+  let(:user) { create(:person) }
+  let(:usecase) { described_class.new(user) }
+  let(:repository_root) do
+    Collection.find_by!(user_id: user.id, label: 'chemotion-repository.net', is_locked: true)
+  end
+
+  describe '#perform!' do
+    it 'creates a root collection' do
+      collection = usecase.perform!(parent_id: nil, label: 'Project', inventory_id: nil)
+
+      expect(collection).to have_attributes(label: 'Project', ancestry: '/', is_locked: false)
+    end
+
+    it 'creates a sub-collection under an ordinary parent' do
+      parent = create(:collection, user: user, label: 'Parent')
+
+      collection = usecase.perform!(parent_id: parent.id, label: 'Child', inventory_id: nil)
+
+      expect(collection.parent_id).to eq(parent.id)
+    end
+
+    # UpdateTree refuses to move anything out of a locked container, so a collection created inside
+    # one could never be moved back out.
+    it 'refuses a locked parent' do
+      expect do
+        usecase.perform!(parent_id: repository_root.id, label: 'Child', inventory_id: nil)
+      end.to raise_error(Usecases::Collections::Errors::CreateForbidden)
+    end
+  end
+end

--- a/spec/usecases/collections/update_tree_spec.rb
+++ b/spec/usecases/collections/update_tree_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Usecases::Collections::UpdateTree do
+  let(:user) { create(:person) }
+  let(:usecase) { described_class.new(user) }
+  # Every Person gets this locked root from User#create_chemotion_public_collection.
+  let(:repository_root) do
+    Collection.find_by!(user_id: user.id, label: 'chemotion-repository.net', is_locked: true)
+  end
+
+  describe '#perform!' do
+    let!(:first) { create(:collection, user: user, label: 'First', position: 1) }
+    let!(:second) { create(:collection, user: user, label: 'Second', position: 2) }
+
+    it 'reparents and renumbers the collections it is given' do
+      usecase.perform!(collections: [{ id: first.id, label: 'First', children: [{ id: second.id, label: 'Second' }] }])
+
+      expect(second.reload).to have_attributes(parent_id: first.id, position: 1)
+    end
+
+    it 'refuses a payload containing a locked collection' do
+      expect do
+        usecase.perform!(collections: [{ id: repository_root.id, label: 'chemotion-repository.net' }])
+      end.to raise_error(Usecases::Collections::Errors::UpdateForbidden)
+    end
+
+    context 'with a collection nested inside a locked one' do
+      # The "transferred" node a gate transfer creates. A tree payload positions a collection by
+      # nesting, so accepting it here would be enough to lift it out of the repository subtree.
+      let!(:transferred) do
+        create(:collection, user: user, label: 'transferred', parent: repository_root, is_locked: true)
+      end
+      let!(:unlocked_child) do
+        create(:collection, user: user, label: 'Legacy child', parent: repository_root)
+      end
+
+      it 'refuses to move the locked child' do
+        expect do
+          usecase.perform!(collections: [{ id: transferred.id, label: 'transferred' }])
+        end.to raise_error(Usecases::Collections::Errors::UpdateForbidden)
+      end
+
+      it 'refuses to move an unlocked child out of the locked container' do
+        expect do
+          usecase.perform!(collections: [{ id: unlocked_child.id, label: 'Legacy child' }])
+        end.to raise_error(Usecases::Collections::Errors::UpdateForbidden)
+      end
+
+      it 'refuses to move a grandchild out of the locked container' do
+        grandchild = create(:collection, user: user, label: 'Notes', parent: unlocked_child)
+
+        expect do
+          usecase.perform!(collections: [{ id: grandchild.id, label: 'Notes' }])
+        end.to raise_error(Usecases::Collections::Errors::UpdateForbidden)
+      end
+
+      it 'still accepts an ordinary collection' do
+        expect { usecase.perform!(collections: [{ id: first.id, label: 'First' }]) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/usecases/collections/withdraw_elements_spec.rb
+++ b/spec/usecases/collections/withdraw_elements_spec.rb
@@ -155,16 +155,17 @@ RSpec.describe Usecases::Collections::WithdrawElements do
     end
   end
 
-  describe 'a group member withdrawing a group-owned element' do
+  describe 'a group member withdrawing from a group-owned collection' do
     let(:group) { create(:group, users: [user]) }
-    let(:group_all) { Collection.get_all_collection_for_user(group.id) }
     let(:group_col) { create(:collection, user: group, label: 'group project') }
     let(:sample) { create(:sample, creator: user, collections: [group_col]) }
 
     before { sample }
 
-    it 'withdraws (and destroys the orphan) because group-owned collections count as owned' do
-      expect { withdraw_from(group_col, sample) }.to change(Sample, :count).by(-1)
+    # Membership is not ownership: the collection belongs to the group, and withdrawing operates on
+    # the user's *own* collections. A member who should be able to act on it gets a share.
+    it 'does not withdraw by membership alone' do
+      expect { withdraw_from(group_col, sample) }.not_to change(Sample, :count)
     end
   end
 end


### PR DESCRIPTION
> **Note — this PR now also changes what "owns a collection" means.** The last two commits are a
> breaking semantic change, not part of the original bug fix. See *Ownership is personal* below.

## Problem

The `transferred` collection — created by a gate transfer under the user's locked
`chemotion-repository.net` root — is shown at the **top level of "My Collections"** even though its
`ancestry` in the database correctly points at that root. Saving the collection tree then makes the
display true: `ancestry` is rewritten to `/` and the collection has permanently left the repository
subtree.

## Why a correct ancestry does not produce nesting

The frontend never derives the parent link from `ancestry`. `addCollectionToTree` derives it by
searching *the array it is inserting into* for a node claiming to be an ancestor:

```js
const parentIndex = collectionTree.findIndex(element => element.isAncestorOf(collection))
```

So a collection nests only if its parent is already an element of that same array — and the
repository root never is. It is assigned to the scalar `chemotion_repository_collection` field and
never pushed into `own_collections`, nor is it inside its own `children` array.

What hides this is the routing line below it: anything whose `ancestorIds` include the repository id
is sent into `chemotion_repository_collection.children`, and the sidebar renders that array under
the "chemotion-repo" group header. **The nesting a user sees there is the group header, not a
parent–child link.** So the fallback in `addCollectionToTree` fires on every load and flattens the
collection to `'/'` — invisible, because the header supplies the apparent nesting — and if the
destination array is chosen wrongly the collection lands in `own_collections` instead, where there
is no header to fake it and it renders as a root.

The destination is chosen by that same scalar field, which was assigned on the **label alone, for
every row carrying it**, so the last one won. A member of a group whose account still carried a
legacy `chemotion-repository.net` collection therefore lost the field to the group's.

## Changes

**1. Remove the obsolete repository collections of group accounts.** A repository collection belongs
to a person; `User#create_chemotion_public_collection` has been Person-only for years, so these are
legacy rows that cannot recur. Soft-deleted, only rows holding nothing, anything with content
reported and left alone.

**2. Keep the repository subtree out of the own-collections tree.** `addCollectionToTree` still
places a parentless collection at the top of the array it is given but no longer rewrites its
`ancestry` — that field is the persisted parent pointer, not display state. The repository node is
matched on `is_locked` as well as the label (an imported archive can carry an unlocked collection of
that name), the first match is kept, and the field is rebuilt per pass.

**3. Lock `transferred`, and keep it reachable.** Every guard that should keep it in place keys off
`is_locked`, yet it was created unlocked. Now created locked, with the existing rows locked by
migration — only those under a locked repository root, never on the label alone. A root-level
`transferred` is reported, not moved: nothing distinguishes one that escaped from one a user made.
`CollectionSubtree.handleClick` now navigates for a locked node as well as expanding it, since
`transferred` has no sub-collections and would otherwise be unclickable.

**4. Keep locked containers closed to tree moves and to creates.** `UpdateTree` excludes a locked
container's whole subtree, not just its direct children — a grandchild listed at the top level
escapes identically. `Create` refuses a locked parent anywhere on the path, which would otherwise
make such a collection immovable for good.

**5. Ownership is personal, group reach is through shares.** `Collection.own_collections_for` and
`#owned_by?` counted a group's collections as owned by every member. Pre-#2783 the code kept three
notions apart — the tree was strictly `user_id = current_user.id`, group reach was an opt-in
argument that additionally required `is_locked = false`, and only element access ever passed
`group_ids`. #2783 merged them, and every consumer inherited group inclusion whether it wanted it or
not: any member could rename, delete, re-parent, share onward or offer pass-ownership of a group's
collection, and because `UpdateTree` writes `user_id: current_user.id` into every payload entry, a
member merely saving their tree reassigned the group's collections to themselves. Dropping the
`is_locked = false` guard is also what pulled a group's locked rows into each member's payload —
the cause of the bug above.

Group membership is meaningful as a **sharee**, and that channel already exists:
`CollectionShare.shared_with` resolves `shared_with_id IN (self, *group_ids)`. So ownership now keys
on `user_id == user.id`, and `accessible_for` / `writable_by` / `belongs_to_or_shared_by` keep group
ids on their share half only — "mine, or shared to me or to one of my groups".

The same conflation was repeated in four other places, each now split: `ElementsPolicy` used one id
list for both the ownership test and the share recipients (so a member holding only `:read_elements`
passed bulk update and destroy as an owner); `ElementDetailLevelCalculator` returned owner-level 10
where the model returned zeros; `CollectionShare.shared_by` resolved the sharer as the member; and
`WithdrawElements` carried its own group-widened query.

**6. Stop giving group accounts an "All" collection.** It backs the MyDB element paths, and
`config/routes.rb` routes a `Group` session to the command-and-control view for `/mydb` — a group
can never use one. Guarded on `Group` specifically rather than on `Person`: `Admin` subclasses
`User`, and admins do hold and use an "All" collection. Existing group rows retired by migration,
and the paths that attach an "All" now nil-check it, since an owner without one is a reachable
state.

## Testing

- Ruby (`spec/api spec/models spec/usecases spec/policies spec/db/migrate spec/jobs spec/services`)
  — 2197 examples, 4 failures, all pre-existing on `main` (attachment path, two RADAR metadata, one
  SFTP admin-device).
- JS — 1502 passing, 0 failing.
- RuboCop clean on every touched file; ESLint at or below baseline.

Six specs asserted the old ownership rule and now assert the new one, across the model, the policy,
the withdraw use case, the element API and group/user creation.

### Staged against a production copy

Both cleanup migrations and the lock migration were run end to end against a copy of a real
database: every `transferred` row locked and nested under its owner's locked repository root, none
at root level, no group-owned collection left alive, 860 person "All" collections intact, and the
shares addressed to groups still resolving (390 rows, 31 collections, 128 members reached).

## Notes

Two known-latent items left alone deliberately. The `transferred` lock cannot distinguish a row a
user created under the repository root via the API from the job's — documented in the migration,
and `Create` now refuses that parent, so the population is bounded. And a collection nested under
the locked "All" would be rejected wholesale by `UpdateTree`; there are none, and `Create` now
prevents making one.
