### PR TITLE
fix(notifications): stop long import-log URL overflowing the toast

### DIFF
--- a/app/assets/stylesheets/components/Notifications.scss
+++ b/app/assets/stylesheets/components/Notifications.scss
@@ -34,4 +34,16 @@
 
 .notification-body {
   @extend .p-3;
+  // Long unbreakable tokens (e.g. an import-log URL made only of underscores and
+  // digits) have no soft break opportunity, so force them to wrap rather than
+  // overflow the toast's maxWidth. overflow-wrap is inherited, so it reaches the
+  // message text.
+  overflow-wrap: anywhere;
+
+  // The message sits in a flex row as div[role="status"]; a flex item defaults to
+  // min-width: auto and refuses to shrink below its widest content, pushing past
+  // the 420px cap. min-width: 0 lets it shrink so the text wraps inside the toast.
+  .d-flex > div[role="status"] {
+    min-width: 0;
+  }
 }

--- a/app/jobs/export_collections_job.rb
+++ b/app/jobs/export_collections_job.rb
@@ -4,6 +4,8 @@ class ExportCollectionsJob < ApplicationJob
   queue_as :export_collections
 
   after_perform do |job|
+    next unless @success
+
     begin
       # Sweep file in 24h
       CleanExportFilesJob.set(queue: "remove_files_#{job.job_id}", wait: 24.hours)
@@ -14,7 +16,8 @@ class ExportCollectionsJob < ApplicationJob
         channel_subject: Channel::COLLECTION_ZIP,
         data_args: { expires_at: @expires_at, operation: 'Export', col_labels: @labels },
         message_from: @user_id,
-        url: @link
+        url: @link,
+        urlTitle: 'Download export archive',
       )
 
       # Email ELNer
@@ -26,7 +29,7 @@ class ExportCollectionsJob < ApplicationJob
       ).deliver_now
     rescue StandardError => e
       Delayed::Worker.logger.error e
-    end if @success
+    end
   end
 
   def perform(collection_ids, extname, nested, user_id)

--- a/app/jobs/import_collections_job.rb
+++ b/app/jobs/import_collections_job.rb
@@ -13,6 +13,7 @@ class ImportCollectionsJob < ApplicationJob
         message_from: @user_id,
         data_args: { col_labels: col_labels, operation: 'import', expires_at: nil },
         url: @log_file_path,
+        urlTitle: 'Download import log',
         autoDismiss: 5,
       )
     end


### PR DESCRIPTION
## What

The link to the collection **import** log overflows the toast notification's container. The
equivalent **export** notification lays out correctly.

## Why it happens

Both notifications use the same channel (`Channel::COLLECTION_ZIP`) and the same renderer, which
falls back to the raw URL as link text when no `urlTitle` is supplied. The difference is the URL shape:

| | URL | Wraps? |
|---|---|---|
| Export | `…/zip/<job-uuid>.zip` — hyphen-separated | Yes (browsers break at hyphens) |
| Import | `…/import_logs/import_collections_20260820_143012_a1b2c3d4.log` — underscores + digits only | **No** — one unbreakable ~60-char token |

The toast is capped at `maxWidth: 420`, and the message sits in a flex row where the flex item
defaults to `min-width: auto`, so it refuses to shrink below its widest unbreakable content and
spills out of the box. Nothing in `Notifications.scss` counteracts this, so it's a latent bug for
*any* long unbreakable URL — the import filename is just the first to hit it.

## Changes

1. **Short link labels** on both jobs (`urlTitle`), so the toast shows a readable label instead of a
   raw URL. This flows through `Channel.build_message`'s `message.merge(args)` into the notification
   content, and `NoticeButton.changeUrl` already prefers `urlTitle` over the raw URL.
   - `import_collections_job.rb`: `'Download import log'`
   - `export_collections_job.rb`: `'Download export archive'` (consistency; wasn't overflowing)
2. **Wrap-proof toast** in `Notifications.scss`: `overflow-wrap: anywhere` on `.notification-body`
   (inherited, reaches the message text) plus `min-width: 0` on the message flex child
   (`.d-flex > div[role="status"]`) so it can shrink below its widest content. This is the safety net:
   no future long token can escape `maxWidth: 420` regardless of what a job puts in `url`.

## QA

1. Import a collection `.zip` (Collections → Import Collection) and confirm the toast reads
   *"Download import log"*, stays inside the box, and the link resolves.
2. Export a collection and confirm *"Download export archive"*.
3. Regression: normal success/error toasts unchanged; `autoDismiss` still fires; same links render
   correctly in the bell dropdown (`NoticeButton`).

To verify the SCSS safety net in isolation, inject a notification with a long `url` and no `urlTitle`
via `rails console` and confirm it wraps rather than overflows.

