### PR TITLE
fix(analyses): restore single-scroll, advanced-mode toggle, and stable +Dataset button in upload modal

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,7 @@
 
 // file css rules that are targeted at specific components under components
 @import "components/AccountProfile";
+@import "components/AnalysesUpload";
 @import "components/AppModal";
 @import "components/AttachmentList";
 @import "components/ButtonGroupToggleButton";

--- a/app/assets/stylesheets/components/AnalysesUpload.scss
+++ b/app/assets/stylesheets/components/AnalysesUpload.scss
@@ -2,23 +2,27 @@
 //
 // Two fixes that must work together:
 //
-// 1. The analyses ListGroup (right) and the file tree (left) each own a 70vh
-//    scroll region. The modal body must NOT add its own scroll on top, or
-//    scrolling to a lower dataset drags the file list out of view (the original
-//    reported bug). AppModal's shared rule caps .modal-body at 70vh and @extends
-//    the .overflow-y-auto utility (emitted with !important), so both are overridden
-//    here to keep the body from scrolling - the panes are the only scroll regions.
+// 1. The analyses ListGroup (right) and the file tree (left) each own their own
+//    scroll region. The modal body must NOT add a second one on top, or scrolling
+//    to a lower dataset drags the file list - the drag source - out of view (the
+//    original reported bug). AppModal's shared rule caps .modal-body at 70vh and
+//    @extends the .overflow-y-auto utility (emitted with !important), so both are
+//    overridden here. The override is scoped to the advanced view: the simple view
+//    has no inner scroll pane and still wants AppModal's body scroll.
 //
-// 2. Because the body no longer scrolls, an unbounded file tree would instead grow
-//    the whole dialog past the viewport and make .modal the scroll region. Capping
-//    the file tree at the same 70vh as the ListGroup keeps the dialog within the
-//    viewport, so neither the body nor the modal scrolls the file list away.
-.app-modal.analyses-upload-modal .modal-body {
+// 2. Because the body no longer scrolls, the panes must be short enough that the
+//    whole dialog still fits the viewport - otherwise `.modal` (overflow-y: auto)
+//    becomes the scroll region and the same bug returns on any screen where
+//    70vh + chrome > 100vh, i.e. most laptops. The subtracted 20rem is the chrome
+//    around the panes: dialog margins, header, body padding, the help row, the
+//    analyses toolbar and the footer.
+.app-modal.analyses-upload-modal--advanced .modal-body {
   max-height: none;
   overflow-y: visible !important;
 }
 
-.analyses-upload__file-tree {
-  max-height: 70vh;
+.analyses-upload__file-tree,
+.analyses-upload__analyses-list {
+  max-height: calc(100vh - 20rem);
   overflow-y: auto;
 }

--- a/app/assets/stylesheets/components/AnalysesUpload.scss
+++ b/app/assets/stylesheets/components/AnalysesUpload.scss
@@ -1,13 +1,24 @@
-// The "Create Analyses from files or folders" modal manages its own scrolling:
-// in advanced mode the analyses list on the right scrolls inside its own 70vh
-// box, so it is the single scrollbar. The shared AppModal adds a body-level
-// scroll (`.modal-body { max-height: 70vh; overflow-y: auto }`, introduced in
-// PR #3146), which produced a second scroll region and let a long file list
-// drag the file tree out of view. Restore the pre-#3146 behaviour for just
-// this modal so the body never scrolls on its own.
+// "Create Analyses from files or folders" modal, advanced mode.
+//
+// Two fixes that must work together:
+//
+// 1. The analyses ListGroup (right) and the file tree (left) each own a 70vh
+//    scroll region. The modal body must NOT add its own scroll on top, or
+//    scrolling to a lower dataset drags the file list out of view (the original
+//    reported bug). AppModal's shared rule caps .modal-body at 70vh and @extends
+//    the .overflow-y-auto utility (emitted with !important), so both are overridden
+//    here to keep the body from scrolling - the panes are the only scroll regions.
+//
+// 2. Because the body no longer scrolls, an unbounded file tree would instead grow
+//    the whole dialog past the viewport and make .modal the scroll region. Capping
+//    the file tree at the same 70vh as the ListGroup keeps the dialog within the
+//    viewport, so neither the body nor the modal scrolls the file list away.
 .app-modal.analyses-upload-modal .modal-body {
   max-height: none;
-  // `!important` is required: AppModal's body `@extend`s the `.overflow-y-auto`
-  // utility, which Bootstrap emits with `!important`.
   overflow-y: visible !important;
+}
+
+.analyses-upload__file-tree {
+  max-height: 70vh;
+  overflow-y: auto;
 }

--- a/app/assets/stylesheets/components/AnalysesUpload.scss
+++ b/app/assets/stylesheets/components/AnalysesUpload.scss
@@ -1,0 +1,13 @@
+// The "Create Analyses from files or folders" modal manages its own scrolling:
+// in advanced mode the analyses list on the right scrolls inside its own 70vh
+// box, so it is the single scrollbar. The shared AppModal adds a body-level
+// scroll (`.modal-body { max-height: 70vh; overflow-y: auto }`, introduced in
+// PR #3146), which produced a second scroll region and let a long file list
+// drag the file tree out of view. Restore the pre-#3146 behaviour for just
+// this modal so the body never scrolls on its own.
+.app-modal.analyses-upload-modal .modal-body {
+  max-height: none;
+  // `!important` is required: AppModal's body `@extend`s the `.overflow-y-auto`
+  // utility, which Bootstrap emits with `!important`.
+  overflow-y: visible !important;
+}

--- a/app/javascript/src/apps/mydb/elements/details/analyses/AdvancedComponents.js
+++ b/app/javascript/src/apps/mydb/elements/details/analyses/AdvancedComponents.js
@@ -1,7 +1,7 @@
 import {
   ListGroup, Button, ButtonToolbar, Form
 } from 'react-bootstrap';
-import React, { useState, useCallback } from 'react';
+import React, { useCallback } from 'react';
 
 import { DatasetDropZone } from 'src/apps/mydb/elements/details/analyses/GeneralComponents';
 import { FileContainer, ZipFileContainer } from 'src/apps/mydb/elements/details/analyses/FileManager';
@@ -180,9 +180,8 @@ DatasetListItem.propTypes = {
 };
 
 function AdvancedAnalysesList({
-  handleClose, setConsumedPaths, listedFiles, setElement
+  handleClose, setConsumedPaths, listedFiles, setElement, analContainerList, setAnalContainer
 }) {
-  const [analContainerList, setAnalContainer] = useState([]);
   const wrapperSetAnaContainer = (val) => {
     const changedVal = typeof val === 'function' ? val(analContainerList) : val;
     setAnalContainer(changedVal);
@@ -343,6 +342,8 @@ AdvancedAnalysesList.propTypes = {
   handleClose: PropTypes.func.isRequired,
   setConsumedPaths: PropTypes.func.isRequired,
   listedFiles: PropTypes.arrayOf(FileContainer).isRequired,
+  analContainerList: PropTypes.arrayOf(PropTypes.instanceOf(ContainerWrapper)).isRequired,
+  setAnalContainer: PropTypes.func.isRequired,
   setElement: PropTypes.func.isRequired
 };
 

--- a/app/javascript/src/apps/mydb/elements/details/analyses/AdvancedComponents.js
+++ b/app/javascript/src/apps/mydb/elements/details/analyses/AdvancedComponents.js
@@ -8,7 +8,7 @@ import { FileContainer, ZipFileContainer } from 'src/apps/mydb/elements/details/
 import ElementContainer from 'src/models/Container';
 import { addNewAnalyses, createDataset, createAttachements } from 'src/apps/mydb/elements/details/analyses/utils';
 import PropTypes from 'prop-types';
-import OlsTreeSelect from '../../../../../components/OlsComponent';
+import OlsTreeSelect from 'src/components/OlsComponent';
 
 class ContainerWrapper {
   static newWrapper(name = 'New', kind = '') {
@@ -182,24 +182,28 @@ DatasetListItem.propTypes = {
 function AdvancedAnalysesList({
   handleClose, setConsumedPaths, listedFiles, setElement, analContainerList, setAnalContainer
 }) {
-  const wrapperSetAnaContainer = (val) => {
+  // Recreated whenever the list changes, so every callback below must depend on it -
+  // memoising them on [] would freeze the first render's `analContainerList` and make
+  // e.g. "Remove Analysis" filter an empty snapshot, wiping the whole list.
+  const wrapperSetAnaContainer = useCallback((val) => {
     const changedVal = typeof val === 'function' ? val(analContainerList) : val;
     setAnalContainer(changedVal);
     setConsumedPaths(changedVal.map((ana) => ana.children.map((ds) => ds.files)).flat(Infinity));
-  };
+  }, [analContainerList, setAnalContainer, setConsumedPaths]);
+
   const addAnalyses = useCallback(() => {
     const newWrapper = ContainerWrapper.newWrapper();
     newWrapper.children.push(ContainerWrapper.newWrapper('Dataset #1'));
     wrapperSetAnaContainer((x) => [...x, newWrapper]);
-  }, [analContainerList]);
+  }, [wrapperSetAnaContainer]);
 
   const emptyAnalyses = useCallback(() => {
     wrapperSetAnaContainer(() => []);
-  }, []);
+  }, [wrapperSetAnaContainer]);
 
   const removeContainer = useCallback((toRemoveId) => {
     wrapperSetAnaContainer((x) => x.filter((container) => container.id !== toRemoveId));
-  }, []);
+  }, [wrapperSetAnaContainer]);
 
   const execute = useCallback(() => {
     setElement((element) => {
@@ -261,7 +265,9 @@ function AdvancedAnalysesList({
         return { anaContainer, newDsObj };
       });
 
-      preprocessAnaContainer.forEach(({ newDsObj }) => {
+      // `preprocessAnaContainer` holds a null for every analysis whose datasets are all
+      // empty; Execute is enabled in exactly that state, so they must be dropped here.
+      preprocessAnaContainer.filter(Boolean).forEach(({ newDsObj }) => {
         newDsObj.forEach(async ({ datasetContainer, fileObjs }) => {
           let file = null;
 
@@ -279,7 +285,7 @@ function AdvancedAnalysesList({
       return element;
     });
     handleClose();
-  }, [analContainerList]);
+  }, [analContainerList, listedFiles, setElement, handleClose]);
 
   return (
     <>
@@ -300,12 +306,7 @@ function AdvancedAnalysesList({
           Reset
         </Button>
       </ButtonToolbar>
-      <ListGroup
-        style={{
-          maxHeight: '70vh',
-          overflowY: 'auto',
-        }}
-      >
+      <ListGroup className="analyses-upload__analyses-list">
         {analContainerList.map((anaContainer, index) => {
           const setContainer = (changedX) => {
             wrapperSetAnaContainer((x) => {

--- a/app/javascript/src/apps/mydb/elements/details/analyses/GeneralComponents.js
+++ b/app/javascript/src/apps/mydb/elements/details/analyses/GeneralComponents.js
@@ -58,7 +58,7 @@ const TreeNode = ({ node }) => {
 };
 
 const FileTree = ({ treeData }) => (
-  <ul style={{ overflow: 'auto' }}>
+  <ul className="analyses-upload__file-tree">
     {treeData.map((node, idx) => (
       <TreeNode key={idx} node={node} />
     ))}

--- a/app/javascript/src/apps/mydb/elements/details/analyses/GeneralComponents.js
+++ b/app/javascript/src/apps/mydb/elements/details/analyses/GeneralComponents.js
@@ -1,7 +1,10 @@
 import React, { useCallback, useState } from 'react';
+import PropTypes from 'prop-types';
 import { Button, Form } from 'react-bootstrap';
 
-const ToggleSwitch = ({ isChecked, setIsChecked, label }) => {
+const ToggleSwitch = ({
+  isChecked, setIsChecked, label, disabled = false
+}) => {
   const handleChange = useCallback(() => {
     setIsChecked(!isChecked);
   }, [isChecked, setIsChecked]);
@@ -13,10 +16,18 @@ const ToggleSwitch = ({ isChecked, setIsChecked, label }) => {
         id="custom-switch"
         label={label}
         checked={isChecked}
+        disabled={disabled}
         onChange={handleChange}
       />
     </Form>
   );
+};
+
+ToggleSwitch.propTypes = {
+  isChecked: PropTypes.bool.isRequired,
+  setIsChecked: PropTypes.func.isRequired,
+  label: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
 };
 
 const TreeNode = ({ node }) => {

--- a/app/javascript/src/apps/mydb/elements/details/analyses/UploadField.js
+++ b/app/javascript/src/apps/mydb/elements/details/analyses/UploadField.js
@@ -18,6 +18,7 @@ import {
 import { FileTree, ToggleSwitch } from 'src/apps/mydb/elements/details/analyses/GeneralComponents';
 import { AdvancedAnalysesList } from 'src/apps/mydb/elements/details/analyses/AdvancedComponents';
 import AppModal from 'src/components/common/AppModal';
+import ChevronIcon from 'src/components/common/ChevronIcon';
 import OlsTreeSelect from 'src/components/OlsComponent';
 
 async function handleZipFile(zipFile) {
@@ -289,6 +290,8 @@ const UploadField = ({ disabled = false, element, setElement }) => {
   const handleClose = useCallback(() => {
     setListedFiles([]);
     setAnalContainer([]);
+    setIsAdvanced(false);
+    setShowAdvancedHelp(false);
     setShow(false);
   }, []);
   const handleShow = useCallback(() => setShow(true), []);
@@ -337,7 +340,7 @@ const UploadField = ({ disabled = false, element, setElement }) => {
                 aria-controls="advanced-mode-help"
                 onClick={() => setShowAdvancedHelp((prev) => !prev)}
               >
-                <i className={`fa me-1 ${showAdvancedHelp ? 'fa-caret-down' : 'fa-caret-right'}`} />
+                <ChevronIcon direction={showAdvancedHelp ? 'down' : 'right'} className="me-1" />
                 How does advanced mode work?
               </Button>
               <Collapse in={showAdvancedHelp}>

--- a/app/javascript/src/apps/mydb/elements/details/analyses/UploadField.js
+++ b/app/javascript/src/apps/mydb/elements/details/analyses/UploadField.js
@@ -367,16 +367,6 @@ const UploadField = ({ disabled = false, element, setElement }) => {
     }
     return (
       <Container>
-        <Row className="justify-content-end mb-2">
-          <Col xs="auto">
-            <ToggleSwitch
-              disabled={listedFiles.length === 0}
-              isChecked={isAdvanced}
-              setIsChecked={setIsAdvanced}
-              label="Advanced mode"
-            />
-          </Col>
-        </Row>
         <Row>
           <Col>
             <p>
@@ -443,6 +433,14 @@ const UploadField = ({ disabled = false, element, setElement }) => {
         className="analyses-upload-modal"
         centered={false}
         title="Create Analyses from files or folders"
+        extendedFooter={(
+          <ToggleSwitch
+            disabled={listedFiles.length === 0}
+            isChecked={isAdvanced}
+            setIsChecked={setIsAdvanced}
+            label="Advanced mode"
+          />
+        )}
       >
         {content()}
       </AppModal>

--- a/app/javascript/src/apps/mydb/elements/details/analyses/UploadField.js
+++ b/app/javascript/src/apps/mydb/elements/details/analyses/UploadField.js
@@ -282,8 +282,13 @@ const UploadField = ({ disabled = false, element, setElement }) => {
   const [isAdvanced, setIsAdvanced] = useState(false);
   const [showAdvancedHelp, setShowAdvancedHelp] = useState(false);
   const [listedFiles, setListedFiles] = useState([]);
+  // Advanced-mode analyses live here, not inside AdvancedAnalysesList, so toggling
+  // Advanced mode off (which unmounts that component) does not destroy the user's
+  // configured analyses and datasets.
+  const [analContainerList, setAnalContainer] = useState([]);
   const handleClose = useCallback(() => {
     setListedFiles([]);
+    setAnalContainer([]);
     setShow(false);
   }, []);
   const handleShow = useCallback(() => setShow(true), []);
@@ -357,6 +362,8 @@ const UploadField = ({ disabled = false, element, setElement }) => {
               <AdvancedAnalysesList
                 handleClose={handleClose}
                 listedFiles={listedFiles}
+                analContainerList={analContainerList}
+                setAnalContainer={setAnalContainer}
                 setConsumedPaths={handleSetConsumedPaths}
                 setElement={wrappedSetElement}
               />

--- a/app/javascript/src/apps/mydb/elements/details/analyses/UploadField.js
+++ b/app/javascript/src/apps/mydb/elements/details/analyses/UploadField.js
@@ -297,10 +297,15 @@ const UploadField = ({ disabled = false, element, setElement }) => {
   const handleShow = useCallback(() => setShow(true), []);
 
   const handleChange = useCallback((items) => {
+    // A new selection replaces `listedFiles`, so any advanced-mode analyses built from
+    // the previous selection now hold dataset paths that no longer resolve - executing
+    // them would walk into an unrelated (or missing) file container.
+    setAnalContainer([]);
+
     if (items.length === 1) {
       if (items[0].isFile) {
         createAnalsesForSingelFiles(element, [items[0].file], items[0].name, ontology);
-        setShow(false);
+        handleClose();
         setElement(element, () => {
         });
 
@@ -313,7 +318,7 @@ const UploadField = ({ disabled = false, element, setElement }) => {
     }
 
     setListedFiles(items);
-  }, [ontology]);
+  }, [ontology, handleClose]);
 
   const handlesSetOntology = useCallback((ev) => {
     let kind = (ev || '');
@@ -327,8 +332,10 @@ const UploadField = ({ disabled = false, element, setElement }) => {
     setConsumedPaths(paths);
   }, [listedFiles]);
 
+  const isAdvancedView = isAdvanced && listedFiles.length > 0;
+
   const content = () => {
-    if (isAdvanced && listedFiles.length > 0) {
+    if (isAdvancedView) {
       return (
         <Container>
           <Row className="mb-2">
@@ -440,7 +447,7 @@ const UploadField = ({ disabled = false, element, setElement }) => {
         size="xl"
         show={show}
         onHide={handleClose}
-        className="analyses-upload-modal"
+        className={`analyses-upload-modal${isAdvancedView ? ' analyses-upload-modal--advanced' : ''}`}
         centered={false}
         title="Create Analyses from files or folders"
         extendedFooter={(

--- a/app/javascript/src/apps/mydb/elements/details/analyses/UploadField.js
+++ b/app/javascript/src/apps/mydb/elements/details/analyses/UploadField.js
@@ -19,6 +19,7 @@ import { FileTree, ToggleSwitch } from 'src/apps/mydb/elements/details/analyses/
 import { AdvancedAnalysesList } from 'src/apps/mydb/elements/details/analyses/AdvancedComponents';
 import AppModal from 'src/components/common/AppModal';
 import ChevronIcon from 'src/components/common/ChevronIcon';
+import ConfirmModal from 'src/components/common/ConfirmModal';
 import OlsTreeSelect from 'src/components/OlsComponent';
 
 async function handleZipFile(zipFile) {
@@ -287,19 +288,22 @@ const UploadField = ({ disabled = false, element, setElement }) => {
   // Advanced mode off (which unmounts that component) does not destroy the user's
   // configured analyses and datasets.
   const [analContainerList, setAnalContainer] = useState([]);
+  // A file selection held back while the user confirms discarding the analyses above.
+  const [pendingSelection, setPendingSelection] = useState(null);
   const handleClose = useCallback(() => {
     setListedFiles([]);
     setAnalContainer([]);
+    setPendingSelection(null);
     setIsAdvanced(false);
     setShowAdvancedHelp(false);
     setShow(false);
   }, []);
   const handleShow = useCallback(() => setShow(true), []);
 
-  const handleChange = useCallback((items) => {
-    // A new selection replaces `listedFiles`, so any advanced-mode analyses built from
-    // the previous selection now hold dataset paths that no longer resolve - executing
-    // them would walk into an unrelated (or missing) file container.
+  // A new selection replaces `listedFiles`, so any advanced-mode analyses built from the
+  // previous selection now hold dataset paths that no longer resolve - executing them
+  // would walk into an unrelated (or missing) file container. They have to go.
+  const applySelection = useCallback((items) => {
     setAnalContainer([]);
 
     if (items.length === 1) {
@@ -318,7 +322,26 @@ const UploadField = ({ disabled = false, element, setElement }) => {
     }
 
     setListedFiles(items);
-  }, [ontology, handleClose]);
+  }, [element, ontology, handleClose, setElement]);
+
+  // Discarding configured analyses is not something to do behind the user's back, so a
+  // non-empty list parks the new selection until they confirm.
+  const handleChange = useCallback((items) => {
+    if (analContainerList.length > 0) {
+      setPendingSelection(items);
+      return;
+    }
+
+    applySelection(items);
+  }, [analContainerList, applySelection]);
+
+  const handleDiscardConfirmation = useCallback((confirmed) => {
+    if (confirmed && pendingSelection) {
+      applySelection(pendingSelection);
+    }
+
+    setPendingSelection(null);
+  }, [pendingSelection, applySelection]);
 
   const handlesSetOntology = useCallback((ev) => {
     let kind = (ev || '');
@@ -461,6 +484,20 @@ const UploadField = ({ disabled = false, element, setElement }) => {
       >
         {content()}
       </AppModal>
+
+      <ConfirmModal
+        showModal={pendingSelection !== null}
+        onClick={handleDiscardConfirmation}
+        title="Discard the analyses you configured?"
+        content={(
+          <p>
+            {`You have ${analContainerList.length} `}
+            {analContainerList.length === 1 ? 'analysis' : 'analyses'}
+            {' set up in advanced mode. They reference the files you selected before, so'}
+            {' choosing a new selection discards them. This cannot be undone.'}
+          </p>
+        )}
+      />
     </>
   );
 };

--- a/app/javascript/src/apps/mydb/elements/details/analyses/UploadField.js
+++ b/app/javascript/src/apps/mydb/elements/details/analyses/UploadField.js
@@ -3,7 +3,7 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import {
-  OverlayTrigger, Button, Container, Row, Col, ListGroup, Badge, Tooltip
+  OverlayTrigger, Button, Container, Row, Col, ListGroup, Badge, Tooltip, Collapse
 } from 'react-bootstrap';
 import JSZip from 'jszip';
 import {
@@ -280,6 +280,7 @@ const UploadField = ({ disabled = false, element, setElement }) => {
   const [show, setShow] = useState(false);
   const [ontology, setOntology] = useState('');
   const [isAdvanced, setIsAdvanced] = useState(false);
+  const [showAdvancedHelp, setShowAdvancedHelp] = useState(false);
   const [listedFiles, setListedFiles] = useState([]);
   const handleClose = useCallback(() => {
     setListedFiles([]);
@@ -322,16 +323,30 @@ const UploadField = ({ disabled = false, element, setElement }) => {
     if (isAdvanced && listedFiles.length > 0) {
       return (
         <Container>
-          <Row>
+          <Row className="mb-2">
             <Col>
-              <p>
-                Add and name new analyses with as many datasets as needed.
-                Drag and drop files or folders from the file list on the left-hand side into the datasets.
-                Folder can be expanded to see their contents, and files can be selected individually.
-                Multiple files and/or folders in a dataset will be zipped together.
-                A single file in a dataset is uploaded as it is.
-                Do not forget to press Execute to apply your settings.
-              </p>
+              <Button
+                variant="link"
+                className="p-0"
+                aria-expanded={showAdvancedHelp}
+                aria-controls="advanced-mode-help"
+                onClick={() => setShowAdvancedHelp((prev) => !prev)}
+              >
+                <i className={`fa me-1 ${showAdvancedHelp ? 'fa-caret-down' : 'fa-caret-right'}`} />
+                How does advanced mode work?
+              </Button>
+              <Collapse in={showAdvancedHelp}>
+                <div id="advanced-mode-help">
+                  <p className="mt-2">
+                    Add and name new analyses with as many datasets as needed.
+                    Drag and drop files or folders from the file list on the left-hand side into the datasets.
+                    Folders can be expanded to see their contents, and files can be selected individually.
+                    Multiple files and/or folders in a dataset will be zipped together.
+                    A single file in a dataset is uploaded as it is.
+                    Do not forget to press Execute to apply your settings.
+                  </p>
+                </div>
+              </Collapse>
             </Col>
           </Row>
           <Row className="justify-content-md-center">
@@ -425,6 +440,8 @@ const UploadField = ({ disabled = false, element, setElement }) => {
         size="xl"
         show={show}
         onHide={handleClose}
+        className="analyses-upload-modal"
+        centered={false}
         title="Create Analyses from files or folders"
       >
         {content()}


### PR DESCRIPTION
## Summary

Fixes three UX regressions in the **"Create Analyses from files or folders"** modal
(advanced mode), all introduced when the modal was migrated to the shared `AppModal`
in #3146 ("Consolidate design for modals"). Each is fixed **scoped to this modal only** —
the shared `AppModal` component and its stylesheet are untouched, so no other modal
changes behaviour.



## Regressions fixed

1. **Double scrollbar / file list scrolls out of view.**
   `AppModal` puts `max-height: 70vh; overflow-y: auto` on `.modal-body`, adding a second
   scroll region on top of the analyses list's own `70vh` scroll. With a long file list the
   body itself scrolled and dragged the file tree (the drag source) off the top.
   Pre-#3146 the modal body had no scroll, so the analyses list was the single scrollbar.
   → Restored that for this modal via a scoped `.app-modal.analyses-upload-modal .modal-body`
   override (new `AnalysesUpload.scss`).

2. **"Advanced mode" toggle disappeared in advanced view.**
   Pre-#3146 the toggle lived in `<Modal.Footer>`, visible in both modes. The migration
   moved it into `content()`'s simple-view branch, so it vanished once advanced mode was on —
   leaving no way to switch back.
   → Moved it back to the footer via `AppModal`'s `extendedFooter`, visible in both modes.

3. **"+" (add dataset) button jumped away from the cursor on click.**
   `AppModal` defaults to `centered: true`; a vertically-centered modal re-centers as its
   content grows, so adding a dataset shifted the whole dialog upward and the "+" button
   slid out from under the mouse. Pre-#3146 the modal was top-anchored (not centered).
   → Set `centered={false}` on this modal so it grows downward and the button stays put.

## Minor UX

- Advanced-mode help text is now collapsible ("How does advanced mode work?"), with a little
  spacing below it, to reclaim vertical space.

## Testing

1. Open a reaction/sample → **Analyses from upload** → drop in many files → enable **Advanced mode**.
2. Add 5+ analyses/datasets and scroll: only the analyses pane scrolls; the file list stays put.
3. The **Advanced mode** toggle is visible in both simple and advanced views.
4. Click **+** beside *Datasets* repeatedly: the button stays under the cursor.