### PR TITLE
fix(clipboard): repair dead citation copy button and add feedback to all copy buttons

### DIFF
--- a/app/javascript/src/apps/admin/devices/DeviceDataCollectorTab.js
+++ b/app/javascript/src/apps/admin/devices/DeviceDataCollectorTab.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, { useState, useEffect, useContext } from 'react';
 import {
-  Form, InputGroup, Tooltip, OverlayTrigger, Button
+  Form, InputGroup
 } from 'react-bootstrap';
 import { Select } from 'src/components/common/Select';
 import { startsWith, endsWith } from 'lodash';
@@ -9,7 +9,7 @@ import { startsWith, endsWith } from 'lodash';
 import AdminFetcher from 'src/fetchers/AdminFetcher';
 import { observer } from 'mobx-react';
 import { StoreContext } from 'src/stores/mobx/RootStore';
-import { copyToClipboard } from 'src/utilities/clipboard';
+import CopyButton from 'src/components/common/CopyButton';
 
 function ListLocalCollector({ localCollectorValues }) {
   return (
@@ -19,15 +19,13 @@ function ListLocalCollector({ localCollectorValues }) {
           <Form.Label className="fw-bold">Local Collector Dir Configuration</Form.Label>
           <Form.Group>
             <InputGroup>
-              <OverlayTrigger placement="right" overlay={<Tooltip id="copy_tooltip">copy to clipboard</Tooltip>}>
-                <Button
-                  size="xxsm"
-                  variant="light"
-                  onClick={() => copyToClipboard(c.path)}
-                >
-                  <i className="fa fa-clipboard" />
-                </Button>
-              </OverlayTrigger>
+              <CopyButton
+                text={c.path}
+                placement="right"
+                variant="light"
+                size="xxsm"
+                tooltipId="copy_tooltip"
+              />
               <Form.Control
                 value={c.path}
                 readOnly

--- a/app/javascript/src/apps/admin/devices/DeviceDataCollectorTab.js
+++ b/app/javascript/src/apps/admin/devices/DeviceDataCollectorTab.js
@@ -24,7 +24,7 @@ function ListLocalCollector({ localCollectorValues }) {
                 placement="right"
                 variant="light"
                 size="xxsm"
-                tooltipId="copy_tooltip"
+                tooltipId={`copy_collector_${c.path}`}
               />
               <Form.Control
                 value={c.path}

--- a/app/javascript/src/apps/mydb/collections/LiteratureModal.js
+++ b/app/javascript/src/apps/mydb/collections/LiteratureModal.js
@@ -5,9 +5,7 @@ import {
   Table,
   Button,
   Row,
-  Col,
-  OverlayTrigger,
-  Tooltip
+  Col
 } from 'react-bootstrap';
 import { Map } from 'immutable';
 import { uniqBy } from 'lodash';
@@ -23,7 +21,7 @@ import Literature from 'src/models/Literature';
 import LiteraturesFetcher from 'src/fetchers/LiteraturesFetcher';
 import UIStore from 'src/stores/alt/stores/UIStore';
 import { StoreContext } from 'src/stores/mobx/RootStore';
-import { copyToClipboard } from 'src/utilities/clipboard';
+import CopyButton from 'src/components/common/CopyButton';
 import ElementIcon from 'src/components/common/ElementIcon';
 
 const Cite = require('citation-js');
@@ -277,24 +275,14 @@ export default class LiteratureModal extends Component {
     return (
       <div className="d-flex flex-grow-1 align-items-baseline justify-content-between">
         {title}
-        <OverlayTrigger
+        <CopyButton
+          text={clipboardText}
           placement="bottom"
-          overlay={
-            <Tooltip id="assign_button">copy to clipboard</Tooltip>
-          }
-        >
-          <Button
-            size="sm"
-            active
-            className="me-2"
-            onClick={(e) => {
-              e.stopPropagation();
-              copyToClipboard(clipboardText);
-            }}
-          >
-            <i className="fa fa-clipboard" />
-          </Button>
-        </OverlayTrigger>
+          tooltipId="assign_button"
+          size="sm"
+          className="me-2"
+          active
+        />
       </div>
     );
   }

--- a/app/javascript/src/apps/mydb/collections/LiteratureModal.js
+++ b/app/javascript/src/apps/mydb/collections/LiteratureModal.js
@@ -278,7 +278,7 @@ export default class LiteratureModal extends Component {
         <CopyButton
           text={clipboardText}
           placement="bottom"
-          tooltipId="assign_button"
+          tooltipId={`copy-${title.replace(/\s+/g, '-')}`}
           size="sm"
           className="me-2"
           active

--- a/app/javascript/src/apps/mydb/elements/details/NumeralInputWithUnitsCompo.js
+++ b/app/javascript/src/apps/mydb/elements/details/NumeralInputWithUnitsCompo.js
@@ -6,7 +6,7 @@ import {
 } from 'react-bootstrap';
 import { metPreConv, metPrefSymbols } from 'src/utilities/metricPrefix';
 import { formatDisplayValue } from 'src/utilities/MathUtils';
-import { copyToClipboard } from 'src/utilities/clipboard';
+import CopyButton from 'src/components/common/CopyButton';
 
 export default class NumeralInputWithUnitsCompo extends Component {
   constructor(props) {
@@ -260,16 +260,13 @@ export default class NumeralInputWithUnitsCompo extends Component {
                 />
                 {prefixSwitch}
                 {showInfoTooltipRequiredVol && (
-                  <OverlayTrigger placement="bottom" overlay={<Tooltip id="assign_button">copy to clipboard</Tooltip>}>
-                    <Button
-                      variant="light"
-                      size={size}
-                      onClick={() => copyToClipboard(displayValue)}
-                      className="ms-1"
-                    >
-                      <i className="fa fa-clipboard" />
-                    </Button>
-                  </OverlayTrigger>
+                  <CopyButton
+                    text={displayValue}
+                    placement="bottom"
+                    variant="light"
+                    size={size}
+                    className="ms-1"
+                  />
                 )}
               </InputGroup>
             );

--- a/app/javascript/src/apps/mydb/elements/details/literature/CitationPanel.js
+++ b/app/javascript/src/apps/mydb/elements/details/literature/CitationPanel.js
@@ -5,6 +5,7 @@ import {
 import { uniq } from 'lodash';
 import { Citation, literatureContent } from 'src/apps/mydb/elements/details/literature/LiteratureCommon';
 import { CitationTypeEOL } from 'src/apps/mydb/elements/details/literature/CitationType';
+import { copyToClipboard } from 'src/utilities/clipboard';
 
 const changeTypeBtn = (litype, updId, fn, typeMap, readOnly = false) => {
   const cands = Object.keys(typeMap).filter((e) => (e !== litype) && e !== 'uncategorized');
@@ -71,8 +72,7 @@ const buildRow = (title, fnDelete, sortedIds, rows, fnUpdate, typeMap, readOnly 
             <OverlayTrigger placement="top" overlay={<Tooltip id="assign_button">copy to clipboard</Tooltip>}>
               <Button
                 active
-                className="clipboardBtn"
-                data-clipboard-text={content}
+                onClick={() => copyToClipboard(content)}
               >
                 <i className="fa fa-clipboard" aria-hidden="true" />
               </Button>

--- a/app/javascript/src/apps/mydb/elements/details/literature/CitationPanel.js
+++ b/app/javascript/src/apps/mydb/elements/details/literature/CitationPanel.js
@@ -5,7 +5,7 @@ import {
 import { uniq } from 'lodash';
 import { Citation, literatureContent } from 'src/apps/mydb/elements/details/literature/LiteratureCommon';
 import { CitationTypeEOL } from 'src/apps/mydb/elements/details/literature/CitationType';
-import { copyToClipboard } from 'src/utilities/clipboard';
+import CopyButton from 'src/components/common/CopyButton';
 
 const changeTypeBtn = (litype, updId, fn, typeMap, readOnly = false) => {
   const cands = Object.keys(typeMap).filter((e) => (e !== litype) && e !== 'uncategorized');
@@ -69,14 +69,7 @@ const buildRow = (title, fnDelete, sortedIds, rows, fnUpdate, typeMap, readOnly 
         </div>
         <div style={{ marginLeft: 'auto' }}>
           <ButtonGroup size="sm">
-            <OverlayTrigger placement="top" overlay={<Tooltip id="assign_button">copy to clipboard</Tooltip>}>
-              <Button
-                active
-                onClick={() => copyToClipboard(content)}
-              >
-                <i className="fa fa-clipboard" aria-hidden="true" />
-              </Button>
-            </OverlayTrigger>
+            <CopyButton text={content} tooltipId="assign_button" active />
             {changeTypeBtn(litype, id, fnUpdate, typeMap, readOnly)}
             <Button
               variant="danger"

--- a/app/javascript/src/apps/mydb/elements/details/literature/CitationPanel.js
+++ b/app/javascript/src/apps/mydb/elements/details/literature/CitationPanel.js
@@ -69,7 +69,7 @@ const buildRow = (title, fnDelete, sortedIds, rows, fnUpdate, typeMap, readOnly 
         </div>
         <div style={{ marginLeft: 'auto' }}>
           <ButtonGroup size="sm">
-            <CopyButton text={content} tooltipId="assign_button" active />
+            <CopyButton text={content} tooltipId={`copy_citation_${id}`} active />
             {changeTypeBtn(litype, id, fnUpdate, typeMap, readOnly)}
             <Button
               variant="danger"

--- a/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetailsMainProperties.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/ReactionDetailsMainProperties.js
@@ -82,7 +82,6 @@ export default class ReactionDetailsMainProperties extends Component {
                 >
                   <Button
                     disabled={!permitOn(reaction)}
-                    className="clipboardBtn"
                     onClick={this.toggleTemperatureChart}
                     variant="light"
                   >

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsDuration.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsDuration.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Row, Col, Button, InputGroup, OverlayTrigger, Tooltip, Form } from 'react-bootstrap';
 import 'moment-precise-range-plugin';
 import { permitOn } from 'src/components/common/uis';
-import { copyToClipboard } from 'src/utilities/clipboard';
+import CopyButton from 'src/components/common/CopyButton';
 
 export default class ReactionDetailsDuration extends Component {
   constructor(props) {
@@ -139,18 +139,13 @@ export default class ReactionDetailsDuration extends Component {
             <Form.Label>Duration</Form.Label>
             <InputGroup>
               <Form.Control type="text" value={durationCalc || ''} disabled placeholder="Duration" />
-              <OverlayTrigger
+              <CopyButton
+                text={durationCalc || ' '}
                 placement="bottom"
-                overlay={<Tooltip id="copy_duration_to_clipboard">copy to clipboard</Tooltip>}
-              >
-                <Button
-                  disabled={!permitOn(reaction) || reaction.gaseous}
-                  variant="light"
-                  onClick={() => copyToClipboard(durationCalc || ' ')}
-                >
-                  <i className="fa fa-clipboard" aria-hidden="true" />
-                </Button>
-              </OverlayTrigger>
+                variant="light"
+                disabled={!permitOn(reaction) || reaction.gaseous}
+                tooltipId="copy_duration_to_clipboard"
+              />
               <OverlayTrigger
                 placement="bottom"
                 overlay={<Tooltip id="copy_durationCalc_to_duration">use this duration<br />(rounded to precision 1)</Tooltip>}

--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -1026,7 +1026,7 @@ export default class SampleDetails extends React.Component {
               text={cas}
               placement="bottom"
               variant="light"
-              tooltipId="assign_button"
+              tooltipId="copy_cas"
             />
           </div>
         </InputGroup>
@@ -1218,7 +1218,7 @@ export default class SampleDetails extends React.Component {
           text={(this.state.showInchikey ? sample.molecule_inchikey : this.state.inchiString) || ' '}
           placement="bottom"
           variant="light"
-          tooltipId="assign_button"
+          tooltipId="copy_inchi"
         />
       </InputGroup>
     );
@@ -1250,7 +1250,7 @@ export default class SampleDetails extends React.Component {
           text={sample.molecule_cano_smiles || ''}
           placement="bottom"
           variant="light"
-          tooltipId="assign_button"
+          tooltipId="copy_smiles"
         />
         <OverlayTrigger placement="bottom" overlay={this.moleculeCreatorTooltip()}>
           <Button
@@ -1282,7 +1282,7 @@ export default class SampleDetails extends React.Component {
           text={sample.molfile || ''}
           placement="bottom"
           variant="light"
-          tooltipId="assign_button"
+          tooltipId="copy_molfile"
         />
         <Button
           variant="light"

--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -66,7 +66,7 @@ import CommentModal from 'src/components/common/CommentModal';
 import { formatTimeStampsOfElement } from 'src/utilities/timezoneHelper';
 import { commentActivation } from 'src/utilities/CommentHelper';
 import PrivateNoteElement from 'src/apps/mydb/elements/details/PrivateNoteElement';
-import { copyToClipboard } from 'src/utilities/clipboard';
+import CopyButton from 'src/components/common/CopyButton';
 // eslint-disable-next-line import/no-named-as-default
 import VersionsTable from 'src/apps/mydb/elements/details/VersionsTable';
 
@@ -1022,14 +1022,12 @@ export default class SampleDetails extends React.Component {
               allowCreateWhileLoading
               formatCreateLabel={(inputValue) => `Create "${inputValue}"`}
             />
-            <OverlayTrigger placement="bottom" overlay={this.clipboardTooltip()}>
-              <Button
-                variant="light"
-                onClick={() => copyToClipboard(cas)}
-              >
-                <i className="fa fa-clipboard" />
-              </Button>
-            </OverlayTrigger>
+            <CopyButton
+              text={cas}
+              placement="bottom"
+              variant="light"
+              tooltipId="assign_button"
+            />
           </div>
         </InputGroup>
         {!validCas && errorMessage}
@@ -1216,26 +1214,13 @@ export default class SampleDetails extends React.Component {
           disabled
           readOnly
         />
-        <OverlayTrigger placement="bottom" overlay={this.clipboardTooltip()}>
-          <Button
-            variant="light"
-            onClick={() => copyToClipboard(
-              (this.state.showInchikey
-                ? sample.molecule_inchikey
-                : this.state.inchiString)
-              || ' '
-            )}
-          >
-            <i className="fa fa-clipboard" />
-          </Button>
-        </OverlayTrigger>
+        <CopyButton
+          text={(this.state.showInchikey ? sample.molecule_inchikey : this.state.inchiString) || ' '}
+          placement="bottom"
+          variant="light"
+          tooltipId="assign_button"
+        />
       </InputGroup>
-    );
-  }
-
-  clipboardTooltip() {
-    return (
-      <Tooltip id="assign_button">copy to clipboard</Tooltip>
     );
   }
 
@@ -1261,14 +1246,12 @@ export default class SampleDetails extends React.Component {
             }
           }}
         />
-        <OverlayTrigger placement="bottom" overlay={this.clipboardTooltip()}>
-          <Button
-            variant="light"
-            onClick={() => copyToClipboard(sample.molecule_cano_smiles || '')}
-          >
-            <i className="fa fa-clipboard" />
-          </Button>
-        </OverlayTrigger>
+        <CopyButton
+          text={sample.molecule_cano_smiles || ''}
+          placement="bottom"
+          variant="light"
+          tooltipId="assign_button"
+        />
         <OverlayTrigger placement="bottom" overlay={this.moleculeCreatorTooltip()}>
           <Button
             variant="light"
@@ -1295,14 +1278,12 @@ export default class SampleDetails extends React.Component {
           disabled
           readOnly
         />
-        <OverlayTrigger placement="bottom" overlay={this.clipboardTooltip()}>
-          <Button
-            variant="light"
-            onClick={() => copyToClipboard(sample.molfile || '')}
-          >
-            <i className="fa fa-clipboard" />
-          </Button>
-        </OverlayTrigger>
+        <CopyButton
+          text={sample.molfile || ''}
+          placement="bottom"
+          variant="light"
+          tooltipId="assign_button"
+        />
         <Button
           variant="light"
           onClick={this.handleMolfileShow}

--- a/app/javascript/src/components/common/CopyButton.js
+++ b/app/javascript/src/components/common/CopyButton.js
@@ -7,7 +7,7 @@ import { copyToClipboard } from 'src/utilities/clipboard';
 // swapping the clipboard icon for a check. Failure feedback (a toast) is handled by
 // copyToClipboard itself, so callers get it for free.
 const CopyButton = ({
-  text, tooltip, tooltipId, placement, variant, size, disabled, className, active,
+  text, tooltip, tooltipId, placement, variant, size, disabled, className, active, ariaLabel,
 }) => {
   const [copied, setCopied] = useState(false);
   const resetTimer = useRef(null);
@@ -23,6 +23,10 @@ const CopyButton = ({
     clearTimeout(resetTimer.current);
     resetTimer.current = setTimeout(() => setCopied(false), 1500);
   };
+
+  // the button is icon-only, so give it an accessible name for screen readers;
+  // default to the tooltip text when it is a plain string
+  const label = ariaLabel || (typeof tooltip === 'string' ? tooltip : 'copy to clipboard');
 
   return (
     // Force the tooltip hidden while copied (controlled show) rather than unmounting the
@@ -40,6 +44,7 @@ const CopyButton = ({
         disabled={disabled}
         className={className}
         active={active}
+        aria-label={label}
         onClick={handleCopy}
       >
         <i className={`fa ${copied ? 'fa-check' : 'fa-clipboard'}`} aria-hidden="true" />
@@ -58,6 +63,7 @@ CopyButton.propTypes = {
   disabled: PropTypes.bool,
   className: PropTypes.string,
   active: PropTypes.bool,
+  ariaLabel: PropTypes.string,
 };
 
 CopyButton.defaultProps = {
@@ -70,6 +76,7 @@ CopyButton.defaultProps = {
   disabled: false,
   className: undefined,
   active: false,
+  ariaLabel: undefined,
 };
 
 export default CopyButton;

--- a/app/javascript/src/components/common/CopyButton.js
+++ b/app/javascript/src/components/common/CopyButton.js
@@ -24,25 +24,26 @@ const CopyButton = ({
     resetTimer.current = setTimeout(() => setCopied(false), 1500);
   };
 
-  const button = (
-    <Button
-      variant={variant}
-      size={size}
-      disabled={disabled}
-      className={className}
-      active={active}
-      onClick={handleCopy}
-    >
-      <i className={`fa ${copied ? 'fa-check' : 'fa-clipboard'}`} aria-hidden="true" />
-    </Button>
-  );
-
-  // once copied, drop the tooltip entirely so no hover text shows during the confirmation
-  if (copied) return button;
-
   return (
-    <OverlayTrigger placement={placement} overlay={<Tooltip id={tooltipId}>{tooltip}</Tooltip>}>
-      {button}
+    // Force the tooltip hidden while copied (controlled show) rather than unmounting the
+    // OverlayTrigger, so the Button is never remounted: keyboard focus and InputGroup/
+    // ButtonGroup chrome stay stable during the confirmation. `undefined` restores normal
+    // hover/focus behaviour.
+    <OverlayTrigger
+      placement={placement}
+      show={copied ? false : undefined}
+      overlay={<Tooltip id={tooltipId}>{tooltip}</Tooltip>}
+    >
+      <Button
+        variant={variant}
+        size={size}
+        disabled={disabled}
+        className={className}
+        active={active}
+        onClick={handleCopy}
+      >
+        <i className={`fa ${copied ? 'fa-check' : 'fa-clipboard'}`} aria-hidden="true" />
+      </Button>
     </OverlayTrigger>
   );
 };

--- a/app/javascript/src/components/common/CopyButton.js
+++ b/app/javascript/src/components/common/CopyButton.js
@@ -1,0 +1,74 @@
+import React, { useState, useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { copyToClipboard } from 'src/utilities/clipboard';
+
+// Icon button that copies `text` to the clipboard and briefly confirms success by
+// swapping the clipboard icon for a check. Failure feedback (a toast) is handled by
+// copyToClipboard itself, so callers get it for free.
+const CopyButton = ({
+  text, tooltip, tooltipId, placement, variant, size, disabled, className, active,
+}) => {
+  const [copied, setCopied] = useState(false);
+  const resetTimer = useRef(null);
+
+  // clear the pending reset if the button unmounts before it fires
+  useEffect(() => () => clearTimeout(resetTimer.current), []);
+
+  const handleCopy = async (e) => {
+    e?.stopPropagation();
+    const ok = await copyToClipboard(text);
+    if (!ok) return;
+    setCopied(true);
+    clearTimeout(resetTimer.current);
+    resetTimer.current = setTimeout(() => setCopied(false), 1500);
+  };
+
+  const button = (
+    <Button
+      variant={variant}
+      size={size}
+      disabled={disabled}
+      className={className}
+      active={active}
+      onClick={handleCopy}
+    >
+      <i className={`fa ${copied ? 'fa-check' : 'fa-clipboard'}`} aria-hidden="true" />
+    </Button>
+  );
+
+  // once copied, drop the tooltip entirely so no hover text shows during the confirmation
+  if (copied) return button;
+
+  return (
+    <OverlayTrigger placement={placement} overlay={<Tooltip id={tooltipId}>{tooltip}</Tooltip>}>
+      {button}
+    </OverlayTrigger>
+  );
+};
+
+CopyButton.propTypes = {
+  text: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  tooltip: PropTypes.node,
+  tooltipId: PropTypes.string,
+  placement: PropTypes.string,
+  variant: PropTypes.string,
+  size: PropTypes.string,
+  disabled: PropTypes.bool,
+  className: PropTypes.string,
+  active: PropTypes.bool,
+};
+
+CopyButton.defaultProps = {
+  text: '',
+  tooltip: 'copy to clipboard',
+  tooltipId: 'copy-to-clipboard-tooltip',
+  placement: 'top',
+  variant: undefined,
+  size: undefined,
+  disabled: false,
+  className: undefined,
+  active: false,
+};
+
+export default CopyButton;

--- a/app/javascript/src/components/searchModal/forms/SearchResultTabContent.js
+++ b/app/javascript/src/components/searchModal/forms/SearchResultTabContent.js
@@ -8,6 +8,7 @@ import UIStore from 'src/stores/alt/stores/UIStore';
 import { StoreContext } from 'src/stores/mobx/RootStore';
 import SampleName from 'src/components/common/SampleName';
 import SvgWithPopover from 'src/components/common/SvgWithPopover';
+import { copyToClipboard as copyTextToClipboard } from 'src/utilities/clipboard';
 
 const SearchResultTabContent = ({ list, tabResult, openDetail }) => {
   const searchStore = useContext(StoreContext).search;
@@ -143,7 +144,7 @@ const SearchResultTabContent = ({ list, tabResult, openDetail }) => {
 
   const copyToClipboard = (element) => {
     if (element.target.dataset.clipboardText) {
-      navigator.clipboard.writeText(element.target.dataset.clipboardText);
+      copyTextToClipboard(element.target.dataset.clipboardText);
     }
   };
 

--- a/app/javascript/src/components/searchModal/forms/SearchResultTabContent.js
+++ b/app/javascript/src/components/searchModal/forms/SearchResultTabContent.js
@@ -8,7 +8,7 @@ import UIStore from 'src/stores/alt/stores/UIStore';
 import { StoreContext } from 'src/stores/mobx/RootStore';
 import SampleName from 'src/components/common/SampleName';
 import SvgWithPopover from 'src/components/common/SvgWithPopover';
-import { copyToClipboard as copyTextToClipboard } from 'src/utilities/clipboard';
+import { copyToClipboard } from 'src/utilities/clipboard';
 
 const SearchResultTabContent = ({ list, tabResult, openDetail }) => {
   const searchStore = useContext(StoreContext).search;
@@ -142,9 +142,9 @@ const SearchResultTabContent = ({ list, tabResult, openDetail }) => {
     );
   };
 
-  const copyToClipboard = (element) => {
+  const handleCopyClick = (element) => {
     if (element.target.dataset.clipboardText) {
-      copyTextToClipboard(element.target.dataset.clipboardText);
+      copyToClipboard(element.target.dataset.clipboardText);
     }
   };
 
@@ -197,8 +197,8 @@ const SearchResultTabContent = ({ list, tabResult, openDetail }) => {
               role="button"
               tabIndex={0}
               className="search-result-tab-content-list"
-              onClick={copyToClipboard}
-              onKeyDown={(e) => e.key === 'Enter' && copyToClipboard(e)}
+              onClick={handleCopyClick}
+              onKeyDown={(e) => e.key === 'Enter' && handleCopyClick(e)}
             >
               {/* Sample grouping header */}
               {showSampleHeader && (

--- a/app/javascript/src/utilities/clipboard.js
+++ b/app/javascript/src/utilities/clipboard.js
@@ -1,14 +1,22 @@
-// Copies text to the clipboard, resolving to true on success and false on failure.
-// navigator.clipboard requires a secure context (https / localhost); on plain
-// http:// origins it is undefined, so fall back to the legacy execCommand path.
-export async function copyToClipboard(text) {
-  if (navigator?.clipboard && window.isSecureContext) {
-    try {
-      await navigator.clipboard.writeText(text);
-      return true;
-    } catch (e) { /* fall through to legacy path */ }
-  }
+import { rootStore } from 'src/stores/mobx/RootStore';
 
+const COPY_TOAST_UID = 'copy-to-clipboard';
+
+// Surfaced only when a copy fails, so a silent no-op can never look like a success.
+// Success stays silent to avoid a toast on every copy click.
+function notifyCopyFailure() {
+  rootStore.notifications.add({
+    title: 'Copy failed',
+    message: 'Could not copy to the clipboard.',
+    level: 'error',
+    position: 'tr',
+    autoDismiss: 5,
+    uid: COPY_TOAST_UID,
+  });
+}
+
+// Legacy fallback for non-secure (http://) contexts where navigator.clipboard is undefined.
+function copyWithExecCommand(text) {
   const ta = document.createElement('textarea');
   ta.value = text;
   ta.setAttribute('readonly', '');
@@ -22,5 +30,30 @@ export async function copyToClipboard(text) {
   let ok = false;
   try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
   document.body.removeChild(ta);
+  return ok;
+}
+
+// Copies text to the clipboard, resolving to true on success and false on failure,
+// and toasts on failure so callers get feedback for free. navigator.clipboard requires
+// a secure context (https / localhost); on plain http:// origins it is undefined, so
+// fall back to the legacy execCommand path.
+export async function copyToClipboard(text) {
+  const value = text == null ? '' : String(text);
+  let ok = false;
+
+  if (navigator?.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(value);
+      ok = true;
+    } catch (e) { /* fall through to the legacy path */ }
+  }
+
+  if (!ok) {
+    ok = copyWithExecCommand(value);
+  }
+
+  if (!ok) {
+    notifyCopyFailure();
+  }
   return ok;
 }

--- a/app/javascript/src/utilities/clipboard.js
+++ b/app/javascript/src/utilities/clipboard.js
@@ -25,12 +25,16 @@ function copyWithExecCommand(text) {
   ta.style.left = '0';
   ta.style.opacity = '0';
   document.body.appendChild(ta);
-  ta.focus();
-  ta.select();
-  let ok = false;
-  try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
-  document.body.removeChild(ta);
-  return ok;
+  try {
+    ta.focus();
+    ta.select();
+    return document.execCommand('copy');
+  } catch (e) {
+    return false;
+  } finally {
+    // always remove the temporary node, even if focus/select/execCommand threw
+    ta.remove();
+  }
 }
 
 // Copies text to the clipboard, resolving to true on success and false on failure,
@@ -49,7 +53,13 @@ export async function copyToClipboard(text) {
   }
 
   if (!ok) {
-    ok = copyWithExecCommand(value);
+    // guard the whole legacy path (createElement/appendChild can throw too) so any
+    // failure resolves to false and toasts rather than rejecting the promise
+    try {
+      ok = copyWithExecCommand(value);
+    } catch (e) {
+      ok = false;
+    }
   }
 
   if (!ok) {

--- a/app/javascript/src/utilities/clipboard.js
+++ b/app/javascript/src/utilities/clipboard.js
@@ -1,3 +1,26 @@
-export function copyToClipboard(text) {
-  return navigator?.clipboard?.writeText(text);
+// Copies text to the clipboard, resolving to true on success and false on failure.
+// navigator.clipboard requires a secure context (https / localhost); on plain
+// http:// origins it is undefined, so fall back to the legacy execCommand path.
+export async function copyToClipboard(text) {
+  if (navigator?.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (e) { /* fall through to legacy path */ }
+  }
+
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.setAttribute('readonly', '');
+  ta.style.position = 'fixed';
+  ta.style.top = '-1000px';
+  ta.style.left = '0';
+  ta.style.opacity = '0';
+  document.body.appendChild(ta);
+  ta.focus();
+  ta.select();
+  let ok = false;
+  try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
+  document.body.removeChild(ta);
+  return ok;
 }

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/literature/CitationPanel.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/literature/CitationPanel.spec.js
@@ -1,0 +1,58 @@
+/* eslint-disable no-undef */
+import React from 'react';
+import { configure, mount } from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import expect from 'expect';
+import sinon from 'sinon';
+import CitationPanel from 'src/apps/mydb/elements/details/literature/CitationPanel';
+import Literature from 'src/models/Literature';
+import * as clipboard from 'src/utilities/clipboard';
+
+configure({ adapter: new Adapter() });
+
+describe('CitationPanel copy button', () => {
+  let copyStub;
+  let wrapper;
+
+  const citation = Literature.buildEmpty();
+  Object.assign(citation, {
+    id: 1,
+    title: 'A Fine Reference',
+    year: 2024,
+    litype: 'uncategorized',
+    user_name: 'Alice',
+  });
+
+  const buildWrapper = () => mount(
+    React.createElement(CitationPanel, {
+      title: 'uncategorized',
+      fnDelete: sinon.spy(),
+      fnUpdate: sinon.spy(),
+      sortedIds: [1],
+      rows: new Map([[1, citation]]),
+      citationMap: { def: 'General' },
+      typeMap: {},
+      readOnly: false,
+    })
+  );
+
+  beforeEach(() => {
+    // stub the shared helper so the test never touches a real clipboard
+    copyStub = sinon.stub(clipboard, 'copyToClipboard').resolves(true);
+    wrapper = buildWrapper();
+  });
+
+  afterEach(() => {
+    copyStub.restore();
+    wrapper.unmount();
+  });
+
+  it('copies the plain-text citation content when the clipboard button is clicked', () => {
+    const copyButton = wrapper.find('i.fa-clipboard').closest('button');
+    expect(copyButton.exists()).toBe(true);
+
+    copyButton.simulate('click');
+
+    expect(copyStub.calledOnceWith('A Fine Reference')).toBe(true);
+  });
+});

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/literature/CitationPanel.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/literature/CitationPanel.spec.js
@@ -50,7 +50,7 @@ describe('CitationPanel copy button', () => {
 
   afterEach(() => {
     copyStub.restore();
-    wrapper.unmount();
+    if (wrapper) wrapper.unmount();
   });
 
   it('copies the plain-text citation content when the button is clicked', async () => {

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/literature/CitationPanel.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/literature/CitationPanel.spec.js
@@ -36,10 +36,16 @@ describe('CitationPanel copy button', () => {
     })
   );
 
+  // click the copy button, then flush the async handler's microtasks before asserting
+  const clickCopy = async () => {
+    wrapper.find('i.fa-clipboard').closest('button').simulate('click');
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+  };
+
   beforeEach(() => {
     // stub the shared helper so the test never touches a real clipboard
-    copyStub = sinon.stub(clipboard, 'copyToClipboard').resolves(true);
-    wrapper = buildWrapper();
+    // (the helper owns the failure toast; that behaviour is covered in clipboard.spec.js)
+    copyStub = sinon.stub(clipboard, 'copyToClipboard');
   });
 
   afterEach(() => {
@@ -47,12 +53,40 @@ describe('CitationPanel copy button', () => {
     wrapper.unmount();
   });
 
-  it('copies the plain-text citation content when the clipboard button is clicked', () => {
-    const copyButton = wrapper.find('i.fa-clipboard').closest('button');
-    expect(copyButton.exists()).toBe(true);
+  it('copies the plain-text citation content when the button is clicked', async () => {
+    copyStub.resolves(true);
+    wrapper = buildWrapper();
 
-    copyButton.simulate('click');
+    await clickCopy();
 
     expect(copyStub.calledOnceWith('A Fine Reference')).toBe(true);
+  });
+
+  it('swaps the clipboard icon for a check icon on success', async () => {
+    copyStub.resolves(true);
+    wrapper = buildWrapper();
+
+    // before clicking: the clipboard icon
+    expect(wrapper.find('i.fa-clipboard').exists()).toBe(true);
+    expect(wrapper.find('i.fa-check').exists()).toBe(false);
+
+    await clickCopy();
+    wrapper.update();
+
+    // after a successful copy: the check icon replaces the clipboard icon
+    expect(wrapper.find('i.fa-check').exists()).toBe(true);
+    expect(wrapper.find('i.fa-clipboard').exists()).toBe(false);
+  });
+
+  it('does not show the confirmation icon when the copy fails', async () => {
+    copyStub.resolves(false);
+    wrapper = buildWrapper();
+
+    await clickCopy();
+    wrapper.update();
+
+    // the button stays in its default state; the helper handles the failure toast
+    expect(wrapper.find('i.fa-clipboard').exists()).toBe(true);
+    expect(wrapper.find('i.fa-check').exists()).toBe(false);
   });
 });

--- a/spec/javascripts/packs/src/components/common/CopyButton.spec.js
+++ b/spec/javascripts/packs/src/components/common/CopyButton.spec.js
@@ -1,0 +1,68 @@
+/* eslint-disable no-undef */
+import React from 'react';
+import { configure, mount } from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import expect from 'expect';
+import sinon from 'sinon';
+import CopyButton from 'src/components/common/CopyButton';
+import * as clipboard from 'src/utilities/clipboard';
+
+configure({ adapter: new Adapter() });
+
+describe('CopyButton', () => {
+  let copyStub;
+  let wrapper;
+
+  const buildWrapper = (props = {}) => mount(
+    React.createElement(CopyButton, { text: 'copy me', ...props })
+  );
+
+  // click the button, then flush the async handler's microtasks before asserting
+  const clickCopy = async () => {
+    wrapper.find('button').simulate('click');
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+  };
+
+  beforeEach(() => {
+    copyStub = sinon.stub(clipboard, 'copyToClipboard');
+  });
+
+  afterEach(() => {
+    copyStub.restore();
+    wrapper.unmount();
+  });
+
+  it('copies the provided text through the shared helper', async () => {
+    copyStub.resolves(true);
+    wrapper = buildWrapper({ text: 'hello' });
+
+    await clickCopy();
+
+    expect(copyStub.calledOnceWith('hello')).toBe(true);
+  });
+
+  it('swaps the clipboard icon for a check icon on success', async () => {
+    copyStub.resolves(true);
+    wrapper = buildWrapper();
+
+    expect(wrapper.find('i.fa-clipboard').exists()).toBe(true);
+    expect(wrapper.find('i.fa-check').exists()).toBe(false);
+
+    await clickCopy();
+    wrapper.update();
+
+    expect(wrapper.find('i.fa-check').exists()).toBe(true);
+    expect(wrapper.find('i.fa-clipboard').exists()).toBe(false);
+  });
+
+  it('keeps the default icon when the copy fails (helper owns the error toast)', async () => {
+    copyStub.resolves(false);
+    wrapper = buildWrapper();
+
+    await clickCopy();
+    wrapper.update();
+
+    expect(wrapper.find('i.fa-clipboard').exists()).toBe(true);
+    expect(wrapper.find('i.fa-check').exists()).toBe(false);
+  });
+});

--- a/spec/javascripts/packs/src/components/common/CopyButton.spec.js
+++ b/spec/javascripts/packs/src/components/common/CopyButton.spec.js
@@ -29,7 +29,14 @@ describe('CopyButton', () => {
 
   afterEach(() => {
     copyStub.restore();
-    wrapper.unmount();
+    if (wrapper) wrapper.unmount();
+  });
+
+  it('exposes an accessible name for the icon-only button', () => {
+    copyStub.resolves(true);
+    wrapper = buildWrapper({ tooltip: 'copy the CAS number' });
+
+    expect(wrapper.find('button').prop('aria-label')).toBe('copy the CAS number');
   });
 
   it('copies the provided text through the shared helper', async () => {

--- a/spec/javascripts/utils/clipboard.spec.js
+++ b/spec/javascripts/utils/clipboard.spec.js
@@ -1,27 +1,35 @@
 /* eslint-disable no-undef */
 import expect from 'expect';
 import sinon from 'sinon';
+import toast from 'react-hot-toast';
 import { copyToClipboard } from 'src/utilities/clipboard';
 
 describe('copyToClipboard', () => {
   let originalExecCommand;
   let originalIsSecureContext;
+  let toastErrorStub;
+  let toastSuccessStub;
 
   beforeEach(() => {
     originalExecCommand = document.execCommand;
     originalIsSecureContext = window.isSecureContext;
+    // the failure notification is routed to react-hot-toast's toast.error
+    toastErrorStub = sinon.stub(toast, 'error');
+    toastSuccessStub = sinon.stub(toast, 'success');
   });
 
   afterEach(() => {
     document.execCommand = originalExecCommand;
     window.isSecureContext = originalIsSecureContext;
+    toastErrorStub.restore();
+    toastSuccessStub.restore();
     delete navigator.clipboard;
     // remove any textarea leaked by a failing test
     document.querySelectorAll('textarea').forEach((ta) => ta.remove());
   });
 
   describe('secure context with navigator.clipboard', () => {
-    it('writes the text via the async clipboard API and resolves true', async () => {
+    it('writes the text via the async clipboard API, resolves true and shows no toast', async () => {
       window.isSecureContext = true;
       const writeText = sinon.stub().resolves();
       navigator.clipboard = { writeText };
@@ -33,6 +41,9 @@ describe('copyToClipboard', () => {
       expect(result).toBe(true);
       // the legacy path must not run when the async API succeeds
       expect(document.execCommand.called).toBe(false);
+      // success stays silent (no toast on every copy)
+      expect(toastErrorStub.called).toBe(false);
+      expect(toastSuccessStub.called).toBe(false);
     });
 
     it('falls back to execCommand when writeText rejects', async () => {
@@ -44,6 +55,7 @@ describe('copyToClipboard', () => {
 
       expect(document.execCommand.calledWith('copy')).toBe(true);
       expect(result).toBe(true);
+      expect(toastErrorStub.called).toBe(false);
     });
   });
 
@@ -59,9 +71,10 @@ describe('copyToClipboard', () => {
       expect(result).toBe(true);
       // the temporary textarea is cleaned up
       expect(document.querySelectorAll('textarea').length).toBe(0);
+      expect(toastErrorStub.called).toBe(false);
     });
 
-    it('resolves false when the legacy copy command fails', async () => {
+    it('resolves false and shows an error toast when the legacy copy command fails', async () => {
       window.isSecureContext = false;
       document.execCommand = sinon.stub().returns(false);
 
@@ -69,6 +82,8 @@ describe('copyToClipboard', () => {
 
       expect(result).toBe(false);
       expect(document.querySelectorAll('textarea').length).toBe(0);
+      // the silent no-op now surfaces as a failure notification
+      expect(toastErrorStub.calledOnce).toBe(true);
     });
   });
 });

--- a/spec/javascripts/utils/clipboard.spec.js
+++ b/spec/javascripts/utils/clipboard.spec.js
@@ -85,5 +85,31 @@ describe('copyToClipboard', () => {
       // the silent no-op now surfaces as a failure notification
       expect(toastErrorStub.calledOnce).toBe(true);
     });
+
+    it('resolves false, cleans up and toasts when execCommand throws', async () => {
+      window.isSecureContext = false;
+      document.execCommand = sinon.stub().throws(new Error('execCommand blew up'));
+
+      const result = await copyToClipboard('throwing exec');
+
+      expect(result).toBe(false);
+      // the temporary textarea is still removed via the finally block
+      expect(document.querySelectorAll('textarea').length).toBe(0);
+      expect(toastErrorStub.calledOnce).toBe(true);
+    });
+
+    it('resolves false (does not reject) and toasts when the DOM setup itself throws', async () => {
+      window.isSecureContext = false;
+      const createElement = sinon.stub(document, 'createElement').throws(new Error('no DOM'));
+
+      try {
+        // must resolve false rather than reject, so callers awaiting it never see a rejection
+        const result = await copyToClipboard('no dom');
+        expect(result).toBe(false);
+        expect(toastErrorStub.calledOnce).toBe(true);
+      } finally {
+        createElement.restore();
+      }
+    });
   });
 });

--- a/spec/javascripts/utils/clipboard.spec.js
+++ b/spec/javascripts/utils/clipboard.spec.js
@@ -13,7 +13,9 @@ describe('copyToClipboard', () => {
   beforeEach(() => {
     originalExecCommand = document.execCommand;
     originalIsSecureContext = window.isSecureContext;
-    // the failure notification is routed to react-hot-toast's toast.error
+    // copyToClipboard calls rootStore.notifications.add({ level: 'error', ... }), which
+    // NotificationsStore routes to react-hot-toast's toast.error. The MST action itself
+    // is protected and cannot be sinon-stubbed, so we assert at the toast seam it delegates to.
     toastErrorStub = sinon.stub(toast, 'error');
     toastSuccessStub = sinon.stub(toast, 'success');
   });
@@ -82,8 +84,12 @@ describe('copyToClipboard', () => {
 
       expect(result).toBe(false);
       expect(document.querySelectorAll('textarea').length).toBe(0);
-      // the silent no-op now surfaces as a failure notification
+      // the silent no-op now surfaces as a failure notification with the expected
+      // message and dedupe uid (buildOptions maps uid -> options.id)
       expect(toastErrorStub.calledOnce).toBe(true);
+      const [message, options] = toastErrorStub.firstCall.args;
+      expect(message).toBe('Could not copy to the clipboard.');
+      expect(options.id).toBe('copy-to-clipboard');
     });
 
     it('resolves false, cleans up and toasts when execCommand throws', async () => {

--- a/spec/javascripts/utils/clipboard.spec.js
+++ b/spec/javascripts/utils/clipboard.spec.js
@@ -1,0 +1,74 @@
+/* eslint-disable no-undef */
+import expect from 'expect';
+import sinon from 'sinon';
+import { copyToClipboard } from 'src/utilities/clipboard';
+
+describe('copyToClipboard', () => {
+  let originalExecCommand;
+  let originalIsSecureContext;
+
+  beforeEach(() => {
+    originalExecCommand = document.execCommand;
+    originalIsSecureContext = window.isSecureContext;
+  });
+
+  afterEach(() => {
+    document.execCommand = originalExecCommand;
+    window.isSecureContext = originalIsSecureContext;
+    delete navigator.clipboard;
+    // remove any textarea leaked by a failing test
+    document.querySelectorAll('textarea').forEach((ta) => ta.remove());
+  });
+
+  describe('secure context with navigator.clipboard', () => {
+    it('writes the text via the async clipboard API and resolves true', async () => {
+      window.isSecureContext = true;
+      const writeText = sinon.stub().resolves();
+      navigator.clipboard = { writeText };
+      document.execCommand = sinon.spy();
+
+      const result = await copyToClipboard('hello world');
+
+      expect(writeText.calledOnceWith('hello world')).toBe(true);
+      expect(result).toBe(true);
+      // the legacy path must not run when the async API succeeds
+      expect(document.execCommand.called).toBe(false);
+    });
+
+    it('falls back to execCommand when writeText rejects', async () => {
+      window.isSecureContext = true;
+      navigator.clipboard = { writeText: sinon.stub().rejects(new Error('denied')) };
+      document.execCommand = sinon.stub().returns(true);
+
+      const result = await copyToClipboard('after rejection');
+
+      expect(document.execCommand.calledWith('copy')).toBe(true);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('non-secure context (no navigator.clipboard)', () => {
+    it('copies through the legacy textarea/execCommand path and resolves true', async () => {
+      window.isSecureContext = false;
+      const execCommand = sinon.stub().returns(true);
+      document.execCommand = execCommand;
+
+      const result = await copyToClipboard('legacy text');
+
+      expect(execCommand.calledOnceWith('copy')).toBe(true);
+      expect(result).toBe(true);
+      // the temporary textarea is cleaned up
+      expect(document.querySelectorAll('textarea').length).toBe(0);
+    });
+
+    it('resolves false when the legacy copy command fails', async () => {
+      window.isSecureContext = false;
+      document.execCommand = sinon.stub().returns(false);
+
+      const result = await copyToClipboard('unhappy path');
+
+      expect(result).toBe(false);
+      expect(document.querySelectorAll('textarea').length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## What & why

The per-reference copy button in the References tab did nothing — it still
carried the `clipboardBtn` / `data-clipboard-text` markup from the removed
`clipboard` npm package, but no handler was ever wired after the package was
dropped. This fixes it and, along the way, hardens copy-to-clipboard behavior
app-wide.

## Changes

- **Fix the dead button** — wire the citation copy button to the shared helper.
- **Harden `copyToClipboard`**
  - Fall back to a legacy `execCommand` path so copy works on plain `http://`
    origins (where `navigator.clipboard` is undefined), not just https/localhost.
  - Return `true`/`false` and **toast on failure** so a silent no-op can never
    look like a success. Every failure resolves `false` (never rejects), even if
    the DOM setup throws.
- **Reusable `CopyButton`** (`components/common/CopyButton.js`) — icon button
  that confirms a successful copy by briefly swapping the clipboard icon for a
  check. Adopted at every icon copy button: SampleDetails (CAS/InChI/SMILES/
  molfile), Required-volume input, reaction duration, device path, literature
  modal, and citations.
- **Route the search-results copy** through the shared helper (it was calling
  `navigator.clipboard` directly, bypassing the fallback + toast).
- Removed the leftover `clipboardBtn` class and now-dead imports/helpers.

## Tests

New specs for the helper (secure path, `execCommand` fallback, throw handling,
failure toast) and for `CopyButton` (icon swap on success, no swap on failure).
Full JS suite green (1617 passing).

## Not included (out of scope)

`LiteratureDetails` (labeled dropdown item), `AuthToken`, and the ketcher
template copy still copy directly; they get the failure toast where they route
through the helper but not the check-icon confirmation.

