### PR TITLE
fix(collections): show shared collections in Assign to Collection modal

### DIFF
--- a/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionActions.js
+++ b/app/javascript/src/apps/mydb/elements/list/selectionActions/SelectionActions.js
@@ -152,7 +152,7 @@ export default class SelectionActions extends React.Component {
         return <SelectionTransferModal
           title="Assign to Collection"
           action="assign"
-          withShared={false}
+          withShared={true}
           withRepository={true}
           onHide={this.hideModal}
         />;


### PR DESCRIPTION
Assign to Collection only listed the user's own collections, while Move to Collection also listed collections shared with the user (filtered by the same AddElements permission level). Align Assign with Move so both present shared collections consistently.
