### PR TITLE
feat(collections): manage and target the locked system collections

### DIFF
--- a/app/api/chemotion/collection_api.rb
+++ b/app/api/chemotion/collection_api.rb
@@ -103,11 +103,11 @@ module Chemotion
         # request outright would override that. Compared by value rather than by key, because the tabs
         # editor always sends the (unchanged) label alongside the layout.
         if collection.is_locked?
-          forbidden = attributes.select do |attribute, value|
+          forbidden = attributes.any? do |attribute, value|
             LockedCollectionGuard::LOCKED_IMMUTABLE_ATTRIBUTES.include?(attribute.to_s) &&
               collection[attribute] != value
           end
-          error!('A locked collection cannot be modified', 403) if forbidden.any?
+          error!('A locked collection cannot be modified', 403) if forbidden
         end
 
         error!(collection.errors.full_messages.join(', '), 422) unless collection.update(attributes)

--- a/app/api/chemotion/collection_api.rb
+++ b/app/api/chemotion/collection_api.rb
@@ -95,10 +95,22 @@ module Chemotion
       end
       put '/:id' do
         collection = Collection.own_collections_for(current_user).find(params[:id])
-        error!('A locked collection cannot be modified', 403) if collection.is_locked?
         attributes = { label: params[:label], tabs_segment: params[:tabs_segment] }.compact
 
-        collection.update(attributes)
+        # A locked collection is not fully immutable: LockedCollectionGuard fixes only
+        # LOCKED_IMMUTABLE_ATTRIBUTES, deliberately leaving tabs_segment editable so the tab layout of
+        # the "All"/repository/transferred collections can be configured like any other. Refusing the
+        # request outright would override that. Compared by value rather than by key, because the tabs
+        # editor always sends the (unchanged) label alongside the layout.
+        if collection.is_locked?
+          forbidden = attributes.select do |attribute, value|
+            LockedCollectionGuard::LOCKED_IMMUTABLE_ATTRIBUTES.include?(attribute.to_s) &&
+              collection[attribute] != value
+          end
+          error!('A locked collection cannot be modified', 403) if forbidden.any?
+        end
+
+        error!(collection.errors.full_messages.join(', '), 422) unless collection.update(attributes)
 
         present collection, with: Entities::OwnCollectionEntity, root: :collection
       end

--- a/app/javascript/src/apps/mydb/collections/CollectionSubtree.js
+++ b/app/javascript/src/apps/mydb/collections/CollectionSubtree.js
@@ -163,7 +163,9 @@ function CollectionSubtree({
               <i className="fa fa-share-alt" />
             </OverlayTrigger>
           )}
-          {sharedWithMe && !root.is_locked && (
+          {/* Suppressed on the synthetic owner-grouping row (id 0), which has no share behind it —
+              not on is_locked, which a genuinely shared system collection also carries. */}
+          {sharedWithMe && root.id !== 0 && (
             <OverlayTrigger
               placement="top"
               overlay={<SharedToMeInfosTooltip collectionId={root.id} owner={root.owner} />}

--- a/app/javascript/src/apps/mydb/collections/CollectionSubtreeFunctions.js
+++ b/app/javascript/src/apps/mydb/collections/CollectionSubtreeFunctions.js
@@ -56,7 +56,10 @@ const CollectionSubtreeFunctions = ({
   );
   // Import samples: not locked and (for shared-with-me) the delegate can add elements.
   const hasAddElementsAccess = !collection.is_locked && hasPermission(PermissionConst.AddElements);
-  const canAddShare = !collection.is_locked && hasPermission(PermissionConst.ManageShares);
+  // Not gated on is_locked: the repository root and "transferred" are locked against renaming,
+  // reparenting and deletion, but they are ordinary owned collections as far as sharing goes —
+  // the API refuses only a pass_ownership offer on them (CollectionShareAPI#prevent_invalid_ownership_offer!).
+  const canAddShare = hasPermission(PermissionConst.ManageShares);
   // Editing a collection's own metadata and publishing it via RADAR act on the collection
   // itself, not on its elements — no permission_level grants a sharee those, only ownership.
   const canManageCollection = !sharedWithMe && !collection.is_locked;

--- a/app/javascript/src/apps/mydb/collections/CollectionTabsEditorModal.js
+++ b/app/javascript/src/apps/mydb/collections/CollectionTabsEditorModal.js
@@ -103,12 +103,23 @@ const CollectionTabsEditorModal = ({ collection, show, onHide }) => {
     setSelectedCategory('sample');
   }, [show, collection, allElements]);
 
-  const handleSave = () => {
+  const handleSave = async () => {
     const layoutSegments = allElements.reduce((acc, { name }) => {
       acc[name] = filterTabLayout(layouts[name]);
       return acc;
     }, {});
-    collectionsStore.updateCollection(collection, layoutSegments);
+
+    // "All" has no per-collection layout: ElementDetailSortTab reads the profile default for it
+    // (refreshTabLayout nulls collectionTabs there) and its own editor skips the collection write
+    // for the same reason. Persisting a tabs_segment nothing reads would look like it took effect.
+    // Editing "All"'s tabs is editing the default layout, which is what the profile write below does.
+    if (!collectionsStore.isAllCollectionId(collection.id)) {
+      // Keep the profile defaults and the modal open on a rejected save — updateCollection reports
+      // the failure, and closing over it would leave the user told it failed while the global
+      // default had moved anyway.
+      const saved = await collectionsStore.updateCollection(collection, layoutSegments);
+      if (!saved) return;
+    }
 
     const userProfile = UserStore.getState().profile;
     // Store each type's default under its own `layout_detail_<name>` key so

--- a/app/javascript/src/apps/mydb/collections/MyCollections.js
+++ b/app/javascript/src/apps/mydb/collections/MyCollections.js
@@ -4,16 +4,20 @@ import { cloneDeep } from 'lodash';
 import { Button, ButtonGroup, Dropdown, Form, OverlayTrigger, Popover } from 'react-bootstrap';
 import { observer } from 'mobx-react';
 import { StoreContext } from 'src/stores/mobx/RootStore';
+import AppModal from 'src/components/common/AppModal';
 import CollectionTabsEditorModal from 'src/apps/mydb/collections/CollectionTabsEditorModal';
 import UserInfosTooltip from 'src/apps/mydb/collections/UserInfosTooltip';
 import useCollectionShares from 'src/apps/mydb/collections/useCollectionShares';
+import { ALL_LABEL, TRANSFERRED_LABEL } from 'src/stores/mobx/CollectionsStore';
 
 const MyCollections = () => {
   const collectionsStore = useContext(StoreContext).collections;
   const tree = collectionsStore.own_collection_tree;
   const [clonedTree, setClonedTree] = useState(cloneDeep(tree));
   const [tabsEditorCollection, setTabsEditorCollection] = useState(null);
+  const [shareAllConfirm, setShareAllConfirm] = useState(null);
   const { openAddShare, openManageShares, shareModals } = useCollectionShares(collectionsStore);
+  const systemCollections = collectionsStore.systemCollections;
 
   useEffect(() => {
     setClonedTree(cloneDeep(tree));
@@ -46,6 +50,16 @@ const MyCollections = () => {
 
   const deleteCollection = (node) => {
     collectionsStore.deleteCollection(node.id);
+  };
+
+  // Every other collection shares a bounded set of elements; "All" holds everything the user owns,
+  // so sharing it is a different order of decision and is confirmed before the share modal opens.
+  const requestAddShare = (node) => {
+    if (node.label === ALL_LABEL) {
+      setShareAllConfirm(node);
+      return;
+    }
+    openAddShare(node);
   };
 
   const addCollectionButton = (node) => (
@@ -173,6 +187,86 @@ const MyCollections = () => {
     );
   };
 
+  // The system collections ("All", the repository root and "transferred") are owned like any other
+  // collection, but locked: the backend refuses to rename, reparent, delete them or create anything
+  // inside them. They are rendered here as a pinned, read-only section rather than as nodes of the
+  // tree below, both so no drag can pick them up (react-ui-tree has no per-node opt-out) and so the
+  // payload of a tree save stays exactly the set of collections the user may actually move.
+  const systemNodeActions = (node) => (
+    <div className="d-flex align-items-center gap-2 flex-shrink-0">
+      <span
+        className="d-inline-flex justify-content-end align-items-center flex-shrink-0"
+        style={{ width: '3rem' }}
+      >
+        {node.shared && (
+          <OverlayTrigger placement="top" overlay={<UserInfosTooltip collectionId={node.id} />}>
+            <span
+              className="text-warning d-inline-flex align-items-center"
+              style={{ cursor: 'default' }}
+            >
+              <i className="fa fa-share-alt" />
+            </span>
+          </OverlayTrigger>
+        )}
+      </span>
+      <ButtonGroup className="flex-shrink-0">
+        <Dropdown>
+          <Dropdown.Toggle
+            size="sm"
+            variant="light"
+            id={`system-collection-more-actions-${node.id}`}
+          >
+            <i className="fa fa-ellipsis-v" />
+          </Dropdown.Toggle>
+          <Dropdown.Menu popperConfig={{ strategy: 'fixed' }} renderOnMount>
+            <Dropdown.Item onClick={() => requestAddShare(node)}>
+              <i className="fa fa-plus me-1" />
+              <i className="fa fa-share-alt me-1" />
+              Add share
+            </Dropdown.Item>
+            {node.shared && (
+              <Dropdown.Item onClick={() => openManageShares(node)}>
+                <i className="fa fa-users me-1" />
+                <i className="fa fa-share-alt me-1" />
+                Manage shares
+              </Dropdown.Item>
+            )}
+            <Dropdown.Divider />
+            <Dropdown.Item onClick={() => setTabsEditorCollection(node)}>
+              <i className="fa fa-sliders me-1" />
+              Edit collection tabs
+            </Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
+      </ButtonGroup>
+    </div>
+  );
+
+  const systemCollectionsSection = () => {
+    if (systemCollections.length === 0) return null;
+
+    return (
+      <div className="system-collections border-bottom pb-2 mb-2">
+        <div className="ms-3 mb-2 fs-5">System collections</div>
+        {systemCollections.map((node) => (
+          <div
+            key={node.id}
+            className="collection-node py-1 d-flex flex-nowrap align-items-center justify-content-between"
+          >
+            <span
+              className={`ms-3 flex-grow-1 min-w-0 me-2 text-truncate${
+                node.label === TRANSFERRED_LABEL ? ' ps-4' : ''
+              }`}
+            >
+              {node.label}
+            </span>
+            {systemNodeActions(node)}
+          </div>
+        ))}
+      </div>
+    );
+  };
+
   const renderNode = (node) => (
     <div className="collection-node py-1 d-flex flex-nowrap align-items-center justify-content-between">
       {label(node)}
@@ -182,6 +276,7 @@ const MyCollections = () => {
 
   return (
     <div className="tree pt-2 h-100 overflow-y-auto">
+      {systemCollectionsSection()}
       <Tree
         paddingLeft={20}
         tree={clonedTree}
@@ -189,6 +284,25 @@ const MyCollections = () => {
         renderNode={renderNode}
       />
       {shareModals}
+      {shareAllConfirm != null && (
+        <AppModal
+          show
+          onHide={() => setShareAllConfirm(null)}
+          title={`Share "${shareAllConfirm.label}"?`}
+          primaryActionLabel="Continue"
+          onPrimaryAction={() => {
+            const node = shareAllConfirm;
+            setShareAllConfirm(null);
+            openAddShare(node);
+          }}
+        >
+          <p>
+            {`"${shareAllConfirm.label}" holds every element you own — sharing it grants the `}
+            recipient access to all of them at once, including elements you add later.
+          </p>
+          <p className="mb-0">Share a specific collection instead if that is not what you want.</p>
+        </AppModal>
+      )}
       {tabsEditorCollection != null && (
         <CollectionTabsEditorModal
           collection={tabsEditorCollection}

--- a/app/javascript/src/apps/mydb/collections/MyCollections.js
+++ b/app/javascript/src/apps/mydb/collections/MyCollections.js
@@ -8,7 +8,6 @@ import AppModal from 'src/components/common/AppModal';
 import CollectionTabsEditorModal from 'src/apps/mydb/collections/CollectionTabsEditorModal';
 import UserInfosTooltip from 'src/apps/mydb/collections/UserInfosTooltip';
 import useCollectionShares from 'src/apps/mydb/collections/useCollectionShares';
-import { ALL_LABEL, TRANSFERRED_LABEL } from 'src/stores/mobx/CollectionsStore';
 
 const MyCollections = () => {
   const collectionsStore = useContext(StoreContext).collections;
@@ -17,7 +16,7 @@ const MyCollections = () => {
   const [tabsEditorCollection, setTabsEditorCollection] = useState(null);
   const [shareAllConfirm, setShareAllConfirm] = useState(null);
   const { openAddShare, openManageShares, shareModals } = useCollectionShares(collectionsStore);
-  const systemCollections = collectionsStore.systemCollections;
+  const { systemCollections } = collectionsStore;
 
   useEffect(() => {
     setClonedTree(cloneDeep(tree));
@@ -52,14 +51,20 @@ const MyCollections = () => {
     collectionsStore.deleteCollection(node.id);
   };
 
+  // The system rows are live store nodes; fetchCollections() clears the locked bucket (see
+  // setOwnCollections), which would leave a node captured in React state detached from the tree.
+  // Both modals only ever read these three fields, so hand them a plain snapshot instead.
+  const systemNodeSnapshot = (node) => ({ id: node.id, label: node.label, tabs_segment: node.tabs_segment });
+
   // Every other collection shares a bounded set of elements; "All" holds everything the user owns,
   // so sharing it is a different order of decision and is confirmed before the share modal opens.
+  // Resolved by id through the store, not by label — the label alone is not reserved.
   const requestAddShare = (node) => {
-    if (node.label === ALL_LABEL) {
-      setShareAllConfirm(node);
+    if (collectionsStore.isAllCollectionId(node.id)) {
+      setShareAllConfirm(systemNodeSnapshot(node));
       return;
     }
-    openAddShare(node);
+    openAddShare(systemNodeSnapshot(node));
   };
 
   const addCollectionButton = (node) => (
@@ -72,6 +77,63 @@ const MyCollections = () => {
     >
       <i className="fa fa-plus" />
     </Button>
+  );
+
+  // Shared by the draggable tree rows and the pinned system rows. `stopDrag` is the only real
+  // difference: react-ui-tree starts a drag on mousedown, so tree rows must swallow it, while the
+  // system section is not part of the tree and has nothing to swallow.
+  const sharedWithIcon = (node, stopDrag) => (
+    <span
+      className="d-inline-flex justify-content-end align-items-center flex-shrink-0"
+      style={{ width: '3rem' }}
+    >
+      {node.shared && (
+        <OverlayTrigger placement="top" overlay={<UserInfosTooltip collectionId={node.id} />}>
+          {/* The handler suppresses react-ui-tree's drag start on a decorative icon; it adds no
+              interaction of its own, so there is no keyboard equivalent to provide. */}
+          {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+          <span
+            className="text-warning d-inline-flex align-items-center"
+            onMouseDown={stopDrag ? (e) => e.stopPropagation() : undefined}
+            style={{ cursor: 'default' }}
+          >
+            <i className="fa fa-share-alt" />
+          </span>
+        </OverlayTrigger>
+      )}
+    </span>
+  );
+
+  const moreActionsDropdown = (node, {
+    idPrefix, stopDrag, onAddShare, onEditTabs, disabled = false,
+  }) => (
+    <Dropdown onMouseDown={stopDrag ? (e) => e.stopPropagation() : undefined}>
+      <Dropdown.Toggle size="sm" variant="light" id={`${idPrefix}-${node.id}`} disabled={disabled}>
+        <i className="fa fa-ellipsis-v" />
+      </Dropdown.Toggle>
+      {/* renderOnMount pre-mounts the menu so Popper has a measurable anchor;
+          without it the fixed-strategy menu detaches to the top of the viewport
+          inside the modal's positioning context. */}
+      <Dropdown.Menu popperConfig={{ strategy: 'fixed' }} renderOnMount>
+        <Dropdown.Item onClick={() => onAddShare(node)}>
+          <i className="fa fa-plus me-1" />
+          <i className="fa fa-share-alt me-1" />
+          Add share
+        </Dropdown.Item>
+        {node.shared && (
+          <Dropdown.Item onClick={() => openManageShares(node)}>
+            <i className="fa fa-users me-1" />
+            <i className="fa fa-share-alt me-1" />
+            Manage shares
+          </Dropdown.Item>
+        )}
+        <Dropdown.Divider />
+        <Dropdown.Item onClick={() => onEditTabs(node)}>
+          <i className="fa fa-sliders me-1" />
+          Edit collection tabs
+        </Dropdown.Item>
+      </Dropdown.Menu>
+    </Dropdown>
   );
 
   const actions = (node) => {
@@ -112,55 +174,15 @@ const MyCollections = () => {
 
     return (
       <div className="d-flex align-items-center gap-2 flex-shrink-0">
-        <span
-          className="d-inline-flex justify-content-end align-items-center flex-shrink-0"
-          style={{ width: '3rem' }}
-        >
-          {node.shared && (
-            <OverlayTrigger placement="top" overlay={<UserInfosTooltip collectionId={node.id} />}>
-              <span
-                className="text-warning d-inline-flex align-items-center"
-                onMouseDown={(e) => e.stopPropagation()}
-                style={{ cursor: 'default' }}
-              >
-                <i className="fa fa-share-alt" />
-              </span>
-            </OverlayTrigger>
-          )}
-        </span>
+        {sharedWithIcon(node, true)}
         <ButtonGroup className="flex-shrink-0">
-          <Dropdown onMouseDown={(e) => e.stopPropagation()}>
-            <Dropdown.Toggle
-              size="sm"
-              variant="light"
-              id={`collection-more-actions-${node.id}`}
-              disabled={node.isNew === true}
-            >
-              <i className="fa fa-ellipsis-v" />
-            </Dropdown.Toggle>
-            {/* renderOnMount pre-mounts the menu so Popper has a measurable anchor;
-                without it the fixed-strategy menu detaches to the top of the viewport
-                inside the modal's positioning context. */}
-            <Dropdown.Menu popperConfig={{ strategy: 'fixed' }} renderOnMount>
-              <Dropdown.Item onClick={() => openAddShare(node)}>
-                <i className="fa fa-plus me-1" />
-                <i className="fa fa-share-alt me-1" />
-                Add share
-              </Dropdown.Item>
-              {node.shared && (
-                <Dropdown.Item onClick={() => openManageShares(node)}>
-                  <i className="fa fa-users me-1" />
-                  <i className="fa fa-share-alt me-1" />
-                  Manage shares
-                </Dropdown.Item>
-              )}
-              <Dropdown.Divider />
-              <Dropdown.Item onClick={() => setTabsEditorCollection(node)}>
-                <i className="fa fa-sliders me-1" />
-                Edit collection tabs
-              </Dropdown.Item>
-            </Dropdown.Menu>
-          </Dropdown>
+          {moreActionsDropdown(node, {
+            idPrefix: 'collection-more-actions',
+            stopDrag: true,
+            onAddShare: openAddShare,
+            onEditTabs: setTabsEditorCollection,
+            disabled: node.isNew === true,
+          })}
           {addCollectionButton(node)}
           <OverlayTrigger animation placement="bottom" root trigger="focus" overlay={popover}>
             <Button size="sm" variant="danger" onMouseDown={(e) => e.stopPropagation()}>
@@ -194,50 +216,14 @@ const MyCollections = () => {
   // payload of a tree save stays exactly the set of collections the user may actually move.
   const systemNodeActions = (node) => (
     <div className="d-flex align-items-center gap-2 flex-shrink-0">
-      <span
-        className="d-inline-flex justify-content-end align-items-center flex-shrink-0"
-        style={{ width: '3rem' }}
-      >
-        {node.shared && (
-          <OverlayTrigger placement="top" overlay={<UserInfosTooltip collectionId={node.id} />}>
-            <span
-              className="text-warning d-inline-flex align-items-center"
-              style={{ cursor: 'default' }}
-            >
-              <i className="fa fa-share-alt" />
-            </span>
-          </OverlayTrigger>
-        )}
-      </span>
+      {sharedWithIcon(node, false)}
       <ButtonGroup className="flex-shrink-0">
-        <Dropdown>
-          <Dropdown.Toggle
-            size="sm"
-            variant="light"
-            id={`system-collection-more-actions-${node.id}`}
-          >
-            <i className="fa fa-ellipsis-v" />
-          </Dropdown.Toggle>
-          <Dropdown.Menu popperConfig={{ strategy: 'fixed' }} renderOnMount>
-            <Dropdown.Item onClick={() => requestAddShare(node)}>
-              <i className="fa fa-plus me-1" />
-              <i className="fa fa-share-alt me-1" />
-              Add share
-            </Dropdown.Item>
-            {node.shared && (
-              <Dropdown.Item onClick={() => openManageShares(node)}>
-                <i className="fa fa-users me-1" />
-                <i className="fa fa-share-alt me-1" />
-                Manage shares
-              </Dropdown.Item>
-            )}
-            <Dropdown.Divider />
-            <Dropdown.Item onClick={() => setTabsEditorCollection(node)}>
-              <i className="fa fa-sliders me-1" />
-              Edit collection tabs
-            </Dropdown.Item>
-          </Dropdown.Menu>
-        </Dropdown>
+        {moreActionsDropdown(node, {
+          idPrefix: 'system-collection-more-actions',
+          stopDrag: false,
+          onAddShare: requestAddShare,
+          onEditTabs: (systemNode) => setTabsEditorCollection(systemNodeSnapshot(systemNode)),
+        })}
       </ButtonGroup>
     </div>
   );
@@ -253,10 +239,12 @@ const MyCollections = () => {
             key={node.id}
             className="collection-node py-1 d-flex flex-nowrap align-items-center justify-content-between"
           >
+            {/* Indent from the node's own ancestry (1.5rem per level, matching Bootstrap's ps-4)
+                rather than from a hard-coded label, so a system collection that is nested
+                differently later still lines up. */}
             <span
-              className={`ms-3 flex-grow-1 min-w-0 me-2 text-truncate${
-                node.label === TRANSFERRED_LABEL ? ' ps-4' : ''
-              }`}
+              className="ms-3 flex-grow-1 min-w-0 me-2 text-truncate"
+              style={{ paddingLeft: `${node.ancestorIds.length * 1.5}rem` }}
             >
               {node.label}
             </span>

--- a/app/javascript/src/apps/mydb/collections/SharedWithMeCollections.js
+++ b/app/javascript/src/apps/mydb/collections/SharedWithMeCollections.js
@@ -35,7 +35,10 @@ function SharedWithMeCollections() {
       return <div className="ms-3 mb-2 fs-5">{node.label}</div>;
     }
 
-    if (node.is_locked) {
+    // The owner-grouping rows are synthetic, with no collection behind them — keyed on the id 0
+    // sentinel setSharedWithMeCollections gives them, not on is_locked, which a genuinely shared
+    // system collection also carries and which would render it as a header instead of a row.
+    if (node.id === 0) {
       return (
         <div
           className="ms-3 mt-3 mb-1 text-muted small text-uppercase fw-semibold border-bottom pb-1"

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionActions.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionActions.js
@@ -144,6 +144,7 @@ export default class SelectionActions extends React.Component {
           title="Move to Collection"
           action="move"
           withShared={true}
+          withRepository={true}
           onHide={this.hideModal}
         />;
 
@@ -152,6 +153,7 @@ export default class SelectionActions extends React.Component {
           title="Assign to Collection"
           action="assign"
           withShared={false}
+          withRepository={true}
           onHide={this.hideModal}
         />;
 

--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionTransferModal.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionTransferModal.js
@@ -12,6 +12,7 @@ function SelectionTransferModal({
   action,
   onHide,
   withShared,
+  withRepository,
 }) {
   const collectionsStore = useContext(StoreContext).collections;
   const [selectedCollection, setSelectedCollection] = useState('');
@@ -53,6 +54,7 @@ function SelectionTransferModal({
           <CollectionSelect
             value={selectedCollection}
             withShared={withShared}
+            withRepository={withRepository}
             onChange={setSelectedCollection}
           />
         </Form.Group>
@@ -77,8 +79,10 @@ SelectionTransferModal.propTypes = {
   action: PropTypes.string.isRequired,
   onHide: PropTypes.func.isRequired,
   withShared: PropTypes.bool,
+  withRepository: PropTypes.bool,
 };
 
 SelectionTransferModal.defaultProps = {
   withShared: false,
+  withRepository: false,
 };

--- a/app/javascript/src/components/common/CollectionSelect.js
+++ b/app/javascript/src/components/common/CollectionSelect.js
@@ -1,9 +1,10 @@
 import React, { useState, useContext } from 'react';
+import PropTypes from 'prop-types';
 import { Select } from 'src/components/common/Select';
 import { collectionOptions } from 'src/utilities/collectionUtilities';
 import { StoreContext } from 'src/stores/mobx/RootStore';
 
-const CollectionSelect = ({ value, withShared, onChange }) => {
+const CollectionSelect = ({ value, withShared, withRepository = false, onChange }) => {
   const collectionsStore = useContext(StoreContext).collections;
   const [selectedCollection, setSelectedCollection] = useState(value || null);
 
@@ -23,7 +24,7 @@ const CollectionSelect = ({ value, withShared, onChange }) => {
   return (
     <Select
       id="modal-collection-id-select"
-      options={collectionOptions(collectionsStore, withShared)}
+      options={collectionOptions(collectionsStore, withShared, withRepository)}
       formatOptionLabel={optionLabel}
       value={selectedCollection}
       getOptionValue={(o) => o.id}
@@ -31,5 +32,18 @@ const CollectionSelect = ({ value, withShared, onChange }) => {
     />
   );
 }
+
+CollectionSelect.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  withShared: PropTypes.bool,
+  withRepository: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
+};
+
+CollectionSelect.defaultProps = {
+  value: null,
+  withShared: false,
+  withRepository: false,
+};
 
 export default CollectionSelect;

--- a/app/javascript/src/components/common/CollectionSelect.js
+++ b/app/javascript/src/components/common/CollectionSelect.js
@@ -4,7 +4,7 @@ import { Select } from 'src/components/common/Select';
 import { collectionOptions } from 'src/utilities/collectionUtilities';
 import { StoreContext } from 'src/stores/mobx/RootStore';
 
-const CollectionSelect = ({ value, withShared, withRepository = false, onChange }) => {
+const CollectionSelect = ({ value, withShared, withRepository, onChange }) => {
   const collectionsStore = useContext(StoreContext).collections;
   const [selectedCollection, setSelectedCollection] = useState(value || null);
 

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -233,12 +233,36 @@ export const CollectionsStore = types
     }),
     updateCollection: flow(function* updateCollection(collection, tabs_segment) {
       const params = { label: collection.label, tabs_segment: tabs_segment }
-      const collectionItem = yield CollectionsFetcher.updateCollection(collection.id, params)
-      if (collectionItem) {
-        self.changeTabsSegmentInTree(self.own_collections, collectionItem)
-        self.setOwnCollectionTree()
-        return self.own_collections
+      let collectionItem
+      try {
+        collectionItem = yield CollectionsFetcher.updateCollection(collection.id, params)
+      } catch (error) {
+        collectionItem = undefined
       }
+
+      // Silently dropping the failure here used to be invisible, because the tab editor was only
+      // reachable on collections the endpoint always accepts. The system collections are editable
+      // from the management modal now, so a rejected save has to say so.
+      if (!collectionItem) {
+        getRoot(self).notificationsStore.add({
+          title: 'Collection Management',
+          message: `The tab layout of "${collection.label}" could not be saved. Please try again.`,
+          level: 'error',
+          autoDismiss: 10,
+        });
+        return null
+      }
+
+      self.changeTabsSegmentInTree(self.own_collections, collectionItem)
+      // The system collections live in the locked bucket and, for the repository subtree, on their
+      // own field — none of which own_collections reaches — so update those too, or the tab editor
+      // reopens with the layout the user just replaced.
+      self.changeTabsSegmentInTree(self.locked_collection, collectionItem)
+      if (self.chemotion_repository_collection) {
+        self.changeTabsSegmentInTree([self.chemotion_repository_collection], collectionItem)
+      }
+      self.setOwnCollectionTree()
+      return self.own_collections
     }),
     deleteCollection: flow(function* deleteCollection(collectionId) {
       const all_collections = yield CollectionsFetcher.deleteCollection(collectionId)
@@ -410,6 +434,16 @@ export const CollectionsStore = types
         );
 
         if (response) {
+          // A move is add-then-remove, and "All" is the one source the remove leg can never succeed
+          // on: RemoveElements refuses it outright, so the element would land in the target (already
+          // committed) and the user would still be told the move failed. Every element belongs to
+          // "All" by definition, so the add alone is the whole move — skip the remove and refresh.
+          if (self.isAllCollectionId(uiState.currentCollection.id)) {
+            ElementActions.refreshElementsAfterCollectionChanges(uiState.currentCollection.id);
+            if (isNewCollection) { self.addNewCollectionToOwnCollection(newCollection); }
+            return;
+          }
+
           const { success, lockedSampleIds } = yield self.removeElementsFromCollection(
             { collection_id: uiState.currentCollection.id, ui_state: uiState },
             { notifyLock: false }
@@ -691,6 +725,21 @@ export const CollectionsStore = types
     },
     get ownCollections() { return values(self.own_collections) },
     get sharedWithMeCollections() { return values(self.shared_with_me_collections) },
+    // "All" is deliberately absent from every collection tree, so `find` cannot resolve it; the
+    // locked bucket is the only place it is reachable by id.
+    isAllCollectionId(collectionId) {
+      const allCollection = self.locked_collection.find((collection) => collection.label === ALL_LABEL);
+      return Boolean(allCollection) && allCollection.id === collectionId;
+    },
+    // The system collections, in the order they are presented: the catch-all first, then the
+    // repository root and the "transferred" node that lives under it. They are kept out of
+    // own_collections (nothing may reparent, rename or delete them), so the management modal reads
+    // them from the locked bucket instead; SYSTEM_LABELS is the presentation order.
+    get systemCollections() {
+      return SYSTEM_LABELS
+        .map((label) => self.locked_collection.find((collection) => collection.label === label))
+        .filter(Boolean);
+    },
     isOwnCollection(collection_id) { return self.ownCollectionIds.indexOf(collection_id) != -1 },
     isSharedCollection(collection_id) { return self.sharedCollectionIds.indexOf(collection_id) != -1 },
     // Ownership is personal and has one definition — Collection#owned_by? is `user_id == user.id`,

--- a/app/javascript/src/stores/mobx/CollectionsStore.jsx
+++ b/app/javascript/src/stores/mobx/CollectionsStore.jsx
@@ -232,6 +232,12 @@ export const CollectionsStore = types
       return true
     }),
     updateCollection: flow(function* updateCollection(collection, tabs_segment) {
+      // PUT /collections/:id is scoped to own_collections_for, so a tab-layout save against a
+      // collection shared *to* this user has always 404'd. The element-detail tab editors reach
+      // this through UIStore's currentCollection, which can be one — skip the doomed request
+      // instead of reporting a failure for a save the user never asked for.
+      if (self.isSharedCollection(collection.id)) return null
+
       const params = { label: collection.label, tabs_segment: tabs_segment }
       let collectionItem
       try {
@@ -434,16 +440,9 @@ export const CollectionsStore = types
         );
 
         if (response) {
-          // A move is add-then-remove, and "All" is the one source the remove leg can never succeed
-          // on: RemoveElements refuses it outright, so the element would land in the target (already
-          // committed) and the user would still be told the move failed. Every element belongs to
-          // "All" by definition, so the add alone is the whole move — skip the remove and refresh.
-          if (self.isAllCollectionId(uiState.currentCollection.id)) {
-            ElementActions.refreshElementsAfterCollectionChanges(uiState.currentCollection.id);
-            if (isNewCollection) { self.addNewCollectionToOwnCollection(newCollection); }
-            return;
-          }
-
+          // No special case for a move out of "All": SelectionActions disables Move there (moving out
+          // of the catch-all is a removal in disguise), and RemoveElements refuses it server-side for
+          // anything that reaches the API directly. A guard here would be unreachable from the UI.
           const { success, lockedSampleIds } = yield self.removeElementsFromCollection(
             { collection_id: uiState.currentCollection.id, ui_state: uiState },
             { notifyLock: false }
@@ -635,10 +634,13 @@ export const CollectionsStore = types
       self.shared_with_me_collection_tree = { label: 'Collections shared with me', id: -1, children: children }
     },
     presortSharedWithMeCollections(collections) {
+      // No is_locked filter. It used to be a harmless no-op — the system collections were not
+      // shareable — but they are now, and dropping them here would accept the share server-side and
+      // then leave the recipient with no way to see it. The owner-grouping rows this tree adds are
+      // synthetic and created below, so they are not affected either way.
       return collections
         .sort(presort)
         .sort((a, b) => (a.owner > b.owner) ? 1 : ((b.owner > a.owner) ? -1 : 0))
-        .filter((c) => !c.is_locked)
     },
     addCollectionToTree(collection, collectionTree) {
       const parentIndex = collectionTree.findIndex(element => element.isAncestorOf(collection))
@@ -656,13 +658,15 @@ export const CollectionsStore = types
         collectionTree[parentIndex].addChild(collection)
       }
     },
+    // Stops at the first match (ids are unique) instead of walking every remaining subtree —
+    // updateCollection now calls this once per bucket (own tree, locked bucket, repository subtree).
     changeTabsSegmentInTree(collections, node) {
-      collections.find((c) => {
-        if (c.id == node.id) {
+      return collections.some((c) => {
+        if (c.id === node.id) {
           c.tabs_segment = node.tabs_segment;
-        } else if (c.children.length >= 1) {
-          self.changeTabsSegmentInTree(c.children, node);
+          return true;
         }
+        return c.children.length >= 1 && self.changeTabsSegmentInTree(c.children, node);
       })
     },
     changeLabelInTree(collections, node, label) {

--- a/app/javascript/src/utilities/collectionUtilities.js
+++ b/app/javascript/src/utilities/collectionUtilities.js
@@ -49,7 +49,7 @@ const makeList = (collections, tree = [], depth = 0) => {
   return tree;
 };
 
-const collectionOptions = (store, showSharedCollections) => {
+const collectionOptions = (store, showSharedCollections, includeRepository = false) => {
   // Label the owned collections as their own react-select group so it sits parallel to the shared
   // groups below, rather than as an unlabelled block of top-level options.
   const groups = [
@@ -72,6 +72,17 @@ const collectionOptions = (store, showSharedCollections) => {
         label: `Shared by ${owner.label}`,
         options: makeList(assignable),
       });
+    });
+  }
+
+  // Opt-in per call site: the repository root and the "transferred" node under it are valid targets
+  // for moving/assigning elements, but not for the other CollectionSelect consumers (picking a parent
+  // for a new shared collection, copying an element). "All" is never offered — every element is in it
+  // already, so assigning to it is a no-op and moving to it is a removal in disguise.
+  if (includeRepository && store.chemotion_repository_collection) {
+    groups.push({
+      label: 'chemotion-repo',
+      options: makeList([store.chemotion_repository_collection]),
     });
   }
 

--- a/spec/api/chemotion/collection_api_spec.rb
+++ b/spec/api/chemotion/collection_api_spec.rb
@@ -250,6 +250,35 @@ describe Chemotion::CollectionAPI do
         expect(response).to have_http_status(:forbidden)
         expect(locked_collection.reload.label).to eq 'All'
       end
+
+      # LockedCollectionGuard fixes label/position/ancestry/is_locked and deliberately leaves
+      # tabs_segment editable, so the tab layout of a system collection is configurable like any
+      # other. Refusing every update to a locked collection would take that away.
+      it 'accepts a tab-layout update' do
+        put "/api/v1/collections/#{locked_collection.id}",
+            params: { tabs_segment: { sample: { 'analyses' => 1 } } }
+
+        expect(response).to have_http_status(:ok)
+        expect(locked_collection.reload.tabs_segment).to eq('sample' => { 'analyses' => '1' })
+      end
+
+      # The tab editor always sends the label alongside the layout, so an unchanged label must not
+      # be mistaken for a rename attempt.
+      it 'accepts a tab-layout update that repeats the unchanged label' do
+        put "/api/v1/collections/#{locked_collection.id}",
+            params: { label: 'All', tabs_segment: { sample: { 'analyses' => 1 } } }
+
+        expect(response).to have_http_status(:ok)
+        expect(locked_collection.reload.tabs_segment).to eq('sample' => { 'analyses' => '1' })
+      end
+
+      it 'refuses a rename bundled with a tab-layout update, saving neither' do
+        put "/api/v1/collections/#{locked_collection.id}",
+            params: { label: 'Renamed', tabs_segment: { sample: { 'analyses' => 1 } } }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(locked_collection.reload).to have_attributes(label: 'All', tabs_segment: {})
+      end
     end
   end
 

--- a/spec/api/chemotion/collection_elements_api_spec.rb
+++ b/spec/api/chemotion/collection_elements_api_spec.rb
@@ -368,5 +368,80 @@ describe Chemotion::CollectionElementsAPI do
       expect(source_collection.reload.samples).to contain_exactly(sample1)
     end
   end
+
+  # The locked system collections are ordinary owned collections as far as element membership goes:
+  # LockedCollectionGuard fixes the collection row itself (label, position, ancestry, is_locked), not
+  # what it contains. "All" is the one exception, and only for removal — it is the catch-all, so
+  # taking an element out of it is a deletion in disguise and RemoveElements refuses it.
+  context 'with the locked system collections' do
+    let(:source_collection_user) { user }
+    let(:target_collection_user) { user }
+    let(:repository_collection) do
+      create(:collection, label: 'chemotion-repository.net', user: user, is_locked: true)
+    end
+    let(:transferred_collection) do
+      create(:collection, label: 'transferred', user: user, is_locked: true, parent: repository_collection)
+    end
+    let(:all_collection) { create(:collection, label: 'All', user: user, is_locked: true) }
+    let(:remove_input) do
+      {
+        ui_state: {
+          currentCollection: { id: 0 },
+          sample: {
+            checkedAll: false,
+            checkedIds: [sample1.id, sample2.id, sample3.id],
+            uncheckedIds: [],
+          },
+        },
+      }
+    end
+
+    it 'assigns elements to the repository collection' do
+      post '/api/v1/collection_elements', params: input.merge(collection_id: repository_collection.id)
+
+      expect(response.status).to eq 201
+      expect(repository_collection.reload.samples).to contain_exactly(sample1, sample2, sample3)
+    end
+
+    it 'assigns elements to the "transferred" collection' do
+      post '/api/v1/collection_elements', params: input.merge(collection_id: transferred_collection.id)
+
+      expect(response.status).to eq 201
+      expect(transferred_collection.reload.samples).to contain_exactly(sample1, sample2, sample3)
+    end
+
+    it 'removes elements from the repository collection' do
+      [sample1, sample2, sample3].each do |sample|
+        CollectionsSample.create!(collection_id: repository_collection.id, sample_id: sample.id)
+      end
+
+      delete "/api/v1/collection_elements/#{repository_collection.id}", params: remove_input, as: :json
+
+      expect(response).to have_http_status(:no_content)
+      expect(repository_collection.reload.samples).to be_empty
+    end
+
+    it 'removes elements from the "transferred" collection' do
+      [sample1, sample2, sample3].each do |sample|
+        CollectionsSample.create!(collection_id: transferred_collection.id, sample_id: sample.id)
+      end
+
+      delete "/api/v1/collection_elements/#{transferred_collection.id}", params: remove_input, as: :json
+
+      expect(response).to have_http_status(:no_content)
+      expect(transferred_collection.reload.samples).to be_empty
+    end
+
+    it 'refuses to remove elements from the "All" collection' do
+      [sample1, sample2, sample3].each do |sample|
+        CollectionsSample.create!(collection_id: all_collection.id, sample_id: sample.id)
+      end
+
+      delete "/api/v1/collection_elements/#{all_collection.id}", params: remove_input, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+      expect(all_collection.reload.samples).to contain_exactly(sample1, sample2, sample3)
+    end
+  end
 end
 # rubocop:enable RSpec/IndexedLet, RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations

--- a/spec/javascripts/packs/src/apps/mydb/collections/CollectionSubtreeFunctions.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/collections/CollectionSubtreeFunctions.spec.js
@@ -75,11 +75,31 @@ describe('CollectionSubtreeFunctions permission gating', () => {
     expect(itemTexts(wrapper)).not.toContain('Manage shares');
   });
 
-  it('locked collection (e.g. All): only Reference Report survives', () => {
+  it('locked collection without share callbacks: only Reference Report survives', () => {
     const wrapper = shallow(
       <CollectionSubtreeFunctions collection={lockedCollection} hasRadar />
     );
     expect(itemTexts(wrapper)).toEqual(['Reference Report']);
+  });
+
+  // A locked collection is fixed in the tree and cannot be renamed or deleted, but it is an
+  // ordinary owned collection for sharing purposes — only a pass_ownership offer is refused, and
+  // that is enforced by the API, not by hiding the menu entry.
+  it('locked collection: offers sharing, but not import or owner-only collection actions', () => {
+    const wrapper = shallow(
+      <CollectionSubtreeFunctions
+        collection={{ ...lockedCollection, shared: true }}
+        hasRadar
+        onAddShare={() => {}}
+        onManageShares={() => {}}
+      />
+    );
+    const texts = itemTexts(wrapper);
+    expect(texts).toContain('Add share');
+    expect(texts).toContain('Manage shares');
+    expect(texts).not.toContain('Import samples to collection');
+    expect(texts).not.toContain('Edit collection metadata');
+    expect(texts).not.toContain('Publish via RADAR');
   });
 
   it('shared-with-me at Read: only Reference Report', () => {

--- a/spec/javascripts/packs/src/apps/mydb/collections/MyCollections.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/collections/MyCollections.spec.js
@@ -41,21 +41,26 @@ const seedStore = (collections) => {
   store.setOwnCollectionTree();
 };
 
+// Every rendered observer — shallow ones included — stays subscribed to the store, so each has to
+// be unmounted before the next example re-seeds it; otherwise it re-renders against nodes
+// applySnapshot has already killed.
+let rendered = [];
+
+const track = (wrapper) => {
+  rendered.push(wrapper);
+  return wrapper;
+};
+
 const renderWith = (collections) => {
   seedStore(collections);
-  return shallow(<MyCollections />);
+  return track(shallow(<MyCollections />));
 };
 
 // The confirm dialog is hook state, and the shallow renderer does not flush a hook update; these
-// two examples mount so the re-render actually happens. A mounted observer stays subscribed to the
-// store, so it has to be unmounted before the next example re-seeds it — otherwise it re-renders
-// against nodes applySnapshot has already killed.
-let mounted = [];
+// two examples mount so the re-render actually happens.
 const mountWith = (collections) => {
   seedStore(collections);
-  const wrapper = mount(<MyCollections />);
-  mounted.push(wrapper);
-  return wrapper;
+  return track(mount(<MyCollections />));
 };
 
 const systemSection = (wrapper) => wrapper.find('.system-collections');
@@ -63,8 +68,8 @@ const allCollections = [allCollection, repositoryRoot, transferred, ordinary];
 
 describe('MyCollections system collections section', () => {
   afterEach(() => {
-    mounted.forEach((wrapper) => wrapper.unmount());
-    mounted = [];
+    rendered.forEach((wrapper) => wrapper.unmount());
+    rendered = [];
   });
 
   it('lists the three system collections above the editable tree', () => {

--- a/spec/javascripts/packs/src/apps/mydb/collections/MyCollections.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/collections/MyCollections.spec.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import expect from 'expect';
+import Enzyme, { mount, shallow } from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import { Button, Dropdown, Form } from 'react-bootstrap';
+import { act } from 'react-dom/test-utils';
+import MyCollections from 'src/apps/mydb/collections/MyCollections';
+import AppModal from 'src/components/common/AppModal';
+import { applySnapshot, getSnapshot } from 'mobx-state-tree';
+import { rootStore } from 'src/stores/mobx/RootStore';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+// The three system collections are owned but locked: the API refuses to rename, reparent or delete
+// them, and refuses to create anything inside them. They are listed here so their shares and tab
+// layout stay reachable, which means the row must not offer any affordance that would fail.
+const collection = (attributes) => ({
+  ancestry: '/', position: null, is_locked: false, shared: false, ...attributes,
+});
+
+const allCollection = collection({ id: 9, label: 'All', position: 0, is_locked: true });
+const repositoryRoot = collection({
+  id: 1, label: 'chemotion-repository.net', position: 1, is_locked: true, shared: true,
+});
+const transferred = collection({
+  id: 3, label: 'transferred', ancestry: '/1/', is_locked: true,
+});
+const ordinary = collection({ id: 4, label: 'Project' });
+
+// MyCollections resolves its store through useContext(StoreContext), whose default value is the
+// module-level rootStore — the shallow renderer walks neither a provider nor a stubbed hook, so the
+// real store is seeded instead.
+const seedStore = (collections) => {
+  const store = rootStore.collections;
+  // setOwnCollections appends; the store is a module-level singleton shared by every example here,
+  // so the trees are reset through a snapshot (own_collections.clear() is action-protected).
+  applySnapshot(store, {
+    ...getSnapshot(store), own_collections: [], locked_collection: [], chemotion_repository_collection: null,
+  });
+  store.setOwnCollections(collections);
+  store.setOwnCollectionTree();
+};
+
+const renderWith = (collections) => {
+  seedStore(collections);
+  return shallow(<MyCollections />);
+};
+
+// The confirm dialog is hook state, and the shallow renderer does not flush a hook update; these
+// two examples mount so the re-render actually happens. A mounted observer stays subscribed to the
+// store, so it has to be unmounted before the next example re-seeds it — otherwise it re-renders
+// against nodes applySnapshot has already killed.
+let mounted = [];
+const mountWith = (collections) => {
+  seedStore(collections);
+  const wrapper = mount(<MyCollections />);
+  mounted.push(wrapper);
+  return wrapper;
+};
+
+const systemSection = (wrapper) => wrapper.find('.system-collections');
+const allCollections = [allCollection, repositoryRoot, transferred, ordinary];
+
+describe('MyCollections system collections section', () => {
+  afterEach(() => {
+    mounted.forEach((wrapper) => wrapper.unmount());
+    mounted = [];
+  });
+
+  it('lists the three system collections above the editable tree', () => {
+    const section = systemSection(renderWith(allCollections));
+
+    expect(section).toHaveLength(1);
+    expect(section.text()).toContain('System collections');
+  });
+
+  it('renders each system collection label as text, never as a rename input', () => {
+    const section = systemSection(renderWith(allCollections));
+
+    expect(section.find(Form.Control)).toHaveLength(0);
+    ['All', 'chemotion-repository.net', 'transferred'].forEach((label) => {
+      expect(section.text()).toContain(label);
+    });
+  });
+
+  it('offers no add-sub-collection or delete button on a system collection', () => {
+    const section = systemSection(renderWith(allCollections));
+
+    expect(section.find(Button)).toHaveLength(0);
+  });
+
+  it('offers share and tab actions, and manage-shares only where the collection is shared', () => {
+    const section = systemSection(renderWith(allCollections));
+    const itemTexts = section.find(Dropdown.Item).map((n) => n.text().replace(/\s+/g, ' ').trim());
+
+    expect(itemTexts.filter((t) => t === 'Add share')).toHaveLength(3);
+    expect(itemTexts.filter((t) => t === 'Edit collection tabs')).toHaveLength(3);
+    expect(itemTexts.filter((t) => t === 'Manage shares')).toHaveLength(1);
+  });
+
+  it('renders nothing when the user has no system collections', () => {
+    const wrapper = renderWith([ordinary]);
+
+    expect(systemSection(wrapper)).toHaveLength(0);
+  });
+
+  // "All" holds every element the user owns, so sharing it is confirmed before the share modal
+  // opens; the other two share straight away.
+  it('confirms before sharing "All"', () => {
+    const wrapper = mountWith(allCollections);
+    const allShareItem = systemSection(wrapper).find(Dropdown.Item).at(0);
+
+    act(() => { allShareItem.props().onClick(); });
+    wrapper.update();
+
+    expect(wrapper.find(AppModal)).toHaveLength(1);
+    expect(wrapper.find(AppModal).prop('title')).toBe('Share "All"?');
+  });
+
+  it('does not confirm before sharing the repository collection', () => {
+    const wrapper = mountWith(allCollections);
+    // Rows: All (share, tabs), repository (share, manage, tabs), transferred (share, tabs).
+    const repositoryShareItem = systemSection(wrapper).find(Dropdown.Item).at(2);
+
+    act(() => { repositoryShareItem.props().onClick(); });
+    wrapper.update();
+
+    // The share modal opens straight away — matched on title, since the share modal is an AppModal
+    // too, so a bare component count cannot tell the confirm dialog from the share dialog.
+    const titles = wrapper.find(AppModal).map((n) => n.prop('title'));
+    expect(titles).not.toContain('Share "chemotion-repository.net"?');
+  });
+});

--- a/spec/javascripts/packs/src/utilities/collectionUtilities.spec.js
+++ b/spec/javascripts/packs/src/utilities/collectionUtilities.spec.js
@@ -46,6 +46,11 @@ describe('collectionUtilities', () => {
           ],
         },
       ],
+      chemotion_repository_collection: {
+        id: 5,
+        label: 'chemotion-repository.net',
+        children: [{ id: 6, label: 'transferred', children: [] }],
+      },
     });
 
     it('groups owned collections under a "My Collections" label', () => {
@@ -73,6 +78,34 @@ describe('collectionUtilities', () => {
       expect(groups.map((g) => g.label)).toEqual(['My Collections', 'Shared by Alice']);
       // Only the collection the user may add elements into is offered.
       expect(groups[1].options.map((o) => o.id)).toEqual([3]);
+    });
+
+    it('omits the repository subtree unless it is asked for', () => {
+      const groups = collectionOptions(store(), true);
+
+      expect(groups.map((g) => g.label)).not.toContain('chemotion-repo');
+    });
+
+    it('offers the repository root and "transferred" when requested', () => {
+      const groups = collectionOptions(store(), false, true);
+
+      expect(groups.map((g) => g.label)).toEqual(['My Collections', 'chemotion-repo']);
+      expect(groups[1].options.map((o) => o.id)).toEqual([5, 6]);
+      expect(groups[1].options.map((o) => o.depth)).toEqual([0, 1]);
+    });
+
+    it('never offers the "All" collection, which is not in any tree', () => {
+      const groups = collectionOptions(store(), true, true);
+      const labels = groups.flatMap((g) => g.options.map((o) => o.label));
+
+      expect(labels).not.toContain('All');
+    });
+
+    it('skips the repository group when the user has no repository collection', () => {
+      const storeWithoutRepository = { ...store(), chemotion_repository_collection: null };
+      const groups = collectionOptions(storeWithoutRepository, false, true);
+
+      expect(groups).toHaveLength(1);
     });
   });
 

--- a/spec/javascripts/stores/mobx/CollectionsStore.spec.js
+++ b/spec/javascripts/stores/mobx/CollectionsStore.spec.js
@@ -525,6 +525,29 @@ describe('CollectionsStore', () => {
       expect(node31.children.map((node) => node.id)).toEqual([45, 33, 34, 35, 36, 37]);
     });
 
+    // The system collections became shareable, so the shared tree must stop dropping locked rows:
+    // the share is accepted server-side, and filtering it out here would leave the recipient with a
+    // share they can never see.
+    it('keeps a shared system collection in the tree', () => {
+      const shared_all = sharedCollection({ id: 7, label: 'All', ancestry: '/', is_locked: true });
+
+      store.setSharedWithMeCollections([shared_all]);
+
+      const ownerRoot = store.shared_with_me_collections[0];
+      expect(ownerRoot.children.map((node) => node.id)).toEqual([7]);
+    });
+
+    // The owner-grouping row is the one locked node the tree creates itself, and the render path
+    // tells it apart by the id 0 sentinel rather than by is_locked.
+    it('still groups under a synthetic owner row of its own', () => {
+      const shared_all = sharedCollection({ id: 7, label: 'All', ancestry: '/', is_locked: true });
+
+      store.setSharedWithMeCollections([shared_all]);
+
+      expect(store.shared_with_me_collections[0]).toHaveProperty('id', 0);
+      expect(store.shared_with_me_collections[0].label).toEqual('Alice');
+    });
+
     it('roots a node under the owner when none of its ancestors are shared at all', () => {
       const e = sharedCollection({ id: 5, label: 'E', ancestry: '/99/' });
 

--- a/spec/javascripts/stores/mobx/CollectionsStore.spec.js
+++ b/spec/javascripts/stores/mobx/CollectionsStore.spec.js
@@ -366,6 +366,50 @@ describe('CollectionsStore', () => {
     });
   });
 
+  describe('.systemCollections', () => {
+    const allCollection = {
+      id: 9, label: 'All', ancestry: '/', position: 0, is_locked: true,
+    };
+    const repositoryRoot = {
+      id: 1, label: 'chemotion-repository.net', ancestry: '/', position: 1, is_locked: true,
+    };
+    const transferred = {
+      id: 3, label: 'transferred', ancestry: '/1/', position: null, is_locked: true,
+    };
+    const ordinary = {
+      id: 4, label: 'Project', ancestry: '/', position: null, is_locked: false,
+    };
+
+    it('lists the three system collections in presentation order', () => {
+      store.setOwnCollections([ordinary, transferred, repositoryRoot, allCollection]);
+
+      expect(store.systemCollections.map((c) => c.label))
+        .toEqual(['All', 'chemotion-repository.net', 'transferred']);
+    });
+
+    it('omits system collections the user does not have', () => {
+      store.setOwnCollections([allCollection, ordinary]);
+
+      expect(store.systemCollections.map((c) => c.id)).toEqual([9]);
+    });
+
+    // The label alone is not reserved: a user may create an ordinary collection called "All".
+    it('ignores an unlocked collection that merely shares a system label', () => {
+      store.setOwnCollections([{ ...allCollection, id: 10, is_locked: false }]);
+
+      expect(store.systemCollections).toEqual([]);
+      expect(store.own_collections.map((c) => c.id)).toEqual([10]);
+    });
+
+    it('resolves the "All" collection by id, which no tree can reach', () => {
+      store.setOwnCollections([allCollection, ordinary]);
+
+      expect(store.isAllCollectionId(9)).toBe(true);
+      expect(store.isAllCollectionId(4)).toBe(false);
+      expect(store.find(9)).toBe(null);
+    });
+  });
+
   describe('.addCollectionToTree', () => {
     it('shows a collection whose parent is missing without rewriting its ancestry', () => {
       const orphan = Collection.create({


### PR DESCRIPTION
Every user has three system-created collections — **All**, **chemotion-repository.net** and
**transferred**. They are locked: they cannot be renamed, deleted, moved in the tree, or given
sub-collections. The client dealt with that by keeping them out of collection management
entirely, which also hid the things that *are* legitimately allowed on them.

Being locked in position and identity is not the same as being unmanageable. This PR makes them
shareable and configurable, and makes the repository collections usable as element destinations.

## What changes

**Collection Management** gains a pinned, non-draggable **System collections** section above the
editable tree, listing the three with `transferred` indented under the repository root. Each row
offers add-share, manage-shares (when shared) and edit-tabs — and no rename field, no add-child,
no delete, no drag handle. A control that cannot work is not shown rather than shown and rejected.

Sharing **All** hands over every element the user owns in one action, so that row confirms first.

The section sits *outside* the `react-ui-tree` widget rather than being rendered as tree nodes:
the library has no per-node drag opt-out, and keeping these rows out of the tree also keeps the
`bulk_update_own_collections` payload exactly the set of collections the user may legitimately
move.

**Sidebar kebab** no longer suppresses sharing on a locked collection — the API refuses only a
`pass_ownership` offer there. Import-samples and metadata/RADAR stay locked-gated.

**Transfer destinations** — `collectionOptions` gained an opt-in `includeRepository` mode, threaded
through `CollectionSelect` → `SelectionTransferModal` → `SelectionActions` for Move and Assign
only. The other two `CollectionSelect` consumers (the parent picker when creating a shared
collection, and `CopyElementModal`) are unaffected. **All** is never offered anywhere: every
element is in it already, so assigning is a no-op and moving to it is a removal in disguise.

**`PUT /collections/:id`** refused every update to a locked collection, which also blocked the tab
layout that `LockedCollectionGuard` deliberately leaves editable (`tabs_segment` is not in
`LOCKED_IMMUTABLE_ATTRIBUTES`). It now rejects only an attribute that would actually change a
fixed one, compared by value because the tab editor always resends the unchanged label, and
reports a rejected update as 422 instead of 200.

## Two defects found while verifying

**A shared system collection never reached its recipient.** `presortSharedWithMeCollections`
filtered out every `is_locked` collection before building the shared tree. That filter dates from
the sharing refactor (#2783), where it mirrored the own-side rule that system collections are not
tree nodes — harmless while they were unshareable, and the whole feature's failure once they are:
the `CollectionShare` was written and then silently invisible. Removing it exposed two render
checks using `is_locked` as a proxy for "synthetic owner-grouping row"; both now key on the `id 0`
sentinel the tree actually assigns, so a genuinely shared system collection renders as a row with
its actions instead of as a section header.

**A failed tab-layout save was swallowed**, with no notification. Invisible before — the editor was
only reachable where the endpoint always accepted — and user-visible as soon as the system
collections are listed.

## Notes on two deliberate choices

**`All` has no per-collection tab layout, by existing design.** `ElementDetailSortTab` nulls
`collectionTabs` for `All` and reads the user-profile default instead, and its own editor already
skips the collection write for that reason. `CollectionTabsEditorModal` now skips it too, so
editing `All`'s tabs is editing the default layout rather than persisting a `tabs_segment` nothing
reads. The modal also stops writing the profile defaults and closing when the collection save was
rejected.

**No client guard for moving out of `All`.** A move is add-then-remove and the remove leg can never
succeed there, but `SelectionActions` already disables Move whenever the current collection is
`All`, so such a guard would be unreachable. `RemoveElements` stays the single enforcement point.

