### PR TITLE
fix(export): include CAS number when exporting shared/synced samples

### DIFF
--- a/lib/export/export_table.rb
+++ b/lib/export/export_table.rb
@@ -8,7 +8,7 @@ module Export
     # names from ReportHelpers::EXP_MAP_ATTR
     # allowed sample/molecule headers for sample detail level 0
     HEADERS_SAMPLE_0 = [
-      'sample external label', 'sample name', 'cas', 'target amount', 'target unit',
+      'sample external label', 'sample name', 'target amount', 'target unit',
       'real amount', 'real unit', 'description', 'purity', 'solvent', 'location',
       'secret', 'short label', 'density', 'melting pt', 'boiling pt', 'created_at',
       'updated_at', 'MW', 'user_labels', 'decoupled', 'molecular mass (decoupled)', 'sum formula (decoupled)',
@@ -16,8 +16,12 @@ module Export
     ].freeze
 
     # allowed sample/molecule headers for sample detail level 10
+    # 'cas' belongs here, not in HEADERS_SAMPLE_0: a CAS number trivially reverse-looks-up to the
+    # full structure via public databases (PubChem, CAS Common Chemistry), so it's structure-
+    # identifying in the same way as molfile/smiles/InChI, unlike the non-identifying physical
+    # properties (MW, melting/boiling point) that level 0 does expose.
     HEADERS_SAMPLE_10 = HEADERS_SAMPLE_0 + [
-      'molfile', 'sample readout', 'image', 'identifier', 'molecule name',
+      'molfile', 'sample readout', 'image', 'identifier', 'molecule name', 'cas',
       'canonical smiles', 'sum formula', 'inchistring', 'InChI' # , 'analyses'
     ].freeze
 

--- a/lib/export/export_table.rb
+++ b/lib/export/export_table.rb
@@ -8,7 +8,7 @@ module Export
     # names from ReportHelpers::EXP_MAP_ATTR
     # allowed sample/molecule headers for sample detail level 0
     HEADERS_SAMPLE_0 = [
-      'sample external label', 'sample name', 'target amount', 'target unit',
+      'sample external label', 'sample name', 'cas', 'target amount', 'target unit',
       'real amount', 'real unit', 'description', 'purity', 'solvent', 'location',
       'secret', 'short label', 'density', 'melting pt', 'boiling pt', 'created_at',
       'updated_at', 'MW', 'user_labels', 'decoupled', 'molecular mass (decoupled)', 'sum formula (decoupled)',

--- a/spec/lib/export/export_excel_spec.rb
+++ b/spec/lib/export/export_excel_spec.rb
@@ -57,6 +57,26 @@ RSpec.describe 'Export::ExportExcel' do
         expect(formated_value).to eq ['13.0', '25 °F', '1', '2.45 M']
       end
     end
+
+    context 'when the sample is reached via a shared/synced collection' do
+      let(:headers) { '@headers00 = ["cas"]' }
+
+      before do
+        sample_json['shared_sync'] = 't'
+        sample_json['dl_s'] = 0
+        sample_json['cas'] = '50-00-0'
+      end
+
+      it 'still includes the cas value (regression guard: HEADERS_SAMPLE_0 must list cas)' do
+        expect(formated_value).to eq ['50-00-0']
+      end
+    end
+  end
+
+  describe 'HEADERS_SAMPLE_0' do
+    it 'includes cas so exports of shared/synced samples still include the CAS column' do
+      expect(Export::ExportTable::HEADERS_SAMPLE_0).to include('cas')
+    end
   end
 
   describe '.get_image_from_svg' do

--- a/spec/lib/export/export_excel_spec.rb
+++ b/spec/lib/export/export_excel_spec.rb
@@ -58,8 +58,24 @@ RSpec.describe 'Export::ExportExcel' do
       end
     end
 
-    context 'when the sample is reached via a shared/synced collection' do
-      let(:headers) { '@headers00 = ["cas"]' }
+    context 'when a full-detail-level shared/synced sample is exported' do
+      # Drives the real HEADERS_SAMPLE_10-based computation (generate_headers_sample), not a
+      # hand-forced @headers100, so this actually exercises the production allowlist.
+      let(:headers) { '@headers = ["cas"]; generate_headers_sample' }
+
+      before do
+        sample_json['shared_sync'] = 't'
+        sample_json['dl_s'] = 10
+        sample_json['cas'] = '50-00-0'
+      end
+
+      it 'includes the cas value (regression guard: HEADERS_SAMPLE_10 must list cas)' do
+        expect(formated_value).to eq ['50-00-0']
+      end
+    end
+
+    context 'when a low-detail-level shared/synced sample is exported' do
+      let(:headers) { '@headers = ["cas"]; generate_headers_sample' }
 
       before do
         sample_json['shared_sync'] = 't'
@@ -67,15 +83,21 @@ RSpec.describe 'Export::ExportExcel' do
         sample_json['cas'] = '50-00-0'
       end
 
-      it 'still includes the cas value (regression guard: HEADERS_SAMPLE_0 must list cas)' do
-        expect(formated_value).to eq ['50-00-0']
+      it 'omits the cas value end-to-end (structure-identifying, gated behind full detail level)' do
+        expect(formated_value).to eq [nil]
       end
     end
   end
 
   describe 'HEADERS_SAMPLE_0' do
-    it 'includes cas so exports of shared/synced samples still include the CAS column' do
-      expect(Export::ExportTable::HEADERS_SAMPLE_0).to include('cas')
+    it 'excludes cas (structure-identifying, must not leak at low detail level)' do
+      expect(Export::ExportTable::HEADERS_SAMPLE_0).not_to include('cas')
+    end
+  end
+
+  describe 'HEADERS_SAMPLE_10' do
+    it 'includes cas so full-detail exports of shared/synced samples still include it' do
+      expect(Export::ExportTable::HEADERS_SAMPLE_10).to include('cas')
     end
   end
 


### PR DESCRIPTION
## Summary

A sample's CAS number was silently dropped from XLSX export whenever the exported sample was
reached through a collection the exporting user does not own outright (a shared or synced
collection). Own-collection exports were unaffected.

## Root cause

`Export::ExportTable::HEADERS_SAMPLE_0`/`HEADERS_SAMPLE_10` (`lib/export/export_table.rb`) are
allowlists of columns that survive export for non-owned samples, gated by sample detail level.
The export SQL already fetches the CAS value correctly (`s.xref->>'cas' as cas` in
`report_helpers.rb`), and the export dialog checks "cas" by default — but `'cas'` was never
added to either allowlist when CAS export was introduced, so it was filtered out for the
non-owned path in `filter_with_permission_and_detail_level`.

## Fix

Add `'cas'` to `HEADERS_SAMPLE_10` (not `HEADERS_SAMPLE_0`): a CAS number trivially
reverse-looks-up to the full structure via public databases (PubChem, CAS Common Chemistry), so
it's structure-identifying in the same way as `molfile`/`canonical smiles`/`InChI` — unlike the
non-identifying physical properties (`MW`, melting/boiling point) that level 0 already exposes.
Gating it behind full detail level keeps that tier's intent (share metadata, withhold
structure) intact.

## Testing

- `bundle exec rspec spec/lib/export/export_excel_spec.rb` — 12 examples, 0 failures. Covers
  both tiers end-to-end via the real `generate_headers_sample` allowlist computation (not a
  hand-forced header list): a full-detail-level shared/synced sample includes `cas`, a
  low-detail-level one omits it. Plus direct constant-membership guards on both
  `HEADERS_SAMPLE_0` (excludes) and `HEADERS_SAMPLE_10` (includes).
- `bundle exec rubocop lib/export/export_table.rb spec/lib/export/export_excel_spec.rb` — clean
  on the changed lines (3 pre-existing, unrelated offenses elsewhere in the file untouched).
