### PR TITLE
fix(ui): replace focus-triggered delete confirm popovers with explicit state

### DIFF
--- a/app/javascript/src/apps/admin/ChemSpectraLayouts.js
+++ b/app/javascript/src/apps/admin/ChemSpectraLayouts.js
@@ -2,10 +2,11 @@
 import React, { Component } from 'react';
 import ChemSpectraFetcher from 'src/fetchers/ChemSpectraFetcher';
 import {
-  Table, Button, Form, Popover, OverlayTrigger, Alert
+  Table, Button, Form, Alert
 } from 'react-bootstrap';
 import AppModal from 'src/components/common/AppModal';
 import { Select } from 'src/components/common/Select';
+import ConfirmDeleteButton from 'src/components/common/ConfirmDeleteButton';
 
 export default class ChemSpectraLayouts extends Component {
   constructor(props) {
@@ -249,44 +250,13 @@ export default class ChemSpectraLayouts extends Component {
                   {defaultLayouts.some(([layout, dataTypes]) => layout === entry.layout
                     && !dataTypes.includes(entry.dataType)) && (
                       <div className="actions d-inline-block">
-                        <OverlayTrigger
-                          root
-                          trigger="focus"
-                          placement="top"
-                          overlay={(
-                            <Popover id="popover-positioned-scrolling-left">
-                              <Popover.Header id="popover-positioned-scrolling-left" as="h5">
-                                Delete this data type?
-                              </Popover.Header>
-                              <Popover.Body className="ps-5">
-                                <Button
-                                  size="sm"
-                                  variant="danger"
-                                  className="me-2"
-                                  onClick={() => {
-                                    this.handleDeleteDataType({ layout: entry.layout, dataType: entry.dataType });
-                                  }}
-                                >
-                                  Yes
-                                </Button>
-                                <Button
-                                  size="sm"
-                                  variant="warning"
-                                  onClick={this.handleClick}
-                                >
-                                  No
-                                </Button>
-                              </Popover.Body>
-                            </Popover>
-                          )}
-                        >
-                          <Button
-                            size="sm"
-                            variant="danger"
-                          >
-                            <i className="fa fa-trash-o" />
-                          </Button>
-                        </OverlayTrigger>
+                        <ConfirmDeleteButton
+                          id={`confirm-delete-datatype-${entry.dataType}`}
+                          header="Delete this data type?"
+                          onConfirm={() => {
+                            this.handleDeleteDataType({ layout: entry.layout, dataType: entry.dataType });
+                          }}
+                        />
                       </div>
                   )}
                 </td>

--- a/app/javascript/src/apps/admin/ChemSpectraLayouts.js
+++ b/app/javascript/src/apps/admin/ChemSpectraLayouts.js
@@ -251,7 +251,6 @@ export default class ChemSpectraLayouts extends Component {
                     && !dataTypes.includes(entry.dataType)) && (
                       <div className="actions d-inline-block">
                         <ConfirmDeleteButton
-                          id={`confirm-delete-datatype-${entry.dataType}`}
                           header="Delete this data type?"
                           onConfirm={() => {
                             this.handleDeleteDataType({ layout: entry.layout, dataType: entry.dataType });

--- a/app/javascript/src/apps/admin/ChemSpectraLayouts.js
+++ b/app/javascript/src/apps/admin/ChemSpectraLayouts.js
@@ -252,6 +252,7 @@ export default class ChemSpectraLayouts extends Component {
                       <div className="actions d-inline-block">
                         <ConfirmDeleteButton
                           header="Delete this data type?"
+                          placement="top"
                           onConfirm={() => {
                             this.handleDeleteDataType({ layout: entry.layout, dataType: entry.dataType });
                           }}

--- a/app/javascript/src/apps/admin/DeleteGroupDeviceButton.js
+++ b/app/javascript/src/apps/admin/DeleteGroupDeviceButton.js
@@ -73,7 +73,6 @@ export default class DeleteGroupDeviceButton extends React.Component {
     return (
       <div className="actions d-inline-block">
         <ConfirmDeleteButton
-          id={`confirm-delete-${rootType}-${groupRec.id}${userRec ? `-${userRec.id}` : ''}`}
           header={msg}
           onConfirm={() => this.confirmDelete(rootType, actionType, groupRec, userRec, isRoot)}
         />

--- a/app/javascript/src/apps/admin/DeleteGroupDeviceButton.js
+++ b/app/javascript/src/apps/admin/DeleteGroupDeviceButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Button, Popover, OverlayTrigger } from 'react-bootstrap';
 import AdminFetcher from 'src/fetchers/AdminFetcher';
+import ConfirmDeleteButton from 'src/components/common/ConfirmDeleteButton';
 
 export default class DeleteGroupDeviceButton extends React.Component {
   constructor(props) {
@@ -70,35 +70,13 @@ export default class DeleteGroupDeviceButton extends React.Component {
       msg = `remove ???: ${groupRec.name}`;
     }
 
-    const popover = (
-      <Popover id="popover-positioned-scrolling-left">
-        <Popover.Header id="popover-positioned-scrolling-left" as="h5">
-          {msg}
-        </Popover.Header>
-        <Popover.Body>
-          <Button size="sm" variant="danger" className='me-2' onClick={() => this.confirmDelete(rootType, actionType, groupRec, userRec, isRoot)}>
-            Yes
-          </Button>
-          <Button size="sm" variant="warning" onClick={this.handleClick} >
-            No
-          </Button>
-        </Popover.Body>
-      </Popover>
-    );
-
     return (
       <div className="actions d-inline-block">
-        <OverlayTrigger
-          animation
-          placement="right"
-          root
-          trigger="focus"
-          overlay={popover}
-        >
-          <Button size="sm" variant="danger" >
-            <i className="fa fa-trash-o" />
-          </Button>
-        </OverlayTrigger>
+        <ConfirmDeleteButton
+          id={`confirm-delete-${rootType}-${groupRec.id}${userRec ? `-${userRec.id}` : ''}`}
+          header={msg}
+          onConfirm={() => this.confirmDelete(rootType, actionType, groupRec, userRec, isRoot)}
+        />
       </div>
     );
   }

--- a/app/javascript/src/apps/admin/TemplateManagement.js
+++ b/app/javascript/src/apps/admin/TemplateManagement.js
@@ -282,7 +282,6 @@ export default class TemplateManagement extends React.Component {
     return (
       <div className="actions d-inline-block">
         <ConfirmDeleteButton
-          id={`confirm-delete-template-${template.id}`}
           header="Delete this template?"
           onConfirm={() => this.handleDeleteTemplate(template)}
         />

--- a/app/javascript/src/apps/admin/TemplateManagement.js
+++ b/app/javascript/src/apps/admin/TemplateManagement.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import {
   Table, Button, Form, Tooltip,
-  OverlayTrigger, Popover, Card, Container
+  OverlayTrigger, Card, Container
 } from 'react-bootstrap';
 import AppModal from 'src/components/common/AppModal';
 import ReportTemplateFetcher from 'src/fetchers/ReportTemplateFetcher';
 import Dropzone from 'src/components/common/Dropzone';
 import { Select } from 'src/components/common/Select';
+import ConfirmDeleteButton from 'src/components/common/ConfirmDeleteButton';
 
 const editTooltip = <Tooltip id="inchi_tooltip">Edit this template</Tooltip>;
 
@@ -278,35 +279,13 @@ export default class TemplateManagement extends React.Component {
   }
 
   renderDeleteButton(template) {
-    const popover = (
-      <Popover id="popover-positioned-scrolling-left">
-        <Popover.Header id="popover-positioned-scrolling-left" as="h5">
-          Delete this template?
-        </Popover.Header>
-        <Popover.Body>
-          <Button size="sm" variant="danger" className="me-1" onClick={() => this.handleDeleteTemplate(template)}>
-            Yes
-          </Button>
-          <Button size="sm" variant="warning" onClick={this.handleClick}>
-            No
-          </Button>
-        </Popover.Body>
-      </Popover>
-    );
-
     return (
       <div className="actions d-inline-block">
-        <OverlayTrigger
-          animation
-          placement="right"
-          root
-          trigger="focus"
-          overlay={popover}
-        >
-          <Button size="sm" variant="danger">
-            <i className="fa fa-trash-o" />
-          </Button>
-        </OverlayTrigger>
+        <ConfirmDeleteButton
+          id={`confirm-delete-template-${template.id}`}
+          header="Delete this template?"
+          onConfirm={() => this.handleDeleteTemplate(template)}
+        />
       </div>
     );
   }

--- a/app/javascript/src/apps/admin/devices/DevicesList.js
+++ b/app/javascript/src/apps/admin/devices/DevicesList.js
@@ -106,7 +106,6 @@ const DevicesList = () => {
     if (device.datacollector_method) {
       return (
         <ConfirmDeleteButton
-          id={`confirm-clear-datacollector-${device.id}`}
           header={`Remove data collector settings of ${device.name}`}
           className="bg-danger-subtle text-danger"
           title="Clear data collector settings"
@@ -126,7 +125,6 @@ const DevicesList = () => {
     if (device.novnc_target) {
       return (
         <ConfirmDeleteButton
-          id={`confirm-clear-novnc-${device.id}`}
           header={`Remove Novnc settings of ${device.name}`}
           className="bg-danger-subtle text-danger"
           title="Clear NoVNC settings"
@@ -147,10 +145,8 @@ const DevicesList = () => {
   }
 
   const deleteButton = (object, type, user) => {
-    const id = user && user.id ? `${object.id}-${user.id}` : `${object.id}`;
     return (
       <ConfirmDeleteButton
-        id={`confirm-delete-${type}-${id}`}
         header={`Remove ${type}: ${object.name}`}
         title="Delete device"
         onConfirm={() => confirmDelete(object, type, user)}

--- a/app/javascript/src/apps/admin/devices/DevicesList.js
+++ b/app/javascript/src/apps/admin/devices/DevicesList.js
@@ -109,7 +109,7 @@ const DevicesList = () => {
           header={`Remove data collector settings of ${device.name}`}
           variant="primary"
           className="bg-danger-subtle text-danger"
-          title="Clear data collector settings"
+          tooltip="Clear data collector settings"
           onConfirm={() => clearDatacollector(device)}
         >
           <i className="fa fa-database" />
@@ -129,7 +129,7 @@ const DevicesList = () => {
           header={`Remove Novnc settings of ${device.name}`}
           variant="primary"
           className="bg-danger-subtle text-danger"
-          title="Clear NoVNC settings"
+          tooltip="Clear NoVNC settings"
           onConfirm={() => clearNovncSettings(device)}
         >
           <i className="fa fa-cogs" />
@@ -150,7 +150,7 @@ const DevicesList = () => {
     return (
       <ConfirmDeleteButton
         header={`Remove ${type}: ${object.name}`}
-        title="Delete device"
+        tooltip="Delete device"
         onConfirm={() => confirmDelete(object, type, user)}
       />
     );

--- a/app/javascript/src/apps/admin/devices/DevicesList.js
+++ b/app/javascript/src/apps/admin/devices/DevicesList.js
@@ -1,9 +1,10 @@
 import React, { useEffect, useContext } from 'react';
-import { Table, Button, ButtonToolbar, Tooltip, OverlayTrigger, Popover, Alert, Card } from 'react-bootstrap';
+import { Table, Button, ButtonToolbar, Tooltip, OverlayTrigger, Alert, Card } from 'react-bootstrap';
 import DeviceModal from './DeviceModal';
 import { endsWith } from 'lodash';
 import { observer } from 'mobx-react';
 import { StoreContext } from 'src/stores/mobx/RootStore';
+import ConfirmDeleteButton from 'src/components/common/ConfirmDeleteButton';
 
 const DevicesList = () => {
   const devicesStore = useContext(StoreContext).devices;
@@ -103,31 +104,16 @@ const DevicesList = () => {
 
   const clearDatacollectorSettingsButton = (device) => {
     if (device.datacollector_method) {
-      const clearPopover = (
-        <Popover id="popover-clear-datacollector">
-          <Popover.Header as="h3">Remove data collector settings of {device.name}</Popover.Header>
-          <Popover.Body>
-            <ButtonToolbar>
-              <Button
-                size="sm"
-                variant="danger"
-                onClick={() => clearDatacollector(device)}>
-                Yes
-              </Button>
-              <Button size="sm" variant="warning">
-                No
-              </Button>
-            </ButtonToolbar>
-          </Popover.Body>
-        </Popover>
-      );
-
       return (
-        <OverlayTrigger placement="right" trigger="focus" overlay={clearPopover}>
-          <Button size="sm" className="bg-danger-subtle text-danger" title="Clear data collector settings">
-            <i className="fa fa-database" />
-          </Button>
-        </OverlayTrigger>
+        <ConfirmDeleteButton
+          id={`confirm-clear-datacollector-${device.id}`}
+          header={`Remove data collector settings of ${device.name}`}
+          className="bg-danger-subtle text-danger"
+          title="Clear data collector settings"
+          onConfirm={() => clearDatacollector(device)}
+        >
+          <i className="fa fa-database" />
+        </ConfirmDeleteButton>
       )
     }
   }
@@ -138,31 +124,16 @@ const DevicesList = () => {
 
   const clearNovncSettingsButton = (device) => {
     if (device.novnc_target) {
-      const clearPopover = (
-        <Popover id="popover-clear-novnc">
-          <Popover.Header as="h3">Remove Novnc settings of {device.name}</Popover.Header>
-          <Popover.Body>
-            <ButtonToolbar>
-              <Button
-                size="sm"
-                variant="danger"
-                onClick={() => clearNovncSettings(device)}>
-                Yes
-              </Button>
-              <Button size="sm" variant="warning">
-                No
-              </Button>
-            </ButtonToolbar>
-          </Popover.Body>
-        </Popover>
-      );
-
       return (
-        <OverlayTrigger placement="right" trigger="focus" overlay={clearPopover}>
-          <Button size="sm" className="bg-danger-subtle text-danger" title="Clear NoVNC settings">
-            <i className="fa fa-cogs" />
-          </Button>
-        </OverlayTrigger>
+        <ConfirmDeleteButton
+          id={`confirm-clear-novnc-${device.id}`}
+          header={`Remove Novnc settings of ${device.name}`}
+          className="bg-danger-subtle text-danger"
+          title="Clear NoVNC settings"
+          onConfirm={() => clearNovncSettings(device)}
+        >
+          <i className="fa fa-cogs" />
+        </ConfirmDeleteButton>
       )
     }
   }
@@ -176,35 +147,14 @@ const DevicesList = () => {
   }
 
   const deleteButton = (object, type, user) => {
-    const deletePopover = (
-      <Popover id="popover-delete-button">
-        <Popover.Header as="h3">Remove {type}: {object.name}</Popover.Header>
-        <Popover.Body>
-          <ButtonToolbar>
-            <Button
-              size="sm"
-              variant="danger"
-              onClick={() => confirmDelete(object, type, user)}>
-              Yes
-            </Button>
-            <Button size="sm" variant="warning">
-              No
-            </Button>
-          </ButtonToolbar>
-        </Popover.Body>
-      </Popover>
-    );
-
+    const id = user && user.id ? `${object.id}-${user.id}` : `${object.id}`;
     return (
-      <OverlayTrigger
-        placement="right"
-        trigger="focus"
-        overlay={deletePopover}
-      >
-        <Button size="sm" variant="danger" title="Delete device">
-          <i className="fa fa-trash-o" />
-        </Button>
-      </OverlayTrigger>
+      <ConfirmDeleteButton
+        id={`confirm-delete-${type}-${id}`}
+        header={`Remove ${type}: ${object.name}`}
+        title="Delete device"
+        onConfirm={() => confirmDelete(object, type, user)}
+      />
     );
   }
 

--- a/app/javascript/src/apps/admin/devices/DevicesList.js
+++ b/app/javascript/src/apps/admin/devices/DevicesList.js
@@ -107,6 +107,7 @@ const DevicesList = () => {
       return (
         <ConfirmDeleteButton
           header={`Remove data collector settings of ${device.name}`}
+          variant="primary"
           className="bg-danger-subtle text-danger"
           title="Clear data collector settings"
           onConfirm={() => clearDatacollector(device)}
@@ -126,6 +127,7 @@ const DevicesList = () => {
       return (
         <ConfirmDeleteButton
           header={`Remove Novnc settings of ${device.name}`}
+          variant="primary"
           className="bg-danger-subtle text-danger"
           title="Clear NoVNC settings"
           onConfirm={() => clearNovncSettings(device)}

--- a/app/javascript/src/apps/moleculeModerator/MoleculeModeratorComponent.js
+++ b/app/javascript/src/apps/moleculeModerator/MoleculeModeratorComponent.js
@@ -159,7 +159,6 @@ export default class MoleculeModeratorComponent extends Component {
     return (
       <ButtonGroup className="actions">
         <ConfirmDeleteButton
-          id={`confirm-delete-molecule-name-${nameObj.id}`}
           header="Delete this molecule name?"
           onConfirm={() => this.confirmDelete(nameObj)}
         />

--- a/app/javascript/src/apps/moleculeModerator/MoleculeModeratorComponent.js
+++ b/app/javascript/src/apps/moleculeModerator/MoleculeModeratorComponent.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import SVG from 'react-inlinesvg';
 import {
-  Card, Container, Col, Button, Row, Table, Popover, ButtonGroup, OverlayTrigger, Tooltip, Form, InputGroup,
+  Card, Container, Col, Button, Row, Table, ButtonGroup, OverlayTrigger, Tooltip, Form, InputGroup,
   Alert
 } from 'react-bootstrap';
 import { findIndex } from 'lodash';
@@ -10,6 +10,7 @@ import MoleculesFetcher from 'src/fetchers/MoleculesFetcher';
 import AppModal from 'src/components/common/AppModal';
 import StructureEditorModal from 'src/components/structureEditor/StructureEditorModal';
 import { isValidMoleculeName } from 'src/utilities/MoleculeNameValidation';
+import ConfirmDeleteButton from 'src/components/common/ConfirmDeleteButton';
 
 export default class MoleculeModeratorComponent extends Component {
   constructor(props) {
@@ -155,35 +156,13 @@ export default class MoleculeModeratorComponent extends Component {
   }
 
   renderDeleteButton(nameObj) {
-    const popover = (
-      <Popover id="popover-positioned-scrolling-left">
-        <Popover.Header>
-          Delete this molecule name?
-        </Popover.Header>
-        <Popover.Body className="d-flex gap-2">
-          <Button size="sm" variant="danger" onClick={() => this.confirmDelete(nameObj)}>
-            Yes
-          </Button>
-          <Button size="sm" variant="warning" onClick={this.handleClick}>
-            No
-          </Button>
-        </Popover.Body>
-      </Popover>
-    );
-
     return (
       <ButtonGroup className="actions">
-        <OverlayTrigger
-          animation
-          placement="right"
-          root
-          trigger="focus"
-          overlay={popover}
-        >
-          <Button size="sm" variant="danger">
-            <i className="fa fa-trash-o" />
-          </Button>
-        </OverlayTrigger>
+        <ConfirmDeleteButton
+          id={`confirm-delete-molecule-name-${nameObj.id}`}
+          header="Delete this molecule name?"
+          onConfirm={() => this.confirmDelete(nameObj)}
+        />
       </ButtonGroup>
     );
   }

--- a/app/javascript/src/apps/mydb/collections/MyCollections.js
+++ b/app/javascript/src/apps/mydb/collections/MyCollections.js
@@ -123,7 +123,6 @@ const MyCollections = () => {
           </Dropdown>
           {addCollectionButton(node)}
           <ConfirmDeleteButton
-            id={`confirm-delete-collection-${node.id}`}
             header={`Do you really want to delete "${node.label}"?`}
             placement="bottom"
             stopMouseDownPropagation

--- a/app/javascript/src/apps/mydb/collections/MyCollections.js
+++ b/app/javascript/src/apps/mydb/collections/MyCollections.js
@@ -1,12 +1,13 @@
 import React, { useState, useEffect, useContext } from 'react';
 import Tree from 'react-ui-tree';
 import { cloneDeep } from 'lodash';
-import { Button, ButtonGroup, Dropdown, Form, OverlayTrigger, Popover } from 'react-bootstrap';
+import { Button, ButtonGroup, Dropdown, Form, OverlayTrigger } from 'react-bootstrap';
 import { observer } from 'mobx-react';
 import { StoreContext } from 'src/stores/mobx/RootStore';
 import CollectionTabsEditorModal from 'src/apps/mydb/collections/CollectionTabsEditorModal';
 import UserInfosTooltip from 'src/apps/mydb/collections/UserInfosTooltip';
 import useCollectionShares from 'src/apps/mydb/collections/useCollectionShares';
+import ConfirmDeleteButton from 'src/components/common/ConfirmDeleteButton';
 
 const MyCollections = () => {
   const collectionsStore = useContext(StoreContext).collections;
@@ -69,33 +70,6 @@ const MyCollections = () => {
       );
     }
 
-    const popover = (
-      <Popover>
-        <Popover.Body>
-          <div className="mb-2">Do you really want to delete &quot;{node.label}&quot;?</div>
-          <ButtonGroup>
-            <Button
-              variant="danger"
-              size="sm"
-              className="me-2"
-              onMouseDown={(e) => e.stopPropagation()}
-              onClick={() => deleteCollection(node)}
-            >
-              Yes
-            </Button>
-            <Button
-              variant="warning"
-              size="sm"
-              onMouseDown={(e) => e.stopPropagation()}
-              onClick={() => {}}
-            >
-              No
-            </Button>
-          </ButtonGroup>
-        </Popover.Body>
-      </Popover>
-    );
-
     return (
       <div className="d-flex align-items-center gap-2 flex-shrink-0">
         <span
@@ -148,11 +122,13 @@ const MyCollections = () => {
             </Dropdown.Menu>
           </Dropdown>
           {addCollectionButton(node)}
-          <OverlayTrigger animation placement="bottom" root trigger="focus" overlay={popover}>
-            <Button size="sm" variant="danger" onMouseDown={(e) => e.stopPropagation()}>
-              <i className="fa fa-trash-o" />
-            </Button>
-          </OverlayTrigger>
+          <ConfirmDeleteButton
+            id={`confirm-delete-collection-${node.id}`}
+            header={`Do you really want to delete "${node.label}"?`}
+            placement="bottom"
+            stopMouseDownPropagation
+            onConfirm={() => deleteCollection(node)}
+          />
         </ButtonGroup>
       </div>
     );

--- a/app/javascript/src/apps/mydb/collections/MyCollections.js
+++ b/app/javascript/src/apps/mydb/collections/MyCollections.js
@@ -125,7 +125,6 @@ const MyCollections = () => {
           <ConfirmDeleteButton
             header={`Do you really want to delete "${node.label}"?`}
             placement="bottom"
-            stopMouseDownPropagation
             onConfirm={() => deleteCollection(node)}
           />
         </ButtonGroup>

--- a/app/javascript/src/components/calendar/CalendarEntryEditor.js
+++ b/app/javascript/src/components/calendar/CalendarEntryEditor.js
@@ -150,7 +150,6 @@ const CalendarEntryEditor = (props) => {
 
     return (
       <ConfirmDeleteButton
-        id={`confirm-delete-calendar-entry-${entry.id}`}
         header="Are you sure you want to delete the calendar entry?"
         size={null}
         onConfirm={() => deleteEntry()}

--- a/app/javascript/src/components/calendar/CalendarEntryEditor.js
+++ b/app/javascript/src/components/calendar/CalendarEntryEditor.js
@@ -1,11 +1,12 @@
 import React, { useContext, useEffect } from 'react';
 import DatePicker from 'react-datepicker';
 import {
-  Form, Button, ButtonToolbar, Alert, Modal, Popover, OverlayTrigger
+  Form, Button, ButtonToolbar, Alert, Modal
 } from 'react-bootstrap';
 import { Select } from 'src/components/common/Select';
 import { capitalizeWords } from 'src/utilities/textHelper';
 import PropTypes from 'prop-types';
+import ConfirmDeleteButton from 'src/components/common/ConfirmDeleteButton';
 
 import { observer } from 'mobx-react';
 import { StoreContext } from 'src/stores/mobx/RootStore';
@@ -147,32 +148,15 @@ const CalendarEntryEditor = (props) => {
   const deleteEntryButton = () => {
     if (entry.id === undefined || !editable) { return null; }
 
-    const popover = (
-      <Popover id="popover-delete-entry">
-        <Popover.Header as="h3">Are you sure you want to delete the calendar entry?</Popover.Header>
-        <Popover.Body>
-          <div className="d-flex gap-2">
-            <Button
-              size="sm"
-              variant="danger"
-              onClick={() => deleteEntry()}
-            >
-              Yes
-            </Button>
-            <Button size="sm" variant="warning">
-              No
-            </Button>
-          </div>
-        </Popover.Body>
-      </Popover>
-    );
-
     return (
-      <OverlayTrigger placement="top" trigger="focus" overlay={popover}>
-        <Button variant="danger">
-          Delete
-        </Button>
-      </OverlayTrigger>
+      <ConfirmDeleteButton
+        id={`confirm-delete-calendar-entry-${entry.id}`}
+        header="Are you sure you want to delete the calendar entry?"
+        size={null}
+        onConfirm={() => deleteEntry()}
+      >
+        Delete
+      </ConfirmDeleteButton>
     );
   };
 

--- a/app/javascript/src/components/calendar/CalendarEntryEditor.js
+++ b/app/javascript/src/components/calendar/CalendarEntryEditor.js
@@ -151,6 +151,7 @@ const CalendarEntryEditor = (props) => {
     return (
       <ConfirmDeleteButton
         header="Are you sure you want to delete the calendar entry?"
+        placement="top"
         size={null}
         onConfirm={() => deleteEntry()}
       >

--- a/app/javascript/src/components/common/ConfirmDeleteButton.js
+++ b/app/javascript/src/components/common/ConfirmDeleteButton.js
@@ -22,6 +22,7 @@ const ConfirmDeleteButton = ({
   children,
 }) => {
   const [target, setTarget] = useState(null);
+  const [tooltipVisible, setTooltipVisible] = useState(false);
   // Lazy initializer so the random id is generated once on mount, not on every render.
   const [tooltipId] = useState(() => `confirm-delete-tooltip-${Math.random().toString(36).slice(2)}`);
 
@@ -53,7 +54,17 @@ const ConfirmDeleteButton = ({
   return (
     <>
       {tooltip ? (
-        <OverlayTrigger placement="top" overlay={<Tooltip id={tooltipId}>{tooltip}</Tooltip>}>
+        // Controlled `show` (gated on `!target`) rather than the default hover/focus state:
+        // clicking the trigger also focuses it (Chromium/Windows), which would otherwise pop
+        // this tooltip open at the same time as the confirm popover, stacked over the same
+        // button. `onToggle` still drives it normally (hover and plain keyboard focus both
+        // work) - it's only forced shut while the confirm popover itself is open.
+        <OverlayTrigger
+          placement="top"
+          show={tooltipVisible && !target}
+          onToggle={setTooltipVisible}
+          overlay={<Tooltip id={tooltipId}>{tooltip}</Tooltip>}
+        >
           {triggerButton}
         </OverlayTrigger>
       ) : triggerButton}

--- a/app/javascript/src/components/common/ConfirmDeleteButton.js
+++ b/app/javascript/src/components/common/ConfirmDeleteButton.js
@@ -18,7 +18,6 @@ const ConfirmDeleteButton = ({
   className,
   title,
   disabled,
-  stopMouseDownPropagation,
   children,
 }) => {
   const [target, setTarget] = useState(null);
@@ -26,9 +25,11 @@ const ConfirmDeleteButton = ({
   // Lazy initializer so the random id is generated once on mount, not on every render.
   const [tooltipId] = useState(() => `confirm-delete-tooltip-${Math.random().toString(36).slice(2)}`);
 
-  const mouseDownProps = stopMouseDownPropagation
-    ? { onMouseDown: (event) => event.stopPropagation() }
-    : {};
+  // Always on, not opt-in: this is meant to be embeddable inline in list/tree rows, exactly
+  // where an ancestor's own mousedown handler (row selection, drag-and-drop) is most likely
+  // to steal the mousedown before the click fires - the same failure class as #2835, just via
+  // a different mechanism. Making a future caller remember to opt in would just reintroduce it.
+  const mouseDownProps = { onMouseDown: (event) => event.stopPropagation() };
 
   const close = () => setTarget(null);
   const confirm = () => {
@@ -76,7 +77,7 @@ const ConfirmDeleteButton = ({
         destructiveActionLabel="Yes"
         hideAction={close}
         hideActionLabel="No"
-        stopMouseDownPropagation={stopMouseDownPropagation}
+        stopMouseDownPropagation
       />
     </>
   );
@@ -92,7 +93,6 @@ ConfirmDeleteButton.propTypes = {
   className: PropTypes.string,
   title: PropTypes.string,
   disabled: PropTypes.bool,
-  stopMouseDownPropagation: PropTypes.bool,
   children: PropTypes.node,
 };
 
@@ -104,7 +104,6 @@ ConfirmDeleteButton.defaultProps = {
   className: undefined,
   title: undefined,
   disabled: false,
-  stopMouseDownPropagation: false,
   children: <i className="fa fa-trash-o" />,
 };
 

--- a/app/javascript/src/components/common/ConfirmDeleteButton.js
+++ b/app/javascript/src/components/common/ConfirmDeleteButton.js
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button, Overlay, OverlayTrigger, Popover, Tooltip,
+} from 'react-bootstrap';
+
+// Confirmation popover for a destructive action, opened/closed by explicit component state
+// instead of `OverlayTrigger`'s focus/blur. A focus-triggered popover hides as soon as its
+// trigger button blurs, and clicking a button inside the popover blurs the trigger before
+// that button's own click event fires - so "Yes" can silently do nothing. That race caused
+// https://github.com/ComPlat/chemotion_ELN/issues/2835.
+const ConfirmDeleteButton = ({
+  id,
+  header,
+  onConfirm,
+  tooltip,
+  placement,
+  size,
+  variant,
+  className,
+  title,
+  disabled,
+  stopMouseDownPropagation,
+  children,
+}) => {
+  const [target, setTarget] = useState(null);
+
+  const mouseDownProps = stopMouseDownPropagation
+    ? { onMouseDown: (event) => event.stopPropagation() }
+    : {};
+
+  const close = () => setTarget(null);
+  const confirm = () => {
+    close();
+    onConfirm();
+  };
+
+  const triggerButton = (
+    <Button
+      size={size}
+      type="button"
+      variant={variant}
+      className={className}
+      title={title}
+      disabled={disabled}
+      onClick={(event) => setTarget((current) => (current ? null : event.currentTarget))}
+      {...mouseDownProps}
+    >
+      {children}
+    </Button>
+  );
+
+  return (
+    <>
+      {tooltip ? (
+        <OverlayTrigger placement="top" overlay={<Tooltip id={`${id}-tooltip`}>{tooltip}</Tooltip>}>
+          {triggerButton}
+        </OverlayTrigger>
+      ) : triggerButton}
+      <Overlay show={!!target} target={target} placement={placement} rootClose onHide={close}>
+        <Popover id={id}>
+          <Popover.Header as="h5">{header}</Popover.Header>
+          <Popover.Body>
+            <div className="d-flex gap-2">
+              <Button size="sm" variant="danger" onClick={confirm} {...mouseDownProps}>
+                Yes
+              </Button>
+              <Button size="sm" variant="warning" onClick={close} {...mouseDownProps}>
+                No
+              </Button>
+            </div>
+          </Popover.Body>
+        </Popover>
+      </Overlay>
+    </>
+  );
+};
+
+ConfirmDeleteButton.propTypes = {
+  id: PropTypes.string.isRequired,
+  header: PropTypes.node.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  tooltip: PropTypes.node,
+  placement: PropTypes.string,
+  size: PropTypes.string,
+  variant: PropTypes.string,
+  className: PropTypes.string,
+  title: PropTypes.string,
+  disabled: PropTypes.bool,
+  stopMouseDownPropagation: PropTypes.bool,
+  children: PropTypes.node,
+};
+
+ConfirmDeleteButton.defaultProps = {
+  tooltip: null,
+  placement: 'right',
+  size: 'sm',
+  variant: 'danger',
+  className: undefined,
+  title: undefined,
+  disabled: false,
+  stopMouseDownPropagation: false,
+  children: <i className="fa fa-trash-o" />,
+};
+
+export default ConfirmDeleteButton;

--- a/app/javascript/src/components/common/ConfirmDeleteButton.js
+++ b/app/javascript/src/components/common/ConfirmDeleteButton.js
@@ -16,7 +16,6 @@ const ConfirmDeleteButton = ({
   size,
   variant,
   className,
-  title,
   disabled,
   children,
 }) => {
@@ -43,7 +42,6 @@ const ConfirmDeleteButton = ({
       type="button"
       variant={variant}
       className={className}
-      title={title}
       disabled={disabled}
       onClick={(event) => setTarget((current) => (current ? null : event.currentTarget))}
       {...mouseDownProps}
@@ -91,7 +89,6 @@ ConfirmDeleteButton.propTypes = {
   size: PropTypes.string,
   variant: PropTypes.string,
   className: PropTypes.string,
-  title: PropTypes.string,
   disabled: PropTypes.bool,
   children: PropTypes.node,
 };
@@ -102,7 +99,6 @@ ConfirmDeleteButton.defaultProps = {
   size: 'sm',
   variant: 'danger',
   className: undefined,
-  title: undefined,
   disabled: false,
   children: <i className="fa fa-trash-o" />,
 };

--- a/app/javascript/src/components/common/ConfirmDeleteButton.js
+++ b/app/javascript/src/components/common/ConfirmDeleteButton.js
@@ -1,16 +1,14 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import {
-  Button, Overlay, OverlayTrigger, Popover, Tooltip,
-} from 'react-bootstrap';
+import { Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import ConfirmationOverlay from 'src/components/common/ConfirmationOverlay';
 
-// Confirmation popover for a destructive action, opened/closed by explicit component state
-// instead of `OverlayTrigger`'s focus/blur. A focus-triggered popover hides as soon as its
-// trigger button blurs, and clicking a button inside the popover blurs the trigger before
-// that button's own click event fires - so "Yes" can silently do nothing. That race caused
-// https://github.com/ComPlat/chemotion_ELN/issues/2835.
+// A self-contained trigger button for ConfirmationOverlay's "click, then confirm in a
+// popover" idiom: it owns the button and the open/closed state itself, so call sites don't
+// each have to wire up their own ref + target state for the common case of "one button
+// opens one confirm popover". The actual popover (and the explicit-state-over-focus/blur
+// fix for https://github.com/ComPlat/chemotion_ELN/issues/2835) is ConfirmationOverlay's.
 const ConfirmDeleteButton = ({
-  id,
   header,
   onConfirm,
   tooltip,
@@ -24,6 +22,8 @@ const ConfirmDeleteButton = ({
   children,
 }) => {
   const [target, setTarget] = useState(null);
+  // Lazy initializer so the random id is generated once on mount, not on every render.
+  const [tooltipId] = useState(() => `confirm-delete-tooltip-${Math.random().toString(36).slice(2)}`);
 
   const mouseDownProps = stopMouseDownPropagation
     ? { onMouseDown: (event) => event.stopPropagation() }
@@ -53,32 +53,26 @@ const ConfirmDeleteButton = ({
   return (
     <>
       {tooltip ? (
-        <OverlayTrigger placement="top" overlay={<Tooltip id={`${id}-tooltip`}>{tooltip}</Tooltip>}>
+        <OverlayTrigger placement="top" overlay={<Tooltip id={tooltipId}>{tooltip}</Tooltip>}>
           {triggerButton}
         </OverlayTrigger>
       ) : triggerButton}
-      <Overlay show={!!target} target={target} placement={placement} rootClose onHide={close}>
-        <Popover id={id}>
-          <Popover.Header as="h5">{header}</Popover.Header>
-          <Popover.Body>
-            <div className="d-flex gap-2">
-              <Button size="sm" variant="danger" onClick={confirm} {...mouseDownProps}>
-                Yes
-              </Button>
-              <Button size="sm" variant="warning" onClick={close} {...mouseDownProps}>
-                No
-              </Button>
-            </div>
-          </Popover.Body>
-        </Popover>
-      </Overlay>
+      <ConfirmationOverlay
+        overlayTarget={target}
+        placement={placement}
+        warningText={header}
+        destructiveAction={confirm}
+        destructiveActionLabel="Yes"
+        hideAction={close}
+        hideActionLabel="No"
+        stopMouseDownPropagation={stopMouseDownPropagation}
+      />
     </>
   );
 };
 
 ConfirmDeleteButton.propTypes = {
-  id: PropTypes.string.isRequired,
-  header: PropTypes.node.isRequired,
+  header: PropTypes.string.isRequired,
   onConfirm: PropTypes.func.isRequired,
   tooltip: PropTypes.node,
   placement: PropTypes.string,

--- a/app/javascript/src/components/common/ConfirmationOverlay.js
+++ b/app/javascript/src/components/common/ConfirmationOverlay.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Button,
@@ -7,7 +7,7 @@ import {
   Tooltip,
 } from 'react-bootstrap';
 
-export default function ConfirmationOverlay({
+const ConfirmationOverlay = ({
   overlayTarget,
   placement,
   warningText,
@@ -17,11 +17,19 @@ export default function ConfirmationOverlay({
   hideActionLabel,
   primaryAction,
   primaryActionLabel,
-}) {
-  const overlayIdRef = useRef(`confirmation-overlay-${Math.random().toString(36).slice(2)}`);
+  stopMouseDownPropagation,
+}) => {
+  // Lazy initializer so the random id is generated once on mount, not on every render.
+  const [overlayId] = useState(() => `confirmation-overlay-${Math.random().toString(36).slice(2)}`);
   const hasDestructiveAction = destructiveAction && destructiveActionLabel;
   const hasHideAction = hideAction && hideActionLabel;
   const hasPrimaryAction = primaryAction && primaryActionLabel;
+  // Guards a button inside a row/tree whose own onMouseDown would otherwise fire first
+  // (e.g. row selection or drag start) - unrelated to the focus/blur race this overlay
+  // already avoids by being driven off explicit `overlayTarget` state.
+  const mouseDownProps = stopMouseDownPropagation
+    ? { onMouseDown: (event) => event.stopPropagation() }
+    : {};
 
   return (
     <Overlay
@@ -31,7 +39,7 @@ export default function ConfirmationOverlay({
       rootClose
       onHide={hideAction || undefined}
     >
-      <Tooltip id={overlayIdRef.current}>
+      <Tooltip id={overlayId}>
         <div className="p2">
           {warningText}
           <ButtonToolbar className="justify-content-end mt-2">
@@ -40,6 +48,7 @@ export default function ConfirmationOverlay({
                 variant="danger"
                 size="xsm"
                 onClick={destructiveAction}
+                {...mouseDownProps}
               >
                 {destructiveActionLabel}
               </Button>
@@ -49,6 +58,7 @@ export default function ConfirmationOverlay({
                 variant="ghost"
                 size="xsm"
                 onClick={hideAction}
+                {...mouseDownProps}
               >
                 {hideActionLabel}
               </Button>
@@ -58,6 +68,7 @@ export default function ConfirmationOverlay({
                 variant="primary"
                 size="xsm"
                 onClick={primaryAction}
+                {...mouseDownProps}
               >
                 {primaryActionLabel}
               </Button>
@@ -67,7 +78,7 @@ export default function ConfirmationOverlay({
       </Tooltip>
     </Overlay>
   );
-}
+};
 
 ConfirmationOverlay.propTypes = {
   overlayTarget: PropTypes.oneOfType([
@@ -82,6 +93,7 @@ ConfirmationOverlay.propTypes = {
   hideActionLabel: PropTypes.string,
   primaryAction: PropTypes.func,
   primaryActionLabel: PropTypes.string,
+  stopMouseDownPropagation: PropTypes.bool,
 };
 
 ConfirmationOverlay.defaultProps = {
@@ -93,4 +105,7 @@ ConfirmationOverlay.defaultProps = {
   hideActionLabel: undefined,
   primaryAction: undefined,
   primaryActionLabel: undefined,
+  stopMouseDownPropagation: false,
 };
+
+export default ConfirmationOverlay;

--- a/app/javascript/src/components/navigation/GroupElement.js
+++ b/app/javascript/src/components/navigation/GroupElement.js
@@ -113,7 +113,7 @@ export default class GroupElement extends React.Component {
 
   // confirm action after pressing yes
   // if type is group, call deleteGroup api, if type is user, call deleteUser api
-  confirmDelete(event, type, groupRec, userRec) {
+  confirmDelete(type, groupRec, userRec) {
     switch (type) {
       case 'group':
         this.props.onDeleteGroup(groupRec.id);
@@ -189,7 +189,7 @@ export default class GroupElement extends React.Component {
       <ConfirmDeleteButton
         header={msg}
         tooltip={tooltip}
-        onConfirm={() => this.confirmDelete(undefined, type, groupRec, userRec)}
+        onConfirm={() => this.confirmDelete(type, groupRec, userRec)}
       />
     );
   }

--- a/app/javascript/src/components/navigation/GroupElement.js
+++ b/app/javascript/src/components/navigation/GroupElement.js
@@ -9,6 +9,7 @@ import {
 } from 'react-bootstrap';
 import UsersFetcher from 'src/fetchers/UsersFetcher';
 import { AsyncSelect } from 'src/components/common/Select';
+import ConfirmDeleteButton from 'src/components/common/ConfirmDeleteButton';
 import _ from 'lodash';
 import { selectUserOptionFormater } from 'src/utilities/selectHelper';
 
@@ -172,6 +173,7 @@ export default class GroupElement extends React.Component {
   renderDeleteButton(type, groupRec, userRec) {
     const { currentUser } = this.props;
     let msg = 'Leave this group?';
+    let tooltip = 'Remove';
     if (type === 'user') {
       if (userRec.id === currentUser.id) {
         msg = 'Leave this group?';
@@ -180,48 +182,16 @@ export default class GroupElement extends React.Component {
       }
     } else {
       msg = 'Remove group?';
+      tooltip = 'Remove group';
     }
 
-    const popover = (
-      <Popover id="popover-positioned-scrolling-left">
-        <Popover.Body>
-          {msg}
-          <div className="mt-2 d-flex gap-2">
-            <Button
-              size="sm"
-              variant="danger"
-              onClick={(event) => this.confirmDelete(event, type, groupRec, userRec)}
-            >
-              Yes
-            </Button>
-            <Button
-              size="sm"
-              variant="warning"
-              onClick={this.handleClick}
-            >
-              No
-            </Button>
-          </div>
-        </Popover.Body>
-      </Popover>
-    );
-
     return (
-      <OverlayTrigger
-        animation
-        placement="right"
-        root
-        trigger="focus"
-        overlay={popover}
-      >
-        <Button
-          size="sm"
-          type="button"
-          variant="danger"
-        >
-          <i className="fa fa-trash-o" />
-        </Button>
-      </OverlayTrigger>
+      <ConfirmDeleteButton
+        id={`confirm-delete-${type}-${groupRec.id}${userRec ? `-${userRec.id}` : ''}`}
+        header={msg}
+        tooltip={tooltip}
+        onConfirm={() => this.confirmDelete(undefined, type, groupRec, userRec)}
+      />
     );
   }
 
@@ -272,12 +242,7 @@ export default class GroupElement extends React.Component {
                   <i className="fa fa-key" />
                 </Button>
               </OverlayTrigger>
-              <OverlayTrigger
-                placement="top"
-                overlay={<Tooltip>Remove group</Tooltip>}
-              >
-                {this.renderDeleteButton('group', groupElement)}
-              </OverlayTrigger>
+              {this.renderDeleteButton('group', groupElement)}
             </>
           )}
         </div>
@@ -353,11 +318,7 @@ export default class GroupElement extends React.Component {
             </Button>
           </OverlayTrigger>
         )}
-        {canDelete && (
-          <OverlayTrigger placement="top" overlay={<Tooltip>Remove</Tooltip>}>
-            {this.renderDeleteButton('user', groupRec, userRec)}
-          </OverlayTrigger>
-        )}
+        {canDelete && this.renderDeleteButton('user', groupRec, userRec)}
       </div>
     );
   }

--- a/app/javascript/src/components/navigation/GroupElement.js
+++ b/app/javascript/src/components/navigation/GroupElement.js
@@ -187,7 +187,6 @@ export default class GroupElement extends React.Component {
 
     return (
       <ConfirmDeleteButton
-        id={`confirm-delete-${type}-${groupRec.id}${userRec ? `-${userRec.id}` : ''}`}
         header={msg}
         tooltip={tooltip}
         onConfirm={() => this.confirmDelete(undefined, type, groupRec, userRec)}

--- a/spec/javascripts/packs/src/components/common/ConfirmDeleteButton.spec.js
+++ b/spec/javascripts/packs/src/components/common/ConfirmDeleteButton.spec.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import { configure, mount } from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import expect from 'expect';
+import sinon from 'sinon';
+import ConfirmDeleteButton from 'src/components/common/ConfirmDeleteButton';
+
+configure({ adapter: new Adapter() });
+
+// Regression coverage for https://github.com/ComPlat/chemotion_ELN/issues/2835: a
+// focus-triggered popover hides itself on blur, and clicking a button inside the popover
+// blurs the trigger before that button's own click event fires, so "Yes" could silently do
+// nothing. These specs drive the component through the real trigger-click -> open ->
+// click-"Yes"/"No" sequence (not internal handlers directly), so a regression back to a
+// focus/blur-driven popover would fail here.
+describe('ConfirmDeleteButton', () => {
+  let onConfirm;
+  let wrapper;
+
+  const findButtonByText = (text) => wrapper
+    .findWhere((node) => node.type() === 'button' && node.text() === text)
+    .first();
+
+  // Overlay uses a Fade transition by default, so a closed popover can still linger in the
+  // DOM mid-exit-animation - checking Overlay's `show` prop reflects the state change
+  // immediately, without depending on transition timing.
+  const isOverlayShown = () => wrapper.find('Overlay').first().prop('show');
+
+  beforeEach(() => {
+    onConfirm = sinon.spy();
+    wrapper = mount(React.createElement(ConfirmDeleteButton, {
+      header: 'Remove this?',
+      onConfirm,
+    }));
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+    sinon.restore();
+  });
+
+  it('does not show the confirmation popover before the trigger is clicked', () => {
+    expect(isOverlayShown()).toBe(false);
+  });
+
+  it('opens the confirmation popover on trigger click', () => {
+    wrapper.find('button').first().simulate('click');
+    wrapper.update();
+
+    expect(isOverlayShown()).toBe(true);
+    expect(wrapper.text()).toContain('Remove this?');
+  });
+
+  it('keeps the popover open on blur (not focus/blur-driven, unlike the old implementation)', () => {
+    wrapper.find('button').first().simulate('click');
+    wrapper.update();
+
+    // This is exactly the mechanism that silently swallowed "Yes" clicks pre-fix: a
+    // focus-triggered popover hides on blur before a click inside it can register.
+    wrapper.find('button').first().simulate('blur');
+    wrapper.update();
+
+    expect(isOverlayShown()).toBe(true);
+  });
+
+  it('calls onConfirm and closes the popover when "Yes" is clicked', () => {
+    wrapper.find('button').first().simulate('click');
+    wrapper.update();
+
+    findButtonByText('Yes').simulate('click');
+    wrapper.update();
+
+    expect(onConfirm.calledOnce).toBe(true);
+    expect(isOverlayShown()).toBe(false);
+  });
+
+  it('closes the popover without calling onConfirm when "No" is clicked', () => {
+    wrapper.find('button').first().simulate('click');
+    wrapper.update();
+
+    findButtonByText('No').simulate('click');
+    wrapper.update();
+
+    expect(onConfirm.called).toBe(false);
+    expect(isOverlayShown()).toBe(false);
+  });
+
+  it('closes the popover again when the trigger is clicked a second time', () => {
+    wrapper.find('button').first().simulate('click');
+    wrapper.update();
+    expect(isOverlayShown()).toBe(true);
+
+    wrapper.find('button').first().simulate('click');
+    wrapper.update();
+    expect(isOverlayShown()).toBe(false);
+  });
+});

--- a/spec/javascripts/packs/src/components/common/ConfirmDeleteButton.spec.js
+++ b/spec/javascripts/packs/src/components/common/ConfirmDeleteButton.spec.js
@@ -94,4 +94,57 @@ describe('ConfirmDeleteButton', () => {
     wrapper.update();
     expect(isOverlayShown()).toBe(false);
   });
+
+  // Regression coverage: clicking a button also focuses it in Chromium/Windows, and
+  // OverlayTrigger's default trigger set is ['hover', 'focus'], so the trigger's own hover
+  // tooltip would pop open at the same time as the confirm popover below it, stacked over
+  // the same icon. `find('Overlay')` distinguishes the two here by `placement` - the
+  // tooltip is always "top", the confirm popover defaults to "right".
+  describe('with a tooltip', () => {
+    let tooltipWrapper;
+
+    const overlayAt = (placement) => tooltipWrapper.find('Overlay')
+      .filterWhere((o) => o.prop('placement') === placement)
+      .first();
+
+    beforeEach(() => {
+      tooltipWrapper = mount(React.createElement(ConfirmDeleteButton, {
+        header: 'Remove this?',
+        tooltip: 'Remove',
+        onConfirm: sinon.spy(),
+      }));
+    });
+
+    afterEach(() => {
+      tooltipWrapper.unmount();
+    });
+
+    it('shows the tooltip on hover alone', () => {
+      tooltipWrapper.find('button').first().simulate('mouseover');
+      tooltipWrapper.update();
+
+      expect(overlayAt('top').prop('show')).toBe(true);
+      expect(overlayAt('right').prop('show')).toBe(false);
+    });
+
+    it('shows the tooltip on keyboard focus alone', () => {
+      tooltipWrapper.find('button').first().simulate('focus');
+      tooltipWrapper.update();
+
+      expect(overlayAt('top').prop('show')).toBe(true);
+      expect(overlayAt('right').prop('show')).toBe(false);
+    });
+
+    it('does not show the tooltip alongside the confirm popover on click', () => {
+      const button = tooltipWrapper.find('button').first();
+      // A real click also fires focus (which is what OverlayTrigger's tooltip listens for);
+      // Enzyme's simulated click alone does not, so both are dispatched explicitly here.
+      button.simulate('click');
+      button.simulate('focus');
+      tooltipWrapper.update();
+
+      expect(overlayAt('top').prop('show')).toBe(false);
+      expect(overlayAt('right').prop('show')).toBe(true);
+    });
+  });
 });

--- a/spec/javascripts/packs/src/components/navigation/GroupElement.spec.js
+++ b/spec/javascripts/packs/src/components/navigation/GroupElement.spec.js
@@ -33,17 +33,13 @@ describe('GroupElement', () => {
     onChangeData: sinon.spy(),
   }));
 
-  // confirmDelete takes the click event explicitly (not the legacy `window.event` global)
-  // so the admin-warning popover can be positioned without relying on an ambient DOM event.
-  const fakeEvent = () => ({ target: null });
-
-  describe('.confirmDelete(event, "user", ...)', () => {
+  describe('.confirmDelete("user", ...)', () => {
     it('removes a member even when they are the sole admin, without touching admin status', () => {
       const groupElement = buildGroupElement([admin]);
       const onDeleteUser = sinon.spy();
       const wrapper = mountElement(groupElement, onDeleteUser);
 
-      wrapper.instance().confirmDelete(fakeEvent(), 'user', groupElement, admin);
+      wrapper.instance().confirmDelete('user', groupElement, admin);
 
       expect(onDeleteUser.calledOnceWith(groupElement, admin)).toBe(true);
       expect(wrapper.instance().state.showAdminAlert).toBe(false);
@@ -55,7 +51,7 @@ describe('GroupElement', () => {
       const onDeleteUser = sinon.spy();
       const wrapper = mountElement(groupElement, onDeleteUser);
 
-      wrapper.instance().confirmDelete(fakeEvent(), 'user', groupElement, member);
+      wrapper.instance().confirmDelete('user', groupElement, member);
 
       expect(onDeleteUser.calledOnceWith(groupElement, member)).toBe(true);
       expect(wrapper.instance().state.showAdminAlert).toBe(false);
@@ -66,7 +62,7 @@ describe('GroupElement', () => {
       const onDeleteUser = sinon.spy();
       const wrapper = mountElement(groupElement, onDeleteUser);
 
-      wrapper.instance().confirmDelete(fakeEvent(), 'user', groupElement, otherAdmin);
+      wrapper.instance().confirmDelete('user', groupElement, otherAdmin);
 
       expect(onDeleteUser.calledOnceWith(groupElement, otherAdmin)).toBe(true);
       expect(wrapper.instance().state.showAdminAlert).toBe(false);


### PR DESCRIPTION
# Summary
  - `OverlayTrigger trigger="focus"` hides its popover on `blur`. Clicking a button inside the popover (e.g. "Yes")
  blurs the trigger before that button's own click event fires, so confirming a delete could silently do nothing. This
  is what caused #2835 (group/member removal).
  - The same "Yes"/"No" confirm-popover pattern was duplicated across 8 places, all exposed to the same race, and all
  relying on it (via a missing or `undefined` `handleClick`) for the "No" button to close the popover at all.
  - Added a shared `ConfirmDeleteButton` (`app/javascript/src/components/common/ConfirmDeleteButton.js`) driven by plain
  component state instead of focus/blur, with explicit Yes/No handlers and `rootClose` for outside-click dismissal.
  - Swapped it into all 8 sites: group/member removal (`GroupElement.js`), collection deletion (`MyCollections.js`),
  admin group/device deletion (`DeleteGroupDeviceButton.js`), ChemSpectra layout deletion (`ChemSpectraLayouts.js`),
  molecule moderator name deletion (`MoleculeModeratorComponent.js`), report template deletion
  (`TemplateManagement.js`), device/data-collector/NoVNC removal (`DevicesList.js`, 3 spots), and calendar entry
  deletion (`CalendarEntryEditor.js`).

  ## Test plan
  - [x] `yarn test` — 1511 passing, 0 failures (incl. `GroupElement.spec.js`'s `confirmDelete` coverage)
  - [x] `yarn eslint` on all touched files — no new lint issues beyond pre-existing debt in `DeleteGroupDeviceButton.js`
  (a file with no `PropTypes` declared at all)
  - [ ] Manual retest of the original repro from #2835 (create group → add member → remove member → confirm) on the
  deployed branch

 Closes #2835