### PR TITLE
feat: create sample structure from a pasted or uploaded molfile

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/SampleDetails.js
@@ -67,6 +67,7 @@ import { formatTimeStampsOfElement } from 'src/utilities/timezoneHelper';
 import { commentActivation } from 'src/utilities/CommentHelper';
 import PrivateNoteElement from 'src/apps/mydb/elements/details/PrivateNoteElement';
 import { copyToClipboard } from 'src/utilities/clipboard';
+import { molfileProblem, MAX_MOLFILE_SIZE } from 'src/utilities/MolfileValidation';
 // eslint-disable-next-line import/no-named-as-default
 import VersionsTable from 'src/apps/mydb/elements/details/VersionsTable';
 
@@ -153,6 +154,7 @@ export default class SampleDetails extends React.Component {
       smileReadonly: !((typeof props.sample.molecule.inchikey === 'undefined')
         || props.sample.molecule.inchikey == null || props.sample.molecule.inchikey === 'DUMMY'),
       smilesInput: '',
+      molfileInput: '',
       molfile: props.sample.molfile || '',
       inchiString: props.sample.molecule_inchistring || '',
       quickCreator: false,
@@ -179,6 +181,10 @@ export default class SampleDetails extends React.Component {
     this.isCASNumberValid = this.isCASNumberValid.bind(this);
     this.handleMolfileShow = this.handleMolfileShow.bind(this);
     this.handleMolfileClose = this.handleMolfileClose.bind(this);
+    this.handleMoleculeByMolfile = this.handleMoleculeByMolfile.bind(this);
+    this.handleMolfileUpload = this.handleMolfileUpload.bind(this);
+    this.handleMolfileInput = this.handleMolfileInput.bind(this);
+    this.molfileFileInput = React.createRef();
     this.handleSampleChanged = this.handleSampleChanged.bind(this);
     this.handleAmountChanged = this.handleAmountChanged.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -254,6 +260,8 @@ export default class SampleDetails extends React.Component {
     this.setState({
       sample,
       smileReadonly,
+      molfile: sample.molfile || '',
+      molfileInput: '',
       loadingMolecule: false,
       isCasLoading: false,
       casInputValue: currentCas,
@@ -299,14 +307,69 @@ export default class SampleDetails extends React.Component {
   }
 
   handleMoleculeBySmile(cas) {
-    const { sample, smilesInput } = this.state;
-    // const casObj = {};
-    MoleculesFetcher.fetchBySmi(smilesInput)
+    const { smilesInput } = this.state;
+    this.createMoleculeFrom(
+      MoleculesFetcher.fetchBySmi(smilesInput),
+      `Cannot create molecule with entered Smiles/CAS! [${smilesInput}]`,
+      cas
+    );
+  }
+
+  handleMolfileUpload(event) {
+    const input = event.target;
+    const file = input.files?.[0];
+    // cleared so re-picking the same file fires change again
+    input.value = '';
+    if (!file) { return; }
+    if (file.size > MAX_MOLFILE_SIZE) {
+      this.notify('Molfile too large', `${file.name} is larger than 5 MB`);
+      return;
+    }
+    file.text()
+      .then((text) => this.handleMolfileInput(text, file.name))
+      .catch(() => this.notify('Error reading file', `Could not read ${file.name}`));
+  }
+
+  handleMolfileInput(text, source) {
+    if (text.length > MAX_MOLFILE_SIZE) {
+      this.notify('Molfile too large', 'That is more than 5 MB of text');
+      return;
+    }
+    const records = text.split(/^\$\$\$\$\s*$/m).filter((record) => record.trim() !== '');
+    this.setState({ molfileInput: records[0] ?? text });
+    if (records.length > 1) {
+      this.notify(
+        'Multiple structures',
+        `${source} holds ${records.length} structures. Only the first was loaded.`,
+        'warning'
+      );
+    }
+  }
+
+  notify(title, message, level = 'error') {
+    this.context.notifications.add({
+      title, message, level, position: 'tc'
+    });
+  }
+
+  handleMoleculeByMolfile() {
+    const { molfileInput, loadingMolecule } = this.state;
+    if (loadingMolecule || molfileProblem(molfileInput)) { return; }
+    this.createMoleculeFrom(
+      MoleculesFetcher.fetchByMolfile(molfileInput),
+      'Cannot create molecule with the entered molfile!'
+    );
+  }
+
+  createMoleculeFrom(request, errorMessage, cas) {
+    const { sample } = this.state;
+    this.setState({ loadingMolecule: true });
+    request
       .then((result) => {
-        if (!result || result == null) {
+        if (!result?.id) {
           this.context.notifications.add({
             title: 'Error on Sample creation',
-            message: `Cannot create molecule with entered Smiles/CAS! [${smilesInput}]`,
+            message: errorMessage,
             level: 'error',
             position: 'tc'
           });
@@ -314,20 +377,26 @@ export default class SampleDetails extends React.Component {
           sample.molfile = result.molfile;
           sample.molecule_id = result.id;
           sample.molecule = result;
-          sample.xref = { ...sample.xref, cas };
+          sample.decoupled = result.inchikey === 'DUMMY';
+          if (cas !== undefined) { sample.xref = { ...sample.xref, cas }; }
           this.setState({
             molfile: result.molfile,
+            molfileInput: '',
             inchiString: result.inchistring,
             quickCreator: true,
             sample,
             smileReadonly: true,
+            showMolfileModal: false,
             pageMessage: result.ob_log
           });
           ElementActions.refreshElements('sample');
         }
-      }).catch((errorMessage) => {
-        console.log(errorMessage);
-      }).finally(() => LoadingActions.stop());
+      }).catch((error) => {
+        console.log(error);
+      }).finally(() => {
+        this.setState({ loadingMolecule: false });
+        LoadingActions.stop();
+      });
   }
 
   handleInventorySample(e) {
@@ -387,6 +456,7 @@ export default class SampleDetails extends React.Component {
 
       this.setState({
         sample,
+        molfile: sample.molfile || '',
         smileReadonly: true,
         pageMessage: result.ob_log,
         loadingMolecule: false
@@ -894,7 +964,7 @@ export default class SampleDetails extends React.Component {
           <Accordion.Body>
             {this.moleculeInchi(sample)}
             {this.moleculeCanoSmiles(sample)}
-            {this.moleculeMolfile(sample)}
+            {this.moleculeMolfile()}
           </Accordion.Body>
         </Accordion.Item>
       </Accordion>
@@ -1247,12 +1317,13 @@ export default class SampleDetails extends React.Component {
 
   moleculeCanoSmiles(sample) {
     const { smileReadonly, smilesInput } = this.state;
+    const shownSmiles = (smileReadonly ? sample.molecule_cano_smiles : smilesInput) || '';
     return (
       <InputGroup className="mb-3">
         <InputGroup.Text>Canonical Smiles</InputGroup.Text>
         <Form.Control
           type="text"
-          value={smileReadonly ? sample.molecule_cano_smiles || '' : smilesInput}
+          value={shownSmiles}
           disabled={smileReadonly}
           readOnly={smileReadonly}
           onChange={(e) => {
@@ -1264,7 +1335,8 @@ export default class SampleDetails extends React.Component {
         <OverlayTrigger placement="bottom" overlay={this.clipboardTooltip()}>
           <Button
             variant="light"
-            onClick={() => copyToClipboard(sample.molecule_cano_smiles || '')}
+            disabled={!shownSmiles}
+            onClick={() => copyToClipboard(shownSmiles)}
           >
             <i className="fa fa-clipboard" />
           </Button>
@@ -1284,21 +1356,28 @@ export default class SampleDetails extends React.Component {
     );
   }
 
-  moleculeMolfile(sample) {
+  moleculeMolfile() {
+    const { smileReadonly, molfile, molfileInput, loadingMolecule } = this.state;
+    const problem = smileReadonly ? null : molfileProblem(molfileInput);
+    const shownMolfile = (smileReadonly ? molfile : molfileInput) || '';
     return (
-      <InputGroup className="mb-3">
+      <InputGroup className="mb-3" hasValidation>
         <InputGroup.Text>Molfile</InputGroup.Text>
         <Form.Control
           as="textarea"
           rows={5}
-          value={this.state.molfile}
-          disabled
-          readOnly
+          placeholder={smileReadonly ? '' : 'Paste a molfile here and save to create the structure'}
+          value={shownMolfile}
+          disabled={smileReadonly}
+          readOnly={smileReadonly}
+          isInvalid={Boolean(problem) && molfileInput.trim() !== ''}
+          onChange={(e) => this.handleMolfileInput(e.target.value, 'What you pasted')}
         />
         <OverlayTrigger placement="bottom" overlay={this.clipboardTooltip()}>
           <Button
             variant="light"
-            onClick={() => copyToClipboard(sample.molfile || '')}
+            disabled={!shownMolfile}
+            onClick={() => copyToClipboard(shownMolfile)}
           >
             <i className="fa fa-clipboard" />
           </Button>
@@ -1309,6 +1388,39 @@ export default class SampleDetails extends React.Component {
         >
           <i className="fa fa-file-text" />
         </Button>
+        <OverlayTrigger
+          placement="bottom"
+          overlay={<Tooltip id="molfile_upload_button">load a .mol / .sdf file</Tooltip>}
+        >
+          <Button
+            variant="light"
+            id="molfile-upload"
+            disabled={smileReadonly}
+            onClick={() => this.molfileFileInput.current?.click()}
+          >
+            <i className="fa fa-upload" />
+          </Button>
+        </OverlayTrigger>
+        <Form.Control
+          type="file"
+          ref={this.molfileFileInput}
+          className="d-none"
+          accept=".mol,.molfile,.sdf"
+          onChange={this.handleMolfileUpload}
+        />
+        <OverlayTrigger placement="bottom" overlay={this.moleculeCreatorTooltip()}>
+          <Button
+            variant="light"
+            id="molfile-create-molecule"
+            disabled={smileReadonly || loadingMolecule || Boolean(problem)}
+            onClick={this.handleMoleculeByMolfile}
+          >
+            <i className="fa fa-save" />
+          </Button>
+        </OverlayTrigger>
+        <Form.Control.Feedback type="invalid">
+          {`This is not a usable molfile: ${problem}.`}
+        </Form.Control.Feedback>
       </InputGroup>
     );
   }
@@ -1486,7 +1598,10 @@ export default class SampleDetails extends React.Component {
   }
 
   renderMolfileModal() {
-    const { molfile, showMolfileModal } = this.state;
+    const {
+      molfile, molfileInput, showMolfileModal, smileReadonly, loadingMolecule
+    } = this.state;
+    const problem = smileReadonly ? null : molfileProblem(molfileInput);
 
     return (
       <AppModal
@@ -1496,15 +1611,24 @@ export default class SampleDetails extends React.Component {
         onHide={this.handleMolfileClose}
         closeLabel="Close"
         showFooter
+        primaryActionLabel={smileReadonly ? undefined : 'Save'}
+        onPrimaryAction={smileReadonly ? undefined : this.handleMoleculeByMolfile}
+        primaryActionDisabled={loadingMolecule || Boolean(problem)}
       >
         <Form.Group controlId="molfileInputModal">
           <Form.Control
             as="textarea"
-            rows={30}
-            readOnly
-            disabled
-            value={molfile}
+            rows={18}
+            placeholder={smileReadonly ? '' : 'Paste a molfile here and save to create the structure'}
+            readOnly={smileReadonly}
+            disabled={smileReadonly}
+            value={smileReadonly ? molfile : molfileInput}
+            isInvalid={Boolean(problem) && molfileInput.trim() !== ''}
+            onChange={(e) => this.handleMolfileInput(e.target.value, 'What you pasted')}
           />
+          <Form.Control.Feedback type="invalid">
+            {`This is not a usable molfile: ${problem}.`}
+          </Form.Control.Feedback>
         </Form.Group>
       </AppModal>
     );

--- a/app/javascript/src/utilities/MolfileValidation.js
+++ b/app/javascript/src/utilities/MolfileValidation.js
@@ -1,0 +1,62 @@
+export const MAX_MOLFILE_SIZE = 5 * 1024 * 1024;
+
+const ATOM_LINE = /^\s*-?\d+\.?\d*\s+-?\d+\.?\d*\s+-?\d+\.?\d*\s+[A-Za-z*][A-Za-z0-9#']*/;
+const COUNTS_LINE = /^[\s\d]{6}/;
+const END_LINE = /^M {2}END\s*$/;
+const V3000_COUNTS = /^M {2}V30 COUNTS (\d+) (\d+)/m;
+const V3000_ATOM_BLOCK = /^M {2}V30 BEGIN ATOM\s*$/m;
+
+// V3000 keeps its real atom and bond counts in an M  V30 COUNTS line, not the counts line.
+const validateV3000 = (text) => {
+  const counts = text.match(V3000_COUNTS);
+  if (!counts) { return 'V3000 file has no COUNTS line'; }
+  if (Number(counts[1]) < 1) { return 'this file holds no atoms'; }
+  if (!V3000_ATOM_BLOCK.test(text)) { return 'V3000 file has no atom block'; }
+  return null;
+};
+
+// Walks the atom block then the bond block, both sized by the counts line.
+const validateV2000 = (lines, atoms, bonds) => {
+  if (atoms < 1) { return 'this file holds no atoms'; }
+
+  const atomLines = lines.slice(4, 4 + atoms);
+  if (atomLines.length < atoms) {
+    return `the counts line promises ${atoms} atoms but only ${atomLines.length} lines follow`;
+  }
+  const badAtom = atomLines.findIndex((line) => !ATOM_LINE.test(line));
+  if (badAtom !== -1) { return `line ${5 + badAtom} is not an atom line`; }
+
+  const bondLines = lines.slice(4 + atoms, 4 + atoms + bonds);
+  if (bondLines.length < bonds) {
+    return `the counts line promises ${bonds} bonds but only ${bondLines.length} lines follow`;
+  }
+  const badBond = bondLines.findIndex((line) => {
+    const from = parseInt(line.slice(0, 3), 10);
+    const to = parseInt(line.slice(3, 6), 10);
+    return !(from >= 1 && from <= atoms && to >= 1 && to <= atoms);
+  });
+  if (badBond !== -1) { return `the bond on line ${5 + atoms + badBond} points at an atom that is not there`; }
+
+  return null;
+};
+
+// Returns a sentence naming the first thing wrong with the text, or null if it is a molfile.
+export const molfileProblem = (text) => {
+  if (!text || !text.trim()) { return 'nothing to read'; }
+
+  const lines = text.split(/\r?\n/);
+  if (lines.length < 5) { return 'too short to be a molfile'; }
+
+  const counts = lines[3];
+  const atoms = parseInt(counts.slice(0, 3), 10);
+  const bonds = parseInt(counts.slice(3, 6), 10);
+  if (!COUNTS_LINE.test(counts) || Number.isNaN(atoms) || Number.isNaN(bonds)) {
+    return 'line 4 should be the counts line - check for extra blank lines at the top';
+  }
+
+  const version = counts.slice(33).trim();
+  if (version && !/^V[23]000$/.test(version)) { return `unknown molfile version "${version}"`; }
+  if (!lines.some((line) => END_LINE.test(line))) { return 'no "M  END" line'; }
+
+  return version === 'V3000' ? validateV3000(text) : validateV2000(lines, atoms, bonds);
+};

--- a/spec/cypress/end_to_end/create_sample_from_molfile.cy.js
+++ b/spec/cypress/end_to_end/create_sample_from_molfile.cy.js
@@ -1,0 +1,50 @@
+describe('Sample Creation from molfile', () => {
+  it('creates sample by pasting a molfile', () => {
+    let moleculeId;
+
+    cy.createDefaultUser('cm1@complat.edu', 'cm1').then((user) => {
+      cy.appFactories([['create', 'collection', { user_id: user[0].id }]]);
+      cy.appFactories([['create', 'molecule']]).then((molecule) => {
+        moleculeId = molecule[0].id;
+      });
+    });
+
+    cy.login('cm1', 'user_password');
+    cy.contains('Collection 1').click();
+    cy.contains('Create').click();
+    cy.contains('Create Sample').click();
+    cy.contains('Chemical identifiers').click();
+    cy.contains('Molfile').siblings('textarea').type(
+      '\n  Ketcher\n\n  1  0  0  0  0  0            999 V2000\n'
+      + '    0.0000    0.0000    0.0000 C   0  0\nM  END',
+      { parseSpecialCharSequences: false }
+    );
+
+    cy.intercept('POST', '**/api/v1/molecules', (req) => {
+      req.reply({
+        statusCode: 200,
+        body: {
+          id: moleculeId,
+          cano_smiles: 'C',
+          inchikey: 'VNWKTOKETHGBQD-UHFFFAOYSA-N',
+          inchistring: 'InChI=1S/CH4/h1H4',
+          iupac_name: 'methane',
+          molecular_weight: 16,
+          sum_formular: 'CH4',
+          molfile: 'DUMMY_MOLFILE',
+          molfile_version: 'V2000',
+          molecule_svg_file: 'dummy.svg',
+          temp_svg: 'dummy.svg',
+          ob_log: ''
+        }
+      });
+    }).as('createMoleculeFromMolfile');
+
+    cy.get('#molfile-create-molecule').click();
+    cy.wait('@createMoleculeFromMolfile');
+    cy.clickDetailFooterButton('Create');
+
+    cy.get('i.icon-sample').closest('button[role="tab"]').click();
+    cy.get('#elements-list-view').contains('cm1-1');
+  });
+});

--- a/spec/javascripts/utils/MolfileValidation.spec.js
+++ b/spec/javascripts/utils/MolfileValidation.spec.js
@@ -1,0 +1,113 @@
+/* eslint-disable no-undef */
+import fs from 'fs';
+import path from 'path';
+import expect from 'expect';
+import { molfileProblem } from '../../../app/javascript/src/utilities/MolfileValidation';
+
+const fixture = (name) => fs.readFileSync(
+  path.join(__dirname, '../../fixtures/structures/molfiles', name),
+  'utf8'
+);
+
+describe('MolfileValidation', () => {
+  const cubane = fixture('cubane.mol');
+  const lines = cubane.split('\n');
+  const corrupt = (index, replacement) => {
+    const copy = lines.slice();
+    copy[index] = replacement;
+    return copy.join('\n');
+  };
+
+  describe('accepts real structures', () => {
+    it('accepts a V2000 molfile', () => {
+      expect(molfileProblem(cubane)).toBeNull();
+    });
+
+    it('accepts Windows line endings', () => {
+      expect(molfileProblem(cubane.replace(/\n/g, '\r\n'))).toBeNull();
+    });
+
+    it('accepts a V3000 molfile', () => {
+      expect(molfileProblem(fixture('multiple_R.mol'))).toBeNull();
+    });
+
+    it('accepts counts over 99, where the columns run together', () => {
+      expect(molfileProblem(fixture('ekowor_uranium.mol'))).toBeNull();
+    });
+
+    it('accepts a single record pulled out of an SDF', () => {
+      expect(molfileProblem(`${cubane}\n$$$$\n`)).toBeNull();
+    });
+
+    it('accepts every molfile fixture in the repo that holds atoms', () => {
+      const dirs = ['structures/molfiles', 'files', '.'];
+      const noStructure = ['pc400.mol'];
+      const rejected = [];
+      dirs.forEach((dir) => {
+        const full = path.join(__dirname, '../../fixtures', dir);
+        fs.readdirSync(full)
+          .filter((name) => name.endsWith('.mol') && !noStructure.includes(name))
+          .forEach((name) => {
+            const problem = molfileProblem(fs.readFileSync(path.join(full, name), 'utf8'));
+            if (problem) { rejected.push(`${dir}/${name}: ${problem}`); }
+          });
+      });
+      expect(rejected).toEqual([]);
+    });
+  });
+
+  describe('rejects anything that is not a structure', () => {
+    const rejected = {
+      'an empty string': '',
+      'whitespace only': '   \n  \n',
+      'a SMILES': 'CCO',
+      'prose ending in M  END': 'Dear team\nthis is a note\nabout nothing\nreally nothing\nM  END',
+      'a CSV': 'name,smiles\nethanol,CCO\nwater,O\nbenzene,c1ccccc1\nM  END',
+      'an HTML page': '<html>\n<head>\n<title>404</title>\n</head>\n<body>M  END</body>\n</html>',
+      'a PubChem error saved as a molfile': 'Status: 400\n OpenBabel\nMessage: failed\n'
+        + '  0  0  0  0  0  0  0  0  0  0999 V2000\nM  END',
+    };
+
+    Object.entries(rejected).forEach(([what, text]) => {
+      it(`rejects ${what}`, () => {
+        expect(molfileProblem(text)).not.toBeNull();
+      });
+    });
+  });
+
+  describe('rejects damaged structures', () => {
+    it('rejects a file with no "M  END"', () => {
+      expect(molfileProblem(cubane.replace(/M {2}END[\s\S]*$/, ''))).toEqual('no "M  END" line');
+    });
+
+    it('rejects an unknown version', () => {
+      expect(molfileProblem(cubane.replace('V2000', 'V9000'))).toEqual('unknown molfile version "V9000"');
+    });
+
+    it('rejects a file cut short mid-structure', () => {
+      expect(molfileProblem(cubane.slice(0, 200))).not.toBeNull();
+    });
+
+    it('rejects fewer atom lines than the counts line promises', () => {
+      expect(molfileProblem(`${lines.slice(0, 7).join('\n')}\nM  END`))
+        .toMatch(/promises 8 atoms/);
+    });
+
+    it('rejects an atom line that is not an atom line', () => {
+      expect(molfileProblem(corrupt(4, 'hello there, not an atom'))).toEqual('line 5 is not an atom line');
+    });
+
+    it('rejects an atom line with no element symbol', () => {
+      expect(molfileProblem(corrupt(4, '   -4.3500    1.8250    0.0000'))).toEqual('line 5 is not an atom line');
+    });
+
+    it('rejects a bond pointing at an atom that does not exist', () => {
+      expect(molfileProblem(corrupt(12, ' 99  3  1  0     0  0'))).toMatch(/points at an atom that is not there/);
+    });
+
+    it('rejects a V3000 file with no COUNTS line', () => {
+      const text = 'x\n y\n\n  0  0  0     0  0              0 V3000\nM  V30 BEGIN CTAB\nM  END';
+      expect(molfileProblem(text)).toEqual('V3000 file has no COUNTS line');
+    });
+  });
+});


### PR DESCRIPTION
Adds an editable Molfile field with save and upload buttons, so a structure can be set without opening Ketcher. Input is checked before sending, and multi-structure files load only the first record.



- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [x] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
