### PR TITLE
fix(UI): fullscreen Spectra Editor modal now fits without scrollbars

### DIFF
--- a/app/assets/stylesheets/legacy/spectra.scss
+++ b/app/assets/stylesheets/legacy/spectra.scss
@@ -6,6 +6,73 @@
   max-width: 22vw;
 }
 
+.spectra-editor-modal-body__editor {
+  height: 100%;
+  min-height: 0;
+
+  // the single bare <div> LayerPrism/MultiJcampsViewer render (CmdBar + .react-spectrum-editor)
+  > div {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .react-spectrum-editor {
+    // Flex-participation only on THIS node — never add a literal `height:`
+    // here. This node is shared with the Cyclic Voltammetry layout's working
+    // `cvEditor` JSS rule (height: calc(90vh - 220px)); a competing height
+    // here would silently override it since this stylesheet loads after the
+    // package's injectFirst JSS. Descendants below are safe to give an
+    // explicit `height: 100%` — MUI's row-direction Grid doesn't reliably
+    // stretch its items' height from flex alone (content-based flex-basis
+    // wins the shrink negotiation), so percentage-height chains are used
+    // instead once this node's own height is bounded.
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+
+    .MuiGrid-container {
+      height: 100%;
+      flex: 1 1 auto;
+      min-height: 0;
+    }
+
+    .MuiGrid-grid-xs-9, .MuiGrid-grid-xs-3 {
+      height: 100%;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+
+      // LayerContent/Panel render an unstyled wrapper <div> here before the
+      // d3-mounted / InfoPanel content; without this it's a block box with
+      // auto height, which breaks the percentage-height chain below it.
+      > div {
+        flex: 1 1 auto;
+        min-height: 0;
+      }
+    }
+
+    .d3Line, .d3Rect, .d3Multi, .d3Svg, .d3SvgRect, .d3SvgMulti {
+      flex: 1 1 auto;
+      min-height: 0;
+      height: 100%;
+    }
+
+    // Scoped to the d3-mounted chart svg only — a bare `svg { ... }` here
+    // would also match small MUI icon svgs elsewhere in the panel (e.g. the
+    // accordion expand chevrons) and blow them up to fill their wrapper.
+    .d3Line svg, .d3Rect svg, .d3Multi svg,
+    .d3Svg, .d3SvgRect, .d3SvgMulti {
+      width: 100%;
+      height: 100%;
+    }
+  }
+}
+
 #ChemSpectra,
 #ChemSpectraEditor {
   display: block;

--- a/app/javascript/src/apps/mydb/elements/details/ViewSpectra.js
+++ b/app/javascript/src/apps/mydb/elements/details/ViewSpectra.js
@@ -1248,7 +1248,7 @@ class ViewSpectra extends React.Component {
     const treePopupContainer = createRef();
 
     return (
-      <div className="d-flex align-items-center gap-3 mb-3" ref={treePopupContainer}>
+      <div className="d-flex align-items-center gap-3 mb-3 flex-shrink-0" ref={treePopupContainer}>
         <Select
           options={dsOptions}
           value={dsOptions.find(({ value }) => value === si.idDt)}
@@ -1301,19 +1301,24 @@ class ViewSpectra extends React.Component {
       <AppModal
         title={modalTitle}
         scrollable
-        size="xxxl"
+        fullscreen
+        bodyClassName="p-0 h-100 overflow-hidden"
         show={showModal}
         animation
         onHide={this.closeOp}
         closeLabel="Close"
         showFooter
       >
-        {this.renderControls(idx)}
-        {
-          showModal && (jcamp || (listMuliSpcs && listMuliSpcs.length > 0))
-            ? this.renderSpectraEditor(jcamp, predictions, listMuliSpcs, listEntityFiles)
-            : this.renderEmpty()
-        }
+        <div className="spectra-editor-modal-body d-flex flex-column h-100 p-4">
+          {this.renderControls(idx)}
+          <div className="spectra-editor-modal-body__editor flex-grow-1 overflow-hidden">
+            {
+              showModal && (jcamp || (listMuliSpcs && listMuliSpcs.length > 0))
+                ? this.renderSpectraEditor(jcamp, predictions, listMuliSpcs, listEntityFiles)
+                : this.renderEmpty()
+            }
+          </div>
+        </div>
       </AppModal>
     );
   }


### PR DESCRIPTION
## Summary
- Switch the Spectra Editor modal to `fullscreen` and pin its toolbar above a properly
  bounded content region, instead of one scrolling `modal-body` swallowing both toolbars.
- Chain `height`/`min-height` through `@complat/react-spectra-editor`'s stable DOM (its
  shared `.react-spectrum-editor` node, MUI's public `Grid` classes, the `d3Line`/`d3Rect`/
  `d3Multi` chart mount points) so the chart svg fills its container instead of overflowing
  on load-time, viewport-derived dimensions — without touching the Cyclic Voltammetry
  layout's own working sizing, which shares that same `.react-spectrum-editor` node.

Before: opening e.g. a `1H`/`13C` NMR analysis on a full-HD screen clipped the chart's
x-axis and let the whole modal body scroll, hiding both the dataset-selector row and the
package's own operations toolbar. After: everything fits, both toolbars stay pinned.

## Test plan
- [x] Verified live (docker dev) on two NMR analyses (`1H`/`13C`) at 1920×1080: no
      scrollbar, x-axis fully visible, both toolbars stay pinned.
- [x] Verified graceful degradation at a smaller 1366×800 viewport.
- [ ] Cyclic Voltammetry / other multi-curve layouts (SEC, AIF, UVVIS, HPLC-UVVIS, LC-MS) —
      not verified live (no sample data available), but protected by construction: the
      shared `.react-spectrum-editor` node only ever receives flex-participation
      properties, never a literal `height`, so its existing `calc(90vh - 220px)` CV sizing
      is untouched.
- [ ] Other `fullscreen` `AppModal` users (`NMRiumDisplayer`, `ImageAnnotationModalSVG`) —
      unaffected by construction, no shared CSS was touched (scoped via `bodyClassName` to
      this one modal instance).
