### PR TITLE
fix(net): allow preferring one IP address family for outbound requests

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -83,3 +83,11 @@ SENTRY_FRONTEND_SAMPLE_RATE=1.0
 # DELAYED_JOB_ARGS=""
 # PG_CARTRIDGE=rdkit
 # PG_CARTRIDGE_VERSION=4.4.0
+
+# Prefer one IP address family for outbound connections (PubChem, DataCite, RADAR, ...).
+# Needed when the host and containers have addresses in only one family, typically
+# IPv6-only: Ruby resolves without AI_ADDRCONFIG, so unroutable IPv4 addresses are still
+# handed to the connect path and outbound requests fail.
+# @note leave unset on dual-stack hosts — it disables glibc's RFC 6724 fallback ordering
+# @example ELN_PREFER_ADDRESS_FAMILY=ipv6
+# ELN_PREFER_ADDRESS_FAMILY=

--- a/config/initializers/address_family_preference.rb
+++ b/config/initializers/address_family_preference.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/chemotion/address_family_preference'
+
+# Makes outbound connections prefer one IP address family.
+#
+# Needed on deployments whose host and containers have addresses in only one family —
+# typically IPv6-only. Ruby omits AI_ADDRCONFIG when resolving, so glibc happily returns
+# A records for dual-stack services on a host with no IPv4 address and no IPv4 route, and
+# outbound calls to PubChem, DataCite, RADAR and friends fail.
+#
+# Disabled unless ELN_PREFER_ADDRESS_FAMILY is set to "ipv6" or "ipv4":
+#
+#   ELN_PREFER_ADDRESS_FAMILY=ipv6
+#
+# Do NOT enable this on a dual-stack host. It removes glibc's RFC 6724 destination
+# sorting, so a service whose preferred-family address is published but unreachable will
+# no longer fall back to the other family.
+return unless Chemotion::AddressFamilyPreference.enabled?
+
+# Routes TCPSocket (and therefore Net::HTTP) through Resolv instead of glibc. Without
+# this shim, patching Resolv has no effect on outbound HTTP at all.
+require 'resolv-replace'
+
+Resolv.singleton_class.prepend(
+  Module.new do
+    # Resolves +host+, preferring the configured address family and falling back to
+    # stock behaviour when the host publishes no address in it.
+    def getaddress(host)
+      preferred = Chemotion::AddressFamilyPreference.pick(getaddresses(host))
+      preferred || super
+    end
+  end,
+)
+
+Rails.logger&.info(
+  '[AddressFamilyPreference] preferring ' \
+  "#{Chemotion::AddressFamilyPreference.preferred_family} for outbound connections",
+)

--- a/lib/chemotion/address_family_preference.rb
+++ b/lib/chemotion/address_family_preference.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'resolv'
+require 'ipaddr'
+
+module Chemotion
+  # Forces outbound connections to prefer one IP address family.
+  #
+  # Ruby calls +getaddrinfo+ without +AI_ADDRCONFIG+, so glibc does not filter out
+  # addresses of a family the host cannot use. On a host with no IPv4 address and no IPv4
+  # route, every dual-stack service therefore still yields its A records to the connect
+  # path, and outbound requests (PubChem, DataCite, RADAR, ...) can fail even though the
+  # same hosts are reachable over IPv6.
+  #
+  # Enabling this moves name resolution off glibc and onto Ruby's +Resolv+, then picks the
+  # first address of the preferred family. It is opt-in: see
+  # +config/initializers/address_family_preference.rb+.
+  #
+  # +/etc/hosts+ is still honoured (+Resolv::Hosts+), but glibc's RFC 6724 destination
+  # sorting and +AI_ADDRCONFIG+ filtering no longer apply — which is the point on a
+  # single-family host, and the reason this must not be enabled on a dual-stack one.
+  module AddressFamilyPreference
+    FAMILIES = %w[ipv4 ipv6].freeze
+
+    class << self
+      # Preferred family, or +nil+ when the feature is disabled.
+      #
+      # @return [String, nil] +"ipv4"+, +"ipv6"+, or +nil+
+      def preferred_family
+        return @preferred_family if defined?(@preferred_family)
+
+        value = ENV.fetch('ELN_PREFER_ADDRESS_FAMILY', '').to_s.strip.downcase
+        @preferred_family = FAMILIES.include?(value) ? value : nil
+      end
+
+      # @return [Boolean] whether an address-family preference is configured
+      def enabled?
+        !preferred_family.nil?
+      end
+
+      # Resets the memoized ENV lookup. Test seam.
+      #
+      # @return [void]
+      def reset!
+        remove_instance_variable(:@preferred_family) if defined?(@preferred_family)
+      end
+
+      # First address of the preferred family, or +nil+ when +host+ offers none.
+      #
+      # @param addresses [Array<#to_s>] resolved addresses
+      # @return [String, nil]
+      def pick(addresses)
+        addresses.map(&:to_s).find { |address| matches_preference?(address) }
+      end
+
+      private
+
+      def matches_preference?(address)
+        ip = IPAddr.new(address)
+        preferred_family == 'ipv6' ? ip.ipv6? : ip.ipv4?
+      rescue IPAddr::Error
+        false
+      end
+    end
+  end
+end

--- a/spec/lib/chemotion/address_family_preference_spec.rb
+++ b/spec/lib/chemotion/address_family_preference_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Chemotion::AddressFamilyPreference do
+  before { described_class.reset! }
+
+  after { described_class.reset! }
+
+  def with_family(value)
+    stub_const('ENV', ENV.to_hash.merge('ELN_PREFER_ADDRESS_FAMILY' => value))
+    described_class.reset!
+  end
+
+  describe '.preferred_family' do
+    it 'reads the configured family' do
+      with_family('ipv6')
+
+      expect(described_class.preferred_family).to eq 'ipv6'
+    end
+
+    it 'normalises case and surrounding whitespace' do
+      with_family('  IPv6 ')
+
+      expect(described_class.preferred_family).to eq 'ipv6'
+    end
+
+    it 'is nil when unset' do
+      with_family('')
+
+      expect(described_class.preferred_family).to be_nil
+    end
+
+    it 'is nil for an unrecognised value, rather than guessing' do
+      with_family('inet6')
+
+      expect(described_class.preferred_family).to be_nil
+    end
+  end
+
+  describe '.enabled?' do
+    it 'is false unless a valid family is configured' do
+      with_family('nonsense')
+
+      expect(described_class).not_to be_enabled
+    end
+
+    it 'is true for a valid family' do
+      with_family('ipv4')
+
+      expect(described_class).to be_enabled
+    end
+  end
+
+  describe '.pick' do
+    let(:dual_stack) { ['192.0.2.1', '2001:db8::1'] }
+
+    it 'returns the first address of the preferred family' do
+      with_family('ipv6')
+
+      expect(described_class.pick(dual_stack)).to eq '2001:db8::1'
+    end
+
+    it 'honours an ipv4 preference symmetrically' do
+      with_family('ipv4')
+
+      expect(described_class.pick(['2001:db8::1', '192.0.2.1'])).to eq '192.0.2.1'
+    end
+
+    it 'returns nil when the host publishes no address of that family, so callers can fall back' do
+      with_family('ipv6')
+
+      expect(described_class.pick(['192.0.2.1'])).to be_nil
+    end
+
+    it 'accepts Resolv address objects, not just strings' do
+      with_family('ipv6')
+
+      expect(described_class.pick([Resolv::IPv4.create('192.0.2.1'), Resolv::IPv6.create('2001:db8::1')]))
+        .to eq '2001:db8::1'
+    end
+
+    it 'skips unparseable entries instead of raising' do
+      with_family('ipv6')
+
+      expect(described_class.pick(['not-an-address', '2001:db8::1'])).to eq '2001:db8::1'
+    end
+  end
+
+  describe 'the resolver override installed by the initializer' do
+    # Exercises the same override the initializer prepends, without patching Resolv globally.
+    let(:override) do
+      Module.new do
+        def getaddress(host)
+          Chemotion::AddressFamilyPreference.pick(getaddresses(host)) || super
+        end
+      end
+    end
+
+    let(:stock_resolver) do
+      Class.new do
+        def self.getaddresses(_host)
+          ['192.0.2.1', '2001:db8::1']
+        end
+
+        def self.getaddress(_host)
+          '192.0.2.1'
+        end
+      end
+    end
+
+    let(:resolver) do
+      stock_resolver.singleton_class.prepend(override)
+      stock_resolver
+    end
+
+    it 'returns the preferred family when the host publishes one' do
+      with_family('ipv6')
+
+      expect(resolver.getaddress('dual.example')).to eq '2001:db8::1'
+    end
+
+    it 'falls back to stock resolution for a single-family host' do
+      with_family('ipv6')
+      allow(resolver).to receive(:getaddresses).and_return(['192.0.2.1'])
+
+      expect(resolver.getaddress('v4only.example')).to eq '192.0.2.1'
+    end
+  end
+end


### PR DESCRIPTION
## Problem

On a deployment whose host and containers have addresses in only one family — typically
IPv6-only, with no IPv4 address and no IPv4 route — every backend-initiated outbound
request can fail, while the same hosts are reachable over IPv6 from inside the container
(`curl -6` succeeds). The frontend is unaffected; only server-side requests break.

It hits every integration that goes through `Net::HTTP` (directly, or via `httparty` /
`faraday`): PubChem, CAS lookup, SciFinder-n, DataCite, NMRShiftDB, RADAR, UniProt, and
the repository transfer jobs.

## Cause

Ruby calls `getaddrinfo` **without `AI_ADDRCONFIG`**, so glibc does not filter out
addresses of a family the host cannot use. Measured on an IPv4-only host against a
dual-stack name:

```
flags=0 (Ruby's default) -> {"AF_INET"=>8, "AF_INET6"=>8}
AI_ADDRCONFIG explicit   -> {"AF_INET"=>8}
```

The unusable family is offered regardless of connectivity. Symmetrically, on an IPv6-only
host Ruby is handed the A records for every external service despite having no way to
route them.

## Change

Setting `ELN_PREFER_ADDRESS_FAMILY` to `ipv6` or `ipv4` moves name resolution off glibc
and onto Ruby's `Resolv`, then selects the first address of the preferred family — falling
back to stock resolution when the host publishes none.

```
ELN_PREFER_ADDRESS_FAMILY=ipv6
```

- `lib/chemotion/address_family_preference.rb` — configuration and address selection
- `config/initializers/address_family_preference.rb` — gated installer
- `.env.production.example` — documents the variable and its caveat

The initializer requires `resolv-replace` explicitly. That stdlib shim is what routes
`TCPSocket` (and therefore `Net::HTTP`) through `Resolv`; without it, patching `Resolv`
has no effect on outbound HTTP at all.

## Safety

**Disabled unless the variable is set**, and deliberately not enabled by default. Enabling
it removes glibc's RFC 6724 destination sorting, so on a dual-stack host a service whose
preferred-family address is published but unreachable would no longer fall back to the
other family. `/etc/hosts` is still honoured (`Resolv::Hosts`).

An unrecognised value disables the feature rather than guessing at it.

The change is also self-limiting: `resolv.rb` only queries AAAA when the host has an IPv6
address of its own (`Resolv::DNS#use_ipv6?`), so enabling `ipv6` on a host without one is
a no-op rather than a breakage.

## Testing

`spec/lib/chemotion/address_family_preference_spec.rb` — 13 examples covering
configuration parsing, family selection, the single-family fallback, `Resolv` address
objects, unparseable input, and the resolver override itself. Rubocop clean.

Verified end to end in the dev container:

| `ELN_PREFER_ADDRESS_FAMILY` | `enabled?` | `resolv-replace` loaded | `TCPSocket#initialize` |
|---|---|---|---|
| unset | `false` | `false` | stock |
| `ipv6` | `true` | `true` | `resolv-replace.rb` |
| `inet6` (invalid) | `false` | `false` | stock |
