### PR TITLE
fix(collections): propagate share rename, permission, and revoke changes to sharees

### DIFF
--- a/app/api/chemotion/collection_share_api.rb
+++ b/app/api/chemotion/collection_share_api.rb
@@ -168,6 +168,25 @@ module Chemotion
       def share_value_defaults(share)
         share.attributes.symbolize_keys.except(*%i[id collection_id shared_with_id created_at updated_at])
       end
+
+      # Tell +user_ids+ (Person and/or Group ids — the notification pipeline resolves a Group to its
+      # members on its own) that something changed on a collection shared with them, on every write
+      # path (create, update, revoke) regardless of which client made the change. Lands in the
+      # "Shared Collection With Me" bucket NoticeButton.js already treats as a signal to refetch the
+      # sharee's collection tree.
+      def notify_share_recipients!(user_ids, text)
+        return if user_ids.blank?
+
+        channel_id = Channel.find_by(subject: Channel::SHARED_COLLECTION_WITH_ME)&.id
+        return unless channel_id
+
+        Message.create_msg_notification(
+          channel_id: channel_id,
+          message_content: { data: text },
+          message_from: current_user.id,
+          message_to: user_ids,
+        )
+      end
     end
 
     resource :collection_shares do
@@ -227,6 +246,8 @@ module Chemotion
         # leave the earlier writes behind.
         ActiveRecord::Base.transaction(requires_new: true) { write_shares!(targets, params[:user_ids], attributes) }
 
+        notify_share_recipients!(params[:user_ids], "#{current_user.name} has shared a collection with you.")
+
         { status: 204 }
       end
 
@@ -283,6 +304,11 @@ module Chemotion
                         new_share_defaults: share_value_defaults(share))
         end
 
+        notify_share_recipients!(
+          [share.shared_with_id],
+          "#{current_user.name} updated your access to a collection shared with you.",
+        )
+
         present share, with: Entities::CollectionShareEntity, root: :collection_share
       end
 
@@ -296,7 +322,8 @@ module Chemotion
         # A user may always reject the share addressed to them personally. `shared_with` would also
         # match a share held by one of their *groups*; revoking that would drop the collection for
         # every other member, so it is not theirs to reject — they leave the group instead.
-        unless CollectionShare.shared_directly_with(current_user).exists?(id: share.id)
+        self_reject = CollectionShare.shared_directly_with(current_user).exists?(id: share.id)
+        unless self_reject
           # Otherwise they must administrate the collection, and must not revoke a share that
           # outranks them.
           collection = find_administrable_collection(share.collection_id)
@@ -306,9 +333,14 @@ module Chemotion
         end
 
         collection = share.collection
+        shared_with_id = share.shared_with_id
         share.destroy!
 
         refresh_shared_flag!(collection)
+        # Self-rejecting is not worth notifying about — the rejecting user already knows.
+        unless self_reject
+          notify_share_recipients!([shared_with_id], "#{current_user.name} removed your access to a shared collection.")
+        end
 
         status 204
         body false

--- a/app/api/chemotion/collection_share_api.rb
+++ b/app/api/chemotion/collection_share_api.rb
@@ -168,25 +168,6 @@ module Chemotion
       def share_value_defaults(share)
         share.attributes.symbolize_keys.except(*%i[id collection_id shared_with_id created_at updated_at])
       end
-
-      # Tell +user_ids+ (Person and/or Group ids — the notification pipeline resolves a Group to its
-      # members on its own) that something changed on a collection shared with them, on every write
-      # path (create, update, revoke) regardless of which client made the change. Lands in the
-      # "Shared Collection With Me" bucket NoticeButton.js already treats as a signal to refetch the
-      # sharee's collection tree.
-      def notify_share_recipients!(user_ids, text)
-        return if user_ids.blank?
-
-        channel_id = Channel.find_by(subject: Channel::SHARED_COLLECTION_WITH_ME)&.id
-        return unless channel_id
-
-        Message.create_msg_notification(
-          channel_id: channel_id,
-          message_content: { data: text },
-          message_from: current_user.id,
-          message_to: user_ids,
-        )
-      end
     end
 
     resource :collection_shares do
@@ -246,7 +227,8 @@ module Chemotion
         # leave the earlier writes behind.
         ActiveRecord::Base.transaction(requires_new: true) { write_shares!(targets, params[:user_ids], attributes) }
 
-        notify_share_recipients!(params[:user_ids], "#{current_user.name} has shared a collection with you.")
+        CollectionShareNotifier.new(current_user)
+                               .notify!(params[:user_ids], "#{current_user.name} has shared a collection with you.")
 
         { status: 204 }
       end
@@ -304,9 +286,10 @@ module Chemotion
                         new_share_defaults: share_value_defaults(share))
         end
 
-        notify_share_recipients!(
+        CollectionShareNotifier.new(current_user).notify!(
           [share.shared_with_id],
           "#{current_user.name} updated your access to a collection shared with you.",
+          silent: true,
         )
 
         present share, with: Entities::CollectionShareEntity, root: :collection_share
@@ -339,7 +322,9 @@ module Chemotion
         refresh_shared_flag!(collection)
         # Self-rejecting is not worth notifying about — the rejecting user already knows.
         unless self_reject
-          notify_share_recipients!([shared_with_id], "#{current_user.name} removed your access to a shared collection.")
+          CollectionShareNotifier.new(current_user).notify!(
+            [shared_with_id], "#{current_user.name} removed your access to a shared collection.", silent: true
+          )
         end
 
         status 204

--- a/app/api/chemotion/message_api.rb
+++ b/app/api/chemotion/message_api.rb
@@ -24,15 +24,20 @@ module Chemotion
         message_list = present(messages, with: Entities::MessageEntity, root: 'messages')
         message_list[:version] = ENV['VERSION_ASSETS'] if ENV['VERSION_ASSETS']
 
-        # .ids does not work here as it uses the primary key which the database view notify_messages does not have
-        channel_5_ids = messages.where(channel_type: 5).pluck(:id)
+        # .ids does not work here as it uses the primary key which the database view notify_messages does not have.
         # A notification whose content is flagged silent (see CollectionShareNotifier) is delivered so
         # the frontend can act on it, but must not sit "unread" waiting for a toast dismiss that will
-        # never come — auto-ack it the same way channel 5 already is.
-        silent_ids = messages.where("content ->> 'silent' = 'true'").pluck(:id)
-        Notification.where(id: (channel_5_ids + silent_ids).uniq).find_each do |notification|
-          notification.update!(is_ack: 1)
-        end
+        # never come — auto-ack it the same way channel 5 already is. update_all (unlike update!)
+        # doesn't auto-touch updated_at, so it's set explicitly to keep that parity.
+        auto_ack_ids = messages.where(channel_type: 5)
+                               .or(messages.where("content ->> 'silent' = 'true'"))
+                               .pluck(:id)
+        # Notification has no validations/callbacks (belongs_to :message/:user only), so update_all
+        # is behaviorally identical to a per-row update! here — see the identical justification on
+        # Usecases::Collections::UpdateTree's own Rails/SkipsModelValidations disable.
+        # rubocop:disable Rails/SkipsModelValidations
+        Notification.where(id: auto_ack_ids).update_all(is_ack: 1, updated_at: Time.current) if auto_ack_ids.any?
+        # rubocop:enable Rails/SkipsModelValidations
       end
 
       desc 'Return spectra messages of the current user'

--- a/app/api/chemotion/message_api.rb
+++ b/app/api/chemotion/message_api.rb
@@ -23,7 +23,11 @@ module Chemotion
 
         # .ids does not work here as it uses the primary key which the database view notify_messages does not have
         channel_5_ids = messages.where(channel_type: 5).pluck(:id)
-        Notification.where(id: channel_5_ids).find_each do |notification|
+        # A notification whose content is flagged silent (see CollectionShareNotifier) is delivered so
+        # the frontend can act on it, but must not sit "unread" waiting for a toast dismiss that will
+        # never come — auto-ack it the same way channel 5 already is.
+        silent_ids = messages.where("content ->> 'silent' = 'true'").pluck(:id)
+        Notification.where(id: (channel_5_ids + silent_ids).uniq).find_each do |notification|
           notification.update!(is_ack: 1)
         end
       end

--- a/app/api/chemotion/message_api.rb
+++ b/app/api/chemotion/message_api.rb
@@ -6,9 +6,12 @@ module Chemotion
     resource :messages do
       desc 'Get message configuration'
       get 'config' do
+        # Floors protect every client from a misconfigured .env driving a runaway polling loop —
+        # regardless of what MESSAGE_AUTO_INTERNAL/MESSAGE_IDLE_TIME are set to (including non-numeric
+        # garbage, which .to_i coerces to 0), the served values can never go below these.
         { messageEnable: ENV['MESSAGE_ENABLE'] || 'true',
-          messageAutoInterval: (ENV['MESSAGE_AUTO_INTERNAL'] || 6000).to_i,
-          idleTimeout: (ENV['MESSAGE_IDLE_TIME'] || 12).to_i }
+          messageAutoInterval: [(ENV['MESSAGE_AUTO_INTERNAL'] || 6000).to_i, 500].max,
+          idleTimeout: [(ENV['MESSAGE_IDLE_TIME'] || 12).to_i, 5].max }
       end
 
       desc 'Return messages of the current user'

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionShareModal.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionShareModal.js
@@ -79,7 +79,6 @@ function SelectionShareModal({
         permissions: permissionsParams,
         label: newCollectionLabel.trim(),
         parentId: parentCollection?.id ?? null,
-        currentUser,
       };
       collectionsStore.collectionShareForElements(params);
     } else if (shareType === 'create') {
@@ -90,7 +89,7 @@ function SelectionShareModal({
         apply_to_subcollections: applyToSubcollections,
         ...permissionsParams
       };
-      collectionsStore.addCollectionShare(params, currentUser, false);
+      collectionsStore.addCollectionShare(params);
     } else if (shareType === 'edit') {
       // edit permissions of collection share
       const params = {

--- a/app/javascript/src/apps/mydb/mainNavigation/topbar/NoticeButton.js
+++ b/app/javascript/src/apps/mydb/mainNavigation/topbar/NoticeButton.js
@@ -81,9 +81,15 @@ const handleNotification = (nots, act, context, needCallback = true, isFirstBatc
       rootStore.notificationsStore.removeByUid(n.id);
     }
     if (act === 'add') {
-      count += 1;
-      if (count > 3) {
-        return;
+      // Silent notifications never produce a toast, so they must not count toward — or be
+      // throttled by — the toast-spam cap below. Counting them here is exactly what made the
+      // "You have N more notifications" summary overcount: it included notifications the user
+      // never saw a toast for in the first place, with nothing to find when they went looking.
+      if (!n.content.silent) {
+        count += 1;
+        if (count > 3) {
+          return;
+        }
       }
       const infoTimeString = formatDate(n.created_at);
       const convertedData = convertCalendarNotificationToLocal(n.content.data);

--- a/app/javascript/src/apps/mydb/mainNavigation/topbar/NoticeButton.js
+++ b/app/javascript/src/apps/mydb/mainNavigation/topbar/NoticeButton.js
@@ -96,13 +96,11 @@ const handleNotification = (nots, act, context, needCallback = true) => {
       const { currentCollection } = UIStore.getState();
       const currentCollectionId = currentCollection?.id;
 
-      const refreshCollectionActions = [
-        'CollectionActions.fetchRemoteCollectionRoots',
-        'CollectionActions.fetchSyncInCollectionRoots',
-        'RefreshChemotionCollection',
-        'CollectionActions.fetchUnsharedCollectionRoots',
-      ];
-      if (refreshCollectionActions.includes(n.content.action) || n.subject === 'Shared Collection With Me') {
+      // Any notification on one of these subjects means the recipient's collection visibility
+      // changed server-side (a share was created/updated/revoked, or an ownership offer was
+      // accepted) — refetch so their tree reflects it without waiting for a page reload.
+      const refreshCollectionSubjects = ['Shared Collection With Me', 'Collection Take Ownership'];
+      if (refreshCollectionSubjects.includes(n.subject)) {
         context.collections.fetchCollections();
       }
 

--- a/app/javascript/src/apps/mydb/mainNavigation/topbar/NoticeButton.js
+++ b/app/javascript/src/apps/mydb/mainNavigation/topbar/NoticeButton.js
@@ -168,6 +168,10 @@ const handleNotification = (nots, act, context, needCallback = true, isFirstBatc
 
   if (shouldRefreshCollections) {
     context.collections.fetchCollections();
+    // Sharee-facing permission-level display (e.g. SharedToMeInfosTooltip) reads a separate,
+    // once-fetched-then-cached store slice that fetchCollections() never touches — refresh it too,
+    // bounded to whatever's already cached (i.e. actually being displayed somewhere).
+    context.collections.refreshMySharedCollectionShares();
   }
 
   if (count > 3) {
@@ -212,7 +216,12 @@ const NoticeButton = () => {
   const intervalRef = useRef(null);
   const prevDbNoticesRef = useRef([]);
   const prevServerVersionRef = useRef('');
-  // Set to false after the first 'add' batch actually runs — see handleNotification's isFirstBatch.
+  // Captured at the point each real fetch resolves (messageFetch/handleShow below), not in the
+  // diff effect: the effect's own initial mount-time run always sees an empty diff before any real
+  // fetch has happened, so it can't tell "no fetch yet" apart from "fetch found nothing new" on its
+  // own. hasFetchedNoticesRef latches permanently true on the first real fetch; the pre-flip value
+  // is what handleNotification's isFirstBatch actually needs.
+  const hasFetchedNoticesRef = useRef(false);
   const isFirstNotificationBatchRef = useRef(true);
 
   // Use refs for values needed inside the polling interval to avoid
@@ -260,6 +269,8 @@ const NoticeButton = () => {
           }
         });
         messages.sort((a, b) => b.id - a.id);
+        isFirstNotificationBatchRef.current = !hasFetchedNoticesRef.current;
+        hasFetchedNoticesRef.current = true;
         setNewNotices(messages);
         setServerVersion(result.version);
       });
@@ -328,6 +339,8 @@ const NoticeButton = () => {
       const unreadMessages = unreadResult.messages.sort((a, b) => b.id - a.id);
 
       setAckNotices(ackMessages);
+      isFirstNotificationBatchRef.current = !hasFetchedNoticesRef.current;
+      hasFetchedNoticesRef.current = true;
       setNewNotices(unreadMessages);
       setShowModal(true);
     });
@@ -573,7 +586,6 @@ const NoticeButton = () => {
 
     if (Object.keys(newMessages).length > 0) {
       handleNotification(newMessages, 'add', context, true, isFirstNotificationBatchRef.current);
-      isFirstNotificationBatchRef.current = false;
     }
     if (Object.keys(remMessages).length > 0) {
       handleNotification(remMessages, 'rem', context, true);

--- a/app/javascript/src/apps/mydb/mainNavigation/topbar/NoticeButton.js
+++ b/app/javascript/src/apps/mydb/mainNavigation/topbar/NoticeButton.js
@@ -43,8 +43,39 @@ const changeUrl = (url, urlTitle) => (url ? (
   <span />
 ));
 
-const handleNotification = (nots, act, context, needCallback = true) => {
+// Any notification on one of these subjects means the recipient's collection visibility changed
+// server-side (a share was created/updated/revoked, or an ownership offer was accepted) — refetch
+// so their tree reflects it without waiting for a page reload.
+const refreshCollectionSubjects = ['Shared Collection With Me', 'Collection Take Ownership'];
+// Legacy action names, predating the subject-based check above, still seeded into Channel.msg_template
+// by old migrations for channels no later migration ever re-pointed at the new subject list: Gate
+// Transfer (db/migrate/20181207100526_add_gate_transfer_notification.rb), Collection Zip import/export
+// and Samples Import (db/migrate/20190617144801_add_collection_zip_notification.rb,
+// db/migrate/20230531142756_add_samples_import_channel.rb). PR #2783 deliberately re-pointed these same
+// strings at the (then-new) MobX fetchCollections() call rather than dropping them — this branch has to
+// stay independently of the subject check above, or those three channels silently stop refreshing the
+// tree.
+const refreshCollectionActions = [
+  'CollectionActions.fetchRemoteCollectionRoots',
+  'CollectionActions.fetchSyncInCollectionRoots',
+  'RefreshChemotionCollection',
+  'CollectionActions.fetchUnsharedCollectionRoots',
+];
+
+const matchesCollectionRefresh = (n) => refreshCollectionSubjects.includes(n.subject)
+  || refreshCollectionActions.includes(n.content.action);
+
+const handleNotification = (nots, act, context, needCallback = true, isFirstBatch = false) => {
   let count = 0;
+
+  // Computed once over the full, uncapped batch — decoupled from the count>3 toast-spam cap below (a
+  // notification past the cap still needs the tree to refresh, it just doesn't get its own toast) — and
+  // skipped entirely for the very first batch after mount: CollectionTree.js already fetches the tree
+  // fresh on its own mount effect, well before this component's first poll can fire, so refetching again
+  // here for a backlog of notifications accumulated since the user's last login is redundant. Any
+  // notification that arrives too early to benefit from that self-heals on the next poll cycle.
+  const shouldRefreshCollections = act === 'add' && !isFirstBatch && nots.some(matchesCollectionRefresh);
+
   nots.forEach((n) => {
     if (act === 'rem') {
       rootStore.notificationsStore.removeByUid(n.id);
@@ -67,42 +98,40 @@ const handleNotification = (nots, act, context, needCallback = true) => {
         );
       }
 
-      const notification = {
-        title: `From ${n.sender_name} on ${infoTimeString}`,
-        message: newText,
-        level: n.content.level || 'warning',
-        autoDismiss: n.content.autoDismiss || 5,
-        position: n.content.position || 'tr',
-        uid: n.id,
-        action: {
-          label: (
-            <span>
-              <i className="fa fa-check" aria-hidden="true" />
-              &nbsp;&nbsp;Got it
-            </span>
-          ),
-          callback() {
-            if (needCallback) {
-              const params = { ids: [] };
-              params.ids[0] = n.id;
-              MessagesFetcher.acknowledgedMessage(params);
-            }
+      // Silent notifications (e.g. a share permission update/revoke, or a rename — see
+      // CollectionShareNotifier on the backend) are delivered so the switch below and the tree-refresh
+      // check can act on them, but must not interrupt the user with a dismiss-required popup; the
+      // backend auto-acknowledges them on delivery instead (see MessageAPI's list endpoint).
+      if (!n.content.silent) {
+        const notification = {
+          title: `From ${n.sender_name} on ${infoTimeString}`,
+          message: newText,
+          level: n.content.level || 'warning',
+          autoDismiss: n.content.autoDismiss || 5,
+          position: n.content.position || 'tr',
+          uid: n.id,
+          action: {
+            label: (
+              <span>
+                <i className="fa fa-check" aria-hidden="true" />
+                &nbsp;&nbsp;Got it
+              </span>
+            ),
+            callback() {
+              if (needCallback) {
+                const params = { ids: [] };
+                params.ids[0] = n.id;
+                MessagesFetcher.acknowledgedMessage(params);
+              }
+            },
           },
-        },
-      };
-      rootStore.notificationsStore.add(notification);
+        };
+        rootStore.notificationsStore.add(notification);
+      }
 
       const { currentPage, itemsPerPage } = InboxStore.getState();
       const { currentCollection } = UIStore.getState();
       const currentCollectionId = currentCollection?.id;
-
-      // Any notification on one of these subjects means the recipient's collection visibility
-      // changed server-side (a share was created/updated/revoked, or an ownership offer was
-      // accepted) — refetch so their tree reflects it without waiting for a page reload.
-      const refreshCollectionSubjects = ['Shared Collection With Me', 'Collection Take Ownership'];
-      if (refreshCollectionSubjects.includes(n.subject)) {
-        context.collections.fetchCollections();
-      }
 
       switch (n.content.action) {
         case 'InboxActions.fetchInbox':
@@ -136,6 +165,10 @@ const handleNotification = (nots, act, context, needCallback = true) => {
       }
     }
   });
+
+  if (shouldRefreshCollections) {
+    context.collections.fetchCollections();
+  }
 
   if (count > 3) {
     const notification = {
@@ -179,6 +212,8 @@ const NoticeButton = () => {
   const intervalRef = useRef(null);
   const prevDbNoticesRef = useRef([]);
   const prevServerVersionRef = useRef('');
+  // Set to false after the first 'add' batch actually runs — see handleNotification's isFirstBatch.
+  const isFirstNotificationBatchRef = useRef(true);
 
   // Use refs for values needed inside the polling interval to avoid
   // stale closures and prevent useCallback/useEffect churn that would
@@ -537,7 +572,8 @@ const NoticeButton = () => {
     const remMessages = _.filter(prevNots, (o) => !_.includes(currentNotIds, o.id));
 
     if (Object.keys(newMessages).length > 0) {
-      handleNotification(newMessages, 'add', context, true);
+      handleNotification(newMessages, 'add', context, true, isFirstNotificationBatchRef.current);
+      isFirstNotificationBatchRef.current = false;
     }
     if (Object.keys(remMessages).length > 0) {
       handleNotification(remMessages, 'rem', context, true);
@@ -584,3 +620,5 @@ const NoticeButton = () => {
 };
 
 export default NoticeButton;
+// Exported for unit testing only — see spec/javascripts/apps/mydb/mainNavigation/topbar/NoticeButton.spec.js.
+export { handleNotification };

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -5,7 +5,6 @@ import { cloneDeep } from 'lodash';
 import CollectionsFetcher from 'src/fetchers/CollectionsFetcher';
 import CollectionSharesFetcher from 'src/fetchers/CollectionSharesFetcher';
 import CollectionElementsFetcher from 'src/fetchers/CollectionElementsFetcher';
-import MessagesFetcher from 'src/fetchers/MessagesFetcher';
 
 import UIActions from 'src/stores/alt/actions/UIActions';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
@@ -268,12 +267,11 @@ export const CollectionsStore = types
         }
       }
     }),
-    addCollectionShare: flow(function* addCollectionShare(params, currentUser) {
+    addCollectionShare: flow(function* addCollectionShare(params) {
       const response = yield CollectionSharesFetcher.addCollectionShare(params)
       if (response.status === 204) {
         self.fetchCollections()
         self.getSharedWithUsers(params.collection_id)
-        self.createSharingMessage(currentUser, params.user_ids)
       }
     }),
     takeOwnership: flow(function* takeOwnership(collectionId) {
@@ -401,7 +399,7 @@ export const CollectionsStore = types
             user_ids: [user.id],
             ...params.permissions
           }
-          self.addCollectionShare(shareParams, params.currentUser)
+          self.addCollectionShare(shareParams)
           self.addNewCollectionToOwnCollection(newCollection)
           // uncheck all
           UIActions.uncheckWholeSelection.defer()
@@ -419,15 +417,6 @@ export const CollectionsStore = types
         const label = hasCustomLabel && multipleRecipients ? `${params.label} – ${user.name}` : params.label;
         self.addElementsToCollectionAndShare(user, { ...params, label });
       });
-    },
-    createSharingMessage(currentUser, userIds) {
-      const messageParams = {
-        channel_id: 4,
-        content: `${currentUser.name} has shared a collection with you.`,
-        user_ids: userIds,
-      };
-
-      MessagesFetcher.createMessage(messageParams)
     },
     addNewCollectionToOwnCollection(newCollection) {
       const collectionItem = Collection.create(newCollection)

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -267,6 +267,12 @@ export const CollectionsStore = types
         }
       }
     }),
+    // Called when a collection-share notification arrives (see NoticeButton.js) so already-displayed
+    // share/permission info doesn't go stale the way fetchCollections() alone leaves it —
+    // getMySharesFor upserts in place, so re-calling it for every cached id is safe.
+    refreshMySharedCollectionShares: flow(function* refreshMySharedCollectionShares() {
+      yield Promise.all(self.my_collection_shares.map((entry) => self.getMySharesFor(entry.id)))
+    }),
     addCollectionShare: flow(function* addCollectionShare(params) {
       const response = yield CollectionSharesFetcher.addCollectionShare(params)
       if (response.status === 204) {

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -34,6 +34,12 @@ export const Collection = types.model({
   is_locked: types.boolean,
   owner: types.maybeNull(types.string), // "First Last (ABBR)" — shown in the provenance popover
   owner_name: types.maybeNull(types.string), // plain "First Last" — the shared tree's owner-root label
+  // The node's ancestry as received from the sharer, before any truncateAncestryAt/resetAncestry
+  // adoption rewrite — kept so sibling ordering can still reflect the sharer's true relative
+  // position (depth + original parent) even after the displayed ancestry has been adjusted. Only
+  // ever set for shared-with-me nodes; stays null for own_collections, where ancestry is never
+  // rewritten, so compareBySharerOrder degrades to the plain position/label compare there.
+  original_ancestry: types.maybeNull(types.string),
   permission_level: types.maybeNull(types.integer), // temp for testing
   position: types.maybeNull(types.number),
   shared: types.maybeNull(types.boolean),
@@ -50,21 +56,24 @@ export const Collection = types.model({
     }
   },
   sortChildren() {
-    self.children.sort((a, b) => {
-      if (a.position != null && b.position != null) { return a.position - b.position }
-      else if (a.position != null && b.position == null) { return -1 }
-      else if (a.position == null && b.position != null) { return 1 }
-      else if (a.label.toUpperCase() < b.label.toUpperCase()) { return -1; }
-      else if (a.label.toUpperCase() == b.label.toUpperCase()) { return 0 }
-      else if (a.label.toUpperCase() > b.label.toUpperCase()) { return 1 }
-      else { console.debug('unsortable collections:', a, b); return 0 }
-    })
+    self.children.sort(compareBySharerOrder)
   },
   resetAncestry() {
     self.ancestry = '/'
   },
+  // Reparents this node to sit directly under ancestorId by truncating the ancestry chain right
+  // after it — used when the node's real parent isn't shared with this user but a more distant
+  // ancestor is (nearest-shared-ancestor "adoption", see setSharedWithMeCollections).
+  truncateAncestryAt(ancestorId) {
+    const ids = self.ancestorIds
+    const index = ids.indexOf(ancestorId)
+    self.ancestry = index === -1 ? '/' : `/${ids.slice(0, index + 1).join('/')}/`
+  },
 })).views(self => ({
   get ancestorIds() { return self.ancestry.split('/').filter(Number).map(element => parseInt(element)) },
+  get originalAncestorIds() {
+    return (self.original_ancestry ?? self.ancestry).split('/').filter(Number).map((el) => parseInt(el, 10))
+  },
   find(collection_id) {
     if (collection_id == self.id) return self;
     if (self.children.length == 0) return null;
@@ -132,6 +141,31 @@ const insertSorted = (siblings, node) => {
   const index = siblings.findIndex((sibling) => compareCollectionSiblings(node, sibling) < 0)
   const insertAt = index === -1 ? siblings.length : index
   return [...siblings.slice(0, insertAt), node, ...siblings.slice(insertAt)]
+}
+
+// Orders siblings — including ones "adopted" together under a parent that isn't their real one —
+// by the sharer's original relative position as closely as this frontend-only view can
+// approximate: a shallower original node always sorts before a deeper one (the 45-before-33..37
+// case), true original siblings (same real parent) are then ordered by their own, genuinely
+// comparable position, and same-depth nodes from different original parents — whose relative
+// order this store has no way to know without the backend data-exposure change that was declined
+// — fall back to comparing their original ancestry path, which at least keeps each original
+// sibling group contiguous as one block instead of scattering it. Degrades to the plain
+// position/label compare when original_ancestry is unset (own_collections, never rewritten).
+const compareBySharerOrder = (a, b) => {
+  if (!a.original_ancestry || !b.original_ancestry) return compareCollectionSiblings(a, b)
+
+  const depthA = a.originalAncestorIds.length
+  const depthB = b.originalAncestorIds.length
+  if (depthA !== depthB) return depthA - depthB
+
+  const parentA = a.originalAncestorIds[depthA - 1]
+  const parentB = b.originalAncestorIds[depthB - 1]
+  if (parentA !== parentB) {
+    return a.original_ancestry < b.original_ancestry ? -1 : (a.original_ancestry > b.original_ancestry ? 1 : 0)
+  }
+
+  return compareCollectionSiblings(a, b)
 }
 
 export const CollectionsStore = types
@@ -535,11 +569,20 @@ export const CollectionsStore = types
         }
         const parentOwnerIndex = self.shared_with_me_collections.findIndex(element => element.owner == collection.owner)
         if (parentOwnerIndex !== -1) {
-          const node = Collection.create(collection);
-          // Preserve the hierarchy when the parent is also shared; when it is not (the branch is
-          // "skipped"), truncate by showing this collection at the top level under its owner.
-          const directParentId = node.ancestorIds[node.ancestorIds.length - 1];
-          if (directParentId == null || !sharedIds.has(directParentId)) { node.resetAncestry(); }
+          const node = Collection.create({ ...collection, original_ancestry: collection.ancestry });
+          // Walk from the nearest ancestor outward so a node whose real parent isn't shared still
+          // nests under the closest ancestor that IS — "orphan adoption" — rather than always
+          // dropping straight to the owner root. Ordering note: presortSharedWithMeCollections sorts
+          // by raw ancestry depth first, and any true ancestor always has strictly smaller raw depth
+          // than its descendant, so by the time this runs for a given node, its nearest shared
+          // ancestor (if any) has already been truncated/inserted earlier in this same forEach —
+          // addCollectionToTree's recursive descent can rely on that.
+          const nearestSharedAncestorId = [...node.ancestorIds].reverse().find((id) => sharedIds.has(id));
+          if (nearestSharedAncestorId != null) {
+            node.truncateAncestryAt(nearestSharedAncestorId);
+          } else {
+            node.resetAncestry();
+          }
           self.addCollectionToTree(node, self.shared_with_me_collections[parentOwnerIndex].children);
         }
       });
@@ -569,15 +612,7 @@ export const CollectionsStore = types
       // setSharedWithMeCollections.
       if (collection.isRootCollection || parentIndex === -1) {
         collectionTree.push(collection)
-        collectionTree.sort((a, b) => {
-          if (a.position != null && b.position != null) { return a.position - b.position }
-          else if (a.position != null && b.position == null) { return -1 }
-          else if (a.position == null && b.position != null) { return 1 }
-          else if (a.label < b.label) { return -1; }
-          else if (a.label == b.label) { return 0 }
-          else if (a.label > b.label) { return 1 }
-          else { console.debug('unsortable collections:', a, b); return 0 }
-        })
+        collectionTree.sort(compareBySharerOrder)
       } else {
         collectionTree[parentIndex].addChild(collection)
       }

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -323,6 +323,11 @@ export const CollectionsStore = types
     updateCollectionShare: flow(function* updateCollectionShare(collectionShareId, params) {
       const collectionShare = yield CollectionSharesFetcher.updateCollectionShare(collectionShareId, params)
       if (collectionShare) {
+        // apply_to_subcollections/include_new_subcollections can cascade this edit onto
+        // descendants not previously shared — PUT's response only carries the one edited share,
+        // never the cascade's effect on those descendants' `shared` flag, so own_collections has
+        // to be refetched to pick it up (mirrors addCollectionShare/deleteCollectionShare below).
+        self.fetchCollections()
         self.getSharedWithUsers(collectionShare.collection_id)
       }
     }),

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -35,9 +35,14 @@ class Message < ApplicationRecord
   end
 
   def self.bulk_create_notifications(channel_id, message_id, user_id, receiver_ids)
-    receiver_ids = "ARRAY#{receiver_ids || []}::int[]"
-    sql = "select generate_notifications(#{channel_id}, #{message_id},
-           #{user_id}, #{receiver_ids}) as message_id"
+    # Integer(...) rather than to_i: any id that is not a clean integer raises here instead of
+    # silently truncating into the query, so no caller-supplied value ever reaches the SQL text
+    # unvalidated. sanitize_sql then does the actual quoting (repo convention, see OlsTerm).
+    ids_literal = "{#{Array(receiver_ids).map { |id| Integer(id) }.join(',')}}"
+    sql = sanitize_sql(
+      ['select generate_notifications(?, ?, ?, ?::int[]) as message_id',
+       Integer(channel_id), Integer(message_id), Integer(user_id), ids_literal],
+    )
     ApplicationRecord.connection.exec_query(sql)
   end
 

--- a/app/services/collection_share_notifier.rb
+++ b/app/services/collection_share_notifier.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Notifies one or more sharees, on the "Shared Collection With Me" channel, that something
+# changed server-side on a collection shared with them — the subject NoticeButton.js
+# already treats as a signal to refetch the sharee's collection tree. Shared between
+# CollectionShareAPI (a Grape endpoint) and UpdateTree (a plain usecase), which is why this
+# doesn't live in either's own helper module.
+class CollectionShareNotifier
+  def initialize(actor)
+    @actor = actor
+  end
+
+  # @param user_ids [Array<Integer>, Integer] recipient id(s) — Person and/or Group; the
+  #   notification pipeline resolves a Group to its members on its own
+  # @param silent [Boolean] true suppresses the recipient's toast popup (it is still
+  #   delivered and visible in their inbox, just auto-acknowledged — see NoticeButton.js's
+  #   use of +content.silent+ and MessageAPI's list endpoint)
+  def notify!(user_ids, text, silent: false)
+    user_ids = Array(user_ids)
+    return if user_ids.blank?
+
+    channel_id = Channel.find_by(subject: Channel::SHARED_COLLECTION_WITH_ME)&.id
+    return unless channel_id
+
+    Message.create_msg_notification(
+      channel_id: channel_id,
+      message_content: { data: text, silent: silent },
+      message_from: @actor.id,
+      message_to: user_ids,
+    )
+  end
+end

--- a/app/usecases/collections/update_tree.rb
+++ b/app/usecases/collections/update_tree.rb
@@ -16,55 +16,54 @@ module Usecases
           add_collection_and_children_to_linear_tree(collection, position: index + 1)
         end
 
-        renamed_shared_entries = renamed_shared_entries_to_notify
+        changed_shared_with_ids_groups = changed_shared_collection_recipients
 
         save_linear_tree_structure!
-        notify_renamed_sharees!(renamed_shared_entries)
+        notify_changed_sharees!(changed_shared_with_ids_groups)
       end
 
       private
 
-      # {label:, shared_with_ids:} for every collection whose label actually changes and which is
-      # shared with someone — the only renames a sharee needs to hear about. Has to be computed
-      # against the labels currently in the DB, and before the write: save_linear_tree_structure!
-      # goes through upsert_all, which skips AR callbacks/dirty-tracking, so there is no "did this
-      # change" signal available afterwards.
-      def renamed_shared_entries_to_notify
-        new_labels_by_id = new_labels_by_id_from_tree
-        changed_ids = renamed_collection_ids(new_labels_by_id)
+      # shared_with_ids for every collection whose label, ancestry, or position actually changes —
+      # a rename, a reparent, or a reorder each change what a sharee's tree shows — and which is
+      # shared with someone. Computed against the values currently in the DB, and before the write:
+      # save_linear_tree_structure! goes through upsert_all, which skips AR callbacks/dirty-tracking,
+      # so there is no "did this change" signal available afterwards. A reparent cascades correctly
+      # to every descendant with no special-casing needed: this method re-flattens the whole
+      # submitted tree every save, so a descendant's own ancestry string changes automatically
+      # whenever any ancestor's position in the hierarchy changes, even an ancestor not shared with
+      # this sharee.
+      def changed_shared_collection_recipients
+        changed_ids = changed_collection_ids
         return [] if changed_ids.empty?
 
         shared_with_ids_by_collection = CollectionShare.where(collection_id: changed_ids)
                                                        .group_by(&:collection_id)
                                                        .transform_values { |shares| shares.map(&:shared_with_id) }
 
-        changed_ids.filter_map do |id|
-          shared_with_ids = shared_with_ids_by_collection[id]
-          next if shared_with_ids.blank?
-
-          { label: new_labels_by_id[id], shared_with_ids: shared_with_ids }
-        end
+        changed_ids.filter_map { |id| shared_with_ids_by_collection[id].presence }
       end
 
-      def new_labels_by_id_from_tree
-        linear_tree_structure.select { |entry| entry[:label] }.to_h { |entry| [entry[:id], entry[:label]] }
+      def new_state_by_id_from_tree
+        linear_tree_structure.select { |entry| entry[:label] }
+                             .to_h { |entry| [entry[:id], entry.values_at(:label, :ancestry, :position)] }
       end
 
-      def renamed_collection_ids(new_labels_by_id)
-        return [] if new_labels_by_id.empty?
+      def changed_collection_ids
+        new_state_by_id = new_state_by_id_from_tree
+        return [] if new_state_by_id.empty?
 
-        current_labels_by_id = Collection.where(id: new_labels_by_id.keys).pluck(:id, :label).to_h
-        new_labels_by_id.reject { |id, label| current_labels_by_id[id] == label }.keys
+        current_state_by_id = Collection.where(id: new_state_by_id.keys)
+                                        .pluck(:id, :label, :ancestry, :position)
+                                        .to_h { |id, *state| [id, state] }
+        new_state_by_id.reject { |id, state| current_state_by_id[id] == state }.keys
       end
 
-      def notify_renamed_sharees!(entries)
+      def notify_changed_sharees!(shared_with_ids_groups)
         notifier = CollectionShareNotifier.new(current_user)
-        entries.each do |entry|
-          notifier.notify!(
-            entry[:shared_with_ids],
-            "#{current_user.name} renamed a shared collection to \"#{entry[:label]}\".",
-            silent: true,
-          )
+        shared_with_ids_groups.each do |shared_with_ids|
+          notifier.notify!(shared_with_ids, "#{current_user.name} made changes to a collection shared with you.",
+                           silent: true)
         end
       end
 

--- a/app/usecases/collections/update_tree.rb
+++ b/app/usecases/collections/update_tree.rb
@@ -30,10 +30,10 @@ module Usecases
       # goes through upsert_all, which skips AR callbacks/dirty-tracking, so there is no "did this
       # change" signal available afterwards.
       def renamed_shared_entries_to_notify
-        changed_ids = renamed_collection_ids
+        new_labels_by_id = new_labels_by_id_from_tree
+        changed_ids = renamed_collection_ids(new_labels_by_id)
         return [] if changed_ids.empty?
 
-        new_labels_by_id = new_labels_by_id_from_tree
         shared_with_ids_by_collection = CollectionShare.where(collection_id: changed_ids)
                                                        .group_by(&:collection_id)
                                                        .transform_values { |shares| shares.map(&:shared_with_id) }
@@ -50,8 +50,7 @@ module Usecases
         linear_tree_structure.select { |entry| entry[:label] }.to_h { |entry| [entry[:id], entry[:label]] }
       end
 
-      def renamed_collection_ids
-        new_labels_by_id = new_labels_by_id_from_tree
+      def renamed_collection_ids(new_labels_by_id)
         return [] if new_labels_by_id.empty?
 
         current_labels_by_id = Collection.where(id: new_labels_by_id.keys).pluck(:id, :label).to_h

--- a/app/usecases/collections/update_tree.rb
+++ b/app/usecases/collections/update_tree.rb
@@ -16,10 +16,66 @@ module Usecases
           add_collection_and_children_to_linear_tree(collection, position: index + 1)
         end
 
+        renamed_shared_entries = renamed_shared_entries_to_notify
+
         save_linear_tree_structure!
+        notify_renamed_sharees!(renamed_shared_entries)
       end
 
       private
+
+      # {label:, shared_with_ids:} for every collection whose label actually changes and which is
+      # shared with someone — the only renames a sharee needs to hear about. Has to be computed
+      # against the labels currently in the DB, and before the write: save_linear_tree_structure!
+      # goes through upsert_all, which skips AR callbacks/dirty-tracking, so there is no "did this
+      # change" signal available afterwards.
+      def renamed_shared_entries_to_notify
+        changed_ids = renamed_collection_ids
+        return [] if changed_ids.empty?
+
+        new_labels_by_id = new_labels_by_id_from_tree
+        shared_with_ids_by_collection = CollectionShare.where(collection_id: changed_ids)
+                                                       .group_by(&:collection_id)
+                                                       .transform_values { |shares| shares.map(&:shared_with_id) }
+
+        changed_ids.filter_map do |id|
+          shared_with_ids = shared_with_ids_by_collection[id]
+          next if shared_with_ids.blank?
+
+          { label: new_labels_by_id[id], shared_with_ids: shared_with_ids }
+        end
+      end
+
+      def new_labels_by_id_from_tree
+        linear_tree_structure.select { |entry| entry[:label] }.to_h { |entry| [entry[:id], entry[:label]] }
+      end
+
+      def renamed_collection_ids
+        new_labels_by_id = new_labels_by_id_from_tree
+        return [] if new_labels_by_id.empty?
+
+        current_labels_by_id = Collection.where(id: new_labels_by_id.keys).pluck(:id, :label).to_h
+        new_labels_by_id.reject { |id, label| current_labels_by_id[id] == label }.keys
+      end
+
+      # Reuses the "Shared Collection With Me" channel the initial share creation notifies on (see
+      # CollectionsStore#createSharingMessage in the frontend) so NoticeButton.js's existing refresh
+      # check picks it up and refetches the sharee's collection tree.
+      def notify_renamed_sharees!(entries)
+        return if entries.empty?
+
+        channel_id = Channel.find_by(subject: Channel::SHARED_COLLECTION_WITH_ME)&.id
+        return unless channel_id
+
+        entries.each do |entry|
+          Message.create_msg_notification(
+            channel_id: channel_id,
+            message_content: { data: "#{current_user.name} renamed a shared collection to \"#{entry[:label]}\"." },
+            message_from: current_user.id,
+            message_to: entry[:shared_with_ids],
+          )
+        end
+      end
 
       # Locked collections (the "All"/repository/transferred roots) are excluded: their label and
       # tree position are system-defined, so a bulk tree update may neither move nor rename them.

--- a/app/usecases/collections/update_tree.rb
+++ b/app/usecases/collections/update_tree.rb
@@ -58,21 +58,13 @@ module Usecases
         new_labels_by_id.reject { |id, label| current_labels_by_id[id] == label }.keys
       end
 
-      # Reuses the "Shared Collection With Me" channel the initial share creation notifies on (see
-      # CollectionsStore#createSharingMessage in the frontend) so NoticeButton.js's existing refresh
-      # check picks it up and refetches the sharee's collection tree.
       def notify_renamed_sharees!(entries)
-        return if entries.empty?
-
-        channel_id = Channel.find_by(subject: Channel::SHARED_COLLECTION_WITH_ME)&.id
-        return unless channel_id
-
+        notifier = CollectionShareNotifier.new(current_user)
         entries.each do |entry|
-          Message.create_msg_notification(
-            channel_id: channel_id,
-            message_content: { data: "#{current_user.name} renamed a shared collection to \"#{entry[:label]}\"." },
-            message_from: current_user.id,
-            message_to: entry[:shared_with_ids],
+          notifier.notify!(
+            entry[:shared_with_ids],
+            "#{current_user.name} renamed a shared collection to \"#{entry[:label]}\".",
+            silent: true,
           )
         end
       end

--- a/spec/api/chemotion/collection_share_api_spec.rb
+++ b/spec/api/chemotion/collection_share_api_spec.rb
@@ -8,6 +8,10 @@ describe Chemotion::CollectionShareAPI do
   let(:collection) { create(:collection, user: user) }
   let(:collection_share) { create(:collection_share, shared_with: other_user, collection: collection) }
 
+  # Notifying a sharee (see POST/PUT/DELETE below) reuses this channel — seeded in production by a
+  # data migration that db:schema:load never runs, so specs that exercise it seed it themselves too.
+  before { create(:channel, subject: Channel::SHARED_COLLECTION_WITH_ME, channel_type: 8) }
+
   describe 'POST /api/v1/collection_shares' do
     let(:create_params) do
       {
@@ -32,6 +36,17 @@ describe Chemotion::CollectionShareAPI do
         collection.reload
       end.to change(CollectionShare, :count).by(create_params[:user_ids].length)
          .and change(collection, :shared?).from(false).to(true)
+    end
+
+    # Emitted server-side so it fires regardless of which client created the share, unlike the old
+    # client-side createSharingMessage this replaces.
+    it 'notifies every recipient so their collection tree refreshes' do
+      expect do
+        post '/api/v1/collection_shares/', params: create_params
+      end.to change(Notification, :count).by(create_params[:user_ids].length)
+
+      expect(Notification.where(user_id: other_user.id)).to exist
+      expect(Notification.where(user_id: third_user.id)).to exist
     end
 
     context 'with apply_to_subcollections' do
@@ -109,6 +124,14 @@ describe Chemotion::CollectionShareAPI do
       expected_result = update_params.dup.stringify_keys
 
       expect(result).to include(expected_result)
+    end
+
+    # Without this, the sharee's "Shared with me" tree only ever reflects a permission change after
+    # a manual reload — their poll only refetches on seeing a new notification (see NoticeButton.js).
+    it 'notifies the sharee so their collection tree refreshes' do
+      expect do
+        put "/api/v1/collection_shares/#{collection_share.id}", params: update_params
+      end.to change(Notification.where(user_id: other_user.id), :count).by(1)
     end
 
     context 'with apply_to_subcollections' do
@@ -219,6 +242,15 @@ describe Chemotion::CollectionShareAPI do
          .and change(collection, :shared?).from(true).to(false)
     end
 
+    # Revoking is the case a stale sharee tree hurts most: the collection stays visible on their
+    # side yet the server no longer serves it. Without a notification here, only a page reload would
+    # ever tell them.
+    it 'notifies the revoked sharee so their collection tree refreshes' do
+      expect do
+        delete "/api/v1/collection_shares/#{collection_share.id}"
+      end.to change(Notification.where(user_id: other_user.id), :count).by(1)
+    end
+
     context 'when the share belongs to one of the requesters groups' do
       let(:collection) { create(:collection, user: other_user) }
       let(:group) { create(:group, users: [user]) }
@@ -267,6 +299,11 @@ describe Chemotion::CollectionShareAPI do
           .to change(CollectionShare, :count).by(-1)
 
         expect(response).to have_http_status(:no_content)
+      end
+
+      it 'does not notify the requester about their own action' do
+        expect { delete "/api/v1/collection_shares/#{own_share.id}" }
+          .not_to change(Notification, :count)
       end
     end
   end

--- a/spec/api/chemotion/collection_share_api_spec.rb
+++ b/spec/api/chemotion/collection_share_api_spec.rb
@@ -49,6 +49,14 @@ describe Chemotion::CollectionShareAPI do
       expect(Notification.where(user_id: third_user.id)).to exist
     end
 
+    # A new share is the one event a sharee should be interrupted for — unlike an update/revoke/rename,
+    # which are delivered silently (see the PUT/DELETE specs below).
+    it 'notifies verbosely, not silently' do
+      post '/api/v1/collection_shares/', params: create_params
+
+      expect(Message.last.content['silent']).to be(false)
+    end
+
     context 'with apply_to_subcollections' do
       let(:child) { create(:collection, user: user, parent: collection) }
 
@@ -132,6 +140,14 @@ describe Chemotion::CollectionShareAPI do
       expect do
         put "/api/v1/collection_shares/#{collection_share.id}", params: update_params
       end.to change(Notification.where(user_id: other_user.id), :count).by(1)
+    end
+
+    # A permission change is housekeeping, not something worth interrupting the sharee for — the
+    # tree still refreshes (see the spec above), it just doesn't pop a dismiss-required toast.
+    it 'notifies silently' do
+      put "/api/v1/collection_shares/#{collection_share.id}", params: update_params
+
+      expect(Message.last.content['silent']).to be(true)
     end
 
     context 'with apply_to_subcollections' do
@@ -249,6 +265,12 @@ describe Chemotion::CollectionShareAPI do
       expect do
         delete "/api/v1/collection_shares/#{collection_share.id}"
       end.to change(Notification.where(user_id: other_user.id), :count).by(1)
+    end
+
+    it 'notifies silently' do
+      delete "/api/v1/collection_shares/#{collection_share.id}"
+
+      expect(Message.last.content['silent']).to be(true)
     end
 
     context 'when the share belongs to one of the requesters groups' do

--- a/spec/api/message_api_spec.rb
+++ b/spec/api/message_api_spec.rb
@@ -96,6 +96,25 @@ describe Chemotion::MessageAPI do
         expect(second_fetch_ids).not_to include(notification.id)
         expect(acked_ids).to include(notification.id)
       end
+
+      # Pins the combined channel_type-5-OR-silent auto-ack query: both categories must still be
+      # acked together in one request, not just each in isolation.
+      it 'auto-acks a channel-5 notification and a silent one together, in a single request' do
+        channel_with_type_five = create(:channel, channel_type: 5)
+        channel_5_message = create(:message, channel_id: channel_with_type_five.id, content: { data: 'chan 5' },
+                                             created_by: u2.id)
+        channel_5_notification = Notification.create!(message: channel_5_message, user: u1, is_ack: false)
+        silent_message = create(:message, channel_id: c_nosys.id, content: { data: 'silent', silent: true },
+                                          created_by: u2.id)
+        silent_notification = Notification.create!(message: silent_message, user: u1, is_ack: false)
+
+        get '/api/v1/messages/list.json?is_ack=0'
+
+        get '/api/v1/messages/list.json?is_ack=1'
+        acked_ids = JSON.parse(response.body)['messages'].pluck('id')
+
+        expect(acked_ids).to include(channel_5_notification.id, silent_notification.id)
+      end
     end
 
     describe 'GET config' do

--- a/spec/api/message_api_spec.rb
+++ b/spec/api/message_api_spec.rb
@@ -69,6 +69,35 @@ describe Chemotion::MessageAPI do
       end
     end
 
+    # No memoized helpers here (this group's ancestors are already at the RSpec/MultipleMemoizedHelpers
+    # cap) — message/notification are plain locals inside the one example that needs them.
+    describe 'a message flagged content.silent' do
+      # It must still be delivered on the first fetch — silent only means "no toast", not "hidden" —
+      # but is auto-acknowledged as a side effect of that same fetch (see MessageAPI's list endpoint),
+      # so it never sits "unread" waiting for a dismiss that will never come (there is no toast to
+      # dismiss it with), while staying visible under is_ack=1 like any other acknowledged message.
+      it 'is delivered once as unread, then auto-acknowledged on that fetch' do
+        message = create(:message, channel_id: c_nosys.id, content: { data: 'permission updated', silent: true },
+                                   created_by: u2.id)
+        # MessageEntity#id is the notify_messages view's id, which is the Notification id, not the
+        # Message id (see MessageEntity's separate `message_id` field) — assert against this one.
+        notification = Notification.create!(message: message, user: u1, is_ack: false)
+
+        get '/api/v1/messages/list.json?is_ack=0'
+        first_fetch_ids = JSON.parse(response.body)['messages'].pluck('id')
+
+        get '/api/v1/messages/list.json?is_ack=0'
+        second_fetch_ids = JSON.parse(response.body)['messages'].pluck('id')
+
+        get '/api/v1/messages/list.json?is_ack=1'
+        acked_ids = JSON.parse(response.body)['messages'].pluck('id')
+
+        expect(first_fetch_ids).to include(notification.id)
+        expect(second_fetch_ids).not_to include(notification.id)
+        expect(acked_ids).to include(notification.id)
+      end
+    end
+
     describe 'publish a message' do
       before do
         post '/api/v1/messages/new', params: { channel_id: m_sys.channel_id, content: m_sys.content[:data] }.to_json,

--- a/spec/api/message_api_spec.rb
+++ b/spec/api/message_api_spec.rb
@@ -98,6 +98,63 @@ describe Chemotion::MessageAPI do
       end
     end
 
+    describe 'GET config' do
+      # Isolates each example's ENV stub instead of a shared `around`, since only two keys ever
+      # need overriding here and different examples override different subsets.
+      def fetch_config
+        get '/api/v1/messages/config'
+        JSON.parse(response.body)
+      end
+
+      it 'defaults to messageAutoInterval 6000 and idleTimeout 12 when unset' do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('MESSAGE_AUTO_INTERNAL').and_return(nil)
+        allow(ENV).to receive(:[]).with('MESSAGE_IDLE_TIME').and_return(nil)
+
+        config = fetch_config
+
+        expect(config['messageAutoInterval']).to eq(6000)
+        expect(config['idleTimeout']).to eq(12)
+      end
+
+      # A misconfigured .env must not be able to drive every client into a runaway polling loop —
+      # the served value is floored regardless of what the deployment sets it to.
+      it 'floors messageAutoInterval at 500 and idleTimeout at 5 when set below that' do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('MESSAGE_AUTO_INTERNAL').and_return('1')
+        allow(ENV).to receive(:[]).with('MESSAGE_IDLE_TIME').and_return('0')
+
+        config = fetch_config
+
+        expect(config['messageAutoInterval']).to eq(500)
+        expect(config['idleTimeout']).to eq(5)
+      end
+
+      # .to_i coerces non-numeric garbage to 0, which then hits the same floor as an explicit
+      # too-low value — no separate guard needed for a malformed (as opposed to merely small) var.
+      it 'floors non-numeric garbage the same way' do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('MESSAGE_AUTO_INTERNAL').and_return('not-a-number')
+        allow(ENV).to receive(:[]).with('MESSAGE_IDLE_TIME').and_return('also-not-a-number')
+
+        config = fetch_config
+
+        expect(config['messageAutoInterval']).to eq(500)
+        expect(config['idleTimeout']).to eq(5)
+      end
+
+      it 'passes through a value already above the floor unchanged' do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('MESSAGE_AUTO_INTERNAL').and_return('8000')
+        allow(ENV).to receive(:[]).with('MESSAGE_IDLE_TIME').and_return('20')
+
+        config = fetch_config
+
+        expect(config['messageAutoInterval']).to eq(8000)
+        expect(config['idleTimeout']).to eq(20)
+      end
+    end
+
     describe 'publish a message' do
       before do
         post '/api/v1/messages/new', params: { channel_id: m_sys.channel_id, content: m_sys.content[:data] }.to_json,

--- a/spec/javascripts/apps/mydb/mainNavigation/topbar/NoticeButton.spec.js
+++ b/spec/javascripts/apps/mydb/mainNavigation/topbar/NoticeButton.spec.js
@@ -15,7 +15,9 @@ const buildNotification = (overrides = {}) => ({
   content: { data: 'hello', ...overrides.content },
 });
 
-const buildContext = () => ({ collections: { fetchCollections: sinon.spy() } });
+const buildContext = () => ({
+  collections: { fetchCollections: sinon.spy(), refreshMySharedCollectionShares: sinon.spy() },
+});
 
 describe('NoticeButton#handleNotification', () => {
   // notificationsStore is a protected MobX-state-tree node — its actions can't be swapped out
@@ -82,6 +84,28 @@ describe('NoticeButton#handleNotification', () => {
       handleNotification([n], 'add', context);
 
       expect(addCallCount()).toBe(1);
+    });
+  });
+
+  describe('refreshing sharee-facing permission info alongside the tree', () => {
+    // fetchCollections() never touches the my_collection_shares cache SharedToMeInfosTooltip reads
+    // from, so a permission-level change refreshed the tree but left the tooltip stale — this must
+    // fire every time the tree refresh does, not as a separate/optional signal.
+    it('calls refreshMySharedCollectionShares whenever fetchCollections is called', () => {
+      const context = buildContext();
+      const n = buildNotification({ subject: 'Shared Collection With Me' });
+
+      handleNotification([n], 'add', context);
+
+      expect(context.collections.fetchCollections.callCount).toBe(1);
+      expect(context.collections.refreshMySharedCollectionShares.callCount).toBe(1);
+    });
+
+    it('does not call it when nothing in the batch matches', () => {
+      const context = buildContext();
+      handleNotification([buildNotification()], 'add', context);
+
+      expect(context.collections.refreshMySharedCollectionShares.callCount).toBe(0);
     });
   });
 

--- a/spec/javascripts/apps/mydb/mainNavigation/topbar/NoticeButton.spec.js
+++ b/spec/javascripts/apps/mydb/mainNavigation/topbar/NoticeButton.spec.js
@@ -1,0 +1,152 @@
+/* eslint-disable import/no-unresolved,no-undef */
+import expect from 'expect';
+import sinon from 'sinon';
+import { onAction } from 'mobx-state-tree';
+import { handleNotification } from 'src/apps/mydb/mainNavigation/topbar/NoticeButton';
+import { rootStore } from 'src/stores/mobx/RootStore';
+
+// Minimal notification shape handleNotification actually reads: id, sender_name, created_at,
+// subject, and content (data/action/silent). Anything else in a real payload is irrelevant here.
+const buildNotification = (overrides = {}) => ({
+  id: overrides.id ?? 1,
+  sender_name: 'Some User',
+  created_at: new Date().toString(),
+  subject: overrides.subject ?? null,
+  content: { data: 'hello', ...overrides.content },
+});
+
+const buildContext = () => ({ collections: { fetchCollections: sinon.spy() } });
+
+describe('NoticeButton#handleNotification', () => {
+  // notificationsStore is a protected MobX-state-tree node — its actions can't be swapped out
+  // via sinon.spy(obj, 'method') (MST blocks redefining action properties directly), so calls are
+  // observed the MST way instead, via onAction middleware.
+  let actionCalls;
+  let disposeActionListener;
+
+  beforeEach(() => {
+    actionCalls = [];
+    disposeActionListener = onAction(rootStore.notificationsStore, (call) => {
+      actionCalls.push(call);
+    });
+  });
+
+  afterEach(() => {
+    disposeActionListener();
+  });
+
+  const addCallCount = () => actionCalls.filter((call) => call.name === 'add').length;
+  const removeByUidCalls = () => actionCalls.filter((call) => call.name === 'removeByUid');
+
+  describe('the legacy content.action refresh branch (Blocking #1)', () => {
+    it('still refreshes the collections tree for a notification carrying only a legacy action, no subject', () => {
+      const context = buildContext();
+      const n = buildNotification({ content: { action: 'RefreshChemotionCollection' } });
+
+      handleNotification([n], 'add', context);
+
+      expect(context.collections.fetchCollections.callCount).toBe(1);
+    });
+
+    it('still refreshes for the other three legacy action strings', () => {
+      const legacyActions = [
+        'CollectionActions.fetchRemoteCollectionRoots',
+        'CollectionActions.fetchSyncInCollectionRoots',
+        'CollectionActions.fetchUnsharedCollectionRoots',
+      ];
+
+      legacyActions.forEach((action) => {
+        const context = buildContext();
+        handleNotification([buildNotification({ content: { action } })], 'add', context);
+        expect(context.collections.fetchCollections.callCount).toBe(1);
+      });
+    });
+  });
+
+  describe('silent vs. verbose toasts', () => {
+    it('skips the toast for a notification flagged content.silent', () => {
+      const context = buildContext();
+      const n = buildNotification({ subject: 'Shared Collection With Me', content: { silent: true } });
+
+      handleNotification([n], 'add', context);
+
+      expect(addCallCount()).toBe(0);
+      // Silent only means "no toast" — the tree still refreshes.
+      expect(context.collections.fetchCollections.callCount).toBe(1);
+    });
+
+    it('still toasts a verbose (non-silent) notification', () => {
+      const context = buildContext();
+      const n = buildNotification({ subject: 'Shared Collection With Me' });
+
+      handleNotification([n], 'add', context);
+
+      expect(addCallCount()).toBe(1);
+    });
+  });
+
+  describe('deduping the collections refresh across a batch', () => {
+    it('calls fetchCollections once, not once per matching notification', () => {
+      const context = buildContext();
+      const nots = [
+        buildNotification({ id: 1, subject: 'Shared Collection With Me' }),
+        buildNotification({ id: 2, subject: 'Shared Collection With Me' }),
+        buildNotification({ id: 3, content: { action: 'RefreshChemotionCollection' } }),
+      ];
+
+      handleNotification(nots, 'add', context);
+
+      expect(context.collections.fetchCollections.callCount).toBe(1);
+    });
+
+    it('does not refresh at all when nothing in the batch matches', () => {
+      const context = buildContext();
+      const nots = [buildNotification({ id: 1 }), buildNotification({ id: 2 })];
+
+      handleNotification(nots, 'add', context);
+
+      expect(context.collections.fetchCollections.callCount).toBe(0);
+    });
+  });
+
+  describe('the first-batch refresh guard', () => {
+    it('skips the refresh on the first batch even with a matching notification', () => {
+      const context = buildContext();
+      const n = buildNotification({ subject: 'Shared Collection With Me' });
+
+      handleNotification([n], 'add', context, true, true);
+
+      expect(context.collections.fetchCollections.callCount).toBe(0);
+    });
+
+    it('still shows the toast on the first batch — only the refresh is skipped', () => {
+      const context = buildContext();
+      const n = buildNotification({ subject: 'Shared Collection With Me' });
+
+      handleNotification([n], 'add', context, true, true);
+
+      expect(addCallCount()).toBe(1);
+    });
+
+    it('refreshes normally once isFirstBatch is false', () => {
+      const context = buildContext();
+      const n = buildNotification({ subject: 'Shared Collection With Me' });
+
+      handleNotification([n], 'add', context, true, false);
+
+      expect(context.collections.fetchCollections.callCount).toBe(1);
+    });
+  });
+
+  describe('act === "rem"', () => {
+    it('removes the toast by uid and never touches the collections refresh', () => {
+      const context = buildContext();
+      const n = buildNotification({ id: 42, subject: 'Shared Collection With Me' });
+
+      handleNotification([n], 'rem', context);
+
+      expect(removeByUidCalls().some((call) => call.args[0] === 42)).toBe(true);
+      expect(context.collections.fetchCollections.callCount).toBe(0);
+    });
+  });
+});

--- a/spec/javascripts/apps/mydb/mainNavigation/topbar/NoticeButton.spec.js
+++ b/spec/javascripts/apps/mydb/mainNavigation/topbar/NoticeButton.spec.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 import { onAction } from 'mobx-state-tree';
 import { handleNotification } from 'src/apps/mydb/mainNavigation/topbar/NoticeButton';
 import { rootStore } from 'src/stores/mobx/RootStore';
+import InboxActions from 'src/stores/alt/actions/InboxActions';
 
 // Minimal notification shape handleNotification actually reads: id, sender_name, created_at,
 // subject, and content (data/action/silent). Anything else in a real payload is irrelevant here.
@@ -84,6 +85,58 @@ describe('NoticeButton#handleNotification', () => {
       handleNotification([n], 'add', context);
 
       expect(addCallCount()).toBe(1);
+    });
+  });
+
+  // Regression coverage: silent notifications never toast, so counting them toward the toast-spam
+  // cap made the "You have N more notifications" summary overcount — the reported symptom was a
+  // batch showing "5 notifications" while only a couple of actual toasts (or none) ever appeared.
+  describe('the "N more notifications" summary cap', () => {
+    const addTitles = () => actionCalls.filter((call) => call.name === 'add').map((call) => call.args[0].title);
+
+    it('does not count silent notifications toward the cap or the summary', () => {
+      const context = buildContext();
+      const nots = [
+        ...Array.from({ length: 2 }, (unused, i) => buildNotification({ id: i, subject: 'Shared Collection With Me' })),
+        ...Array.from({ length: 5 }, (unused, i) => buildNotification({
+          id: 100 + i, subject: 'Shared Collection With Me', content: { silent: true },
+        })),
+      ];
+
+      handleNotification(nots, 'add', context);
+
+      // 2 verbose toasts, no "N more" summary (verbose count never exceeds 3).
+      expect(addCallCount()).toBe(2);
+      expect(addTitles().some((title) => title.includes('more notification'))).toBe(false);
+    });
+
+    it('still summarizes correctly when every notification in the batch is verbose (regression guard)', () => {
+      const context = buildContext();
+      const nots = Array.from({ length: 5 }, (unused, i) => buildNotification({ id: i, subject: 'Shared Collection With Me' }));
+
+      handleNotification(nots, 'add', context);
+
+      // First 3 toast individually, plus one summary toast for the remaining 2 — unchanged from
+      // before this fix.
+      expect(addCallCount()).toBe(4);
+      expect(addTitles()).toContain('You have 2 more notifications');
+    });
+
+    it('still dispatches a silent notification\'s action even past where the old cap would have hit', () => {
+      const context = buildContext();
+      const nots = [
+        ...Array.from({ length: 4 }, (unused, i) => buildNotification({ id: i, subject: 'Shared Collection With Me' })),
+        buildNotification({ id: 200, content: { silent: true, action: 'InboxActions.fetchInbox' } }),
+      ];
+      const fetchInboxSpy = sinon.stub(InboxActions, 'fetchInbox');
+
+      try {
+        handleNotification(nots, 'add', context);
+
+        expect(fetchInboxSpy.called).toBe(true);
+      } finally {
+        fetchInboxSpy.restore();
+      }
     });
   });
 

--- a/spec/javascripts/stores/mobx/CollectionsStore.spec.js
+++ b/spec/javascripts/stores/mobx/CollectionsStore.spec.js
@@ -114,6 +114,48 @@ describe('CollectionsStore', () => {
     });
   });
 
+  // Regression coverage: apply_to_subcollections/include_new_subcollections can cascade an edit
+  // onto descendants not previously shared, but PUT's response only ever carries the one edited
+  // share — never the cascade's effect on those descendants' `shared` flag — so own_collections
+  // has to be refetched to pick it up, the same way addCollectionShare/deleteCollectionShare
+  // already do. Without this, the owner's own tree kept showing newly-cascaded subcollections as
+  // unshared until a page reload.
+  describe('.updateCollectionShare', () => {
+    let updateStub;
+    let fetchCollectionsStub;
+    let getSharedWithUsersStub;
+
+    beforeEach(() => {
+      updateStub = sinon.stub(CollectionSharesFetcher, 'updateCollectionShare');
+      fetchCollectionsStub = sinon.stub(CollectionsFetcher, 'fetchCollections').resolves({ own: [], shared_with_me: [] });
+      // Unrelated to what this action's tested for — stubbed only so the store's own
+      // getSharedWithUsers call doesn't attempt a real network request in this environment.
+      getSharedWithUsersStub = sinon.stub(CollectionSharesFetcher, 'getCollectionSharedWithUsers').resolves([]);
+    });
+
+    afterEach(() => {
+      updateStub.restore();
+      fetchCollectionsStub.restore();
+      getSharedWithUsersStub.restore();
+    });
+
+    it('refetches collections on a successful update', async () => {
+      updateStub.resolves({ collection_id: 1 });
+
+      await store.updateCollectionShare(7, { permission_level: 1, apply_to_subcollections: true });
+
+      expect(fetchCollectionsStub.called).toBe(true);
+    });
+
+    it('does not refetch when the update fails (falsy response)', async () => {
+      updateStub.resolves(undefined);
+
+      await store.updateCollectionShare(7, { permission_level: 1 });
+
+      expect(fetchCollectionsStub.called).toBe(false);
+    });
+  });
+
   // Regression coverage for ComPlat/chemotion-eln#598: adding a collection (via the "+"
   // button, or "Assign/Move to Collection" with a brand-new name) used to rebuild
   // own_collection_tree from own_collections unconditionally, silently discarding any

--- a/spec/javascripts/stores/mobx/CollectionsStore.spec.js
+++ b/spec/javascripts/stores/mobx/CollectionsStore.spec.js
@@ -6,6 +6,7 @@ import { Collection } from 'src/stores/mobx/CollectionsStore';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
 import CollectionElementsFetcher from 'src/fetchers/CollectionElementsFetcher';
 import CollectionsFetcher from 'src/fetchers/CollectionsFetcher';
+import CollectionSharesFetcher from 'src/fetchers/CollectionSharesFetcher';
 
 // Pins removeElementsFromCollection's return contract { success, lockedSampleIds }. moveElementsToCollection
 // and the lock toast both branch on it, and the fetcher's return-shape change (boolean -> object|null|
@@ -301,6 +302,63 @@ describe('CollectionsStore', () => {
 
       expect(store.own_collections.map((c) => c.id)).toEqual([9]);
       expect(store.own_collections[0].ancestry).toEqual('/1/');
+    });
+  });
+
+  // Regression coverage: a collection-share notification (create/update/revoke/rename) only ever
+  // called fetchCollections(), which never touches my_collection_shares — so a sharee's permission-level
+  // tooltip stayed stale after a live permission change even though the tree itself refreshed
+  // correctly. This is the sibling refresh NoticeButton.js now calls alongside fetchCollections().
+  describe('.refreshMySharedCollectionShares', () => {
+    let getMySharesStub;
+
+    // SharedWithUser's MST model requires every detail-level column plus shared_with(_id/_type) —
+    // only permission_level varies across these fixtures.
+    const sharedWithUser = (permissionLevel) => ({
+      id: 101,
+      celllinesample_detail_level: 0,
+      devicedescription_detail_level: 0,
+      element_detail_level: 0,
+      permission_level: permissionLevel,
+      reaction_detail_level: 0,
+      researchplan_detail_level: 0,
+      sample_detail_level: 0,
+      screen_detail_level: 0,
+      sequencebasedmacromoleculesample_detail_level: 0,
+      shared_with: 'Some User',
+      shared_with_id: 1,
+      shared_with_type: 'Person',
+      wellplate_detail_level: 0,
+    });
+
+    beforeEach(() => {
+      getMySharesStub = sinon.stub(CollectionSharesFetcher, 'getMyCollectionShares');
+    });
+
+    afterEach(() => {
+      getMySharesStub.restore();
+    });
+
+    it('re-fetches shares only for collection ids already cached, updating them in place', async () => {
+      getMySharesStub.withArgs(1).resolves([sharedWithUser(1)]);
+      getMySharesStub.withArgs(2).resolves([sharedWithUser(3)]);
+      // Seed the cache the way getMySharesFor itself would (called once per id already).
+      await store.getMySharesFor(1);
+      await store.getMySharesFor(2);
+      getMySharesStub.resetHistory();
+      getMySharesStub.withArgs(1).resolves([sharedWithUser(9)]);
+
+      await store.refreshMySharedCollectionShares();
+
+      expect(getMySharesStub.calledWith(1)).toBe(true);
+      expect(getMySharesStub.calledWith(2)).toBe(true);
+      expect(store.mySharesFor(1).shared_with_users[0].permission_level).toBe(9);
+    });
+
+    it('is a no-op when nothing has been cached yet', async () => {
+      await store.refreshMySharedCollectionShares();
+
+      expect(getMySharesStub.called).toBe(false);
     });
   });
 });

--- a/spec/javascripts/stores/mobx/CollectionsStore.spec.js
+++ b/spec/javascripts/stores/mobx/CollectionsStore.spec.js
@@ -361,4 +361,60 @@ describe('CollectionsStore', () => {
       expect(getMySharesStub.called).toBe(false);
     });
   });
+
+  // Regression coverage for the nearest-shared-ancestor "adoption" fix: a node whose real parent
+  // isn't shared used to have its ENTIRE ancestry wiped to root (discarding a closer surviving
+  // shared ancestor), and — for two or more levels of shared descendants below such a gap — could
+  // throw inside fetchCollections entirely (undefined.addChild), per the traced A/B/C/D scenario.
+  describe('.setSharedWithMeCollections', () => {
+    const sharedCollection = (overrides) => ({
+      is_locked: false, owner: 'Alice', owner_name: 'Alice', position: 1, ...overrides,
+    });
+
+    it('adopts a node under its nearest shared ancestor when the direct parent is not shared', () => {
+      // A (shared, root) -> B (id 2, NOT shared) -> C (shared) -> D (shared)
+      const a = sharedCollection({ id: 1, label: 'A', ancestry: '/' });
+      const c = sharedCollection({ id: 3, label: 'C', ancestry: '/1/2/' });
+      const d = sharedCollection({ id: 4, label: 'D', ancestry: '/1/2/3/' });
+
+      store.setSharedWithMeCollections([a, c, d]);
+
+      const ownerRoot = store.shared_with_me_collections[0];
+      expect(ownerRoot.children.map((node) => node.id)).toEqual([1]);
+      const nodeA = ownerRoot.children[0];
+      expect(nodeA.children.map((node) => node.id)).toEqual([3]);
+      const nodeC = nodeA.children[0];
+      expect(nodeC.children.map((node) => node.id)).toEqual([4]);
+    });
+
+    // Regression coverage for the sibling-ordering refinement: position is only comparable among
+    // true original siblings. 33-37 are true siblings under /31/32/ (32 unshared); 45 (ancestry
+    // /31/, shallower) used to interleave with them because raw position was compared directly
+    // across unrelated original parents. Depth must win first: 45 before the whole 33-37 block,
+    // which stays contiguous and in original relative order since its own position IS comparable.
+    it('orders adopted siblings by original depth first, keeping true-sibling blocks contiguous and in order', () => {
+      const thirtyOne = sharedCollection({ id: 31, label: '31', ancestry: '/' });
+      const siblings = [33, 34, 35, 36, 37].map((id, index) => (
+        sharedCollection({ id, label: String(id), ancestry: '/31/32/', position: index + 1 })
+      ));
+      const fortyFive = sharedCollection({ id: 45, label: '45', ancestry: '/31/', position: 2 });
+
+      store.setSharedWithMeCollections([thirtyOne, fortyFive, ...siblings]);
+
+      const ownerRoot = store.shared_with_me_collections[0];
+      const node31 = ownerRoot.children[0];
+      expect(node31.id).toBe(31);
+      expect(node31.children.map((node) => node.id)).toEqual([45, 33, 34, 35, 36, 37]);
+    });
+
+    it('roots a node under the owner when none of its ancestors are shared at all', () => {
+      const e = sharedCollection({ id: 5, label: 'E', ancestry: '/99/' });
+
+      store.setSharedWithMeCollections([e]);
+
+      const ownerRoot = store.shared_with_me_collections[0];
+      expect(ownerRoot.children.map((node) => node.id)).toEqual([5]);
+      expect(ownerRoot.children[0].ancestry).toEqual('/');
+    });
+  });
 });

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+describe Message do
+  let(:sender) { create(:person) }
+  let(:receiver) { create(:person) }
+  let(:other_receiver) { create(:person) }
+  let(:channel) { create(:channel, channel_type: 8) }
+
+  describe '.create_msg_notification' do
+    it 'creates the message and a notification per receiver' do
+      expect do
+        described_class.create_msg_notification(
+          channel_id: channel.id,
+          message_content: { data: 'hello' },
+          message_from: sender.id,
+          message_to: [receiver.id, other_receiver.id],
+        )
+      end.to change(described_class, :count).by(1)
+         .and change(Notification, :count).by(2)
+
+      expect(Notification.where(user_id: [receiver.id, other_receiver.id]).count).to eq(2)
+    end
+
+    # bulk_create_notifications used to build its SQL by interpolating channel_id/message_id/
+    # user_id/receiver_ids straight into the query string. It now runs every id through
+    # Integer(...) before it ever reaches SQL text, so anything that is not a clean integer blows
+    # up here instead of being silently smuggled into the query.
+    it 'raises rather than build a query from a non-integer receiver id' do
+      expect do
+        described_class.create_msg_notification(
+          channel_id: channel.id,
+          message_content: { data: 'hello' },
+          message_from: sender.id,
+          message_to: ["#{receiver.id}); select 1"],
+        )
+      end.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/services/collection_share_notifier_spec.rb
+++ b/spec/services/collection_share_notifier_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe CollectionShareNotifier do
+  let(:actor) { create(:person) }
+  let(:recipient) { create(:person) }
+  let(:notifier) { described_class.new(actor) }
+
+  # Seeded in production by a data migration that db:schema:load never runs, so specs that exercise
+  # notify! have to seed it themselves too (same pattern as collection_share_api_spec.rb).
+  before { create(:channel, subject: Channel::SHARED_COLLECTION_WITH_ME, channel_type: 8) }
+
+  describe '#notify!' do
+    it 'creates a message and a notification for the recipient' do
+      expect do
+        notifier.notify!(recipient.id, 'hello')
+      end.to change(Message, :count).by(1)
+         .and change(Notification.where(user_id: recipient.id), :count).by(1)
+    end
+
+    it 'defaults to verbose (silent: false)' do
+      notifier.notify!(recipient.id, 'hello')
+
+      expect(Message.last.content['silent']).to be(false)
+    end
+
+    it 'records silent: true when asked' do
+      notifier.notify!(recipient.id, 'hello', silent: true)
+
+      expect(Message.last.content['silent']).to be(true)
+    end
+
+    it 'accepts a single id or an array of ids' do
+      other_recipient = create(:person)
+
+      expect do
+        notifier.notify!([recipient.id, other_recipient.id], 'hello')
+      end.to change(Notification, :count).by(2)
+    end
+
+    it 'is a no-op when user_ids is blank' do
+      expect { notifier.notify!(nil, 'hello') }.not_to change(Message, :count)
+      expect { notifier.notify!([], 'hello') }.not_to change(Message, :count)
+    end
+
+    it 'is a no-op when the Shared Collection With Me channel is missing' do
+      Channel.find_by(subject: Channel::SHARED_COLLECTION_WITH_ME).destroy!
+
+      expect { notifier.notify!(recipient.id, 'hello') }.not_to change(Message, :count)
+    end
+  end
+end

--- a/spec/usecases/collections/update_tree_spec.rb
+++ b/spec/usecases/collections/update_tree_spec.rb
@@ -60,5 +60,36 @@ RSpec.describe Usecases::Collections::UpdateTree do
         expect { usecase.perform!(collections: [{ id: first.id, label: 'First' }]) }.not_to raise_error
       end
     end
+
+    context 'when a renamed collection is shared with someone' do
+      let(:sharee) { create(:person) }
+
+      before do
+        create(:collection_share, collection: first, shared_with: sharee)
+        # Notifying a sharee reuses this channel — seeded in production by a data migration that
+        # db:schema:load never runs, so it has to be seeded here too.
+        create(:channel, subject: Channel::SHARED_COLLECTION_WITH_ME, channel_type: 8)
+      end
+
+      # Without this, the sharee's "Shared with me" tree keeps showing the old label until they
+      # reload the page — their poll only refetches on seeing a new notification (NoticeButton.js).
+      it 'notifies the sharee so their collection tree refreshes' do
+        expect do
+          usecase.perform!(collections: [{ id: first.id, label: 'Renamed' }])
+        end.to change(Notification.where(user_id: sharee.id), :count).by(1)
+      end
+
+      it 'does not notify when the label is left unchanged (a pure reorder/reparent)' do
+        payload = [{ id: first.id, label: 'First', children: [{ id: second.id, label: 'Second' }] }]
+
+        expect { usecase.perform!(collections: payload) }.not_to change(Notification, :count)
+      end
+    end
+
+    it 'does not notify anyone when the renamed collection has no shares' do
+      expect do
+        usecase.perform!(collections: [{ id: first.id, label: 'Renamed' }])
+      end.not_to change(Notification, :count)
+    end
   end
 end

--- a/spec/usecases/collections/update_tree_spec.rb
+++ b/spec/usecases/collections/update_tree_spec.rb
@@ -87,10 +87,39 @@ RSpec.describe Usecases::Collections::UpdateTree do
         expect(Message.last.content['silent']).to be(true)
       end
 
-      it 'does not notify when the label is left unchanged (a pure reorder/reparent)' do
+      # Reparenting/reordering an unshared sibling (second) must not spuriously notify the sharee
+      # about `first`, which is genuinely untouched by this save.
+      it 'does not notify when the shared collection itself is unchanged (only an unshared sibling moves)' do
         payload = [{ id: first.id, label: 'First', children: [{ id: second.id, label: 'Second' }] }]
 
         expect { usecase.perform!(collections: payload) }.not_to change(Notification, :count)
+      end
+
+      it 'does not notify when nothing about the shared collection changes' do
+        payload = [{ id: first.id, label: 'First' }, { id: second.id, label: 'Second' }]
+
+        expect { usecase.perform!(collections: payload) }.not_to change(Notification, :count)
+      end
+
+      # The sharee's tree is rebuilt from live ancestry/position on every refetch (see
+      # CollectionsStore.jsx), so a reparent needs the same "please refetch" signal a rename gets —
+      # without it, nesting silently drifts out of sync until an unrelated notification (or a page
+      # reload) happens to trigger a refresh.
+      it 'notifies when only the ancestry changes (a reparent, no rename)' do
+        container = create(:collection, user: user, label: 'Container')
+        payload = [{ id: container.id, label: 'Container', children: [{ id: first.id, label: 'First' }] }]
+
+        expect do
+          usecase.perform!(collections: payload)
+        end.to change(Notification.where(user_id: sharee.id), :count).by(1)
+      end
+
+      it 'notifies when only the position changes (a reorder, no rename or reparent)' do
+        payload = [{ id: second.id, label: 'Second' }, { id: first.id, label: 'First' }]
+
+        expect do
+          usecase.perform!(collections: payload)
+        end.to change(Notification.where(user_id: sharee.id), :count).by(1)
       end
     end
 

--- a/spec/usecases/collections/update_tree_spec.rb
+++ b/spec/usecases/collections/update_tree_spec.rb
@@ -79,6 +79,14 @@ RSpec.describe Usecases::Collections::UpdateTree do
         end.to change(Notification.where(user_id: sharee.id), :count).by(1)
       end
 
+      # A rename is housekeeping, not something worth interrupting the sharee for — the tree still
+      # refreshes (see the spec above), it just doesn't pop a dismiss-required toast.
+      it 'notifies silently' do
+        usecase.perform!(collections: [{ id: first.id, label: 'Renamed' }])
+
+        expect(Message.last.content['silent']).to be(true)
+      end
+
       it 'does not notify when the label is left unchanged (a pure reorder/reparent)' do
         payload = [{ id: first.id, label: 'First', children: [{ id: second.id, label: 'Second' }] }]
 


### PR DESCRIPTION
All shared collection changes produce server-side notifications.
Fixed security issue in message creation.