### PR TITLE
fix(collections): make the element collection-label badge legible and its warning owner-only

### DIFF
--- a/app/api/entities/collection_share_entity.rb
+++ b/app/api/entities/collection_share_entity.rb
@@ -18,6 +18,11 @@ module Entities
     expose! :sequencebasedmacromoleculesample_detail_level
     expose! :wellplate_detail_level
 
+    # Both dereference the association unguarded, and may: collection_shares.shared_with_id has a
+    # FK to users, so the row cannot outlive the account, and the association is declared
+    # +with_deleted+ so a *soft*-deleted sharee still resolves. Before that, a deleted sharee made
+    # this nil and every reader of the share 500ed. Keep them non-nil strings regardless — the
+    # frontend's mobx model declares both as required types.string.
     def shared_with
       "#{object.shared_with.name} (#{object.shared_with.name_abbreviation})"
     end

--- a/app/javascript/src/apps/mydb/elements/details/ElementDetailCard.js
+++ b/app/javascript/src/apps/mydb/elements/details/ElementDetailCard.js
@@ -24,6 +24,7 @@ export default function ElementDetailCard({
   isPendingToSave,
   title,
   titleTooltip,
+  titleAppendixLeading,
   titleAppendix,
   headerToolbar,
   headerBanner,
@@ -143,11 +144,18 @@ export default function ElementDetailCard({
   // Build title icon with ElementIcon
   const titleIcon = <ElementIcon element={element} />;
 
-  // Build title appendix with element labels + user labels + original appendix
+  // Title appendix: user labels, then whatever the element type wants ahead of the collection
+  // badge, then the badge, then the rest of its appendix. The split exists so a detail header can
+  // reproduce the order its list row uses — the badge sits between the reaction and analyses
+  // labels there (see SampleGroupItem), and this is the only seam that lets an element type put
+  // something in front of it without every caller having to render the badge itself.
   const elementTitleAppendix = (
     <>
-      {!element.isNew && <ElementCollectionLabels element={element} placement="right" size="sm" variant="secondary" />}
       {showUserLabels && <ShowUserLabels element={element} />}
+      {titleAppendixLeading}
+      {!element.isNew && (
+        <ElementCollectionLabels element={element} placement="right" size="xxsm" variant="light" />
+      )}
       {titleAppendix}
     </>
   );
@@ -232,6 +240,7 @@ ElementDetailCard.propTypes = {
   isPendingToSave: PropTypes.bool,
   title: PropTypes.node.isRequired,
   titleTooltip: PropTypes.string,
+  titleAppendixLeading: PropTypes.node,
   titleAppendix: PropTypes.node,
   headerToolbar: PropTypes.node,
   headerBanner: PropTypes.node,
@@ -249,6 +258,7 @@ ElementDetailCard.propTypes = {
 ElementDetailCard.defaultProps = {
   isPendingToSave: undefined,
   titleTooltip: null,
+  titleAppendixLeading: null,
   titleAppendix: null,
   headerToolbar: null,
   headerBanner: null,

--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -110,10 +110,15 @@ const sampleTitle = (sample) => {
   return inventoryLabel || sample.title();
 };
 
+// Split around the collection badge so the header reads in the same order as the list row
+// (SampleGroupItem): reaction, collection, analyses.
+const sampleTitleAppendixLeading = (sample) => (
+  <ElementReactionLabels element={sample} key={`${sample.id}_reactions`} />
+);
+
 const sampleTitleAppendix = (sample, handleFastInput) => (
   <>
     <ElementAnalysesLabels element={sample} key={`${sample.id}_analyses`} />
-    <ElementReactionLabels element={sample} key={`${sample.id}_reactions`} />
     <PubchemLabels element={sample} />
     {sample.isNew && !sample.isMixture() && <FastInput fnHandle={handleFastInput} />}
   </>
@@ -1601,6 +1606,7 @@ export default class SampleDetails extends React.Component {
         footerToolbar={this.sampleFooter()}
         title={sampleTitle(sample)}
         titleTooltip={formatTimeStampsOfElement(sample || {})}
+        titleAppendixLeading={sampleTitleAppendixLeading(sample)}
         titleAppendix={sampleTitleAppendix(sample, this.handleFastInput)}
         onSave={() => this.saveSampleOrChemical()}
         saveDisabled={saveDisabled}

--- a/app/javascript/src/apps/mydb/elements/labels/ElementCollectionLabels.js
+++ b/app/javascript/src/apps/mydb/elements/labels/ElementCollectionLabels.js
@@ -7,15 +7,38 @@ import {
   Button, Dropdown
 } from 'react-bootstrap';
 import UserStore from 'src/stores/alt/stores/UserStore';
+import PermissionIcons from 'src/apps/mydb/collections/PermissionIcons';
 import { aviatorNavigationWithCollectionId } from 'src/utilities/routesUtils';
 import { observer } from 'mobx-react';
 import { StoreContext } from 'src/stores/mobx/RootStore';
 
+// Warning texts for the two distinguishable dual-ownership cases. Both use the same glyph —
+// what differs is whether the other collection is one the viewer can actually reach.
+const DUAL_OWNED_REACHABLE = 'Also shared with you elsewhere';
+const DUAL_OWNED_UNREACHABLE = "Also present in a collection you can't access";
+
+// Both share directions use `fa-share-alt`, matching the rest of the app: the collection sidebar
+// already marks an own collection the viewer shared out with this glyph (MyCollections.js), and a
+// badge that disagreed with the tree one screen away would cost more than the local ambiguity it
+// removed. The two directions are told apart by position and by the `title` on every chip, not by
+// the glyph. If the app ever settles on a distinct shared-out glyph, change it here and there
+// together.
+const SHARED_WITH_ME_ICON = 'fa fa-share-alt';
+const SHARED_OUT_ICON = 'fa fa-share-alt';
+
+const pluralCollections = (count) => (count === 1 ? 'collection' : 'collections');
+
+// Each chip renders only when it applies, so an element in a single own collection shows one
+// count and nothing else. `sharedOutCount` is the subset of the viewer's own collections that
+// they have shared out to someone — derived from `Collection.shared`, already fetched. Every chip
+// spells its counts out in a `title`: the glyphs alone are not self-describing, and the button's
+// own title is reserved for the dual-ownership warning.
 const CollectionToggle = React.forwardRef(({
   onClick,
-  labelsCount,
-  totalSharedCollections,
-  isDualOwned,
+  ownCount,
+  sharedOutCount,
+  sharedCount,
+  dualOwnedTitle,
   size,
   variant,
 }, ref) => (
@@ -24,33 +47,54 @@ const CollectionToggle = React.forwardRef(({
     size={size}
     variant={variant}
     className="text-nowrap"
-    title={isDualOwned ? 'This element is also in a collection you do not own' : undefined}
+    title={dualOwnedTitle || undefined}
     onClick={(e) => {
       e.preventDefault();
       e.stopPropagation();
       onClick(e);
     }}
   >
-    <i className="fa fa-list" />
-    {` ${labelsCount} `}
-    {' | '}
-    <span className={isDualOwned ? 'text-warning' : undefined}>
-      <i className="fa fa-share-alt" />
-      {`${totalSharedCollections} `}
-    </span>
+    {ownCount > 0 && (
+      <span
+        className="collection-labels-own"
+        title={`In ${ownCount} of your own ${pluralCollections(ownCount)}${
+          sharedOutCount > 0 ? `, ${sharedOutCount} of which you shared with others` : ''}`}
+      >
+        <i className="fa fa-list" />
+        {` ${ownCount}`}
+        {sharedOutCount > 0 && ` [${sharedOutCount}]`}
+      </span>
+    )}
+    {sharedCount > 0 && (
+      <span
+        className={`collection-labels-shared${ownCount > 0 ? ' ms-1' : ''}`}
+        title={`In ${sharedCount} ${pluralCollections(sharedCount)} shared with you`}
+      >
+        <i className={SHARED_WITH_ME_ICON} />
+        {` ${sharedCount}`}
+      </span>
+    )}
+    {dualOwnedTitle && (
+      // Persistent, not color-only and not hover-only: the warning has to survive both a
+      // colour-blind viewer and a touch device with no hover.
+      <span className="collection-labels-dual-owned text-warning ms-1">
+        <i className="fa fa-exclamation-triangle" />
+      </span>
+    )}
   </Button>
 ));
 CollectionToggle.displayName = 'CollectionToggle';
 CollectionToggle.propTypes = {
   onClick: PropTypes.func.isRequired,
-  labelsCount: PropTypes.number.isRequired,
-  totalSharedCollections: PropTypes.number.isRequired,
-  isDualOwned: PropTypes.bool,
+  ownCount: PropTypes.number.isRequired,
+  sharedOutCount: PropTypes.number.isRequired,
+  sharedCount: PropTypes.number.isRequired,
+  dualOwnedTitle: PropTypes.string,
   size: PropTypes.string,
   variant: PropTypes.string,
 };
 CollectionToggle.defaultProps = {
-  isDualOwned: false,
+  dualOwnedTitle: null,
   size: 'xxsm',
   variant: 'light',
 };
@@ -70,53 +114,140 @@ const ElementCollectionLabels = ({ element, size, variant }) => {
     aviatorNavigationWithCollectionId(label.id, element.type, element.id, true, true);
   };
 
-  const formatItems = (labels) => {
-    return labels.map((label) => {
-      const collectionFromStore = collectionsStore.find(label.id);
-      if (!collectionFromStore) return null;
-
-      return (
-        <Dropdown.Item key={label.id} onClick={(e) => handleOnClick(label, e)}>
-          {collectionFromStore.label}
-        </Dropdown.Item>
-      );
-    });
-  };
-
-  const renderCollectionsItems = (title, labels) => {
-    if (labels.length === 0) return null;
-    return (
-      <>
-        <Dropdown.Header>{title}</Dropdown.Header>
-        {formatItems(labels)}
-      </>
-    );
-  };
-
   // Guard against malformed entries: legacy/un-backfilled tags can contain null elements or
   // entries without a real collection id, which would otherwise throw on `label.id`.
   const validLabels = element.tag.taggable_data.collection_labels
     .filter((label) => label && label.id != null);
-  const ownCollections = validLabels.filter((label) => collectionsStore.isOwnCollection(label.id));
-  const sharedCollections = validLabels.filter((label) => collectionsStore.isSharedCollection(label.id));
+  // One pass, one store lookup per label. Both `isOwnCollection` and `isSharedCollection` scan a
+  // computed id array, and `find` walks the collection trees, so the counts and the menu resolve
+  // each label once and carry the collection along instead of re-resolving it per render helper.
+  //
+  // "Own" is `user_id == current_user.id` and nothing else, so this includes the viewer's own
+  // repository subtree ("chemotion-repository.net" and "transferred"). Unlike the locked "All"
+  // bucket — dropped server-side because it holds every element by definition and says nothing —
+  // having reached the repository is a specific fact about this element, and the collection is
+  // right there in the sidebar. Someone else's repository subtree is not in this store and
+  // correctly stays unreachable.
+  //
+  // A label that resolves to no tree at all is a collection someone else owns and has not shared
+  // with the viewer; only its count is kept. The ids already ship to the owner at detail level 10 —
+  // this only derives a boolean from them, and never names the collection or its owner.
+  const ownEntries = [];
+  const sharedEntries = [];
+  let unreachableCount = 0;
+  validLabels.forEach((label) => {
+    const isOwn = collectionsStore.isOwnCollection(label.id);
+    // An id in either tree always resolves through `find`; a label that somehow does not is
+    // counted as unreachable rather than inflating a chip the menu then cannot name.
+    const collection = (isOwn || collectionsStore.isSharedCollection(label.id))
+      ? collectionsStore.find(label.id)
+      : null;
+    if (!collection) { unreachableCount += 1; return; }
+    (isOwn ? ownEntries : sharedEntries).push({ label, collection });
+  });
 
-  if (ownCollections.length === 0 && sharedCollections.length === 0) { return (<span />); }
+  if (ownEntries.length === 0 && sharedEntries.length === 0) { return (<span />); }
+
+  const sharedOutCount = ownEntries.filter(({ collection }) => collection.shared === true).length;
+
+  const dualOwnedMessages = [];
+  if (ownEntries.length > 0 && sharedEntries.length > 0) {
+    dualOwnedMessages.push(DUAL_OWNED_REACHABLE);
+  }
+  if (ownEntries.length > 0 && unreachableCount > 0) {
+    dualOwnedMessages.push(DUAL_OWNED_UNREACHABLE);
+  }
+
+  const renderOwnCollections = () => {
+    if (ownEntries.length === 0) return null;
+    return (
+      <>
+        <Dropdown.Header>My Collections</Dropdown.Header>
+        {ownEntries.map(({ label, collection }) => (
+          <Dropdown.Item key={label.id} onClick={(e) => handleOnClick(label, e)}>
+            {collection.label}
+            {collection.shared === true && (
+              <i
+                className={`${SHARED_OUT_ICON} ms-1 text-body-secondary`}
+                title="You shared this collection with others"
+              />
+            )}
+          </Dropdown.Item>
+        ))}
+      </>
+    );
+  };
+
+  // Grouped by owner so "three collections from two people" reads as such. Keyed on `owner`
+  // ("First Last (ABBR)") exactly as the store's own grouping in `setSharedWithMeCollections`: two
+  // users can share a plain name, so `owner_name` alone would merge them into one group — and it is
+  // also the React key here. The group is still labelled with the plain `owner_name`.
+  //
+  // The group name behind `shared_via_group` deliberately stays out: it needs a per-collection
+  // `mySharesFor` fetch, and a dense element list would fire one per badge.
+  const renderSharedCollections = () => {
+    if (sharedEntries.length === 0) return null;
+
+    const byOwner = new Map();
+    sharedEntries.forEach((entry) => {
+      const { collection } = entry;
+      const ownerKey = collection.owner || collection.owner_name || 'Unknown owner';
+      if (!byOwner.has(ownerKey)) byOwner.set(ownerKey, []);
+      byOwner.get(ownerKey).push(entry);
+    });
+
+    return (
+      <>
+        <Dropdown.Header>Shared Collections</Dropdown.Header>
+        {Array.from(byOwner.entries()).map(([ownerKey, entries]) => (
+          <React.Fragment key={ownerKey}>
+            <Dropdown.ItemText className="small text-body-secondary">
+              {entries[0].collection.owner_name || ownerKey}
+            </Dropdown.ItemText>
+            {entries.map(({ label, collection }) => (
+              <Dropdown.Item key={label.id} onClick={(e) => handleOnClick(label, e)}>
+                <span className="me-1">{collection.label}</span>
+                {collection.shared_via_group && (
+                  <span className="me-1 text-body-secondary">(via group)</span>
+                )}
+                {collection.permission_level != null && (
+                  <PermissionIcons pl={collection.permission_level} />
+                )}
+              </Dropdown.Item>
+            ))}
+          </React.Fragment>
+        ))}
+      </>
+    );
+  };
 
   return (
     <Dropdown>
       <Dropdown.Toggle
         as={CollectionToggle}
         id="dropdown-custom-components"
-        labelsCount={ownCollections.length}
-        totalSharedCollections={sharedCollections.length}
-        isDualOwned={ownCollections.length > 0 && sharedCollections.length > 0}
+        ownCount={ownEntries.length}
+        sharedOutCount={sharedOutCount}
+        sharedCount={sharedEntries.length}
+        dualOwnedTitle={dualOwnedMessages.join(' · ') || null}
         size={size}
         variant={variant}
       />
       {createPortal(
         <Dropdown.Menu>
-          {renderCollectionsItems('My Collections', ownCollections)}
-          {renderCollectionsItems('Shared Collections', sharedCollections)}
+          {renderOwnCollections()}
+          {renderSharedCollections()}
+          {dualOwnedMessages.length > 0 && (
+            <>
+              <Dropdown.Divider />
+              {dualOwnedMessages.map((message) => (
+                <Dropdown.ItemText key={message} className="small text-warning">
+                  <i className="fa fa-exclamation-triangle me-1" />
+                  {message}
+                </Dropdown.ItemText>
+              ))}
+            </>
+          )}
         </Dropdown.Menu>,
         document.body
       )}

--- a/app/javascript/src/apps/mydb/elements/labels/ElementCollectionLabels.js
+++ b/app/javascript/src/apps/mydb/elements/labels/ElementCollectionLabels.js
@@ -4,27 +4,34 @@ import React, { useContext } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import {
-  Button, Dropdown
+  Button, Dropdown, OverlayTrigger
 } from 'react-bootstrap';
 import UserStore from 'src/stores/alt/stores/UserStore';
 import PermissionIcons from 'src/apps/mydb/collections/PermissionIcons';
+import UserInfosTooltip from 'src/apps/mydb/collections/UserInfosTooltip';
+import SharedToMeInfosTooltip from 'src/apps/mydb/collections/SharedToMeInfosTooltip';
 import { aviatorNavigationWithCollectionId } from 'src/utilities/routesUtils';
 import { observer } from 'mobx-react';
 import { StoreContext } from 'src/stores/mobx/RootStore';
 
-// Warning texts for the two distinguishable dual-ownership cases. Both use the same glyph —
-// what differs is whether the other collection is one the viewer can actually reach.
-const DUAL_OWNED_REACHABLE = 'Also shared with you elsewhere';
+// Exactly one of these is a warning. Being co-present in a collection the viewer *can* open is
+// ordinary collaboration and only earns a line in the popover; being co-present in one they
+// cannot open is the thing they have no other way to discover, and is the only case that earns
+// the triangle.
+const COPRESENT_REACHABLE_INFO = 'Also shared with you elsewhere';
 const DUAL_OWNED_UNREACHABLE = "Also present in a collection you can't access";
 
-// Both share directions use `fa-share-alt`, matching the rest of the app: the collection sidebar
-// already marks an own collection the viewer shared out with this glyph (MyCollections.js), and a
-// badge that disagreed with the tree one screen away would cost more than the local ambiguity it
-// removed. The two directions are told apart by position and by the `title` on every chip, not by
-// the glyph. If the app ever settles on a distinct shared-out glyph, change it here and there
-// together.
-const SHARED_WITH_ME_ICON = 'fa fa-share-alt';
-const SHARED_OUT_ICON = 'fa fa-share-alt';
+// Directional glyphs from the chemstrap-icons font (global-styles/icons.scss), so the two share
+// directions cannot be mistaken for each other: incoming = shared to the viewer, outgoing = the
+// viewer shared it out. `type-icon` carries no glyph of its own — it matches how SidebarButton
+// emits these — the meaning is entirely in `icon-incoming` / `icon-outgoing`.
+const SHARED_WITH_ME_ICON = 'type-icon icon-incoming';
+const SHARED_OUT_ICON = 'type-icon icon-outgoing';
+// The popover lists collections, one per row, the way the sidebar does — so it marks a shared-out
+// one the way the sidebar does too (MyCollections.js, CollectionSubtree.js). The directional pair
+// above earns its keep only in the summary chip, where the two counts sit side by side and must
+// not be read as each other; in a list of rows there is nothing to confuse it with.
+const SHARED_OUT_ROW_ICON = 'fa fa-share-alt';
 
 const pluralCollections = (count) => (count === 1 ? 'collection' : 'collections');
 
@@ -32,13 +39,13 @@ const pluralCollections = (count) => (count === 1 ? 'collection' : 'collections'
 // count and nothing else. `sharedOutCount` is the subset of the viewer's own collections that
 // they have shared out to someone — derived from `Collection.shared`, already fetched. Every chip
 // spells its counts out in a `title`: the glyphs alone are not self-describing, and the button's
-// own title is reserved for the dual-ownership warning.
+// own title is reserved for the warning.
 const CollectionToggle = React.forwardRef(({
   onClick,
   ownCount,
   sharedOutCount,
   sharedCount,
-  dualOwnedTitle,
+  warningTitle,
   size,
   variant,
 }, ref) => (
@@ -47,7 +54,7 @@ const CollectionToggle = React.forwardRef(({
     size={size}
     variant={variant}
     className="text-nowrap"
-    title={dualOwnedTitle || undefined}
+    title={warningTitle || undefined}
     onClick={(e) => {
       e.preventDefault();
       e.stopPropagation();
@@ -61,8 +68,13 @@ const CollectionToggle = React.forwardRef(({
           sharedOutCount > 0 ? `, ${sharedOutCount} of which you shared with others` : ''}`}
       >
         <i className="fa fa-list" />
-        {` ${ownCount}`}
-        {sharedOutCount > 0 && ` [${sharedOutCount}]`}
+        {` ${ownCount} `}
+        {sharedOutCount > 0 && (
+          <>
+            <i className={`${SHARED_OUT_ICON} me-1`} />
+            {`${sharedOutCount}`}
+          </>
+        )}
       </span>
     )}
     {sharedCount > 0 && (
@@ -74,10 +86,11 @@ const CollectionToggle = React.forwardRef(({
         {` ${sharedCount}`}
       </span>
     )}
-    {dualOwnedTitle && (
-      // Persistent, not color-only and not hover-only: the warning has to survive both a
-      // colour-blind viewer and a touch device with no hover.
-      <span className="collection-labels-dual-owned text-warning ms-1">
+    {warningTitle && (
+      // Persistent, not hover-only, so it survives a touch device. It takes the label's own font
+      // colour here — the glyph alone carries the signal, and the popover states it in warning
+      // colour with the reason spelled out.
+      <span className="collection-labels-dual-owned ms-1">
         <i className="fa fa-exclamation-triangle" />
       </span>
     )}
@@ -89,12 +102,12 @@ CollectionToggle.propTypes = {
   ownCount: PropTypes.number.isRequired,
   sharedOutCount: PropTypes.number.isRequired,
   sharedCount: PropTypes.number.isRequired,
-  dualOwnedTitle: PropTypes.string,
+  warningTitle: PropTypes.string,
   size: PropTypes.string,
   variant: PropTypes.string,
 };
 CollectionToggle.defaultProps = {
-  dualOwnedTitle: null,
+  warningTitle: null,
   size: 'xxsm',
   variant: 'light',
 };
@@ -150,13 +163,22 @@ const ElementCollectionLabels = ({ element, size, variant }) => {
 
   const sharedOutCount = ownEntries.filter(({ collection }) => collection.shared === true).length;
 
-  const dualOwnedMessages = [];
-  if (ownEntries.length > 0 && sharedEntries.length > 0) {
-    dualOwnedMessages.push(DUAL_OWNED_REACHABLE);
-  }
-  if (ownEntries.length > 0 && unreachableCount > 0) {
-    dualOwnedMessages.push(DUAL_OWNED_UNREACHABLE);
-  }
+  // Ownership is the whole gate, matching ElementPolicy, which resolves every capability to "is
+  // it in a collection I own" (record_is_in_own_collection?). Own a collection holding this
+  // element and you are told it also sits somewhere you cannot see — whoever holds it, and
+  // whether or not anyone has shared anything back. Own none of them and you are only a sharee:
+  // where else it lives belongs to the people who do own it.
+  //
+  // Deliberately not narrowed by who holds the hidden collection. An earlier version suppressed
+  // the warning whenever the viewer held any share for the element, on the theory that they had
+  // arrived through someone else — but an unrelated colleague's share then masked a genuine third
+  // party holding the element, which is precisely the thing the owner cannot discover any other
+  // way. Telling the two apart would need the hidden collection's owner, and collection_labels
+  // carries `{id}` and nothing else, so it is not knowable here. It also should not matter.
+  const showUnreachableWarning = ownEntries.length > 0 && unreachableCount > 0;
+  // Not a warning: both collections are open to the viewer. It earns a popover line because
+  // removing the element from their own collection will not remove it from the other one.
+  const showReachableInfo = ownEntries.length > 0 && sharedEntries.length > 0;
 
   const renderOwnCollections = () => {
     if (ownEntries.length === 0) return null;
@@ -167,10 +189,13 @@ const ElementCollectionLabels = ({ element, size, variant }) => {
           <Dropdown.Item key={label.id} onClick={(e) => handleOnClick(label, e)}>
             {collection.label}
             {collection.shared === true && (
-              <i
-                className={`${SHARED_OUT_ICON} ms-1 text-body-secondary`}
-                title="You shared this collection with others"
-              />
+              // Same icon and same tooltip as the sidebar: hover names who it is shared with, and
+              // at what permission. Costs nothing until then — the overlay is not mounted while
+              // hidden, so its fetch does not run, and the menu's rows do not exist at all until
+              // the popover is first opened. Do not add `renderOnMount` to the menu below.
+              <OverlayTrigger placement="top" overlay={<UserInfosTooltip collectionId={label.id} />}>
+                <i className={`${SHARED_OUT_ROW_ICON} ms-1 text-body-secondary`} />
+              </OverlayTrigger>
             )}
           </Dropdown.Item>
         ))}
@@ -178,13 +203,19 @@ const ElementCollectionLabels = ({ element, size, variant }) => {
     );
   };
 
-  // Grouped by owner so "three collections from two people" reads as such. Keyed on `owner`
-  // ("First Last (ABBR)") exactly as the store's own grouping in `setSharedWithMeCollections`: two
-  // users can share a plain name, so `owner_name` alone would merge them into one group — and it is
-  // also the React key here. The group is still labelled with the plain `owner_name`.
+  // Grouped by owner so "three collections from two people" reads as such, and sorted by owner
+  // then label: the tag array's order is arbitrary, so without this the same shares appear in a
+  // different order on every element and disagree with the sidebar, which presorts by owner.
   //
-  // The group name behind `shared_via_group` deliberately stays out: it needs a per-collection
-  // `mySharesFor` fetch, and a dense element list would fire one per badge.
+  // Keyed on `owner` ("First Last (ABBR)") exactly as the store's own grouping in
+  // `setSharedWithMeCollections`: two users can share a plain name, so `owner_name` alone would
+  // merge them into one group — and it is also the React key here. The group is still labelled
+  // with the plain `owner_name`.
+  //
+  // "(via group)" stays generic in the row itself — naming the group needs a per-collection
+  // `mySharesFor` fetch, and a dense element list would once have fired one per badge. Hovering
+  // the row lifts that: the tooltip is not mounted until then, so the fetch is per-hover, and it
+  // names the group along with every other share that reaches the viewer.
   const renderSharedCollections = () => {
     if (sharedEntries.length === 0) return null;
 
@@ -196,23 +227,47 @@ const ElementCollectionLabels = ({ element, size, variant }) => {
       byOwner.get(ownerKey).push(entry);
     });
 
+    const sortedGroups = Array.from(byOwner.entries())
+      .map(([ownerKey, entries]) => [
+        ownerKey,
+        entries.slice().sort((a, b) => a.collection.label.localeCompare(b.collection.label)),
+      ])
+      .sort(([, a], [, b]) => (
+        (a[0].collection.owner_name || '').localeCompare(b[0].collection.owner_name || '')
+      ));
+
     return (
       <>
-        <Dropdown.Header>Shared Collections</Dropdown.Header>
-        {Array.from(byOwner.entries()).map(([ownerKey, entries]) => (
+        <Dropdown.Header>
+          <i className={`${SHARED_WITH_ME_ICON} me-1`} />
+          Shared with me by
+        </Dropdown.Header>
+        {sortedGroups.map(([ownerKey, entries]) => (
           <React.Fragment key={ownerKey}>
             <Dropdown.ItemText className="small text-body-secondary">
               {entries[0].collection.owner_name || ownerKey}
             </Dropdown.ItemText>
             {entries.map(({ label, collection }) => (
               <Dropdown.Item key={label.id} onClick={(e) => handleOnClick(label, e)}>
-                <span className="me-1">{collection.label}</span>
-                {collection.shared_via_group && (
-                  <span className="me-1 text-body-secondary">(via group)</span>
-                )}
-                {collection.permission_level != null && (
-                  <PermissionIcons pl={collection.permission_level} />
-                )}
+                <OverlayTrigger
+                  placement="top"
+                  overlay={(
+                    <SharedToMeInfosTooltip
+                      collectionId={label.id}
+                      owner={collection.owner_name || collection.owner}
+                    />
+                  )}
+                >
+                  <span>
+                    <span className="me-1">{collection.label}</span>
+                    {collection.shared_via_group && (
+                      <span className="me-1 text-body-secondary">(via group)</span>
+                    )}
+                    {collection.permission_level != null && (
+                      <PermissionIcons pl={collection.permission_level} />
+                    )}
+                  </span>
+                </OverlayTrigger>
               </Dropdown.Item>
             ))}
           </React.Fragment>
@@ -229,7 +284,7 @@ const ElementCollectionLabels = ({ element, size, variant }) => {
         ownCount={ownEntries.length}
         sharedOutCount={sharedOutCount}
         sharedCount={sharedEntries.length}
-        dualOwnedTitle={dualOwnedMessages.join(' · ') || null}
+        warningTitle={showUnreachableWarning ? DUAL_OWNED_UNREACHABLE : null}
         size={size}
         variant={variant}
       />
@@ -237,15 +292,20 @@ const ElementCollectionLabels = ({ element, size, variant }) => {
         <Dropdown.Menu>
           {renderOwnCollections()}
           {renderSharedCollections()}
-          {dualOwnedMessages.length > 0 && (
+          {(showUnreachableWarning || showReachableInfo) && (
             <>
               <Dropdown.Divider />
-              {dualOwnedMessages.map((message) => (
-                <Dropdown.ItemText key={message} className="small text-warning">
+              {showUnreachableWarning && (
+                <Dropdown.ItemText className="small text-warning">
                   <i className="fa fa-exclamation-triangle me-1" />
-                  {message}
+                  {DUAL_OWNED_UNREACHABLE}
                 </Dropdown.ItemText>
-              ))}
+              )}
+              {showReachableInfo && (
+                <Dropdown.ItemText className="small text-body-secondary">
+                  {COPRESENT_REACHABLE_INFO}
+                </Dropdown.ItemText>
+              )}
             </>
           )}
         </Dropdown.Menu>,

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -658,7 +658,16 @@ export const CollectionsStore = types
     get sharedWithMeCollections() { return values(self.shared_with_me_collections) },
     isOwnCollection(collection_id) { return self.ownCollectionIds.indexOf(collection_id) != -1 },
     isSharedCollection(collection_id) { return self.sharedCollectionIds.indexOf(collection_id) != -1 },
-    get ownCollectionIds() { return self.own_collections.flatMap(collection => collection.idAndDescendantIds) },
+    // Ownership is personal and has one definition — Collection#owned_by? is `user_id == user.id`,
+    // and the `own` payload is `own_collections_for`, i.e. every collection with that user_id. The
+    // repository subtree is part of that; it only sits on its own field because the sidebar renders
+    // it as a separate section, which must not narrow what the user owns.
+    get ownCollectionIds() {
+      const repositoryIds = self.chemotion_repository_collection
+        ? self.chemotion_repository_collection.idAndDescendantIds
+        : [];
+      return self.own_collections.flatMap((collection) => collection.idAndDescendantIds).concat(repositoryIds);
+    },
     get sharedCollectionIds() { return self.shared_with_me_collections.flatMap(collection => collection.idAndDescendantIds) },
     descendantIds(collection) { return collection.children.flatMap(collection => collection.idAndDescendantIds) },
     sharedWithUsers(collection_id) { return self.collection_shares.find((share) => share.id == collection_id) },

--- a/app/models/collection_share.rb
+++ b/app/models/collection_share.rb
@@ -54,7 +54,11 @@ class CollectionShare < ApplicationRecord
   }.freeze
 
   belongs_to :collection
-  belongs_to :shared_with, class_name: 'User'
+  # +with_deleted+: User is acts_as_paranoid, and nothing purges collection_shares when an account
+  # is soft-deleted — the row survives and keeps collections.shared true, so the UI still offers
+  # the share. Without this the association resolves to nil and every reader of the share (the
+  # sidebar hover, the manage-shares modal, the element-list prefetch) 500s on it.
+  belongs_to :shared_with, -> { with_deleted }, class_name: 'User', inverse_of: false
 
   # Shares on the user's *own* collections. Personal, like Collection#owned_by?: a share a group
   # made is the group's to enumerate or revoke, not each member's.

--- a/spec/api/chemotion/collection_share_api_spec.rb
+++ b/spec/api/chemotion/collection_share_api_spec.rb
@@ -271,6 +271,34 @@ describe Chemotion::CollectionShareAPI do
     end
   end
 
+  # Nothing purges collection_shares when an account is deleted, and collections.shared stays
+  # true, so the owner keeps seeing the share icon. Listing the share must survive the sharee
+  # being gone — hovering that icon used to 500 on the entity dereferencing a nil association.
+  describe 'GET /api/v1/collection_shares with a deleted sharee' do
+    subject(:list) do
+      get "/api/v1/collection_shares?collection_id=#{collection.id}"
+      response
+    end
+
+    before { collection_share }
+
+    context 'when the sharee account is soft-deleted' do
+      before { other_user.destroy }
+
+      it 'still lists the share, naming the deleted user' do
+        expect(list).to have_http_status(:ok)
+        expect(parsed_json_response['collection_shares']).to contain_exactly(
+          include('shared_with' => "#{other_user.name} (#{other_user.name_abbreviation})",
+                  'shared_with_type' => 'Person'),
+        )
+      end
+    end
+
+    it 'cannot be reached by a hard destroy — the FK to users forbids it' do
+      expect { other_user.really_destroy! }.to raise_error(ActiveRecord::InvalidForeignKey)
+    end
+  end
+
   describe 'GET /api/v1/collection_shares/for_me' do
     subject(:shares) do
       get "/api/v1/collection_shares/for_me?collection_id=#{collection.id}"

--- a/spec/javascripts/packs/src/apps/mydb/elements/labels/ElementCollectionLabels.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/labels/ElementCollectionLabels.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import expect from 'expect';
 import sinon from 'sinon';
 import Enzyme, { mount } from 'enzyme';
+import { OverlayTrigger } from 'react-bootstrap';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 // RootStore must be required BEFORE the component under test. This is the first spec to mount a
 // component that transitively imports `src/utilities/routesUtils`, and the reverse order trips a
@@ -19,11 +20,19 @@ Enzyme.configure({ adapter: new Adapter() });
 // root and its "transferred" child). The store keeps that subtree on its own field for the
 // sidebar, but `isOwnCollection` counts it as own — ownership is `user_id == current_user.id`,
 // see the `.ownCollectionIds` cases in CollectionsStore.spec.js.
+// The share fetchers are spied, never stubbed with data: the point of the tooltips is that they
+// are not mounted until hovered, so these must stay uncalled through render and open.
+const shareFetches = { own: sinon.spy(), sharedToMe: sinon.spy() };
+
 const storeFor = (collections) => ({
   collections: {
     find: (id) => collections.find((c) => c.id === id) || null,
     isOwnCollection: (id) => collections.some((c) => c.id === id && (c.own || c.repository)),
     isSharedCollection: (id) => collections.some((c) => c.id === id && c.sharedWithMe),
+    sharedWithUsers: () => undefined,
+    mySharesFor: () => undefined,
+    getSharedWithUsers: shareFetches.own,
+    getMySharesFor: shareFetches.sharedToMe,
   },
 });
 
@@ -51,6 +60,8 @@ describe('ElementCollectionLabels', () => {
   let userStub;
 
   beforeEach(() => {
+    shareFetches.own.resetHistory();
+    shareFetches.sharedToMe.resetHistory();
     userStub = sinon.stub(UserStore, 'getState').returns({ currentUser: { id: 1 } });
   });
 
@@ -107,7 +118,7 @@ describe('ElementCollectionLabels', () => {
         elementWith([1, 2])
       );
 
-      expect(wrapper.find('.collection-labels-own').first().text().trim()).toEqual('2 [1]');
+      expect(wrapper.find('.collection-labels-own').first().text().trim()).toEqual('2 1');
     });
 
     it('shows only the shared-with-me chip when the viewer owns none of them', () => {
@@ -121,14 +132,33 @@ describe('ElementCollectionLabels', () => {
       expect(wrapper.find('.collection-labels-dual-owned')).toHaveLength(0);
     });
 
-    it('warns, with the reachable wording, when the element is both owned and shared to the viewer', () => {
+    // S3/user1. Co-presence in a collection the viewer can open is ordinary collaboration: the
+    // shared chip already says so, and the popover explains the consequence. No triangle.
+    it('does not warn when the other collection is one the viewer can open', () => {
       const wrapper = render(
         [{ id: 1, label: 'Mine', own: true }, { id: 5, label: 'Theirs', sharedWithMe: true, owner_name: 'Ada L' }],
         elementWith([1, 5])
       );
 
-      expect(wrapper.find('.collection-labels-dual-owned')).toHaveLength(1);
-      expect(wrapper.find('button').first().prop('title')).toEqual('Also shared with you elsewhere');
+      expect(wrapper.find('.collection-labels-dual-owned')).toHaveLength(0);
+      expect(wrapper.find('button').first().prop('title')).toEqual(undefined);
+    });
+
+    // The triangle must stay bound to the unreachable case alone; a refactor that re-attached it
+    // to "has any message" would silently resurrect the benign warning.
+    it('keeps the triangle off when only the reachable case applies', () => {
+      const wrapper = render(
+        [
+          { id: 1, label: 'Mine', own: true },
+          { id: 2, label: 'Also mine', own: true },
+          { id: 5, label: 'Theirs', sharedWithMe: true, owner_name: 'Ada L' },
+        ],
+        elementWith([1, 2, 5])
+      );
+
+      expect(wrapper.find('.collection-labels-own').first().text().trim()).toEqual('2');
+      expect(wrapper.find('.collection-labels-shared').first().text().trim()).toEqual('1');
+      expect(wrapper.find('.collection-labels-dual-owned')).toHaveLength(0);
     });
 
     it('counts the viewer\'s own repository subtree as own, with no warning', () => {
@@ -170,11 +200,11 @@ describe('ElementCollectionLabels', () => {
       expect(wrapper.find('button').first().prop('title'))
         .toEqual("Also present in a collection you can't access");
     });
-    // Both causes can be live at once: one collection of the other user's is shared back, another
-    // is not. The two are computed independently and both messages surface - an if/else here would
-    // silently drop the "can't access" half, which is the one the viewer cannot find out any other
-    // way.
-    it('shows both warning messages when both causes apply at once', () => {
+    // Ownership wins over the share. This viewer holds the element in a collection of their own
+    // (id 1) as well as through someone else's share (id 2); id 3 is a collection they cannot
+    // resolve. Owning any of it is enough to be told - how they first came across the element
+    // does not enter into it.
+    it('warns a viewer who owns a collection for it, even though a share also reaches them', () => {
       const wrapper = render(
         [
           { id: 1, label: 'Sylvie Import', own: true },
@@ -190,7 +220,56 @@ describe('ElementCollectionLabels', () => {
       expect(wrapper.find('.collection-labels-shared').first().text().trim()).toEqual('1');
       expect(wrapper.find('.collection-labels-dual-owned')).toHaveLength(1);
       expect(wrapper.find('button').first().prop('title'))
-        .toEqual("Also shared with you elsewhere · Also present in a collection you can't access");
+        .toEqual("Also present in a collection you can't access");
+    });
+
+    // The only suppression there is: own nothing here and the element is simply not yours to be
+    // told about.
+    it('stays silent for a sharee who owns none of the collections', () => {
+      const wrapper = render(
+        [
+          { id: 1, label: 'Shared to me', sharedWithMe: true, owner_name: 'Ada L' },
+          { id: 2, label: 'The owner\'s other collection' },
+        ],
+        elementWith([1, 2])
+      );
+
+      expect(wrapper.find('.collection-labels-own')).toHaveLength(0);
+      expect(wrapper.find('.collection-labels-shared').first().text().trim()).toEqual('1');
+      expect(wrapper.find('.collection-labels-dual-owned')).toHaveLength(0);
+    });
+
+    // The case this rule exists for: a colleague's share (id 5) has nothing to do with the third
+    // party holding id 9, and must not mask it. An earlier version let any share suppress the
+    // warning, which hid exactly this - the one thing the owner cannot find out another way.
+    it('does not let an unrelated share mask a third party holding the element', () => {
+      const wrapper = render(
+        [
+          { id: 1, label: 'Mine', own: true },
+          { id: 5, label: 'Unrelated shared', sharedWithMe: true, owner_name: 'Ada L' },
+          { id: 9, label: 'Hidden third party' },
+        ],
+        elementWith([1, 5, 9])
+      );
+
+      expect(wrapper.find('.collection-labels-dual-owned')).toHaveLength(1);
+    });
+
+    // ...and equally when the hidden collection belongs to the very person who shared to them.
+    // Whose it is deliberately does not enter the rule; that it is not the viewer's does.
+    it('warns even when the hidden collection belongs to the sharer themselves', () => {
+      const wrapper = render(
+        [
+          { id: 1, label: 'Mine', own: true },
+          {
+            id: 5, label: 'Shared by Ada', sharedWithMe: true, owner: 'Ada L (AL)', owner_name: 'Ada L',
+          },
+          { id: 9, label: "Ada's other collection" },
+        ],
+        elementWith([1, 5, 9])
+      );
+
+      expect(wrapper.find('.collection-labels-dual-owned')).toHaveLength(1);
     });
   });
 
@@ -220,7 +299,7 @@ describe('ElementCollectionLabels', () => {
 
       const text = wrapper.find('.dropdown-menu').first().text();
       expect(text).toContain('My Collections');
-      expect(text).toContain('Shared Collections');
+      expect(text).toContain('Shared with me by');
       // One heading per owner, not one per collection.
       expect(text.match(/Ada L/g)).toHaveLength(1);
       expect(text.match(/Grace H/g)).toHaveLength(1);
@@ -252,6 +331,23 @@ describe('ElementCollectionLabels', () => {
       expect(text).not.toContain('(JM1)');
     });
 
+    it('sorts the owner groups alphabetically, and each owner\'s collections by label', () => {
+      const wrapper = open(render(
+        [
+          { id: 5, label: 'Zulu', sharedWithMe: true, owner: 'Zoe A (ZA)', owner_name: 'Zoe A' },
+          { id: 6, label: 'Bravo', sharedWithMe: true, owner: 'Ada L (AL)', owner_name: 'Ada L' },
+          { id: 7, label: 'Alpha', sharedWithMe: true, owner: 'Ada L (AL)', owner_name: 'Ada L' },
+        ],
+        elementWith([5, 6, 7])
+      ));
+
+      const text = wrapper.find('.dropdown-menu').first().text();
+      // Ada before Zoe even though Zoe's collection came first in the tag; Alpha before Bravo
+      // even though Bravo came first.
+      expect(text.indexOf('Ada L')).toBeLessThan(text.indexOf('Zoe A'));
+      expect(text.indexOf('Alpha')).toBeLessThan(text.indexOf('Bravo'));
+    });
+
     it('marks a group-mediated share without naming the group', () => {
       const wrapper = open(render(
         [{
@@ -263,29 +359,60 @@ describe('ElementCollectionLabels', () => {
       expect(wrapper.find('.dropdown-menu').first().text()).toContain('(via group)');
     });
 
-    it('lists both warning messages as separate lines when both apply', () => {
+    it('offers the sidebar\'s share tooltip on an own collection that is shared out', () => {
+      const wrapper = open(render(
+        [{ id: 1, label: 'Mine', own: true, shared: true }],
+        elementWith([1])
+      ));
+
+      expect(wrapper.find('.dropdown-menu').first().find(OverlayTrigger).length).toBeGreaterThan(0);
+      expect(wrapper.find('.dropdown-menu').first().find('i.fa-share-alt')).toHaveLength(1);
+    });
+
+    // The property that makes a tooltip per row affordable at 15-60 badges a page: the overlay is
+    // not mounted until it is hovered, so nothing fetches on render or on open. If someone adds
+    // renderOnMount to the menu, or hoists the fetch out of the tooltip, this fails.
+    it('fetches no share information until a tooltip is actually hovered', () => {
+      open(render(
+        [
+          { id: 1, label: 'Mine', own: true, shared: true },
+          {
+            id: 5, label: 'Theirs', sharedWithMe: true, owner: 'Ada L (AL)', owner_name: 'Ada L',
+          },
+        ],
+        elementWith([1, 5])
+      ));
+
+      expect(shareFetches.own.called).toBe(false);
+      expect(shareFetches.sharedToMe.called).toBe(false);
+    });
+
+    it('states the reachable case as neutral text, never as a warning', () => {
       const wrapper = open(render(
         [
           { id: 1, label: 'Sylvie Import', own: true },
           { id: 2, label: 'Theirs, shared', sharedWithMe: true, owner_name: 'Sylvia V' },
-          { id: 3, label: 'Theirs, not shared' },
         ],
-        elementWith([1, 2, 3])
+        elementWith([1, 2])
       ));
 
-      const text = wrapper.find('.dropdown-menu').first().text();
-      expect(text).toContain('Also shared with you elsewhere');
-      expect(text).toContain("Also present in a collection you can't access");
+      const menu = wrapper.find('.dropdown-menu').first();
+      expect(menu.text()).toContain('Also shared with you elsewhere');
+      expect(menu.text()).not.toContain("Also present in a collection you can't access");
+      // neutral: no warning colour and no triangle anywhere in the menu
+      expect(menu.find('.text-warning')).toHaveLength(0);
+      expect(menu.find('.fa-exclamation-triangle')).toHaveLength(0);
     });
 
-    it('spells out the dual-ownership warning as persistent text', () => {
+    it('spells the warning out as persistent text, in warning colour', () => {
       const wrapper = open(render(
         [{ id: 1, label: 'Mine', own: true }, { id: 9, label: 'Foreign' }],
         elementWith([1, 9])
       ));
 
-      expect(wrapper.find('.dropdown-menu').first().text())
-        .toContain("Also present in a collection you can't access");
+      const menu = wrapper.find('.dropdown-menu').first();
+      expect(menu.text()).toContain("Also present in a collection you can't access");
+      expect(menu.find('.text-warning').length).toBeGreaterThan(0);
     });
   });
 });

--- a/spec/javascripts/packs/src/apps/mydb/elements/labels/ElementCollectionLabels.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/labels/ElementCollectionLabels.spec.js
@@ -1,0 +1,291 @@
+import React from 'react';
+import expect from 'expect';
+import sinon from 'sinon';
+import Enzyme, { mount } from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+// RootStore must be required BEFORE the component under test. This is the first spec to mount a
+// component that transitively imports `src/utilities/routesUtils`, and the reverse order trips a
+// pre-existing circular-import bug ("Super expression must either be null or a function" thrown
+// from src/models/Component.js). CollectionsStore.spec.js already relies on the same ordering.
+import { StoreContext } from 'src/stores/mobx/RootStore';
+import ElementCollectionLabels from 'src/apps/mydb/elements/labels/ElementCollectionLabels';
+import UserStore from 'src/stores/alt/stores/UserStore';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+// A plain-object stand-in for the mobx CollectionsStore: the component only ever calls these
+// three, and building a real RootStore would drag the fetchers in for no added coverage.
+// `repository: true` marks a collection in the viewer's own repository subtree (the repository
+// root and its "transferred" child). The store keeps that subtree on its own field for the
+// sidebar, but `isOwnCollection` counts it as own — ownership is `user_id == current_user.id`,
+// see the `.ownCollectionIds` cases in CollectionsStore.spec.js.
+const storeFor = (collections) => ({
+  collections: {
+    find: (id) => collections.find((c) => c.id === id) || null,
+    isOwnCollection: (id) => collections.some((c) => c.id === id && (c.own || c.repository)),
+    isSharedCollection: (id) => collections.some((c) => c.id === id && c.sharedWithMe),
+  },
+});
+
+const elementWith = (ids) => ({
+  id: 42,
+  type: 'sample',
+  tag: { taggable_data: { collection_labels: ids.map((id) => (id == null ? id : { id })) } },
+});
+
+// The dropdown menu is portalled into document.body, and the whole mocha run shares one jsdom, so
+// every mount has to be torn down or the menus of earlier cases stay attached for later specs.
+const mounted = [];
+
+const render = (collections, element) => {
+  const wrapper = mount(
+    <StoreContext.Provider value={storeFor(collections)}>
+      <ElementCollectionLabels element={element} />
+    </StoreContext.Provider>
+  );
+  mounted.push(wrapper);
+  return wrapper;
+};
+
+describe('ElementCollectionLabels', () => {
+  let userStub;
+
+  beforeEach(() => {
+    userStub = sinon.stub(UserStore, 'getState').returns({ currentUser: { id: 1 } });
+  });
+
+  afterEach(() => {
+    while (mounted.length > 0) mounted.pop().unmount();
+    userStub.restore();
+  });
+
+  describe('guards', () => {
+    it('renders nothing without a signed-in user', () => {
+      userStub.returns({ currentUser: null });
+
+      const wrapper = render([{ id: 1, label: 'A', own: true }], elementWith([1]));
+
+      expect(wrapper.find('button')).toHaveLength(0);
+    });
+
+    it('renders nothing when no label resolves to an own or shared collection', () => {
+      // The one id present belongs to a collection in neither tree - nothing to show, and
+      // notably no bare warning either (the "unreachable" signal is only for owners).
+      const wrapper = render([{ id: 9, label: 'Foreign' }], elementWith([9]));
+
+      expect(wrapper.find('button')).toHaveLength(0);
+    });
+
+    it('ignores malformed label entries instead of throwing on them', () => {
+      const element = {
+        id: 42,
+        type: 'sample',
+        tag: { taggable_data: { collection_labels: [null, {}, { id: 1 }] } },
+      };
+
+      const wrapper = render([{ id: 1, label: 'A', own: true }], element);
+
+      expect(wrapper.find('.collection-labels-own').first().text().trim()).toEqual('1');
+    });
+  });
+
+  describe('the badge chips', () => {
+    it('shows only the own-count chip, with no sub-count, when nothing is shared out', () => {
+      const wrapper = render(
+        [{ id: 1, label: 'A', own: true, shared: false }, { id: 2, label: 'B', own: true, shared: false }],
+        elementWith([1, 2])
+      );
+
+      expect(wrapper.find('.collection-labels-own').first().text().trim()).toEqual('2');
+      expect(wrapper.find('.collection-labels-shared')).toHaveLength(0);
+      expect(wrapper.find('.collection-labels-dual-owned')).toHaveLength(0);
+    });
+
+    it('appends the shared-out sub-count when some own collections are shared out', () => {
+      const wrapper = render(
+        [{ id: 1, label: 'A', own: true, shared: true }, { id: 2, label: 'B', own: true, shared: false }],
+        elementWith([1, 2])
+      );
+
+      expect(wrapper.find('.collection-labels-own').first().text().trim()).toEqual('2 [1]');
+    });
+
+    it('shows only the shared-with-me chip when the viewer owns none of them', () => {
+      const wrapper = render(
+        [{ id: 5, label: 'Theirs', sharedWithMe: true, owner_name: 'Ada L' }],
+        elementWith([5])
+      );
+
+      expect(wrapper.find('.collection-labels-own')).toHaveLength(0);
+      expect(wrapper.find('.collection-labels-shared').first().text().trim()).toEqual('1');
+      expect(wrapper.find('.collection-labels-dual-owned')).toHaveLength(0);
+    });
+
+    it('warns, with the reachable wording, when the element is both owned and shared to the viewer', () => {
+      const wrapper = render(
+        [{ id: 1, label: 'Mine', own: true }, { id: 5, label: 'Theirs', sharedWithMe: true, owner_name: 'Ada L' }],
+        elementWith([1, 5])
+      );
+
+      expect(wrapper.find('.collection-labels-dual-owned')).toHaveLength(1);
+      expect(wrapper.find('button').first().prop('title')).toEqual('Also shared with you elsewhere');
+    });
+
+    it('counts the viewer\'s own repository subtree as own, with no warning', () => {
+      // "transferred" lives under the repository root, which the store keeps off own_collections.
+      // It is still the viewer's own collection and is reachable from their sidebar, so it must
+      // not read as "a collection you can't access".
+      const wrapper = render(
+        [
+          { id: 1, label: 'Mine', own: true },
+          { id: 2, label: 'chemotion-repository.net', repository: true },
+          { id: 3, label: 'transferred', repository: true },
+        ],
+        elementWith([1, 3])
+      );
+
+      expect(wrapper.find('.collection-labels-own').first().text().trim()).toEqual('2');
+      expect(wrapper.find('.collection-labels-dual-owned')).toHaveLength(0);
+      expect(wrapper.find('button').first().prop('title')).toEqual(undefined);
+    });
+
+    it('still warns about someone else\'s repository subtree, which this store cannot resolve', () => {
+      const wrapper = render(
+        [{ id: 1, label: 'Mine', own: true }, { id: 9, label: 'transferred' }],
+        elementWith([1, 9])
+      );
+
+      expect(wrapper.find('.collection-labels-dual-owned')).toHaveLength(1);
+      expect(wrapper.find('button').first().prop('title'))
+        .toEqual("Also present in a collection you can't access");
+    });
+
+    it('warns, with the unreachable wording, when an owner\'s element sits in a collection they cannot resolve', () => {
+      const wrapper = render(
+        [{ id: 1, label: 'Mine', own: true }, { id: 9, label: 'Foreign' }],
+        elementWith([1, 9])
+      );
+
+      expect(wrapper.find('.collection-labels-dual-owned')).toHaveLength(1);
+      expect(wrapper.find('button').first().prop('title'))
+        .toEqual("Also present in a collection you can't access");
+    });
+    // Both causes can be live at once: one collection of the other user's is shared back, another
+    // is not. The two are computed independently and both messages surface - an if/else here would
+    // silently drop the "can't access" half, which is the one the viewer cannot find out any other
+    // way.
+    it('shows both warning messages when both causes apply at once', () => {
+      const wrapper = render(
+        [
+          { id: 1, label: 'Sylvie Import', own: true },
+          {
+            id: 2, label: 'My project with Steven Su', sharedWithMe: true, owner_name: 'Sylvia V', permission_level: 5,
+          },
+          { id: 3, label: 'Addition' },
+        ],
+        elementWith([1, 2, 3])
+      );
+
+      expect(wrapper.find('.collection-labels-own').first().text().trim()).toEqual('1');
+      expect(wrapper.find('.collection-labels-shared').first().text().trim()).toEqual('1');
+      expect(wrapper.find('.collection-labels-dual-owned')).toHaveLength(1);
+      expect(wrapper.find('button').first().prop('title'))
+        .toEqual("Also shared with you elsewhere · Also present in a collection you can't access");
+    });
+  });
+
+  describe('the popover', () => {
+    const open = (wrapper) => {
+      wrapper.find('button').first().simulate('click');
+      wrapper.update();
+      return wrapper;
+    };
+
+    it('groups the shared collections by their owner', () => {
+      const wrapper = open(render(
+        [
+          { id: 1, label: 'Mine', own: true },
+          {
+            id: 5, label: 'From Ada', sharedWithMe: true, owner_name: 'Ada L', permission_level: 0,
+          },
+          {
+            id: 6, label: 'Also from Ada', sharedWithMe: true, owner_name: 'Ada L', permission_level: 0,
+          },
+          {
+            id: 7, label: 'From Grace', sharedWithMe: true, owner_name: 'Grace H', permission_level: 0,
+          },
+        ],
+        elementWith([1, 5, 6, 7])
+      ));
+
+      const text = wrapper.find('.dropdown-menu').first().text();
+      expect(text).toContain('My Collections');
+      expect(text).toContain('Shared Collections');
+      // One heading per owner, not one per collection.
+      expect(text.match(/Ada L/g)).toHaveLength(1);
+      expect(text.match(/Grace H/g)).toHaveLength(1);
+      expect(text).toContain('From Ada');
+      expect(text).toContain('Also from Ada');
+      expect(text).toContain('From Grace');
+    });
+
+    // Two people can carry the same plain name, so grouping on `owner_name` would fold them into a
+    // single heading (and reuse one React key). `owner` carries the unique abbreviation, which is
+    // exactly why the store groups the shared tree on it - the plain name is only the label.
+    it('keeps two same-named owners apart, labelling both with the plain name', () => {
+      const wrapper = open(render(
+        [
+          {
+            id: 5, label: 'From the first Jan', sharedWithMe: true, owner: 'Jan Meyer (JM1)', owner_name: 'Jan Meyer',
+          },
+          {
+            id: 6, label: 'From the second Jan', sharedWithMe: true, owner: 'Jan Meyer (JM2)', owner_name: 'Jan Meyer',
+          },
+        ],
+        elementWith([5, 6])
+      ));
+
+      const text = wrapper.find('.dropdown-menu').first().text();
+      expect(text.match(/Jan Meyer/g)).toHaveLength(2);
+      expect(text).toContain('From the first Jan');
+      expect(text).toContain('From the second Jan');
+      expect(text).not.toContain('(JM1)');
+    });
+
+    it('marks a group-mediated share without naming the group', () => {
+      const wrapper = open(render(
+        [{
+          id: 5, label: 'From Ada', sharedWithMe: true, owner_name: 'Ada L', shared_via_group: true,
+        }],
+        elementWith([5])
+      ));
+
+      expect(wrapper.find('.dropdown-menu').first().text()).toContain('(via group)');
+    });
+
+    it('lists both warning messages as separate lines when both apply', () => {
+      const wrapper = open(render(
+        [
+          { id: 1, label: 'Sylvie Import', own: true },
+          { id: 2, label: 'Theirs, shared', sharedWithMe: true, owner_name: 'Sylvia V' },
+          { id: 3, label: 'Theirs, not shared' },
+        ],
+        elementWith([1, 2, 3])
+      ));
+
+      const text = wrapper.find('.dropdown-menu').first().text();
+      expect(text).toContain('Also shared with you elsewhere');
+      expect(text).toContain("Also present in a collection you can't access");
+    });
+
+    it('spells out the dual-ownership warning as persistent text', () => {
+      const wrapper = open(render(
+        [{ id: 1, label: 'Mine', own: true }, { id: 9, label: 'Foreign' }],
+        elementWith([1, 9])
+      ));
+
+      expect(wrapper.find('.dropdown-menu').first().text())
+        .toContain("Also present in a collection you can't access");
+    });
+  });
+});

--- a/spec/javascripts/stores/mobx/CollectionsStore.spec.js
+++ b/spec/javascripts/stores/mobx/CollectionsStore.spec.js
@@ -291,6 +291,38 @@ describe('CollectionsStore', () => {
     });
   });
 
+  // Ownership is personal and singular: Collection#owned_by? is `user_id == user.id`, and the
+  // `own` payload is every collection with that user_id. Holding the repository subtree on its own
+  // field is a rendering concern for the sidebar - it must not shrink what the user owns, or
+  // features gated on isOwnCollection silently switch off inside the repository section.
+  describe('.ownCollectionIds', () => {
+    const repositoryRoot = {
+      id: 1, label: 'chemotion-repository.net', ancestry: '/', position: null, is_locked: true,
+    };
+    const transferred = {
+      id: 3, label: 'transferred', ancestry: '/1/', position: null, is_locked: false,
+    };
+    const ordinary = {
+      id: 4, label: 'Project', ancestry: '/', position: null, is_locked: false,
+    };
+
+    it('counts the repository subtree as own even though it is held off own_collections', () => {
+      store.setOwnCollections([repositoryRoot, transferred, ordinary]);
+
+      expect(store.own_collections.map((c) => c.id)).toEqual([4]);
+      expect(store.ownCollectionIds.slice().sort()).toEqual([1, 3, 4]);
+      expect(store.isOwnCollection(1)).toBe(true);
+      expect(store.isOwnCollection(3)).toBe(true);
+    });
+
+    it('reports no repository ids when the user has no repository subtree', () => {
+      store.setOwnCollections([ordinary]);
+
+      expect(store.ownCollectionIds).toEqual([4]);
+      expect(store.isOwnCollection(3)).toBe(false);
+    });
+  });
+
   describe('.addCollectionToTree', () => {
     it('shows a collection whose parent is missing without rewriting its ancestry', () => {
       const orphan = Collection.create({


### PR DESCRIPTION
The collection badge on an element had flattened to two bare counts separated by a pipe, with "this element is also in someone else's collection" signalled only by a colour change and a hover title — unreadable on a touch device, invisible to a colour-blind reader, and with no way to tell *also shared with me* apart from *also somewhere I can't see*.

####  Single ownership as owner
<img width="181" height="153" alt="image" src="https://github.com/user-attachments/assets/3006510e-d4ec-41da-ab43-d65f868d2d6a" />

####  Single ownership as sharee
<img width="360" height="136" alt="image" src="https://github.com/user-attachments/assets/e05aefdd-f004-49ea-9bfc-5020c7566f0f" />

#### Multiple ownerships - reachable collection
<img width="354" height="244" alt="image" src="https://github.com/user-attachments/assets/38795619-b3b3-4f33-ad1a-29d254ae50df" />

#### Multiple ownerships - unreachable collection
<img width="368" height="281" alt="image" src="https://github.com/user-attachments/assets/976b1313-1f36-43b3-9a14-c473d8efa3ab" />


### The badge

Each part now renders only when it applies:

- **`▤ 3 ↗ 1`** — in 3 of your own collections, 1 of which you have shared out. The sub-count is read off `Collection.shared`, which the store already fetches, so no backend change.
- **`↘ 2`** — also in 2 collections shared with you. Directional glyphs, so the two share directions can't be mistaken for each other.
- **`⚠`** — the element is also in a collection you cannot open.

Every chip carries a `title` spelling its count out in words, and the triangle is drawn persistently rather than by colour alone.

### Who gets the warning

Gated on ownership: own a collection holding the element and you are told it also sits somewhere you cannot see; own none of them and you are not. That is the same line `ElementPolicy` draws everywhere else — `record_is_in_own_collection?` is what every capability resolves to — so the badge stops inventing a second notion of ownership.

Who holds the hidden collection deliberately does not narrow it further. An intermediate version suppressed the warning whenever the viewer held *any* share for the element; on production-shaped data an unrelated colleague's share then masked a genuine third party holding the element, which is the one thing an owner cannot discover another way. Telling those apart would need the hidden collection's owner, and `collection_labels` carries `{id}` and nothing else.

Co-presence in a collection the viewer *can* open is no longer a warning at all — the shared count already says so. It keeps a plain line in the popover, because removing the element from your own collection still won't remove it from theirs.

### The popover

Grouped by owner (keyed on the abbreviation, so two people with the same plain name stay apart), sorted by owner then label, retitled **Shared with me by**. Rows carry the sidebar's own icon and its tooltips — who an own collection is shared with, and how a shared one reaches you, group included.

That last part retires a constraint this file used to document: the group behind *(via group)* was left unnamed because resolving it needed a fetch per badge. An overlay isn't mounted while hidden and `Dropdown.Menu` doesn't render rows until first opened, so a table of badges fetches nothing until someone opens one popover and hovers one row. A spec pins that, and fails if the menu ever gains `renderOnMount` or the fetch is hoisted.

### Alongside

- `ownCollectionIds` omitted the repository subtree, so `isOwnCollection` contradicted `Collection#owned_by?` for exactly those collections and the badge called the viewer's own `transferred` one they can't access. Folded back in. `ElementDetailSortTab`, the only other caller, gains the tab-layout editor inside the repository section, which follows from the same definition.
- The detail header rendered the badge at `btn-sm btn-secondary` beside `btn-light btn-xxsm` labels, and in a different order from the list row. `ElementDetailCard` gains a `titleAppendixLeading` slot so a header can reproduce its list order without every caller having to render the badge itself — six of the nine detail components pass no appendix at all and would otherwise lose it.
- **Separate commit:** deleting a user is a soft delete and nothing purges the shares they were on, so `belongs_to :shared_with` resolved to `nil` through the paranoia scope and `CollectionShareEntity#shared_with` dereferenced it — a 500 on every read of that collection's shares, hit by the sidebar hover, the Manage-shares modal (leaving the orphan unrevokable), and the element list's prefetch. Scoped `with_deleted`.

### Testing

1536 JS specs pass; the badge gains its first spec file (18 cases) plus two `ownCollectionIds` cases on the store spec and two on `collection_share_api_spec`. Behaviour was checked against a production-sized dataset throughout — the ownership gate, the repository-subtree fix, and the dual-ownership cases each have real accounts behind them.

### Known gaps

- If another user's only link to the element is their locked **All**, nothing warns: `collection_tag` drops every locked All, so no entry for them exists to reason about. Closing it needs a tag rebuild.
- `collection_labels` is not filtered per viewer, so the ids ship regardless of what the badge renders. Filtering them server-side would close that and subsume the rule here.
- Sample and SBMM detail headers omit labels their list rows show (wellplate/generic, and reaction respectively). Follow-up.
