### PR TITLE
fix(components): coerce relative_molecular_weight to Float at the write boundary

### DIFF
--- a/app/api/chemotion/component_api.rb
+++ b/app/api/chemotion/component_api.rb
@@ -42,6 +42,7 @@ module Chemotion
             optional :amount_mol, type: Float, desc: 'Component moles'
             optional :amount_l, type: Float, desc: 'Component volume'
             optional :amount_g, type: Float, desc: 'Component mass'
+            optional :relative_molecular_weight, type: Float, desc: 'Relative molecular weight in g/mol'
             optional :density, type: Float, desc: 'Density in g/ml'
             optional :molarity_unit, type: String, desc: 'Molarity unit'
             optional :molarity_value, type: Float, desc: 'Molarity value'

--- a/app/usecases/components/create.rb
+++ b/app/usecases/components/create.rb
@@ -94,24 +94,31 @@ module Usecases
         return if total_mixture_mass <= 0
 
         @components.each do |component_params|
-          component_properties = component_params[:component_properties]
-          next unless component_properties
-
-          # Only calculate relative molecular weight if it doesn't exist yet
-          # This preserves existing relative_molecular_weight values when amount_g changes.
-          # Coerce before comparing: the reaction material-update path reaches this usecase
-          # without Grape coercion, so the value can be a numeric string ("150.0") or a blank
-          # placeholder; `String > 0` would raise ArgumentError and crash the save.
-          existing_relative_mw = component_properties[:relative_molecular_weight]
-          next if existing_relative_mw.to_f.positive?
-
-          amount_mol = component_properties[:amount_mol].to_f
-          next if amount_mol <= 0
-
-          # Calculate relative molecular weight: total mass (g) / amount mol (mol) = g/mol
-          relative_mw = total_mixture_mass / amount_mol
-          component_properties[:relative_molecular_weight] = relative_mw
+          assign_relative_molecular_weight(component_params[:component_properties], total_mixture_mass)
         end
+      end
+
+      # Sets `relative_molecular_weight` on a single component's properties in place.
+      def assign_relative_molecular_weight(component_properties, total_mixture_mass)
+        return unless component_properties
+
+        # Only calculate relative molecular weight if it doesn't exist yet; this preserves
+        # existing values when amount_g changes. The reaction material-update path reaches this
+        # usecase without Grape coercion, so the value can arrive as a numeric string ("150.0")
+        # or a blank placeholder. Coerce to Float up front (`String > 0` would raise
+        # ArgumentError) and, when preserving, write the Float back so a string never persists
+        # for downstream readers.
+        existing_relative_mw = component_properties[:relative_molecular_weight].to_f
+        if existing_relative_mw.positive?
+          component_properties[:relative_molecular_weight] = existing_relative_mw
+          return
+        end
+
+        amount_mol = component_properties[:amount_mol].to_f
+        return if amount_mol <= 0
+
+        # Calculate relative molecular weight: total mass (g) / amount mol (mol) = g/mol
+        component_properties[:relative_molecular_weight] = total_mixture_mass / amount_mol
       end
     end
   end

--- a/app/usecases/components/create.rb
+++ b/app/usecases/components/create.rb
@@ -98,9 +98,12 @@ module Usecases
           next unless component_properties
 
           # Only calculate relative molecular weight if it doesn't exist yet
-          # This preserves existing relative_molecular_weight values when amount_g changes
+          # This preserves existing relative_molecular_weight values when amount_g changes.
+          # Coerce before comparing: the reaction material-update path reaches this usecase
+          # without Grape coercion, so the value can be a numeric string ("150.0") or a blank
+          # placeholder; `String > 0` would raise ArgumentError and crash the save.
           existing_relative_mw = component_properties[:relative_molecular_weight]
-          next if existing_relative_mw && existing_relative_mw > 0
+          next if existing_relative_mw.to_f.positive?
 
           amount_mol = component_properties[:amount_mol].to_f
           next if amount_mol <= 0

--- a/spec/api/chemotion/component_api_spec.rb
+++ b/spec/api/chemotion/component_api_spec.rb
@@ -99,5 +99,33 @@ describe Chemotion::ComponentAPI do
       expect(response).to have_http_status(:success)
       expect(Component.count).to eq(1)
     end
+
+    # Regression: relative_molecular_weight was undeclared, so a client-sent string persisted
+    # verbatim and later crashed report generation and the mixture-weight write path
+    # (ComPlat/chemotion_ELN#3170). Declaring it Float makes Grape coerce it at the boundary.
+    it 'coerces a numeric-string relative_molecular_weight to a Float' do
+      params = {
+        sample_id: sample.id,
+        components: [
+          {
+            id: component.id,
+            name: 'Updated Component',
+            position: 1,
+            component_properties: {
+              molecule_id: molecule.id,
+              amount_mol: 0.5,
+              relative_molecular_weight: '150.0',
+            },
+          },
+        ],
+      }
+
+      put '/api/v1/components', params: params, as: :json
+
+      expect(response).to have_http_status(:success)
+      stored = Component.find(component.id).component_properties['relative_molecular_weight']
+      expect(stored).to eq(150.0)
+      expect(stored).to be_a(Float)
+    end
   end
 end

--- a/spec/usecases/components/create_spec.rb
+++ b/spec/usecases/components/create_spec.rb
@@ -345,7 +345,7 @@ RSpec.describe Usecases::Components::Create do
       # Regression: the reaction material-update path reaches this usecase without Grape
       # coercion, so relative_molecular_weight can arrive as a string. `String > 0` used to
       # raise ArgumentError and crash the save (ComPlat/chemotion_ELN#3170, write path).
-      it 'preserves an existing numeric-string relative_molecular_weight without raising' do
+      it 'preserves and normalizes an existing numeric-string relative_molecular_weight to a Float' do
         components_params = [
           {
             id: 'new_1',
@@ -364,7 +364,7 @@ RSpec.describe Usecases::Components::Create do
         expect { use_case.send(:calculate_relative_molecular_weights) }.not_to raise_error
 
         internal = use_case.instance_variable_get(:@components)
-        expect(internal.first[:component_properties][:relative_molecular_weight]).to eq('250.0')
+        expect(internal.first[:component_properties][:relative_molecular_weight]).to be(250.0)
       end
 
       it 'recalculates when relative_molecular_weight is a blank string, without raising' do

--- a/spec/usecases/components/create_spec.rb
+++ b/spec/usecases/components/create_spec.rb
@@ -341,6 +341,53 @@ RSpec.describe Usecases::Components::Create do
         internal = use_case.instance_variable_get(:@components)
         expect(internal.first[:component_properties][:relative_molecular_weight]).to eq(500.0)
       end
+
+      # Regression: the reaction material-update path reaches this usecase without Grape
+      # coercion, so relative_molecular_weight can arrive as a string. `String > 0` used to
+      # raise ArgumentError and crash the save (ComPlat/chemotion_ELN#3170, write path).
+      it 'preserves an existing numeric-string relative_molecular_weight without raising' do
+        components_params = [
+          {
+            id: 'new_1',
+            name: 'Test Component',
+            position: 1,
+            component_properties: {
+              molecule_id: molecule_1.id,
+              amount_mol: 0.3,
+              relative_molecular_weight: '250.0',
+            },
+          },
+        ]
+
+        use_case = described_class.new(sample, components_params)
+
+        expect { use_case.send(:calculate_relative_molecular_weights) }.not_to raise_error
+
+        internal = use_case.instance_variable_get(:@components)
+        expect(internal.first[:component_properties][:relative_molecular_weight]).to eq('250.0')
+      end
+
+      it 'recalculates when relative_molecular_weight is a blank string, without raising' do
+        components_params = [
+          {
+            id: 'new_1',
+            name: 'Test Component',
+            position: 1,
+            component_properties: {
+              molecule_id: molecule_1.id,
+              amount_mol: 0.3,
+              relative_molecular_weight: '',
+            },
+          },
+        ]
+
+        use_case = described_class.new(sample, components_params)
+
+        expect { use_case.send(:calculate_relative_molecular_weights) }.not_to raise_error
+
+        internal = use_case.instance_variable_get(:@components)
+        expect(internal.first[:component_properties][:relative_molecular_weight]).to eq(500.0)
+      end
     end
   end
 end


### PR DESCRIPTION
`relative_molecular_weight` was the only numeric component field not declared in the
components params block, so a client-sent string was persisted uncoerced. That string
then crashed both the mixture DOCX report (`Float / "150.0"` → TypeError) and the
component write path (`"150.0" > 0` → `ArgumentError: comparison of String with 0
failed`). This fixes the root cause at the API boundary and hardens the shared usecase.

### Changes
- **`component_api.rb`:** declare `optional :relative_molecular_weight, type: Float`
  alongside its numeric siblings, so Grape coerces numeric strings and rejects
  non-numeric input on the standalone component API.
- **`Components::Create`:** compare with `existing_relative_mw.to_f.positive?` instead
  of `existing_relative_mw > 0`. The reaction material-update flow reaches this usecase
  via `Reconcile` *without* Grape coercion, so the API declaration alone doesn't cover
  it; this also stays safe for legacy rows that already hold string values.

### Tests
- `component_api_spec`: a numeric-string `relative_molecular_weight` is coerced to and
  stored as a Float.
- `create_spec`: numeric-string and blank-string values no longer raise and behave
  correctly (preserve vs. recalculate).

