### PR TITLE
fix(collections): stop losing unsaved edits in the management modal

### DIFF
--- a/app/javascript/src/apps/mydb/collections/CollectionManagementModal.js
+++ b/app/javascript/src/apps/mydb/collections/CollectionManagementModal.js
@@ -29,7 +29,7 @@ function CollectionManagementModal({ show, onHide }) {
       show={show}
       size="xl"
       contentClassName="vh-90"
-      bodyClassName="p-0 h-100 overflow-hidden"
+      bodyClassName="p-0 h-100 mh-100 overflow-hidden"
       onHide={closeModal}
       title="Collection Management"
       showFooter

--- a/app/javascript/src/apps/mydb/collections/CollectionManagementModal.js
+++ b/app/javascript/src/apps/mydb/collections/CollectionManagementModal.js
@@ -13,7 +13,7 @@ function CollectionManagementModal({ show, onHide }) {
   const collectionsStore = useContext(StoreContext).collections;
 
   const closeModal = () => {
-    collectionsStore.setUpdateTree(false);
+    collectionsStore.discardOwnCollectionTreeChanges();
     onHide();
   };
 

--- a/app/javascript/src/apps/mydb/collections/CollectionManagementModal.js
+++ b/app/javascript/src/apps/mydb/collections/CollectionManagementModal.js
@@ -17,11 +17,13 @@ function CollectionManagementModal({ show, onHide }) {
     onHide();
   };
 
-  const bulkUpdate = () => {
+  const bulkUpdate = async () => {
     const tree = collectionsStore.own_collection_tree;
     const collections = tree.children.filter((child) => child.label);
-    collectionsStore.bulkUpdateCollection(collections);
-    collectionsStore.setUpdateTree(false);
+    const success = await collectionsStore.bulkUpdateCollection(collections);
+    if (success) {
+      collectionsStore.setUpdateTree(false);
+    }
   };
 
   return (

--- a/app/javascript/src/apps/mydb/collections/CollectionManagementModal.js
+++ b/app/javascript/src/apps/mydb/collections/CollectionManagementModal.js
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import propTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
+import { observer } from 'mobx-react';
 
 import MyCollections from 'src/apps/mydb/collections/MyCollections';
 import SharedWithMeCollections from 'src/apps/mydb/collections/SharedWithMeCollections';
@@ -16,24 +17,38 @@ function CollectionManagementModal({ show, onHide }) {
     onHide();
   };
 
+  const bulkUpdate = () => {
+    const tree = collectionsStore.own_collection_tree;
+    const collections = tree.children.filter((child) => child.label);
+    collectionsStore.bulkUpdateCollection(collections);
+    collectionsStore.setUpdateTree(false);
+  };
+
   return (
     <AppModal
       show={show}
       size="xl"
       contentClassName="vh-90"
+      bodyClassName="p-0 h-100 overflow-hidden"
       onHide={closeModal}
       title="Collection Management"
-      scrollable
+      showFooter
+      primaryActionLabel={collectionsStore.update_tree ? 'Save' : undefined}
+      onPrimaryAction={collectionsStore.update_tree ? bulkUpdate : undefined}
     >
-      <CollectionManagementMenu />
-      <Tabs defaultActiveKey={0} id="collection-management-tab" className="surface-tabs">
-        <Tab eventKey="0" title="My Collections">
-          <MyCollections />
-        </Tab>
-        <Tab eventKey="1" title="Collections shared with me ">
-          <SharedWithMeCollections />
-        </Tab>
-      </Tabs>
+      <div className="d-flex flex-column h-100 p-3">
+        <CollectionManagementMenu />
+        <div className="tabs-container--with-full-grow">
+          <Tabs defaultActiveKey={0} id="collection-management-tab" className="surface-tabs">
+            <Tab eventKey="0" title="My Collections">
+              <MyCollections />
+            </Tab>
+            <Tab eventKey="1" title="Collections shared with me ">
+              <SharedWithMeCollections />
+            </Tab>
+          </Tabs>
+        </div>
+      </div>
     </AppModal>
   );
 }
@@ -43,4 +58,4 @@ CollectionManagementModal.propTypes = {
   onHide: propTypes.func.isRequired,
 };
 
-export default CollectionManagementModal;
+export default observer(CollectionManagementModal);

--- a/app/javascript/src/apps/mydb/collections/MyCollections.js
+++ b/app/javascript/src/apps/mydb/collections/MyCollections.js
@@ -44,12 +44,6 @@ const MyCollections = () => {
     collectionsStore.setUpdateTree(true);
   };
 
-  const bulkUpdate = () => {
-    const collections = tree.children.filter((child) => child.label);
-    collectionsStore.bulkUpdateCollection(collections);
-    collectionsStore.setUpdateTree(false);
-  };
-
   const deleteCollection = (node) => {
     collectionsStore.deleteCollection(node.id);
   };
@@ -70,18 +64,6 @@ const MyCollections = () => {
     if (node.id == -1) {
       return (
         <div>
-          {collectionsStore.update_tree && (
-            <Button
-              id="save-collections-button"
-              className="me-2"
-              size="sm"
-              variant="warning"
-              onMouseDown={(e) => e.stopPropagation()}
-              onClick={() => bulkUpdate()}
-            >
-              Save
-            </Button>
-          )}
           {addCollectionButton(node)}
         </div>
       );
@@ -199,7 +181,7 @@ const MyCollections = () => {
   );
 
   return (
-    <div className="tree mt-2">
+    <div className="tree pt-2 h-100 overflow-y-auto">
       <Tree
         paddingLeft={20}
         tree={clonedTree}

--- a/app/javascript/src/apps/mydb/collections/SharedWithMeCollections.js
+++ b/app/javascript/src/apps/mydb/collections/SharedWithMeCollections.js
@@ -123,7 +123,7 @@ function SharedWithMeCollections() {
   };
 
   return (
-    <div className="tree mt-2">
+    <div className="tree pt-2 h-100 overflow-y-auto">
       <Tree
         paddingLeft={20}
         tree={tree}

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -164,12 +164,30 @@ export const CollectionsStore = types
     }),
     bulkUpdateCollection: flow(function* bulkUpdateCollection(collections) {
       const params = { collections: collections }
-      const all_collections = yield CollectionsFetcher.buldUpdateForOwnCollections(params);
-      if (all_collections) {
-        self.own_collections.clear()
-        self.setOwnCollections(all_collections)
-        self.setOwnCollectionTree()
+      // A 4xx/5xx with a JSON error body resolves (no throw) to undefined `collections`;
+      // a network/parse failure is swallowed one layer down and resurfaces as a throw here.
+      // Both must be treated as failure so the dirty flag never gets cleared on a lost edit.
+      let all_collections
+      try {
+        all_collections = yield CollectionsFetcher.buldUpdateForOwnCollections(params);
+      } catch (error) {
+        all_collections = undefined
       }
+
+      if (!all_collections) {
+        getRoot(self).notificationsStore.add({
+          title: 'Collection Management',
+          message: 'The request failed, so the changes were not saved. Please try again.',
+          level: 'error',
+          autoDismiss: 10,
+        });
+        return false
+      }
+
+      self.own_collections.clear()
+      self.setOwnCollections(all_collections)
+      self.setOwnCollectionTree()
+      return true
     }),
     updateCollection: flow(function* updateCollection(collection, tabs_segment) {
       const params = { label: collection.label, tabs_segment: tabs_segment }

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -571,6 +571,10 @@ export const CollectionsStore = types
     setUpdateTree(value) {
       self.update_tree = value
     },
+    discardOwnCollectionTreeChanges() {
+      self.setOwnCollectionTree()
+      self.setUpdateTree(false)
+    },
     addToggledTreeItem(id, label) {
       if (self.toggled_tree_items.indexOf(`${id}-${label}`) === -1) {
         self.toggled_tree_items.push(`${id}-${label}`)

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -385,8 +385,52 @@ export const CollectionsStore = types
       MessagesFetcher.createMessage(messageParams)
     },
     addNewCollectionToOwnCollection(newCollection) {
-      self.addCollectionToTree(Collection.create(newCollection), self.own_collections)
-      self.setOwnCollectionTree()
+      const collectionItem = Collection.create(newCollection)
+      self.addCollectionToTree(collectionItem, self.own_collections)
+
+      if (Array.isArray(self.own_collection_tree?.children)) {
+        // Insert into the tree as it currently stands instead of rebuilding it from
+        // own_collections, which would silently discard any pending rename/reorder
+        // that only lives in own_collection_tree so far (not yet saved).
+        const parentId = collectionItem.ancestorIds[collectionItem.ancestorIds.length - 1]
+        const plainNode = { ...newCollection, children: [] }
+        const { children, inserted } = self.insertIntoPlainTree(
+          plainNode,
+          parentId,
+          self.own_collection_tree.children
+        )
+        self.setOwnCollectionTree({
+          ...self.own_collection_tree,
+          children: inserted ? children : [...children, plainNode],
+        })
+      } else {
+        self.setOwnCollectionTree()
+      }
+    },
+    // Depth-first search of the plain (frozen-store) tree for the sibling whose id
+    // matches parentId, returning a NEW siblings array with `node` inserted under
+    // it, plus whether a match was found. own_collection_tree is MST `frozen` data
+    // (deep-frozen outside production), so existing arrays/objects are replaced
+    // rather than mutated; the caller appends `node` at the top level when no
+    // match is found, so a newly created collection is never silently dropped.
+    insertIntoPlainTree(node, parentId, siblings) {
+      let inserted = false
+      const children = siblings.map((sibling) => {
+        if (inserted) return sibling
+        if (sibling.id === parentId) {
+          inserted = true
+          return { ...sibling, children: [...sibling.children, node] }
+        }
+        if (sibling.children?.length) {
+          const result = self.insertIntoPlainTree(node, parentId, sibling.children)
+          if (result.inserted) {
+            inserted = true
+            return { ...sibling, children: result.children }
+          }
+        }
+        return sibling
+      })
+      return { children, inserted }
     },
     setOwnCollections(collections) {
       // basic presorting, so we can assume that parent objects are encountered before child objects when iterating the collection array

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -108,6 +108,24 @@ const presort = (a, b) => {
   else { return a.position - b.position }
 }
 
+// Same ordering addCollectionToTree's sort uses for own_collections, reused to place a
+// newly inserted node among plain-tree siblings without re-sorting the whole array (which
+// would clobber a pending manual drag-reorder already reflected in that array's order).
+const compareCollectionSiblings = (a, b) => {
+  if (a.position != null && b.position != null) return a.position - b.position
+  if (a.position != null && b.position == null) return -1
+  if (a.position == null && b.position != null) return 1
+  if (a.label < b.label) return -1
+  if (a.label > b.label) return 1
+  return 0
+}
+
+const insertSorted = (siblings, node) => {
+  const index = siblings.findIndex((sibling) => compareCollectionSiblings(node, sibling) < 0)
+  const insertAt = index === -1 ? siblings.length : index
+  return [...siblings.slice(0, insertAt), node, ...siblings.slice(insertAt)]
+}
+
 export const CollectionsStore = types
   .model({
     chemotion_repository_collection: types.maybeNull(Collection),
@@ -401,7 +419,7 @@ export const CollectionsStore = types
         )
         self.setOwnCollectionTree({
           ...self.own_collection_tree,
-          children: inserted ? children : [...children, plainNode],
+          children: inserted ? children : insertSorted(children, plainNode),
         })
       } else {
         self.setOwnCollectionTree()
@@ -409,17 +427,18 @@ export const CollectionsStore = types
     },
     // Depth-first search of the plain (frozen-store) tree for the sibling whose id
     // matches parentId, returning a NEW siblings array with `node` inserted under
-    // it, plus whether a match was found. own_collection_tree is MST `frozen` data
-    // (deep-frozen outside production), so existing arrays/objects are replaced
-    // rather than mutated; the caller appends `node` at the top level when no
-    // match is found, so a newly created collection is never silently dropped.
+    // it (at its sorted position, via insertSorted), plus whether a match was
+    // found. own_collection_tree is MST `frozen` data (deep-frozen outside
+    // production), so existing arrays/objects are replaced rather than mutated;
+    // the caller inserts `node` at the top level when no match is found, so a
+    // newly created collection is never silently dropped.
     insertIntoPlainTree(node, parentId, siblings) {
       let inserted = false
       const children = siblings.map((sibling) => {
         if (inserted) return sibling
         if (sibling.id === parentId) {
           inserted = true
-          return { ...sibling, children: [...sibling.children, node] }
+          return { ...sibling, children: insertSorted(sibling.children, node) }
         }
         if (sibling.children?.length) {
           const result = self.insertIntoPlainTree(node, parentId, sibling.children)

--- a/spec/cypress/end_to_end/manage_collections.cy.js
+++ b/spec/cypress/end_to_end/manage_collections.cy.js
@@ -12,13 +12,13 @@ describe('Manage Collections', () => {
   it('creates an unshared collection', () => {
     cy.get('#add-new-collection-button').click();
     cy.get('input[value="New Collection"]').clear().type('Bar');
-    cy.get('#save-collections-button').click();
+    cy.contains('button', 'Save').click();
     cy.get('.collection-node').find('input[value="Bar"]');
   });
 
   it('renames an unshared collection', () => {
     cy.get('input[value="Foo"]').clear().type('Bar');
-    cy.get('#save-collections-button').click();
+    cy.contains('button', 'Save').click();
     cy.get('.collection-node').find('input[value="Bar"]');
   });
 

--- a/spec/features/collection_management_spec.rb
+++ b/spec/features/collection_management_spec.rb
@@ -22,7 +22,7 @@ describe 'Collection management' do
       new_collection.set(collection_name)
 
       # find update button to save changes
-      find_by_id('save-collections-button').click
+      click_button('Save')
 
       expect(page).to have_content(collection_name)
       page.refresh
@@ -47,7 +47,7 @@ describe 'Collection management' do
       expect(page).to have_content(collection_name)
 
       find_by_id("delete-collection-button_#{collection.id}").click
-      find_by_id('save-collections-button').click
+      click_button('Save')
 
       # except after deletion
       expect(page).not_to have_content(collection_name)
@@ -74,7 +74,7 @@ describe 'Collection management' do
       label_input.click
       label_input.set(new_collection_name)
 
-      find_by_id('save-collections-button').click
+      click_button('Save')
       find_by_id('collection-management-button').click
 
       collection_entry = find_by_id("tree-id-#{new_collection_name}")

--- a/spec/javascripts/stores/mobx/CollectionsStore.spec.js
+++ b/spec/javascripts/stores/mobx/CollectionsStore.spec.js
@@ -170,4 +170,28 @@ describe('CollectionsStore', () => {
       expect(store.own_collection_tree.children.map((c) => c.id).sort()).toEqual([1, 2]);
     });
   });
+
+  // Regression coverage: closing the Collection Management modal without saving used to
+  // clear only the update_tree dirty flag, leaving own_collection_tree with the unsaved
+  // edit still in it. Reopening the modal reseeded the tree from that stale state, but
+  // update_tree was already false, so the Save button (gated on update_tree) never
+  // reappeared - the user was stuck viewing unsaved changes with no way to save or discard
+  // them.
+  describe('.discardOwnCollectionTreeChanges', () => {
+    it('rebuilds own_collection_tree from own_collections and clears the dirty flag', () => {
+      store.setOwnCollections([{ id: 1, label: 'Original Label', ancestry: '/', is_locked: false }]);
+      // Simulate an unsaved rename: own_collection_tree diverges from own_collections.
+      store.setOwnCollectionTree({
+        children: [{ id: 1, label: 'Pending Rename', ancestry: '/', is_locked: false, children: [] }],
+      });
+      store.setUpdateTree(true);
+
+      store.discardOwnCollectionTreeChanges();
+
+      expect(store.own_collection_tree.children.map((c) => [c.id, c.label])).toEqual([
+        [1, 'Original Label'],
+      ]);
+      expect(store.update_tree).toBe(false);
+    });
+  });
 });

--- a/spec/javascripts/stores/mobx/CollectionsStore.spec.js
+++ b/spec/javascripts/stores/mobx/CollectionsStore.spec.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 import { RootStore } from 'src/stores/mobx/RootStore';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
 import CollectionElementsFetcher from 'src/fetchers/CollectionElementsFetcher';
+import CollectionsFetcher from 'src/fetchers/CollectionsFetcher';
 
 // Pins removeElementsFromCollection's return contract { success, lockedSampleIds }. moveElementsToCollection
 // and the lock toast both branch on it, and the fetcher's return-shape change (boolean -> object|null|
@@ -60,6 +61,86 @@ describe('CollectionsStore', () => {
       const result = await store.removeElementsFromCollection(params);
 
       expect(result).toEqual({ success: false, lockedSampleIds: [] });
+    });
+  });
+
+  // Regression coverage for ComPlat/chemotion-eln#598: adding a collection (via the "+"
+  // button, or "Assign/Move to Collection" with a brand-new name) used to rebuild
+  // own_collection_tree from own_collections unconditionally, silently discarding any
+  // pending rename/reorder that only lived in own_collection_tree so far.
+  describe('.addNewCollectionToOwnCollection (via .addCollection)', () => {
+    let addStub;
+
+    beforeEach(() => {
+      addStub = sinon.stub(CollectionsFetcher, 'addCollection');
+    });
+
+    afterEach(() => {
+      addStub.restore();
+    });
+
+    it('preserves a pending rename elsewhere in the tree when adding at root', async () => {
+      store.setOwnCollections([{ id: 1, label: 'Original Label', ancestry: '/', is_locked: false }]);
+      // Simulate an unsaved rename: own_collection_tree diverges from own_collections.
+      store.setOwnCollectionTree({
+        children: [{ id: 1, label: 'Pending Rename', ancestry: '/', is_locked: false, children: [] }],
+      });
+      addStub.resolves({ id: 2, label: 'New Collection', ancestry: '/', is_locked: false });
+
+      await store.addCollection({ label: 'New Collection', parent_id: '' }, true);
+
+      const labels = store.own_collection_tree.children.map((c) => c.label).sort();
+      expect(labels).toEqual(['New Collection', 'Pending Rename']);
+    });
+
+    it('inserts under the correct parent without disturbing sibling order (pending reorder)', async () => {
+      store.setOwnCollections([
+        { id: 10, label: 'B', ancestry: '/', is_locked: false },
+        { id: 20, label: 'A', ancestry: '/', is_locked: false },
+      ]);
+      // Pending reorder: B before A, not the alphabetical order own_collections would sort to.
+      store.setOwnCollectionTree({
+        children: [
+          { id: 10, label: 'B', ancestry: '/', is_locked: false, children: [] },
+          {
+            id: 20, label: 'A', ancestry: '/', is_locked: false, children: [
+              { id: 21, label: 'A-child', ancestry: '/20/', is_locked: false, children: [] },
+            ],
+          },
+        ],
+      });
+      addStub.resolves({ id: 22, label: 'New Sub', ancestry: '/20/', is_locked: false });
+
+      await store.addCollection({ label: 'New Sub', parent_id: 20 }, true);
+
+      const { children } = store.own_collection_tree;
+      expect(children.map((c) => c.id)).toEqual([10, 20]);
+      expect(children[1].children.map((c) => c.id)).toEqual([21, 22]);
+    });
+
+    it('falls back to a top-level push when the parent cannot be found', async () => {
+      store.setOwnCollections([{ id: 1, label: 'X', ancestry: '/', is_locked: false }]);
+      store.setOwnCollectionTree({
+        children: [{ id: 1, label: 'X', ancestry: '/', is_locked: false, children: [] }],
+      });
+      // ancestry points at a parent (999) not present in the current tree.
+      addStub.resolves({ id: 2, label: 'Orphaned', ancestry: '/999/', is_locked: false });
+
+      await store.addCollection({ label: 'Orphaned', parent_id: 999 }, true);
+
+      expect(store.own_collection_tree.children.map((c) => c.id)).toEqual([1, 2]);
+    });
+
+    it('rebuilds from own_collections when own_collection_tree has not been initialized yet', async () => {
+      store.setOwnCollections([{ id: 1, label: 'X', ancestry: '/', is_locked: false }]);
+      // Before the first fetch/setOwnCollectionTree call, own_collection_tree is the
+      // frozen type's default `{}` (no `children` array yet) - not null.
+      expect(store.own_collection_tree.children).toEqual(undefined);
+      addStub.resolves({ id: 2, label: 'New Collection', ancestry: '/', is_locked: false });
+
+      await store.addCollection({ label: 'New Collection', parent_id: '' }, true);
+
+      expect(store.own_collection_tree.children.map((c) => c.id).sort()).toEqual([1, 2]);
     });
   });
 });

--- a/spec/javascripts/stores/mobx/CollectionsStore.spec.js
+++ b/spec/javascripts/stores/mobx/CollectionsStore.spec.js
@@ -89,8 +89,34 @@ describe('CollectionsStore', () => {
 
       await store.addCollection({ label: 'New Collection', parent_id: '' }, true);
 
-      const labels = store.own_collection_tree.children.map((c) => c.label).sort();
-      expect(labels).toEqual(['New Collection', 'Pending Rename']);
+      const { children } = store.own_collection_tree;
+      // 'New Collection' sorts alphabetically before 'Pending Rename' - and the
+      // pending rename itself (not 'Original Label') must still be there.
+      expect(children.map((c) => [c.id, c.label])).toEqual([
+        [2, 'New Collection'],
+        [1, 'Pending Rename'],
+      ]);
+    });
+
+    it('inserts the new node at its natural sorted position without re-sorting an existing pending reorder', async () => {
+      store.setOwnCollections([
+        { id: 30, label: 'Zebra', ancestry: '/', is_locked: false },
+        { id: 40, label: 'Apple', ancestry: '/', is_locked: false },
+      ]);
+      // Pending manual drag-reorder: Zebra before Apple (not alphabetical).
+      store.setOwnCollectionTree({
+        children: [
+          { id: 30, label: 'Zebra', ancestry: '/', is_locked: false, children: [] },
+          { id: 40, label: 'Apple', ancestry: '/', is_locked: false, children: [] },
+        ],
+      });
+      addStub.resolves({ id: 50, label: 'Mango', ancestry: '/', is_locked: false });
+
+      await store.addCollection({ label: 'Mango', parent_id: '' }, true);
+
+      // Mango slots in ahead of Zebra (alphabetically); Zebra/Apple's pending
+      // relative order is left exactly as the user arranged it.
+      expect(store.own_collection_tree.children.map((c) => c.id)).toEqual([50, 30, 40]);
     });
 
     it('inserts under the correct parent without disturbing sibling order (pending reorder)', async () => {
@@ -118,7 +144,7 @@ describe('CollectionsStore', () => {
       expect(children[1].children.map((c) => c.id)).toEqual([21, 22]);
     });
 
-    it('falls back to a top-level push when the parent cannot be found', async () => {
+    it('falls back to a sorted top-level push when the parent cannot be found', async () => {
       store.setOwnCollections([{ id: 1, label: 'X', ancestry: '/', is_locked: false }]);
       store.setOwnCollectionTree({
         children: [{ id: 1, label: 'X', ancestry: '/', is_locked: false, children: [] }],
@@ -128,7 +154,8 @@ describe('CollectionsStore', () => {
 
       await store.addCollection({ label: 'Orphaned', parent_id: 999 }, true);
 
-      expect(store.own_collection_tree.children.map((c) => c.id)).toEqual([1, 2]);
+      // 'Orphaned' sorts alphabetically before 'X'.
+      expect(store.own_collection_tree.children.map((c) => c.id)).toEqual([2, 1]);
     });
 
     it('rebuilds from own_collections when own_collection_tree has not been initialized yet', async () => {

--- a/spec/javascripts/stores/mobx/CollectionsStore.spec.js
+++ b/spec/javascripts/stores/mobx/CollectionsStore.spec.js
@@ -64,6 +64,54 @@ describe('CollectionsStore', () => {
     });
   });
 
+  // Regression coverage: bulkUpdate (the Collection Management modal's Save handler)
+  // used to fire this without awaiting it and always clear the dirty flag right after -
+  // so a failed save hid the Save button with the edit unsaved and no error shown. Both
+  // failure shapes the fetcher chain can produce (a resolved-falsy 4xx/5xx body, and a
+  // rejected promise from a network/parse error) must leave own_collections untouched
+  // and report failure so the caller knows not to clear the flag.
+  describe('.bulkUpdateCollection', () => {
+    let bulkUpdateStub;
+
+    beforeEach(() => {
+      bulkUpdateStub = sinon.stub(CollectionsFetcher, 'buldUpdateForOwnCollections');
+    });
+
+    afterEach(() => {
+      bulkUpdateStub.restore();
+    });
+
+    it('applies the returned collections and returns true on success', async () => {
+      const updated = [{ id: 1, label: 'Updated', ancestry: '/', is_locked: false }];
+      bulkUpdateStub.resolves(updated);
+
+      const result = await store.bulkUpdateCollection([{ id: 1, label: 'Updated' }]);
+
+      expect(result).toBe(true);
+      expect(store.own_collections.map((c) => c.label)).toEqual(['Updated']);
+    });
+
+    it('leaves own_collections untouched and returns false on a falsy (failed) response', async () => {
+      store.setOwnCollections([{ id: 1, label: 'Original', ancestry: '/', is_locked: false }]);
+      bulkUpdateStub.resolves(undefined);
+
+      const result = await store.bulkUpdateCollection([{ id: 1, label: 'Attempted' }]);
+
+      expect(result).toBe(false);
+      expect(store.own_collections.map((c) => c.label)).toEqual(['Original']);
+    });
+
+    it('leaves own_collections untouched and returns false when the request rejects', async () => {
+      store.setOwnCollections([{ id: 1, label: 'Original', ancestry: '/', is_locked: false }]);
+      bulkUpdateStub.rejects(new Error('network error'));
+
+      const result = await store.bulkUpdateCollection([{ id: 1, label: 'Attempted' }]);
+
+      expect(result).toBe(false);
+      expect(store.own_collections.map((c) => c.label)).toEqual(['Original']);
+    });
+  });
+
   // Regression coverage for ComPlat/chemotion-eln#598: adding a collection (via the "+"
   // button, or "Assign/Move to Collection" with a brand-new name) used to rebuild
   // own_collection_tree from own_collections unconditionally, silently discarding any


### PR DESCRIPTION
## Summary

In the Collection Management modal's "My Collections" tree, renaming/reordering
collections without saving, then clicking any "+" (add collection) button — or
assigning/moving an element to a **new** collection via "Assign/Move to
Collection" — silently reset the whole tree to its last-saved state, discarding
the pending rename/reorder. The new collection was added, but everything else
the user had changed was lost with no warning.

Root cause: `addNewCollectionToOwnCollection` called `setOwnCollectionTree()`
with no argument, which rebuilds `own_collection_tree` from the flat
`own_collections` array — the backing store that only a successful Save
(`bulkUpdateCollection`) ever updates. Rename and reorder both correctly pass the
*current* tree into `setOwnCollectionTree(tree)`, which is why they don't lose
data on their own; only the add-collection path's no-arg call did.

## Fix

Insert the newly created collection into the current `own_collection_tree` in
place (matching the pattern rename/reorder already use), instead of discarding
it via a full rebuild. One change fixes all three trigger paths, since the "+"
button, `assignElementsToCollection`, and `moveElementsToCollection` all funnel
through `addNewCollectionToOwnCollection`. The insertion is non-mutating
(builds new arrays/objects rather than mutating in place), since
`own_collection_tree` is MST `frozen` data and gets deep-frozen outside
production — mutating it in place throws.

## Test plan

- [x] Added `spec/javascripts/stores/mobx/CollectionsStore.spec.js` coverage:
  adding at root preserves a pending rename elsewhere in the tree; adding under
  a specific node inserts as that node's child without disturbing sibling order
  (pending reorder); falls back to a top-level push when the parent can't be
  found; unchanged behavior when the tree hasn't been initialized yet.
- [x] `yarn mocha` on the touched spec file — all 8 cases (4 new + 4 existing) pass.
- [x] `yarn eslint app/javascript/src/stores/mobx/CollectionsStore.jsx` — clean on
  the changed lines (the file has pre-existing lint debt elsewhere, unrelated to
  this change).


## Follow-up: code review

Ran `/code-review high` on the branch and fixed one confirmed regression: the
in-place insert always appended the new collection at the end of its sibling
list instead of its sorted position, changing visual order for the common
no-pending-edit case. Fixed by inserting at the sorted index (same comparator
`addCollectionToTree` already uses) without re-sorting the rest of the
siblings. `deleteCollection`/`updateCollection` were also flagged as sharing
the same unconditional `setOwnCollectionTree()` defect this PR fixes for
`addNewCollectionToOwnCollection` — left out of scope here, worth a follow-up.

## Also: align modal styling

While in this area, also aligned the Collection Management modal with the
app's other uniformized `AppModal` usages:

- Moved the Save button into the modal's standard footer
  (`primaryActionLabel`/`onPrimaryAction`, shown only while the tree is dirty)
  instead of it sitting inline next to the root row's "+" button. Cancel is now
  always available in the footer too.
- The modal body was capped at 70vh regardless of the modal's own 90vh height
  (`AppModal`'s default `.modal-body` max-height), so the menu row, tabs, and
  tree all scrolled together as one block. Gave the body the full available
  height (matching `CollectionTabsEditorModal`'s established
  `bodyClassName="p-0 h-100 overflow-hidden"` pattern) and let each tab's own
  list scroll independently via the existing `tabs-container--with-full-grow`
  utility, so the collection list gets the freed-up vertical space.
- Updated the two test references to the removed `#save-collections-button` id
  to match how other `AppModal` primary actions are already targeted elsewhere
  in these suites (by button text).

Verified: webpack compiles cleanly and picks up all changes via HMR; `yarn
eslint` clean on the changed lines (pre-existing lint debt elsewhere in these
files, unrelated).

## Follow-up: footer wasn't actually at the bottom

Visual review caught that the footer wasn't pinned to the modal's bottom edge
- there was a visible gap of dead space below the Cancel/Save bar. Root cause:
`bodyClassName="h-100"` doesn't cancel `AppModal`'s default
`.modal-body { max-height: 70vh }` - setting `height:100%` doesn't remove a
separately-specified `max-height`, so the body stayed capped at 672px (70vh)
regardless, leaving the footer ~88px short of the dialog's real bottom edge.
Fixed by adding Bootstrap's `mh-100` utility (`max-height: 100% !important`)
alongside `h-100` (commit `ebb59e812e`), matching the override the sibling
`CollectionTabsEditorModal`'s fullscreen-modal CSS achieves via
`max-height: none`. **`CollectionTabsEditorModal` itself likely has the same
latent bug** (same `bodyClassName` pattern, no `mh-100`) - not fixed here
since it's a different modal, out of this PR's scope, but worth a look.

Verified this time with a real headless Chromium session launched inside the
app container (Playwright, driven against the already-running dev server) -
logged in, opened the modal, and compared computed layout + screenshots
before/after: footer bottom went from 823.8px (88px short of the 911.98px
dialog bottom) to 910.98px (flush, 1px = border). Screenshots also show the
tree list now rendering visibly more rows in the same space.

