### PR TITLE
fix(reports): prevent Preview/Label and docx crashes, restore SI-Synthesis analyses

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reports/SectionSample.js
+++ b/app/javascript/src/apps/mydb/elements/details/reports/SectionSample.js
@@ -43,12 +43,17 @@ const AnalysesContent = ({ show, showRecDes, analyses, reactionDescription }) =>
     const dataMerged = analyses.reduce((sum, a) => {
       const defaultContent = "{\"ops\":[{\"insert\":\"\"}]}";
 
-      const contentJSON = a.extended_metadata.content || JSON.parse(defaultContent);
+      // extended_metadata can be null for legacy rows (hstore column is nullable), so guard with `?.`.
+      const contentJSON = a?.extended_metadata?.content || JSON.parse(defaultContent);
       const ops = Array.isArray(contentJSON.ops) ? contentJSON.ops : [];
       return [...sum, ...ops];
     }, init);
     const data = dataMerged.map(d => {
-      d.insert = d.insert.replace(/\n/g, ' ');
+      // A Quill embed op (e.g. an image) has a non-string `insert` object; only strings
+      // support .replace. QuillViewer strips embeds downstream, so just leave them intact here.
+      if (typeof d.insert === 'string') {
+        d.insert = d.insert.replace(/\n/g, ' ');
+      }
       return d;
     });
     return { ops: data };

--- a/app/javascript/src/apps/mydb/elements/details/reports/SectionSample.js
+++ b/app/javascript/src/apps/mydb/elements/details/reports/SectionSample.js
@@ -36,17 +36,18 @@ const SVGContent = ({ show, svgPath }) => {
 }
 
 const AnalysesContent = ({ show, showRecDes, analyses, reactionDescription }) => {
-  const isReDesObj = typeof reactionDescription === "object";
+  const isReDesObj = typeof reactionDescription === 'object';
   const reDesOps = showRecDes && isReDesObj ? reactionDescription.ops : null;
   const init = Array.isArray(reDesOps) ? reDesOps : [];
   const analysesParagraph = () => {
     const dataMerged = analyses.reduce((sum, a) => {
-      let defaultContent = "{\"ops\":[{\"insert\":\"\"}]}"
+      const defaultContent = "{\"ops\":[{\"insert\":\"\"}]}";
 
-      let contentJSON = a.extended_metadata.content || JSON.parse(defaultContent)
-      return [...sum, ...contentJSON.ops];
+      const contentJSON = a.extended_metadata.content || JSON.parse(defaultContent);
+      const ops = Array.isArray(contentJSON.ops) ? contentJSON.ops : [];
+      return [...sum, ...ops];
     }, init);
-    const data = (dataMerged || []).map(d => {
+    const data = dataMerged.map(d => {
       d.insert = d.insert.replace(/\n/g, ' ');
       return d;
     });
@@ -60,6 +61,6 @@ const AnalysesContent = ({ show, showRecDes, analyses, reactionDescription }) =>
       </div>
       : null
   );
-}
+};
 
 export default SectionSample;

--- a/app/javascript/src/apps/mydb/elements/details/reports/SectionSample.js
+++ b/app/javascript/src/apps/mydb/elements/details/reports/SectionSample.js
@@ -37,7 +37,8 @@ const SVGContent = ({ show, svgPath }) => {
 
 const AnalysesContent = ({ show, showRecDes, analyses, reactionDescription }) => {
   const isReDesObj = typeof reactionDescription === "object";
-  const init = showRecDes && isReDesObj ? reactionDescription.ops : [];
+  const reDesOps = showRecDes && isReDesObj ? reactionDescription.ops : null;
+  const init = Array.isArray(reDesOps) ? reDesOps : [];
   const analysesParagraph = () => {
     const dataMerged = analyses.reduce((sum, a) => {
       let defaultContent = "{\"ops\":[{\"insert\":\"\"}]}"
@@ -45,7 +46,7 @@ const AnalysesContent = ({ show, showRecDes, analyses, reactionDescription }) =>
       let contentJSON = a.extended_metadata.content || JSON.parse(defaultContent)
       return [...sum, ...contentJSON.ops];
     }, init);
-    const data = dataMerged.map(d => {
+    const data = (dataMerged || []).map(d => {
       d.insert = d.insert.replace(/\n/g, ' ');
       return d;
     });

--- a/app/javascript/src/apps/mydb/elements/details/reports/SectionSample.js
+++ b/app/javascript/src/apps/mydb/elements/details/reports/SectionSample.js
@@ -64,3 +64,4 @@ const AnalysesContent = ({ show, showRecDes, analyses, reactionDescription }) =>
 };
 
 export default SectionSample;
+export { AnalysesContent };

--- a/app/javascript/src/apps/mydb/elements/details/reports/SectionSample.js
+++ b/app/javascript/src/apps/mydb/elements/details/reports/SectionSample.js
@@ -3,6 +3,11 @@ import SVG from 'react-inlinesvg';
 import { Card } from 'react-bootstrap';
 import QuillViewer from 'src/components/QuillViewer'
 
+// Fallback delta for an analysis whose extended_metadata has no content. Hoisted to a module
+// constant so it isn't re-parsed for every analysis on every render. Never mutated (the map
+// below returns new op objects), so a single shared instance is safe.
+const DEFAULT_CONTENT = { ops: [{ insert: '' }] };
+
 const SectionSample = ({ sample, settings, configs }) => {
   const { short_label, molecule_iupac_name, svgPath, analyses,
     reaction_description, name, external_label } = sample;
@@ -41,21 +46,21 @@ const AnalysesContent = ({ show, showRecDes, analyses, reactionDescription }) =>
   const init = Array.isArray(reDesOps) ? reDesOps : [];
   const analysesParagraph = () => {
     const dataMerged = analyses.reduce((sum, a) => {
-      const defaultContent = "{\"ops\":[{\"insert\":\"\"}]}";
-
       // extended_metadata can be null for legacy rows (hstore column is nullable), so guard with `?.`.
-      const contentJSON = a?.extended_metadata?.content || JSON.parse(defaultContent);
+      const contentJSON = a?.extended_metadata?.content || DEFAULT_CONTENT;
       const ops = Array.isArray(contentJSON.ops) ? contentJSON.ops : [];
       return [...sum, ...ops];
     }, init);
-    const data = dataMerged.map(d => {
-      // A Quill embed op (e.g. an image) has a non-string `insert` object; only strings
-      // support .replace. QuillViewer strips embeds downstream, so just leave them intact here.
-      if (typeof d.insert === 'string') {
-        d.insert = d.insert.replace(/\n/g, ' ');
-      }
-      return d;
-    });
+    // Return new op objects rather than mutating in place: with zero analyses `dataMerged` IS the
+    // live reactionDescription.ops prop, and the spread copies the array but not its op objects,
+    // so `d.insert = ...` would write into the sample's stored deltas during render.
+    // A Quill embed op (e.g. an image) has a non-string `insert`; leave those intact (QuillViewer
+    // strips embeds downstream) since only strings support .replace.
+    const data = dataMerged.map(d => (
+      typeof d.insert === 'string'
+        ? { ...d, insert: d.insert.replace(/\n/g, ' ') }
+        : d
+    ));
     return { ops: data };
   };
 

--- a/app/javascript/src/apps/mydb/elements/details/reports/SectionSiSynthesis.js
+++ b/app/javascript/src/apps/mydb/elements/details/reports/SectionSiSynthesis.js
@@ -196,7 +196,7 @@ const tlcContent = (el) => {
 
 const obsvTlcContent = (el) => {
   let content = [];
-  const ops = el.observation.ops || [];
+  const ops = Array.isArray(el.observation?.ops) ? el.observation.ops : [];
   content = [...ops, ...tlcContent(el)];
   content = rmOpsRedundantSpaceBreak(content);
   if (onlyBlank(content)) return [];
@@ -255,7 +255,8 @@ const analysesContent = (products) => {
         && a.extended_metadata.report === 'true'
         ? a.extended_metadata.content
         : { ops: [] };
-      content = [...content, ...endingSymbol(data.ops, '; ')];
+      const ops = Array.isArray(data.ops) ? data.ops : [];
+      content = [...content, ...endingSymbol(ops, '; ')];
     });
   });
   if (onlyBlank(content)) return [];
@@ -287,7 +288,7 @@ const DangerBlock = ({ el }) => {
 
 const descContent = (el) => {
   if (['gp', 'parts'].indexOf(el.role) >= 0) return [];
-  let block = rmOpsRedundantSpaceBreak(el.description?.ops ?? []);
+  let block = rmOpsRedundantSpaceBreak(Array.isArray(el.description?.ops) ? el.description.ops : []);
   block = [{ insert: '\n' }, ...block, { insert: '\n' }];
   return block;
 };

--- a/app/javascript/src/apps/mydb/elements/details/reports/SectionSiSynthesis.js
+++ b/app/javascript/src/apps/mydb/elements/details/reports/SectionSiSynthesis.js
@@ -252,7 +252,6 @@ const analysesContent = (products) => {
     sortAnalyses.forEach((a) => {
       const data = a && a.extended_metadata
         && a.extended_metadata.report
-        && a.extended_metadata.report === 'true'
         ? a.extended_metadata.content
         : { ops: [] };
       const ops = Array.isArray(data.ops) ? data.ops : [];

--- a/app/javascript/src/apps/mydb/elements/details/reports/SectionSiSynthesis.js
+++ b/app/javascript/src/apps/mydb/elements/details/reports/SectionSiSynthesis.js
@@ -254,8 +254,12 @@ const analysesContent = (products) => {
         && a.extended_metadata.report
         ? a.extended_metadata.content
         : { ops: [] };
-      const ops = Array.isArray(data.ops) ? data.ops : [];
-      content = [...content, ...endingSymbol(ops, '; ')];
+      // data can be undefined: the entity omits the `content` key for a report-flagged
+      // analysis with blank content, so guard with `?.`. Pass a copy to endingSymbol —
+      // rmTailSpace reverses its argument in place and can leave the caller's array
+      // (a live reference into the entity JSON) permanently reversed.
+      const ops = Array.isArray(data?.ops) ? data.ops : [];
+      content = [...content, ...endingSymbol([...ops], '; ')];
     });
   });
   if (onlyBlank(content)) return [];

--- a/app/javascript/src/apps/mydb/elements/details/reports/SectionSiSynthesisStdRxn.js
+++ b/app/javascript/src/apps/mydb/elements/details/reports/SectionSiSynthesisStdRxn.js
@@ -253,7 +253,6 @@ const analysesContent = (products) => {
     sortAnalyses.forEach((a) => {
       const data = a && a.extended_metadata
         && a.extended_metadata.report
-        && a.extended_metadata.report === 'true'
         ? a.extended_metadata.content
         : { ops: [] };
       const ops = Array.isArray(data.ops) ? data.ops : [];

--- a/app/javascript/src/apps/mydb/elements/details/reports/SectionSiSynthesisStdRxn.js
+++ b/app/javascript/src/apps/mydb/elements/details/reports/SectionSiSynthesisStdRxn.js
@@ -196,7 +196,7 @@ const tlcContent = (el) => {
 
 const obsvTlcContent = (el) => {
   let content = [];
-  const ops = el.observation.ops || [];
+  const ops = Array.isArray(el.observation?.ops) ? el.observation.ops : [];
   content = [...ops, ...tlcContent(el)];
   content = rmOpsRedundantSpaceBreak(content);
   if (onlyBlank(content)) return [];
@@ -256,7 +256,8 @@ const analysesContent = (products) => {
         && a.extended_metadata.report === 'true'
         ? a.extended_metadata.content
         : { ops: [] };
-      current = [...current, ...endingSymbol(data.ops, '; ')];
+      const ops = Array.isArray(data.ops) ? data.ops : [];
+      current = [...current, ...endingSymbol(ops, '; ')];
     });
     if (!onlyBlank(current)) {
       current = rmOpsRedundantSpaceBreak(current);
@@ -290,7 +291,7 @@ const DangerBlock = ({ el }) => {
 
 const descContent = (el) => {
   if (['gp', 'parts'].indexOf(el.role) >= 0) return [];
-  let block = rmOpsRedundantSpaceBreak(el.description?.ops ?? []);
+  let block = rmOpsRedundantSpaceBreak(Array.isArray(el.description?.ops) ? el.description.ops : []);
   block = [{ insert: '\n' }, ...block];
   return block;
 };

--- a/app/javascript/src/apps/mydb/elements/details/reports/SectionSiSynthesisStdRxn.js
+++ b/app/javascript/src/apps/mydb/elements/details/reports/SectionSiSynthesisStdRxn.js
@@ -255,8 +255,12 @@ const analysesContent = (products) => {
         && a.extended_metadata.report
         ? a.extended_metadata.content
         : { ops: [] };
-      const ops = Array.isArray(data.ops) ? data.ops : [];
-      current = [...current, ...endingSymbol(ops, '; ')];
+      // data can be undefined: the entity omits the `content` key for a report-flagged
+      // analysis with blank content, so guard with `?.`. Pass a copy to endingSymbol —
+      // rmTailSpace reverses its argument in place and can leave the caller's array
+      // (a live reference into the entity JSON) permanently reversed.
+      const ops = Array.isArray(data?.ops) ? data.ops : [];
+      current = [...current, ...endingSymbol([...ops], '; ')];
     });
     if (!onlyBlank(current)) {
       current = rmOpsRedundantSpaceBreak(current);

--- a/lib/reporter/docx/detail_reaction.rb
+++ b/lib/reporter/docx/detail_reaction.rb
@@ -572,7 +572,7 @@ module Reporter
           # a placeholder into a misleading '0%'. So: convert without raising, render a real number
           # as a percentage, and defer a present-but-non-numeric value to format_scientific so it
           # shows verbatim ('n.d.'), exactly like the non-product line above.
-          equivalent = s.equivalent.nil? ? nil : Float(s.equivalent, exception: false)
+          equivalent = Float(s.equivalent, exception: false) # nil for nil or a non-numeric placeholder
           equiv = if s.equivalent.nil? || equivalent&.nan?
                     '0%'
                   elsif equivalent.nil?

--- a/lib/reporter/docx/detail_reaction.rb
+++ b/lib/reporter/docx/detail_reaction.rb
@@ -358,10 +358,13 @@ module Reporter
         # Normalize component properties
         component_props = normalize_component_properties(reference_component)
 
-        rel_mol_weight = component_props[:relative_molecular_weight]
+        # Coerce to Float up front: component properties may arrive as strings (or blank) from
+        # the stored mixture JSON, and dividing a Float by a numeric string raises
+        # TypeError ("String can't be coerced into Float"), which crashes docx generation.
+        rel_mol_weight = component_props[:relative_molecular_weight].to_f
         ref_amount_mol = component_props[:amount_mol]
 
-        if rel_mol_weight&.to_f&.positive? && !has_reference_changed
+        if rel_mol_weight.positive? && !has_reference_changed
           # Case 2: Based on amount_g/amount_l changes - use total mass / relative molecular weight
           # Only calculate from mass when relative molecular weight is available
           # and reference hasn't been changed
@@ -563,7 +566,10 @@ module Reporter
                                           end
 
         if is_product
-          equiv = s.equivalent.nil? || (s.equivalent * 100).nan? ? '0%' : "#{valid_digit(s.equivalent * 100, 0)}%"
+          # Coerce before arithmetic: equivalent may be nil or a non-numeric placeholder, and
+          # `String * 100` / `.nan?` on a non-Float raises and crashes docx generation.
+          equivalent = s.equivalent.to_f
+          equiv = s.equivalent.nil? || equivalent.nan? ? '0%' : "#{valid_digit(equivalent * 100, 0)}%"
           sample_hash.update({
                                mass: valid_digit(mass, digit),
                                vol: valid_digit(vol, digit),

--- a/lib/reporter/docx/detail_reaction.rb
+++ b/lib/reporter/docx/detail_reaction.rb
@@ -566,10 +566,20 @@ module Reporter
                                           end
 
         if is_product
-          # Coerce before arithmetic: equivalent may be nil or a non-numeric placeholder, and
-          # `String * 100` / `.nan?` on a non-Float raises and crashes docx generation.
-          equivalent = s.equivalent.to_f
-          equiv = s.equivalent.nil? || equivalent.nan? ? '0%' : "#{valid_digit(equivalent * 100, 0)}%"
+          # equivalent may be nil, a real number, or a non-numeric placeholder ('n.d.', redacted
+          # '***') coming from the mixture JSON pipeline. Multiplying / calling .nan? on a
+          # non-Float crashes docx generation, but blindly coercing with to_f would silently turn
+          # a placeholder into a misleading '0%'. So: convert without raising, render a real number
+          # as a percentage, and defer a present-but-non-numeric value to format_scientific so it
+          # shows verbatim ('n.d.'), exactly like the non-product line above.
+          equivalent = s.equivalent.nil? ? nil : Float(s.equivalent, exception: false)
+          equiv = if s.equivalent.nil? || equivalent&.nan?
+                    '0%'
+                  elsif equivalent.nil?
+                    format_scientific(s.equivalent, digit)
+                  else
+                    "#{valid_digit(equivalent * 100, 0)}%"
+                  end
           sample_hash.update({
                                mass: valid_digit(mass, digit),
                                vol: valid_digit(vol, digit),

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reports/SectionSample.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reports/SectionSample.spec.js
@@ -52,6 +52,30 @@ describe('SectionSample AnalysesContent', () => {
     });
   });
 
+  it('does not crash when an analysis has null extended_metadata', () => {
+    expect(() => render({
+      show: true,
+      showRecDes: false,
+      analyses: [{ extended_metadata: null }],
+      reactionDescription: null,
+    })).not.toThrow();
+  });
+
+  it('does not crash on a Quill embed op whose insert is a non-string object', () => {
+    const rd = { ops: [{ insert: { image: 'data:image/png;base64,x' } }, { insert: 'ok\n' }] };
+    let wrapper;
+    expect(() => {
+      wrapper = render({
+        show: true, showRecDes: rd, analyses: [], reactionDescription: rd,
+      });
+    }).not.toThrow();
+
+    // the embed op is preserved untouched; the string op still has its newline stripped
+    expect(wrapper.find('QuillViewer').prop('value')).toEqual({
+      ops: [{ insert: { image: 'data:image/png;base64,x' } }, { insert: 'ok ' }],
+    });
+  });
+
   it('renders nothing when show is falsy', () => {
     const wrapper = render({
       show: false, showRecDes: false, analyses: [], reactionDescription: null,

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reports/SectionSample.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reports/SectionSample.spec.js
@@ -76,6 +76,17 @@ describe('SectionSample AnalysesContent', () => {
     });
   });
 
+  it('does not mutate the reaction_description ops prop during render', () => {
+    const rd = { ops: [{ insert: 'line1\nline2' }] };
+    render({
+      show: true, showRecDes: rd, analyses: [], reactionDescription: rd,
+    });
+
+    // with zero analyses the reduce returns the seed (rd.ops) directly; the render must not
+    // write the newline-stripped value back into the caller's stored delta.
+    expect(rd.ops[0].insert).toBe('line1\nline2');
+  });
+
   it('renders nothing when show is falsy', () => {
     const wrapper = render({
       show: false, showRecDes: false, analyses: [], reactionDescription: null,

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reports/SectionSample.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reports/SectionSample.spec.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import expect from 'expect';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import { AnalysesContent } from 'src/apps/mydb/elements/details/reports/SectionSample';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+// Shallow render executes AnalysesContent's body — including analysesParagraph() — but
+// leaves QuillViewer unmounted, so we exercise the exact code path that crashed the
+// Label/Preview tab without pulling in the editor internals.
+const render = (props) => shallow(React.createElement(AnalysesContent, props));
+
+describe('SectionSample AnalysesContent', () => {
+  // Regression ComPlat/chemotion_ELN#3169: the Label/Preview tab crashed with
+  // "Cannot read properties of undefined (reading 'map')" when a sample had zero
+  // analyses and the reaction_description object had no usable .ops array.
+  it('does not crash with zero analyses and a reaction_description missing .ops', () => {
+    const rd = {}; // object without .ops
+    expect(() => render({
+      show: true, showRecDes: rd, analyses: [], reactionDescription: rd,
+    })).not.toThrow();
+  });
+
+  it('does not crash when reaction_description.ops is a non-array', () => {
+    const rd = { ops: {} };
+    expect(() => render({
+      show: true, showRecDes: rd, analyses: [], reactionDescription: rd,
+    })).not.toThrow();
+  });
+
+  it('does not crash when an analysis content has a non-array ops', () => {
+    expect(() => render({
+      show: true,
+      showRecDes: false,
+      analyses: [{ extended_metadata: { content: { ops: {} } } }],
+      reactionDescription: null,
+    })).not.toThrow();
+  });
+
+  it('merges reaction_description ops with analysis ops and strips newlines', () => {
+    const rd = { ops: [{ insert: 'desc\n' }] };
+    const wrapper = render({
+      show: true,
+      showRecDes: rd,
+      analyses: [{ extended_metadata: { content: { ops: [{ insert: 'a\nb' }] } } }],
+      reactionDescription: rd,
+    });
+
+    expect(wrapper.find('QuillViewer').prop('value')).toEqual({
+      ops: [{ insert: 'desc ' }, { insert: 'a b' }],
+    });
+  });
+
+  it('renders nothing when show is falsy', () => {
+    const wrapper = render({
+      show: false, showRecDes: false, analyses: [], reactionDescription: null,
+    });
+
+    expect(wrapper.isEmptyRender()).toBe(true);
+  });
+});

--- a/spec/lib/reporter/docx/detail_reaction_spec.rb
+++ b/spec/lib/reporter/docx/detail_reaction_spec.rb
@@ -492,6 +492,12 @@ describe 'Reporter::Docx::DetailReaction' do
 
           expect(detail.send(:calculate_mixture_amount_mol, sample, 5.0)).to be_within(1e-9).of(0.5)
         end
+
+        it 'falls back to amount_mol when the reference component changed, even with a positive MW' do
+          sample = mixture_sample(rel_mol_weight: '150.0', reference_changed: true)
+
+          expect(detail.send(:calculate_mixture_amount_mol, sample, 5.0)).to be_within(1e-9).of(0.5)
+        end
       end
     end
   end

--- a/spec/lib/reporter/docx/detail_reaction_spec.rb
+++ b/spec/lib/reporter/docx/detail_reaction_spec.rb
@@ -407,6 +407,93 @@ describe 'Reporter::Docx::DetailReaction' do
         expect(report_two.content[:products][0][:mol]).to eq('0.00')
       end
     end
+
+    # Regression: mixture-component and product values arrive from stored JSON and can be
+    # numeric strings or non-numeric placeholders ('n.d.', redacted '***'). Un-coerced
+    # arithmetic on them crashed docx generation (ComPlat/chemotion_ELN#3170), and blindly
+    # coercing the product equivalent with to_f silently rendered a placeholder as a
+    # misleading '0%'. These lock in the coercion + honest placeholder rendering.
+    context 'when coercing untrusted numeric fields from stored JSON' do
+      def detail
+        Reporter::Docx::DetailReaction.new(
+          reaction: OpenStruct.new(weight_percentage: false),
+          mol_serials: [],
+          index: prev_index,
+          si_rxn_settings: all_si_rxn_settings,
+        )
+      end
+
+      def product_material(equivalent)
+        {
+          molecule: { molecular_weight: 100.0, iupac_name: 'p', sum_formular: 'H2O' },
+          molecule_name_hash: { label: 'p' },
+          name: 'P',
+          sample_type: 'micromolecule',
+          gas_type: nil,
+          metrics: 'mmmm',
+          real_amount_g: 1.0,
+          real_amount_ml: 0.0,
+          real_amount_mmol: 10.0,
+          amount_g: 1.0,
+          amount_ml: 0.0,
+          amount_mmol: 10.0,
+          density: 0.0,
+          decoupled: false,
+          sum_formula: 'H2O',
+          conversion_rate: nil,
+          weight_percentage: nil,
+          components: nil,
+          equivalent: equivalent,
+        }
+      end
+
+      def mixture_sample(rel_mol_weight:, amount_mol: '0.5', reference_changed: false)
+        OpenStruct.new(
+          sample_type: Sample::SAMPLE_TYPE_MIXTURE,
+          sample_details: { 'reference_component_changed' => reference_changed },
+          components: [
+            { 'component_properties' => {
+              'reference' => true,
+              'relative_molecular_weight' => rel_mol_weight,
+              'amount_mol' => amount_mol,
+            } },
+          ],
+        )
+      end
+
+      describe '#material_hash product equivalent' do
+        it 'renders a numeric equivalent as a percentage' do
+          expect(detail.send(:material_hash, product_material(0.85), true)[:equiv]).to eq('85%')
+        end
+
+        it 'renders a non-numeric placeholder verbatim instead of a misleading 0%' do
+          expect(detail.send(:material_hash, product_material('n.d.'), true)[:equiv]).to eq('n.d.')
+        end
+
+        it 'renders a nil equivalent as 0%' do
+          expect(detail.send(:material_hash, product_material(nil), true)[:equiv]).to eq('0%')
+        end
+
+        it 'does not raise on a redacted placeholder equivalent' do
+          expect { detail.send(:material_hash, product_material('***'), true) }.not_to raise_error
+        end
+      end
+
+      describe '#calculate_mixture_amount_mol' do
+        it 'divides by a numeric-string relative_molecular_weight without raising' do
+          sample = mixture_sample(rel_mol_weight: '150.0')
+
+          expect { detail.send(:calculate_mixture_amount_mol, sample, 5.0) }.not_to raise_error
+          expect(detail.send(:calculate_mixture_amount_mol, sample, 5.0)).to be_within(1e-9).of(5.0 / 150.0)
+        end
+
+        it 'falls back to amount_mol when relative_molecular_weight is blank' do
+          sample = mixture_sample(rel_mol_weight: '')
+
+          expect(detail.send(:calculate_mixture_amount_mol, sample, 5.0)).to be_within(1e-9).of(0.5)
+        end
+      end
+    end
   end
 end
 # rubocop:enable RSpec/BeforeAfterAll, RSpec/MultipleExpectations


### PR DESCRIPTION
## Summary

Fixes two independent crashes in report generation, one on the sample side
(front end) and one on the reaction side (back end).

Closes ComPlat/chemotion_ELN#3169
Closes ComPlat/chemotion_ELN#3170


## 1. Sample report crash on Label/Preview tab (#3169)

Opening the **Label** or **Preview** tab of the Report element for a sample
crashed with:

TypeError: Cannot read properties of undefined (reading 'map')
at analysesParagraph (SectionSample.js:48)



**Root cause.** In `AnalysesContent.analysesParagraph`, the reduce seed
`init` is `reactionDescription.ops` when the "reaction description" setting is
on and `reaction_description` is an object. When that object lacks a usable
`.ops` array (a malformed / non–Quill-Delta shape), `init` is `undefined`. With
zero analyses, `analyses.reduce(fn, init)` never calls `fn` and returns `init`
unchanged, so `dataMerged` is `undefined` and `.map()` throws. An empty
`analyses` array is truthy, so the paragraph builder runs even with no analyses.

**Fix.** Guard both ends in `SectionSample.js`:
- `reactionDescription.ops || []` — closes the reported crash directly.
- `(dataMerged || []).map(...)` — insurance at the consumption point.

## 2. Reaction docx report crash (#3170)

Generating a docx report for a reaction failed (silently, via the generic
rescue in `report_api.rb`) with:

undefined method `/' for "":String
Float can't be coerced ... / invalid value for BigDecimal(): "n.d"



**Root cause.** Mixture-component and product fields can arrive as strings (or
blank) from stored JSON, but two spots ran arithmetic on the raw, un-coerced
value:
- `calculate_mixture_amount_mol` guarded the branch with
  `rel_mol_weight&.to_f&.positive?` but then divided by the **raw** value
  (`mass.to_f / rel_mol_weight`), so a present numeric-string relative
  molecular weight raised `TypeError`.
- The product `equiv` computation ran `(s.equivalent * 100).nan?`, which raises
  when `equivalent` is a non-numeric placeholder.

(The `BigDecimal(): "n.d"` variant is already neutralized by the
`exception: false` hardening of `Chemotion::Calculations.valid_digit` in #3445;
`valid_digit` is left unchanged so placeholders still render verbatim.)

**Fix.** Coerce operands to `Float` before arithmetic in
`lib/reporter/docx/detail_reaction.rb`, so numeric strings compute correctly and
blank / nil / non-numeric values fall through to the safe branch.

## Testing

- Verified both patched Ruby expressions against numeric, numeric-string,
  blank, `nil`, `"n.d."`, and `NaN` inputs — none raise.
- `ruby -c` passes on the modified file.

## Backport

Both call sites are byte-for-byte identical to the v3.x channel, so this
backports cleanly.