### PR TITLE
fix(groups): restrict group members and admins to Person records

### DIFF
--- a/app/api/chemotion/group_api.rb
+++ b/app/api/chemotion/group_api.rb
@@ -24,8 +24,8 @@ module Chemotion
         group_params[:email] ||= format('%<time>i@eln.edu', time: Time.now.getutc.to_i)
         group_params[:password] = Devise.friendly_token.first(8)
         group_params[:password_confirmation] = group_params[:password]
-        group_params[:users] = User.where(id: [current_user.id] + users)
-        group_params[:admins] = User.where(id: current_user.id)
+        group_params[:users] = Person.where(id: [current_user.id] + users)
+        group_params[:admins] = Person.where(id: current_user.id)
 
         new_group = Group.new(group_params)
         present new_group, with: Entities::GroupEntity, root: 'group' if new_group.save!
@@ -86,7 +86,7 @@ module Chemotion
             post do
               error!('401 Unauthorized', 401) unless @policy.manage?
 
-              @group.admins << User.where(id: params[:user_id]) unless @group.admins.exists?(id: params[:user_id])
+              @group.admins << Person.where(id: params[:user_id]) unless @group.admins.exists?(id: params[:user_id])
               present @group, with: Entities::GroupEntity, root: 'group'
             end
 

--- a/spec/api/chemotion/group_api_spec.rb
+++ b/spec/api/chemotion/group_api_spec.rb
@@ -40,6 +40,19 @@ describe Chemotion::GroupAPI do
       expect(new_group.admins.first).to eq(user)
       expect(user.administrated_accounts.where(name_abbreviation: 'JFC')).not_to be_empty
     end
+
+    context 'when a group id is passed in users' do
+      let(:params) do
+        {
+          first_name: 'My', last_name: 'Fanclub', email: 'jane.s@fan.club',
+          name_abbreviation: 'JFC', users: [group_admin.id, group.id]
+        }
+      end
+
+      it 'does not nest the other group as a member' do
+        expect(new_group.users.pluck(:id)).to contain_exactly(user.id, group_admin.id)
+      end
+    end
   end
 
   describe 'GET /api/v1/groups' do
@@ -306,6 +319,18 @@ describe Chemotion::GroupAPI do
       it 'promotes the member to admin' do
         execute_request
         expect(group.reload.admins.pluck(:id)).to include(member.id)
+      end
+    end
+
+    context 'when the target id is another group' do
+      subject(:execute_request) { post "/api/v1/groups/#{group.id}/admins/#{other_group.id}" }
+
+      let(:other_group) { create(:group, admins: [non_member], users: [non_member]) }
+      let(:user) { group_admin }
+
+      it 'does not promote the other group to admin' do
+        execute_request
+        expect(group.reload.admins.pluck(:id)).not_to include(other_group.id)
       end
     end
   end


### PR DESCRIPTION
Group creation and admin promotion used User.where, so a Group id passed as a member or admin would slip through, nesting one group inside another. The members-add endpoint already scoped to Person; make creation and admin promotion consistent with it.
