### PR TITLE
fix(import): ignore empty PolymersList tags and stop corrupting molfile headers

### DIFF
--- a/app/api/chemotion/molecule_api.rb
+++ b/app/api/chemotion/molecule_api.rb
@@ -250,8 +250,11 @@ module Chemotion
           svg = KetcherService::SVGProcessor.clean_and_trim_svg(svg) || svg
           svg_process = SVG::Processor.new.structure_svg('ketcher_epam', svg, svg_digest, true)
         else
-          # Molfile has PolymersList tag -> use Indigo first; else Ketcher first; fallback to OpenBabel.
-          svg_service = Chemotion::SvgRenderer.has_polymers_list_tag?(molfile) ? 'indigo' : 'ketcher'
+          # Molfile has an actual PolymersList payload -> use Indigo first; else Ketcher first; fallback to OpenBabel.
+          # NB: has_polymer_content? (not has_polymers_list_tag?) -- Ketcher also emits an empty
+          # "> <PolymersList>" tag for ordinary, non-polymer structures, which must not be forced
+          # through Indigo with polymer-specific rendering options.
+          svg_service = Chemotion::MolfilePolymerSupport.has_polymer_content?(molfile) ? 'indigo' : 'ketcher'
           svg = Molecule.svg_reprocess(nil, molfile, service: svg_service)
           return error!('Failed to generate SVG from molfile', 422) if svg.blank?
 

--- a/lib/chemotion/molfile_polymer_support.rb
+++ b/lib/chemotion/molfile_polymer_support.rb
@@ -8,55 +8,142 @@ module Chemotion
     TEXT_NODE_TAG = '> <TextNode>'
     TEXT_NODE_CLOSE_TAG = '> </TextNode>'
     M_END_MARKER = 'M  END'
+    # An SDF data block ends at the next data header ("> <Tag>"), at the record separator, or --
+    # for the malformed-but-real legacy layout described in .data_block_body -- at "M  END".
+    SDF_DATA_HEADER_PREFIX = '> <'
+    SDF_RECORD_SEPARATOR = '$$$$'
 
     module_function
 
     # rubocop:disable Naming/PredicatePrefix
     def has_polymers_list_tag?(molfile)
-      return false if molfile.blank?
+      return false if molfile.nil?
 
-      molfile.to_s.include?(POLYMERS_LIST_TAG)
+      # Scrub before the substring check: molfile.blank? (used prior to this guard) is a regex
+      # match under the hood and raises ArgumentError on non-UTF-8 bytes -- see #to_utf8.
+      to_utf8(molfile).include?(POLYMERS_LIST_TAG)
     end
 
     def has_text_node_tag?(molfile)
-      return false if molfile.blank?
+      return false if molfile.nil?
 
-      molfile.to_s.include?(TEXT_NODE_TAG)
+      to_utf8(molfile).include?(TEXT_NODE_TAG)
     end
 
     def has_polymer_or_textnode_blocks?(molfile)
       has_polymers_list_tag?(molfile) || has_text_node_tag?(molfile)
     end
 
+    # True only when a PolymersList block carries a payload. Ketcher writes an empty
+    # "> <PolymersList>" block for structures that have no polymer at all; those must take the
+    # ordinary molecule path, not the polymer one (which would give them a synthetic
+    # POLYMER_<sha> inchikey and an Indigo-rendered SVG).
+    #
+    # @param molfile [String, nil]
+    # @return [Boolean]
     def has_polymer_content?(molfile)
       polymers_list_payload(molfile).present?
     end
     # rubocop:enable Naming/PredicatePrefix
 
+    # Body of the molfile's "> <PolymersList>" block(s), flattened to a single space-joined line.
+    #
+    # Every block is scanned, because a molfile can carry a redundant indices-only block
+    # ("0 1 2") followed by the full-format one ("0/95/1.00-1.00"); the full-format block wins so
+    # callers get the template ids. A block ends at the next SDF data header or at +$$$$+ — not at
+    # end-of-string — so a following "> <TextNode>" block is never mistaken for polymer payload.
+    #
+    # @param molfile [String, nil]
+    # @return [String] the payload, or +''+ when there is no block or every block is empty
     def polymers_list_payload(molfile)
-      return nil if molfile.blank?
+      blocks = polymers_list_blocks(molfile)
+      return '' if blocks.empty?
 
-      body = molfile.to_s.dup.force_encoding('UTF-8')[
-        />\s*<\s*PolymersList\s*>[^\S\n]*\n([\s\S]*?)(?=\n\s*>\s*<\s|\z)/i, 1
-      ]
-      return nil if body.nil?
-
-      body.lines.map(&:strip).reject { |line| line.empty? || line == '$$$$' }.join(' ').presence
+      blocks.find { |content| content.include?('/') } || blocks.first
     end
 
-    def normalize_for_open_babel(molfile)
-      return molfile if molfile.blank?
+    # @param molfile [String, nil]
+    # @return [Array<String>] one space-joined payload per non-empty "> <PolymersList>" block
+    def polymers_list_blocks(molfile)
+      return [] if molfile.nil?
 
-      molfile = molfile.to_s
+      # No String#blank? on the raw argument: ActiveSupport's implementation is a regex match and
+      # raises ArgumentError on a molfile carrying non-UTF-8 bytes. #to_utf8 scrubs first.
+      lines = to_utf8(molfile).lines
+      lines.each_index.with_object([]) do |index, blocks|
+        next unless lines[index].strip == POLYMERS_LIST_TAG
+
+        content = data_block_body(lines, index)
+        blocks << content unless content.empty?
+      end
+    end
+
+    # Collects the payload lines that follow the data header at +header_index+.
+    #
+    # Terminates on "M  END" as well as on the next data header / "$$$$". A well-formed SDF never
+    # needs that: data blocks follow the CTAB, so "M  END" is already behind us. But ketcher-rails
+    # (2016-2024) wrote "> <PolymersList>" *inside* the CTAB, ahead of "M  END", and ~130 such
+    # samples are still stored. Without this guard the marker is swallowed into the payload
+    # ("0" becomes "0 M  END"), and -- worse -- an *empty* legacy block yields the payload
+    # "M  END", which is +present?+ and so makes .has_polymer_content? report a polymer for an
+    # ordinary molecule: exactly the false positive this module exists to prevent.
+    #
+    # @param lines [Array<String>] all molfile lines
+    # @param header_index [Integer] index of the "> <Tag>" line
+    # @return [String] space-joined, blank-stripped payload (+''+ when the block is empty)
+    def data_block_body(lines, header_index)
+      body = []
+      lines[(header_index + 1)..].to_a.each do |raw|
+        line = raw.strip
+        break if data_block_terminator?(line)
+
+        body << line unless line.empty?
+      end
+      body.join(' ')
+    end
+
+    # @param line [String] an already-stripped molfile line
+    # @return [Boolean] whether the line ends the data block that precedes it
+    def data_block_terminator?(line)
+      line.start_with?(SDF_DATA_HEADER_PREFIX) ||
+        line == SDF_RECORD_SEPARATOR ||
+        # Loose match, matching #keep_only_ctab: writers vary the inner spacing of "M  END".
+        line.match?(/\AM\s+END\z/i)
+    end
+
+    # Appends the trailing newline Open Babel needs. Deliberately does NOT touch the front of the
+    # molfile: MOL is positional, line 1 is the title and may legitimately be empty, so callers
+    # must preserve a leading newline rather than have it re-added here. Prepending
+    # unconditionally shifts a *titled* molfile ("benzene\\n  Mrv…") down one line and Open Babel
+    # then returns a blank inchikey — see +ImportSamples#get_data_from_molfile+, which +rstrip+s
+    # (not +strip+s) its input for exactly this reason.
+    #
+    # @param molfile [String, nil]
+    # @return [String] the padded molfile, never nil
+    def normalize_for_open_babel(molfile)
+      # Scrub before the blank? check: ActiveSupport's #blank? is a regex match and raises
+      # ArgumentError on non-UTF-8 bytes (see #to_utf8) -- this method's own callers are not all
+      # guaranteed to have scrubbed already.
+      molfile = to_utf8(molfile)
+      return "\n" if molfile.blank?
+
       molfile.end_with?("\n") ? molfile : "#{molfile}\n"
     end
 
     # Strip PolymersList and TextNode blocks, then keep only CTAB (up to and including M  END).
     # Use for Open Babel / inchikey so it does not see custom blocks.
     def clean_molfile_for_inchikey(raw_molfile)
-      return nil if raw_molfile.blank?
+      return nil if raw_molfile.nil?
 
-      s = raw_molfile.to_s.dup.force_encoding('UTF-8')
+      # Scrub before the blank? check: ActiveSupport's #blank? raises ArgumentError on non-UTF-8
+      # bytes (see #to_utf8) -- checking on the raw argument would reintroduce that crash here.
+      s = to_utf8(raw_molfile)
+      return nil if s.blank?
+
+      # NB: the `<\s` in the lookahead is deliberate — it does not match a following `> <Tag>`
+      # header, so each block is deleted through to end-of-string. That is what this method wants
+      # (only the CTAB survives #keep_only_ctab anyway), unlike .polymers_list_payload, which has
+      # to stop at the next header.
       s = s.gsub(/>\s*<\s*PolymersList\s*>[\s\S]*?(?=\n\s*>\s*<\s|\z)/i, '')
       s = s.gsub(/>\s*<\s*TextNode\s*>[\s\S]*?(?=\n\s*>\s*<\s|\z)/i, '')
       keep_only_ctab(s)
@@ -64,9 +151,13 @@ module Chemotion
 
     # Keep only the CTAB (up to and including first M  END). Safe for Open Babel.
     def keep_only_ctab(molfile)
+      return molfile if molfile.nil?
+
+      # Scrub before the blank? check: ActiveSupport's #blank? raises ArgumentError on non-UTF-8
+      # bytes (see #to_utf8) -- this is on the hot path for every plain (non-polymer) import row.
+      molfile = to_utf8(molfile)
       return molfile if molfile.blank?
 
-      molfile = molfile.to_s.dup.force_encoding('UTF-8')
       lines = molfile.lines
       m_end_index = lines.index { |line| line.match?(/\s*M\s+END\s*/i) }
       if m_end_index
@@ -77,6 +168,17 @@ module Chemotion
       else
         molfile
       end
+    end
+
+    # Import sources (Excel round-trips, mis-detected SDF encodings) hand us bytes that are not
+    # valid UTF-8. A bare +force_encoding+ leaves the string invalid and every subsequent regex or
+    # +String#match?+ over it raises ArgumentError, taking the whole import down; +scrub+ replaces
+    # the offending bytes instead. Always returns a fresh, unfrozen string.
+    #
+    # @param molfile [#to_s]
+    # @return [String] UTF-8, valid-encoding copy
+    def to_utf8(molfile)
+      molfile.to_s.dup.force_encoding('UTF-8').scrub
     end
   end
 end

--- a/lib/chemotion/molfile_polymer_support.rb
+++ b/lib/chemotion/molfile_polymer_support.rb
@@ -27,14 +27,36 @@ module Chemotion
     def has_polymer_or_textnode_blocks?(molfile)
       has_polymers_list_tag?(molfile) || has_text_node_tag?(molfile)
     end
+
+    def has_polymer_content?(molfile)
+      polymers_list_payload(molfile).present?
+    end
     # rubocop:enable Naming/PredicatePrefix
+
+    def polymers_list_payload(molfile)
+      return nil if molfile.blank?
+
+      body = molfile.to_s.dup.force_encoding('UTF-8')[
+        />\s*<\s*PolymersList\s*>[^\S\n]*\n([\s\S]*?)(?=\n\s*>\s*<\s|\z)/i, 1
+      ]
+      return nil if body.nil?
+
+      body.lines.map(&:strip).reject { |line| line.empty? || line == '$$$$' }.join(' ').presence
+    end
+
+    def normalize_for_open_babel(molfile)
+      return molfile if molfile.blank?
+
+      molfile = molfile.to_s
+      molfile.end_with?("\n") ? molfile : "#{molfile}\n"
+    end
 
     # Strip PolymersList and TextNode blocks, then keep only CTAB (up to and including M  END).
     # Use for Open Babel / inchikey so it does not see custom blocks.
     def clean_molfile_for_inchikey(raw_molfile)
       return nil if raw_molfile.blank?
 
-      s = raw_molfile.to_s.force_encoding('UTF-8')
+      s = raw_molfile.to_s.dup.force_encoding('UTF-8')
       s = s.gsub(/>\s*<\s*PolymersList\s*>[\s\S]*?(?=\n\s*>\s*<\s|\z)/i, '')
       s = s.gsub(/>\s*<\s*TextNode\s*>[\s\S]*?(?=\n\s*>\s*<\s|\z)/i, '')
       keep_only_ctab(s)
@@ -44,7 +66,7 @@ module Chemotion
     def keep_only_ctab(molfile)
       return molfile if molfile.blank?
 
-      molfile = molfile.to_s.force_encoding('UTF-8')
+      molfile = molfile.to_s.dup.force_encoding('UTF-8')
       lines = molfile.lines
       m_end_index = lines.index { |line| line.match?(/\s*M\s+END\s*/i) }
       if m_end_index

--- a/lib/chemotion/svg_renderer.rb
+++ b/lib/chemotion/svg_renderer.rb
@@ -17,14 +17,18 @@ module Chemotion
     #
     # @param struct [String] The molfile structure to render
     # @param service [String, Symbol, nil] Preferred service: :indigo, :ketcher, or :open_babel. When nil, uses
-    #   Indigo first if molfile contains a PolymersList tag, otherwise Ketcher first; then falls back to OpenBabel.
+    #   Indigo first if molfile has an actual PolymersList payload, otherwise Ketcher first; then falls back to OpenBabel.
     # @return [String, nil] The rendered SVG, or nil if all services fail
     def self.render_svg_from_molfile(struct, service: nil)
-      has_polymer = has_polymers_list_tag?(struct)
       polymer_data = parse_polymer_payload(struct)
+      # has_polymer_list? reflects actual PolymersList *payload* (parsed from polymer_data),
+      # not merely the tag's presence: Ketcher also emits an empty "> <PolymersList>" block for
+      # ordinary, non-polymer structures (see Chemotion::MolfilePolymerSupport.has_polymer_content?),
+      # and those must not get polymer-specific Indigo options/service ordering.
+      has_polymer = has_polymer_list?(polymer_data)
       # Use cleaned_struct only for rendering (Indigo/Ketcher/OpenBabel may not handle > <PolymersList>). The full struct is passed to finalize_svg for injection.
       render_struct = polymer_data[:cleaned_struct]
-      chain = service_chain(service, struct)
+      chain = service_chain(service, has_polymer)
       indigo_options = has_polymer ? { scale_factor: 90, label_font_size: 5 } : {}
 
       chain.each do |name|
@@ -45,8 +49,12 @@ module Chemotion
     end
 
     # Returns the ordered list of service names to try (e.g. %i[indigo ketcher open_babel]).
-    # When service is nil: if molfile has PolymersList tag use Indigo first, else Ketcher first; then fallback to OpenBabel.
-    def self.service_chain(service, struct)
+    # When service is nil: if the molfile has an actual PolymersList payload use Indigo first,
+    # else Ketcher first; then fallback to OpenBabel.
+    #
+    # @param has_polymer [Boolean] from {.render_svg_from_molfile}'s has_polymer_list? check --
+    #   NOT raw tag presence, which Ketcher also emits (empty) for ordinary structures.
+    def self.service_chain(service, has_polymer)
       case service.to_s.presence&.downcase
       when 'indigo'
         %i[indigo ketcher open_babel]
@@ -55,8 +63,8 @@ module Chemotion
       when 'open_babel'
         %i[open_babel]
       else
-        # Default: PolymersList present -> Indigo first; else Ketcher first
-        has_polymers_list_tag?(struct) ? %i[indigo ketcher open_babel] : %i[ketcher open_babel]
+        # Default: real PolymersList payload present -> Indigo first; else Ketcher first
+        has_polymer ? %i[indigo ketcher open_babel] : %i[ketcher open_babel]
       end
     end
 
@@ -206,35 +214,14 @@ module Chemotion
       }
     end
 
+    # Delegates to {Chemotion::MolfilePolymerSupport.polymers_list_payload}, which owns the
+    # block-scanning rules (stop at the next "> <Tag>" header or "$$$$"; prefer the full-format
+    # block over a redundant indices-only one) shared with the importers' polymer detection.
+    #
+    # @param source [String, nil] full molfile
+    # @return [String] space-joined PolymersList payload, or +''+ when there is none
     def self.extract_polymers_line(source)
-      lines = source.to_s.lines
-      # When there are multiple "> <PolymersList>" blocks (e.g. redundant indices-only then full format), prefer the one with full format (contains "/") so we get correct template_id.
-      blocks = []
-      idx = 0
-      while idx < lines.length
-        start_idx = lines[idx..].find_index { |line| line.strip == '> <PolymersList>' }
-        break unless start_idx
-
-        start_idx += idx
-        data = []
-        i = start_idx + 1
-        while i < lines.length
-          line = lines[i].strip
-          break if line.start_with?('> <') || line == '$$$$'
-
-          data << line unless line.empty?
-          i += 1
-        end
-        content = data.join(' ').strip
-        blocks << content unless content.empty?
-        idx = start_idx + 1
-      end
-
-      return '' if blocks.empty?
-
-      # Prefer block that contains full format (e.g. "0/95/1.00-1.00") over indices-only ("0 1 2")
-      full_format_block = blocks.find { |content| content.include?('/') }
-      full_format_block.presence || blocks.first.to_s
+      Chemotion::MolfilePolymerSupport.polymers_list_payload(source)
     end
 
     def self.parse_polymers_line(polymers_line)
@@ -256,10 +243,17 @@ module Chemotion
 
       return full_format if full_format.any?
 
-      # Fallback: PolymersList content is indices-only (e.g. "0 1 2" or "0") — build default polymer entries so injection runs.
+      # Fallback for the pre-full-format grammars, all of which start with the atom index:
+      #   "0 1 2"          indices only            (ketcher-rails, 2016+)
+      #   "0s" / "7s"      index + shape letter    (ketcher-rails, 2017+; "s" = Surface)
+      #   "0s/1.00-2.00"   index + letter + size   (transitional)
+      # Only the leading digits are read: the shape letter cannot be mapped to a template id
+      # (it distinguishes Surface from Bead, not one of the ~100 template ids), so these still
+      # fall back to the default template below. Parsing the index is what matters -- without it
+      # the token is dropped, no polymer entry is built, and the sample renders with polymer
+      # service ordering but no shape injected at all.
       indices = polymers_line.split(/\s+/).filter_map do |token|
-        n = Integer(token, exception: false)
-        n if n.is_a?(Integer) && n >= 0
+        Integer(token[/\A\d+/].to_s, exception: false)
       end
       indices.map { |atom_index| { atom_index: atom_index, template_id: 1, height: 2.0, width: 2.0 } }
     end

--- a/lib/import/import_collections.rb
+++ b/lib/import/import_collections.rb
@@ -291,8 +291,7 @@ module Import
         end
 
         # Priority: molfile > cano_smiles > dummy (if decoupled and both blank)
-        # When molfile has > <PolymersList>, use full molfile and Molecule.svg_reprocess so polymers use SvgRenderer.
-        if molfile.present? && Chemotion::MolfilePolymerSupport.has_polymers_list_tag?(molfile)
+        if molfile.present? && Chemotion::MolfilePolymerSupport.has_polymer_content?(molfile)
           molecule = find_or_create_molecule_for_polymer_molfile(molfile.to_s)
         end
         # Always use molfile if available (highest priority)

--- a/lib/import/import_collections.rb
+++ b/lib/import/import_collections.rb
@@ -291,12 +291,21 @@ module Import
         end
 
         # Priority: molfile > cano_smiles > dummy (if decoupled and both blank)
+        # A non-empty "> <PolymersList>" block means keep the full molfile and let
+        # Molecule.svg_reprocess run, so polymers render via SvgRenderer.
         if molfile.present? && Chemotion::MolfilePolymerSupport.has_polymer_content?(molfile)
           molecule = find_or_create_molecule_for_polymer_molfile(molfile.to_s)
         end
         # Always use molfile if available (highest priority)
         if molfile.present?
-          molecule ||= Molecule.find_or_create_by_molfile(molfile, defer_pubchem_lookup: @defer_pubchem_lookup)
+          # CTAB-only for the Molecule lookup/store: molfile may still carry a (possibly-empty)
+          # "> <PolymersList>"/"> <TextNode>" tag here (has_polymer_content? above decided this row
+          # is NOT a polymer), and SvgRenderer must never see it or it re-triggers Indigo-first
+          # rendering with polymer-specific options for an ordinary molecule. The Sample's own
+          # molfile column is unaffected -- it is sliced from `fields` directly, further below.
+          molecule ||= Molecule.find_or_create_by_molfile(
+            Chemotion::MolfilePolymerSupport.keep_only_ctab(molfile), defer_pubchem_lookup: @defer_pubchem_lookup
+          )
         end
 
         # Use cano_smiles if molfile is missing or invalid but cano_smiles is available

--- a/lib/import/import_samples.rb
+++ b/lib/import/import_samples.rb
@@ -269,16 +269,13 @@ module Import
     def get_data_from_molfile(row)
       @polymer_svg_file_after_reprocess = nil
       raw_molfile = row_value_case_insensitive(row, 'molfile').to_s.strip
-      # When molfile has > <PolymersList>, use full molfile and Molecule.svg_reprocess so polymers use SvgRenderer.
-      if raw_molfile.include?(Chemotion::MolfilePolymerSupport::POLYMERS_LIST_TAG)
+      if Chemotion::MolfilePolymerSupport.has_polymer_content?(raw_molfile)
         result = Import::PolymerMoleculeResolver.call(raw_molfile, defer_pubchem_lookup: @defer_pubchem_lookup)
         return [result.molecule, result.raw_molfile]
       end
 
       sanitized = sanitize_molfile_for_import(raw_molfile)
-      molfile_for_babel = sanitized.dup
-      molfile_for_babel = "\n#{molfile_for_babel}" unless molfile_for_babel.start_with?("\n")
-      molfile_for_babel = "#{molfile_for_babel}\n" unless molfile_for_babel.end_with?("\n")
+      molfile_for_babel = Chemotion::MolfilePolymerSupport.normalize_for_open_babel(sanitized)
       babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile_for_babel, render_svg: false)
       inchikey = babel_info[:inchikey]
       if inchikey.presence
@@ -333,8 +330,7 @@ module Import
       ori_molf = Chemotion::OpenBabelService.smiles_to_molfile(smiles)
       return nil if ori_molf.blank?
 
-      ori_molf = "\n#{ori_molf}" unless ori_molf.start_with?("\n")
-      ori_molf = "#{ori_molf}\n" unless ori_molf.end_with?("\n")
+      ori_molf = Chemotion::MolfilePolymerSupport.normalize_for_open_babel(ori_molf)
       babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(ori_molf, render_svg: false)
       molfile_coord = Chemotion::OpenBabelService.add_molfile_coordinate(ori_molf)
       inchikey = babel_info[:inchikey] if inchikey.blank? && babel_info.present?

--- a/lib/import/import_samples.rb
+++ b/lib/import/import_samples.rb
@@ -164,8 +164,10 @@ module Import
         molecule, raw_molfile = get_data_from_molfile(row)
         if molecule.present?
           [molecule, raw_molfile]
-        elsif raw_molfile.to_s.include?(Chemotion::MolfilePolymerSupport::POLYMERS_LIST_TAG)
+        elsif Chemotion::MolfilePolymerSupport.has_polymer_content?(raw_molfile)
           # Polymer molfile but molecule not created (e.g. inchikey blank); do not fall back to smiles or we get same dummy molecule for every row.
+          # Must use the same predicate as #get_data_from_molfile: an *empty* "> <PolymersList>"
+          # block is not a polymer, so those rows keep the ordinary smiles fallback.
           nil
         elsif smiles?(row)
           m, _molfile_coord, go_to_next = get_data_from_smiles(row, index)
@@ -267,8 +269,11 @@ module Import
     end
 
     def get_data_from_molfile(row)
-      @polymer_svg_file_after_reprocess = nil
-      raw_molfile = row_value_case_insensitive(row, 'molfile').to_s.strip
+      # rstrip, not strip: MOL line 1 is the title and is empty for Ketcher/ISIS molfiles.
+      # Stripping it away shifts every CTAB line up by one and Open Babel returns a blank inchikey.
+      raw_molfile = row_value_case_insensitive(row, 'molfile').to_s.rstrip
+      # A non-empty "> <PolymersList>" block means keep the full molfile and let
+      # Import::PolymerMoleculeResolver run Molecule.svg_reprocess, so polymers render via SvgRenderer.
       if Chemotion::MolfilePolymerSupport.has_polymer_content?(raw_molfile)
         result = Import::PolymerMoleculeResolver.call(raw_molfile, defer_pubchem_lookup: @defer_pubchem_lookup)
         return [result.molecule, result.raw_molfile]

--- a/lib/import/import_sdf.rb
+++ b/lib/import/import_sdf.rb
@@ -365,14 +365,23 @@ class Import::ImportSdf < Import::ImportSamples
     babel_info_array.map.with_index do |babel_info, i|
       mf = molfiles[i]
       if Chemotion::MolfilePolymerSupport.has_polymer_content?(mf.to_s)
-        find_or_create_polymer_molfile_entry(mf.to_s.strip, babel_info)
+        # rstrip, not strip: MOL line 1 (title) may legitimately be empty for Ketcher/ISIS
+        # molfiles; a full strip would delete that blank line and shift the CTAB up by one,
+        # corrupting the header the same way this PR fixes on the xlsx import path (see
+        # Chemotion::MolfilePolymerSupport.normalize_for_open_babel, which only ever appends).
+        find_or_create_polymer_molfile_entry(mf.to_s.rstrip, babel_info)
       elsif babel_info && babel_info[:inchikey].present?
-        m = Molecule.find_or_create_by_molfile(mf, defer_pubchem_lookup: @defer_pubchem_lookup, **babel_info)
+        # Sanitize to CTAB-only before storing/rendering: mf still carries the SDF data block
+        # (including a possibly-empty "> <PolymersList>"/"> <TextNode>" tag, since has_polymer_content?
+        # just decided this row is NOT a polymer) which SvgRenderer must never see, or it re-triggers
+        # Indigo-first rendering with polymer-specific options for an ordinary molecule.
+        sanitized_mf = sanitize_molfile(mf)
+        m = Molecule.find_or_create_by_molfile(sanitized_mf, defer_pubchem_lookup: @defer_pubchem_lookup, **babel_info)
         process_molfile_opt_data(mf).merge(
           inchikey: m.inchikey,
           svg: "molecules/#{m.molecule_svg_file}",
           name: m.iupac_name,
-          molfile: mf,
+          molfile: sanitized_mf,
         )
       else
         { name: nil, inchikey: nil, svg: 'no_image_180.svg' }
@@ -406,7 +415,10 @@ class Import::ImportSdf < Import::ImportSamples
   # Returns [molecule, molfile_for_sample, babel_info]. When molfile has PolymersList/TextNode,
   # keeps full molfile and uses polymer find/create + SVG reprocess; otherwise sanitizes and finds by inchikey.
   def molecule_and_molfile_for_row(molfile)
-    raw = molfile.to_s.strip
+    # rstrip, not strip: MOL line 1 (title) may legitimately be empty for Ketcher/ISIS molfiles; a
+    # full strip deletes that blank line and shifts the CTAB up by one before PolymerMoleculeResolver
+    # ever sees it (its normalize_for_open_babel only ever appends, per its own doc comment).
+    raw = molfile.to_s.rstrip
     if Chemotion::MolfilePolymerSupport.has_polymer_content?(raw)
       result = Import::PolymerMoleculeResolver.call(raw, defer_pubchem_lookup: @defer_pubchem_lookup)
       [result.molecule, result.raw_molfile, result.babel_info]

--- a/lib/import/import_sdf.rb
+++ b/lib/import/import_sdf.rb
@@ -364,7 +364,7 @@ class Import::ImportSdf < Import::ImportSamples
 
     babel_info_array.map.with_index do |babel_info, i|
       mf = molfiles[i]
-      if Chemotion::MolfilePolymerSupport.has_polymers_list_tag?(mf.to_s)
+      if Chemotion::MolfilePolymerSupport.has_polymer_content?(mf.to_s)
         find_or_create_polymer_molfile_entry(mf.to_s.strip, babel_info)
       elsif babel_info && babel_info[:inchikey].present?
         m = Molecule.find_or_create_by_molfile(mf, defer_pubchem_lookup: @defer_pubchem_lookup, **babel_info)
@@ -407,7 +407,7 @@ class Import::ImportSdf < Import::ImportSamples
   # keeps full molfile and uses polymer find/create + SVG reprocess; otherwise sanitizes and finds by inchikey.
   def molecule_and_molfile_for_row(molfile)
     raw = molfile.to_s.strip
-    if Chemotion::MolfilePolymerSupport.has_polymers_list_tag?(raw)
+    if Chemotion::MolfilePolymerSupport.has_polymer_content?(raw)
       result = Import::PolymerMoleculeResolver.call(raw, defer_pubchem_lookup: @defer_pubchem_lookup)
       [result.molecule, result.raw_molfile, result.babel_info]
     else

--- a/lib/import/polymer_molecule_resolver.rb
+++ b/lib/import/polymer_molecule_resolver.rb
@@ -41,7 +41,9 @@ module Import
 
       # render_svg: false — the polymer SVG is rendered separately through Indigo in
       # #reattach_svg_if_present; OpenBabel's would be discarded either way.
-      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(pad(cleaned), render_svg: false)
+      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(
+        Chemotion::MolfilePolymerSupport.normalize_for_open_babel(cleaned), render_svg: false
+      )
       molecule = if babel_info[:inchikey].present?
                    Molecule.find_or_create_by_molfile(raw, defer_pubchem_lookup: @defer_pubchem_lookup, **babel_info)
                  else
@@ -55,12 +57,6 @@ module Import
     end
 
     private
-
-    def pad(molfile)
-      m = molfile.dup
-      m = "\n#{m}" unless m.start_with?("\n")
-      m.end_with?("\n") ? m : "#{m}\n"
-    end
 
     def reattach_svg_if_present(molecule, raw)
       reprocessed_svg = Molecule.svg_reprocess(nil, raw, service: :indigo)

--- a/spec/lib/chemotion/molfile_polymer_support_spec.rb
+++ b/spec/lib/chemotion/molfile_polymer_support_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Chemotion::MolfilePolymerSupport do
+  let(:ctab) do
+    <<~CTAB
+      null
+        Ketcher  6232611422D 1   1.00000     0.00000     0
+
+        1  0  0  0  0  0  0  0  0  0999 V2000
+          2.0250   -2.0250    0.0000 R#   0  0  0  0  0  0  0  0  0  0  0  0
+      M  END
+
+    CTAB
+  end
+
+  describe '.polymers_list_payload' do
+    it 'returns the payload of a populated block' do
+      molfile = "#{ctab}> <PolymersList>\n0/95/1.00-1.00\n$$$$\n"
+
+      expect(described_class.polymers_list_payload(molfile)).to eq('0/95/1.00-1.00')
+    end
+
+    it 'stops at the next SDF data header instead of swallowing it' do
+      molfile = "#{ctab}> <PolymersList>\n0/95/1.00-1.00\n> <TextNode>\n0#0ce7f3#t_95_0#label\n> </TextNode>\n$$$$\n"
+
+      expect(described_class.polymers_list_payload(molfile)).to eq('0/95/1.00-1.00')
+    end
+
+    it 'returns an empty string for an empty block followed by another data block' do
+      molfile = "#{ctab}> <PolymersList>\n> <TextNode>\n0#0ce7f3#t_95_0#label\n> </TextNode>\n$$$$\n"
+
+      expect(described_class.polymers_list_payload(molfile)).to eq('')
+    end
+
+    it 'prefers the full-format block over a redundant indices-only one' do
+      molfile = "#{ctab}> <PolymersList>\n0 1 2\n> <PolymersList>\n0/95/1.00-1.00\n$$$$\n"
+
+      expect(described_class.polymers_list_payload(molfile)).to eq('0/95/1.00-1.00')
+    end
+
+    it 'falls through an empty first block to a populated later one' do
+      molfile = "#{ctab}> <PolymersList>\n\n> <PolymersList>\n7/52/1.50-2.00\n$$$$\n"
+
+      expect(described_class.polymers_list_payload(molfile)).to eq('7/52/1.50-2.00')
+    end
+
+    it 'handles CRLF line endings' do
+      molfile = "M  END\r\n> <PolymersList>\r\n7/52/1.50-2.00\r\n> <TextNode>\r\nx\r\n$$$$\r\n"
+
+      expect(described_class.polymers_list_payload(molfile)).to eq('7/52/1.50-2.00')
+    end
+
+    it 'scrubs non-UTF-8 bytes rather than raising' do
+      molfile = (+"M  END\n> <PolymersList>\n\xE4 data\n$$$$\n").force_encoding('UTF-8')
+
+      expect { described_class.polymers_list_payload(molfile) }.not_to raise_error
+    end
+
+    it 'returns an empty string when there is no block at all' do
+      expect(described_class.polymers_list_payload(ctab)).to eq('')
+      expect(described_class.polymers_list_payload(nil)).to eq('')
+    end
+  end
+
+  describe '.has_polymer_content?' do
+    it 'is true only when a block carries a payload' do
+      populated = "#{ctab}> <PolymersList>\n0/95/1.00-1.00\n> <TextNode>\nx\n> </TextNode>\n$$$$\n"
+      empty = "#{ctab}> <PolymersList>\n> <TextNode>\nx\n> </TextNode>\n$$$$\n"
+
+      expect(described_class.has_polymer_content?(populated)).to be(true)
+      expect(described_class.has_polymer_content?(empty)).to be(false)
+    end
+
+    it 'is false for a molfile with no PolymersList tag' do
+      expect(described_class.has_polymer_content?(ctab)).to be(false)
+    end
+  end
+
+  describe '.normalize_for_open_babel' do
+    # MOL is positional: line 1 is the title and may be empty. Padding must only ever append,
+    # never prepend -- prepending corrupts a titled molfile, and the untitled case is preserved
+    # upstream by rstrip (see ImportSamples#get_data_from_molfile).
+    it 'preserves an untitled molfile\'s leading empty title line' do
+      untitled = "\n  Ketcher\n\n  1  0  0  0  0  0  0  0  0  0999 V2000\nM  END"
+
+      expect(described_class.normalize_for_open_babel(untitled))
+        .to eq("\n  Ketcher\n\n  1  0  0  0  0  0  0  0  0  0999 V2000\nM  END\n")
+    end
+
+    it 'does not shift a titled molfile down a line' do
+      titled = "benzene\n  Mrv1234\n\n  1  0  0  0  0  0  0  0  0  0999 V2000\nM  END"
+
+      expect(described_class.normalize_for_open_babel(titled))
+        .to eq("benzene\n  Mrv1234\n\n  1  0  0  0  0  0  0  0  0  0999 V2000\nM  END\n")
+    end
+
+    it 'does not add a second trailing newline' do
+      expect(described_class.normalize_for_open_babel("\nX\n")).to eq("\nX\n")
+    end
+
+    it 'returns a bare newline for blank input' do
+      expect(described_class.normalize_for_open_babel(nil)).to eq("\n")
+      expect(described_class.normalize_for_open_babel('')).to eq("\n")
+    end
+  end
+
+  # ketcher-rails (2016-2024) wrote "> <PolymersList>" *inside* the CTAB, ahead of "M  END".
+  # ~130 such samples are still stored; these fixtures are reduced from real ones.
+  describe 'legacy in-CTAB PolymersList blocks' do
+    let(:legacy_ctab_head) do
+      <<~HEAD
+        #{' '}
+          Ketcher 09231611312D 1   1.00000     0.00000     0
+
+          3  2  0     0  0            999 V2000
+            9.5920   -3.1000    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
+           10.4580   -2.6000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+        M  RGP  1   1   1
+      HEAD
+    end
+
+    it 'does not swallow the end-of-CTAB marker into the payload (sample 13207 shape)' do
+      molfile = "#{legacy_ctab_head}> <PolymersList>\n0\nM  END\n\n$$$$\n"
+
+      expect(described_class.polymers_list_payload(molfile)).to eq('0')
+    end
+
+    it 'keeps every index of a multi-index legacy block (sample 13210 shape)' do
+      molfile = "#{legacy_ctab_head}> <PolymersList>\n0 10 12\nM  END\n\n$$$$\n"
+
+      expect(described_class.polymers_list_payload(molfile)).to eq('0 10 12')
+    end
+
+    it 'reports no polymer content for an empty in-CTAB block' do
+      # Before "M  END" terminated a data block this yielded the payload "M  END", which is
+      # present? -- so an ordinary molecule was misreported as a polymer.
+      molfile = "#{legacy_ctab_head}> <PolymersList>\nM  END\n\n$$$$\n"
+
+      expect(described_class.polymers_list_payload(molfile)).to eq('')
+      expect(described_class.has_polymer_content?(molfile)).to be(false)
+    end
+
+    it 'prefers the post-M-END full-format block over legacy in-CTAB ones (sample 440603 shape)' do
+      molfile = "#{legacy_ctab_head}> <PolymersList>\n0\n> <PolymersList>\n0\n" \
+                "M  END\n\n> <PolymersList>\n0/95/1.00-1.00\n$$$$\n"
+
+      expect(described_class.polymers_list_payload(molfile)).to eq('0/95/1.00-1.00')
+      expect(described_class.has_polymer_content?(molfile)).to be(true)
+    end
+
+    it 'tolerates non-canonical spacing in the end-of-CTAB marker' do
+      molfile = "#{legacy_ctab_head}> <PolymersList>\n0\nM END\n\n$$$$\n"
+
+      expect(described_class.polymers_list_payload(molfile)).to eq('0')
+    end
+  end
+end

--- a/spec/lib/chemotion/svg_renderer_spec.rb
+++ b/spec/lib/chemotion/svg_renderer_spec.rb
@@ -345,4 +345,45 @@ RSpec.describe Chemotion::SvgRenderer do
       expect(result).not_to be_nil
     end
   end
+
+  describe '.parse_polymers_line' do
+    it 'parses the current full format' do
+      expect(described_class.parse_polymers_line('0/95/1.00-1.00'))
+        .to eq([{ atom_index: 0, template_id: 95, height: 1.0, width: 1.0 }])
+    end
+
+    it 'parses the indices-only legacy format' do
+      result = described_class.parse_polymers_line('0 10 12')
+
+      expect(result.map { |p| p[:atom_index] }).to eq([0, 10, 12])
+    end
+
+    # ketcher-rails also wrote "<index><shapeLetter>" ("s" = Surface); 63 such samples exist.
+    # The letter distinguishes Surface from Bead, not a template id, so these keep the default
+    # template -- but the *index* must survive, or no shape is injected at all.
+    it 'parses the index+letter legacy format (sample 14956 shape)' do
+      expect(described_class.parse_polymers_line('0s'))
+        .to eq([{ atom_index: 0, template_id: 1, height: 2.0, width: 2.0 }])
+    end
+
+    it 'parses several index+letter tokens' do
+      result = described_class.parse_polymers_line('0s 7s')
+
+      expect(result.map { |p| p[:atom_index] }).to eq([0, 7])
+    end
+
+    it 'parses the transitional index+letter+size format (sample 388803 shape)' do
+      expect(described_class.parse_polymers_line('0s/1.00-2.00'))
+        .to eq([{ atom_index: 0, template_id: 1, height: 2.0, width: 2.0 }])
+    end
+
+    it 'drops tokens with no leading index' do
+      expect(described_class.parse_polymers_line('M END')).to eq([])
+    end
+
+    it 'returns an empty array for a blank line' do
+      expect(described_class.parse_polymers_line('')).to eq([])
+      expect(described_class.parse_polymers_line(nil)).to eq([])
+    end
+  end
 end

--- a/spec/lib/chemotion/svg_renderer_spec.rb
+++ b/spec/lib/chemotion/svg_renderer_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe Chemotion::SvgRenderer do
     it 'parses the indices-only legacy format' do
       result = described_class.parse_polymers_line('0 10 12')
 
-      expect(result.map { |p| p[:atom_index] }).to eq([0, 10, 12])
+      expect(result.pluck(:atom_index)).to eq([0, 10, 12])
     end
 
     # ketcher-rails also wrote "<index><shapeLetter>" ("s" = Surface); 63 such samples exist.
@@ -369,7 +369,7 @@ RSpec.describe Chemotion::SvgRenderer do
     it 'parses several index+letter tokens' do
       result = described_class.parse_polymers_line('0s 7s')
 
-      expect(result.map { |p| p[:atom_index] }).to eq([0, 7])
+      expect(result.pluck(:atom_index)).to eq([0, 7])
     end
 
     it 'parses the transitional index+letter+size format (sample 388803 shape)' do

--- a/spec/lib/import/import_samples_spec.rb
+++ b/spec/lib/import/import_samples_spec.rb
@@ -244,6 +244,25 @@ RSpec.describe 'Import::ImportSamples' do
         expect(raw_molfile).to eq(polymer_molfile)
       end
     end
+
+    context 'when the PolymersList block is empty' do
+      # Ketcher emits an empty "> <PolymersList>" block for structures with no polymer at all.
+      # Those must take the ordinary molecule path -- routing them through the resolver gives every
+      # such row a synthetic POLYMER_<sha> inchikey. The following "> <TextNode>" block is the
+      # regression case: it must not be read as PolymersList payload.
+      let(:empty_polymer_molfile) do
+        "some ctab\nM  END\n> <PolymersList>\n> <TextNode>\n0#0ce7f3#t_95_0#label\n> </TextNode>\n$$$$\n"
+      end
+
+      it 'does not delegate to Import::PolymerMoleculeResolver' do
+        allow(Import::PolymerMoleculeResolver).to receive(:call)
+        allow(Chemotion::OpenBabelService).to receive(:molecule_info_from_molfile).and_return({ inchikey: nil })
+
+        importer.get_data_from_molfile({ 'molfile' => empty_polymer_molfile })
+
+        expect(Import::PolymerMoleculeResolver).not_to have_received(:call)
+      end
+    end
   end
 
   describe '#assign_molecule_data' do


### PR DESCRIPTION
Ketcher writes an empty "> <PolymersList>" block for ordinary, non-polymer structures.
Those molfiles were treated as polymers throughout import and rendering, giving every
such row a synthetic POLYMER_<sha> inchikey — collapsing them onto one dummy molecule —
and an Indigo-rendered SVG with polymer-specific options.

Polymer detection now keys on the block's payload rather than the tag's presence, with
the block-scanning rules owned by Chemotion::MolfilePolymerSupport and shared by the
importers and SvgRenderer:

- A data block ends at the next "> <Tag>" header, at "$$$$", or at "M  END", so a
  following "> <TextNode>" is never read as polymer payload and the legacy in-CTAB
  layout ketcher-rails wrote no longer swallows the end-of-CTAB marker into the payload.
- Legacy PolymersList grammars ("0s", "0s/1.00-2.00") parse their atom index instead of
  being dropped, so the shape is still injected.
- Non-polymer rows store CTAB-only molfiles, keeping SDF data blocks away from SvgRenderer.

Molfile headers are no longer corrupted on import: molfiles are rstripped rather than
stripped and the Open Babel padding only appends, so a titled molfile is not shifted
down a line into a blank inchikey.

Molfiles carrying non-UTF-8 bytes are scrubbed rather than raising ArgumentError out of
ActiveSupport's #blank?, which previously aborted the whole import.