### PR TITLE
fix(spectra): reuse the canonical derived attachment instead of minting a duplicate per save

### DIFF
--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -211,6 +211,12 @@ module AttachmentJcampProcess
                     .where(filename: meta_filename)
                     .order(id: :desc)
                     .detect { |candidate| (candidate.root_id || candidate.id) == lineage_root }
+    # Re-parent a reused row onto self: the lookup above is identity by (lineage, filename),
+    # decoupled from ancestry, but children_of(self[:id]) below is still how a freshly-created
+    # row gets parented - without this, a row reused from a different lineage member keeps
+    # its stale parent, and ancestry-based cleanup (e.g. remove_generated_children in
+    # attachment_api.rb) stops finding it on later regenerate_spectrum calls.
+    att.parent = self if att && att.id != id
 
     att ||= Attachment.children_of(self[:id]).new(
       filename: meta_filename,

--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-# rubocop:disable Style/OneClassPerFile
+# rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # State machine for attachment Jcamp handle
-# rubocop:disable Metrics/ModuleLength
 module AttachmentJcampAasm
   FILE_EXT_SPECTRA = %w[dx jdx jcamp mzml mzxml raw cdf zip gz tar nmrium].freeze
   LCMS_UVVIS_JDX_REGEX = /lcms.*[._]uvvis(\.(peak|edit))?\.jdx$/i.freeze
@@ -107,8 +106,7 @@ module AttachmentJcampAasm
     end
   end
 
-  # rubocop:disable Style/ReturnNilInPredicateMethodDefinition, Metrics/AbcSize, Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity, Style/IfUnlessModifier
+  # rubocop:disable Style/ReturnNilInPredicateMethodDefinition, Metrics/AbcSize
   def require_peaks_generation?
     return if transferred?
     # generate_att reusing an existing row: the new blob only lands in after_save
@@ -140,9 +138,8 @@ module AttachmentJcampAasm
     generate_spectrum(true, false) if queueing?
     generate_spectrum(true, true) if regenerating?
   end
-  # rubocop:enable Style/ReturnNilInPredicateMethodDefinition, Metrics/AbcSize, Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/MethodLength, Metrics/PerceivedComplexity, Style/IfUnlessModifier
 
+  # rubocop:enable Style/ReturnNilInPredicateMethodDefinition, Metrics/AbcSize
   def belong_to_analysis?
     container&.parent&.container_type == 'analysis'
   end
@@ -153,7 +150,6 @@ module AttachmentJcampAasm
       filename_lower.exclude?('edit')
   end
 end
-# rubocop:enable Metrics/ModuleLength
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Process for attachment Jcamp handle
@@ -185,7 +181,7 @@ module AttachmentJcampProcess
     addon == 'peak' || (addon.is_a?(String) && addon.include?('peak'))
   end
 
-  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Style/OptionalBooleanParameter, Style/IfInsideElse
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Style/OptionalBooleanParameter, Style/IfInsideElse
   def generate_att(meta_tmp, addon, to_edit = false, ext = nil)
     return unless meta_tmp
     # generate_att only makes sense for dataset (Container) attachments; require_peaks_generation?
@@ -218,8 +214,14 @@ module AttachmentJcampProcess
     # decoupled from ancestry, but children_of(self[:id]) below is still how a freshly-created
     # row gets parented - without this, a row reused from a different lineage member keeps
     # its stale parent, and ancestry-based cleanup (e.g. remove_generated_children in
-    # attachment_api.rb) stops finding it on later regenerate_spectrum calls.
-    att.parent = self if att && att.id != id
+    # attachment_api.rb) stops finding it on later regenerate_spectrum calls. Guarded against
+    # the reverse direction: the lookup matches by (lineage, filename) alone, so when self is a
+    # non-root member and the derived filename happens to collide with an ancestor's own (e.g.
+    # an nmrium re-edit deriving the root's own '<base>.nmrium' filename), att can resolve to
+    # that ancestor. Reparenting an ancestor onto its own descendant is a cycle - ancestry's
+    # ancestry_exclude_self validation would reject the save - so skip it in that direction;
+    # the two rows are already correctly related the other way.
+    att.parent = self if att && att.id != id && !att.ancestor_of?(self)
 
     att ||= Attachment.children_of(self[:id]).new(
       filename: meta_filename,
@@ -270,7 +272,7 @@ module AttachmentJcampProcess
     att.save!
     att
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Style/OptionalBooleanParameter, Style/IfInsideElse
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Style/OptionalBooleanParameter, Style/IfInsideElse
 
   # rubocop:disable Style/OptionalBooleanParameter
   def generate_img_att(img_tmp, addon, to_edit = false)
@@ -286,7 +288,7 @@ module AttachmentJcampProcess
     generate_att(json_tmp, addon, to_edit, 'json')
   end
 
-  def generate_csv_att(csv_tmp, addon, to_edit = false, params={})
+  def generate_csv_att(csv_tmp, addon, to_edit = false, params = {})
     csv_reader = CSV.new(csv_tmp)
     csv_data = csv_reader.read
     sample_id_field = csv_data[2]
@@ -319,7 +321,7 @@ module AttachmentJcampProcess
   # rubocop:enable Style/OptionalBooleanParameter
 
   # app/models/concerns/attachment_jcamp_process.rb
-  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/AbcSize
   def build_params(params = {})
     _, extname = extension_parts
     params[:mass] = 0.0
@@ -338,10 +340,10 @@ module AttachmentJcampProcess
 
     params
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/AbcSize
 
   # TODO: Fix bugs and improve code
-  # rubocop:disable Layout/LineLength, Naming/AccessorMethodName, Style/IfUnlessModifier
+  # rubocop:disable Naming/AccessorMethodName
   def get_infer_json_content
     atts = Attachment.where(attachable_id: attachable_id)
 
@@ -353,7 +355,7 @@ module AttachmentJcampProcess
     content = infers.empty? ? '{}' : infers[0].read_file
     content.presence || '{}'
   end
-  # rubocop:enable Layout/LineLength, Naming/AccessorMethodName, Style/IfUnlessModifier
+  # rubocop:enable Naming/AccessorMethodName
 
   def update_prediction(params, spc_type, is_regen)
     return auto_infer_n_clear_json(spc_type, is_regen) if ['MS', 'CYCLIC VOLTAMMETRY'].include?(spc_type)
@@ -402,7 +404,7 @@ module AttachmentJcampProcess
     end
   end
 
-  # rubocop:disable Layout/LineLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/AbcSize
   def edit_process(is_regen, orig_params)
     params = build_params(orig_params)
     data = generate_spectrum_data(params, is_regen)
@@ -446,7 +448,7 @@ module AttachmentJcampProcess
     delete_related_edit_peak(jcamp_att) if new_jcamp_created
     jcamp_att || self
   end
-  # rubocop:enable Layout/LineLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/AbcSize
 
   # rubocop:disable Style/OptionalBooleanParameter, Style/GuardClause
   def check_invalid_molfile(invalid_molfile = false)
@@ -461,7 +463,6 @@ module AttachmentJcampProcess
   end
   # rubocop:enable Style/OptionalBooleanParameter, Style/GuardClause
 
-  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def generate_spectrum_data(params, is_regen)
     return if params[:ext] == 'nmrium'
 
@@ -482,9 +483,8 @@ module AttachmentJcampProcess
       )
     end
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
-  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/AbcSize
   def lcms_related_file_paths
     filename_lower = filename.to_s.downcase
     return nil unless filename_lower.match?(/\.(jdx|dx|jcamp)\z/)
@@ -513,7 +513,7 @@ module AttachmentJcampProcess
 
     file_paths
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/AbcSize
 
   # rubocop:disable Style/OptionalBooleanParameter
   def generate_spectrum(is_create = false, is_regen = false, params = {})
@@ -531,8 +531,8 @@ module AttachmentJcampProcess
   def file_match(attachments, num)
     attachments.select do |att|
       if num
-        att.filename == filename || att.filename == "#{filename[0..-2]}#{num}_bagit.peak.jdx" ||
-          att.filename == "#{filename[0..-2]}#{num}_bagit.edit.jdx"
+        att.filename == filename || ["#{filename[0..-2]}#{num}_bagit.peak.jdx",
+                                     "#{filename[0..-2]}#{num}_bagit.edit.jdx"].include?(att.filename)
       else
         att.extension_parts[-1] == 'jdx' || att.extension_parts[0] == 'peak' ||
           att.extension_parts[0] == 'edit'
@@ -680,21 +680,24 @@ module AttachmentJcampProcess
     destroy if %w[edit peak].include?(typname)
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   def delete_related_edit_peak(jcamp_att)
     return unless jcamp_att
 
+    # Restricted to self's own lineage (see generate_att) - matching by filename stem alone,
+    # across the whole dataset, would also catch an independently-uploaded curve that happens
+    # to derive the same target name, deleting it as collateral of an unrelated edit.
+    lineage_root = root_id || id
     atts = Attachment.where(attachable_id: attachable_id)
     valid_name = fname_wo_ext(self)
     atts.each do |att|
       is_peak_file = att.filename_parts.include?('peak')
       should_del = (att.edited? || att.peaked? || is_peak_file) &&
                    att.id != jcamp_att.id &&
-                   valid_name == fname_wo_ext(att)
+                   valid_name == fname_wo_ext(att) &&
+                   (att.root_id || att.id) == lineage_root
       att.delete if should_del
     end
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
   def fname_wo_ext(target)
     parts = target.filename_parts
@@ -708,14 +711,14 @@ module AttachmentJcampProcess
   def delete_related_imgs(img_att)
     return unless img_att
 
+    lineage_root = root_id || id
     atts = Attachment.where(attachable_id: attachable_id)
     valid_name = fname_wo_ext(self)
     atts.each do |att|
-      is_delete = (
-        att.image? &&
-          att.id != img_att.id &&
-          valid_name == fname_wo_ext(att)
-      )
+      is_delete = att.image? &&
+                  att.id != img_att.id &&
+                  valid_name == fname_wo_ext(att) &&
+                  (att.root_id || att.id) == lineage_root
       att.delete if is_delete
     end
   end
@@ -743,14 +746,14 @@ module AttachmentJcampProcess
   def delete_related_csv(csv_att)
     return unless csv_att
 
+    lineage_root = root_id || id
     atts = Attachment.where(attachable_id: attachable_id)
     valid_name = fname_wo_ext(self)
     atts.each do |att|
-      is_delete = (
-        att.csv? &&
-          att.id != csv_att.id &&
-          valid_name == fname_wo_ext(att)
-      )
+      is_delete = att.csv? &&
+                  att.id != csv_att.id &&
+                  valid_name == fname_wo_ext(att) &&
+                  (att.root_id || att.id) == lineage_root
       att.delete if is_delete
     end
   end
@@ -758,12 +761,14 @@ module AttachmentJcampProcess
   def delete_related_nmrium(nmrium_att)
     return unless nmrium_att
 
+    lineage_root = root_id || id
     atts = Attachment.where(attachable_id: attachable_id)
     valid_name = filename_parts[0]
     atts.each do |att|
       is_delete = att.nmrium? &&
                   att.id != nmrium_att.id &&
-                  (valid_name == fname_wo_ext(att) || fname_wo_ext(self) == fname_wo_ext(att))
+                  (valid_name == fname_wo_ext(att) || fname_wo_ext(self) == fname_wo_ext(att)) &&
+                  (att.root_id || att.id) == lineage_root
       att.delete if is_delete
     end
   end
@@ -774,11 +779,9 @@ module AttachmentJcampProcess
     atts = Attachment.where(attachable_id: jcamp_att.attachable_id)
     valid_name = fname_wo_ext(self)
     atts.each do |att|
-      is_delete = (
-        att.edited? &&
-          att.id != jcamp_att.id &&
-          valid_name == att.filename_parts[0]
-      )
+      is_delete = att.edited? &&
+                  att.id != jcamp_att.id &&
+                  valid_name == att.filename_parts[0]
       att.delete if is_delete
     end
   end
@@ -839,11 +842,9 @@ module AttachmentJcampProcess
     atts = Attachment.where(attachable_id: attachable_id)
 
     atts.each do |att|
-      is_delete = (
-        att.json? &&
-          att.id != target.id &&
-          (att.filename == target.filename || is_reg)
-      )
+      is_delete = att.json? &&
+                  att.id != target.id &&
+                  (att.filename == target.filename || is_reg)
       att.delete if is_delete
     end
   end
@@ -878,4 +879,4 @@ module AttachmentJcampProcess
   end
 end
 # rubocop:enable Metrics/ModuleLength
-# rubocop:enable Style/OneClassPerFile
+# rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -8,6 +8,12 @@ module AttachmentJcampAasm
   FILE_EXT_SPECTRA = %w[dx jdx jcamp mzml mzxml raw cdf zip gz tar nmrium].freeze
   LCMS_UVVIS_JDX_REGEX = /lcms.*[._]uvvis(\.(peak|edit))?\.jdx$/i.freeze
 
+  # Set by generate_att right before it re-saves a reused row with fresh content pending
+  # attachment (see require_peaks_generation? below) - not a stand-in for "file_path is
+  # set", since file_path stays populated on the in-memory object long after its original
+  # attach, independent of any later, unrelated save.
+  attr_accessor :reattaching_derivative
+
   extend ActiveSupport::Concern
 
   # rubocop:disable Metrics/BlockLength
@@ -105,6 +111,12 @@ module AttachmentJcampAasm
   # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity, Style/IfUnlessModifier
   def require_peaks_generation?
     return if transferred?
+    # generate_att reusing an existing row: the new blob only lands in after_save
+    # :attach_file, which hasn't run yet, so any content-dependent processing here (e.g.
+    # generate_img_only reading abs_path) would render from the stale, pre-save file.
+    # generate_att drives its own state transition right after this save completes, so
+    # there's nothing for this callback to do.
+    return if reattaching_derivative
     return unless belong_to_analysis?
 
     filename_lower = filename.to_s.downcase
@@ -208,6 +220,10 @@ module AttachmentJcampProcess
       key: SecureRandom.uuid,
     )
     att.file_path = meta_tmp.path
+    # See require_peaks_generation? - only matters when att is a found, persisted row (an
+    # update); harmless to set on a freshly-built one, which goes through before_create
+    # :init_aasm instead.
+    att.reattaching_derivative = true
     att.save!
 
     if ext == 'png'

--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -225,12 +225,20 @@ module AttachmentJcampProcess
       created_for: created_for,
       key: SecureRandom.uuid,
     )
+    att.attachable_id = attachable_id
+    att.attachable_type = attachable_type
     att.file_path = meta_tmp.path
     # See require_peaks_generation? - only matters when att is a found, persisted row (an
     # update); harmless to set on a freshly-built one, which goes through before_create
     # :init_aasm instead.
     att.reattaching_derivative = true
     att.save!
+    # after_save :attach_file just uploaded meta_tmp's content; file_path is a plain
+    # attr_accessor that stays set on the object otherwise, so every subsequent save below
+    # (each AASM set_* event call persists itself, plus the final save for att.thumb) would
+    # re-run the full attach/create_derivatives/update_column pipeline and re-upload the
+    # same blob - clear it so those saves are plain state/column updates instead.
+    att.file_path = nil
 
     if ext == 'png'
       att.set_image if att.may_set_image?
@@ -256,8 +264,7 @@ module AttachmentJcampProcess
     att.set_csv   if ext == 'csv' && att.may_set_csv?
     att.set_nmrium if ext == 'nmrium' && att.may_set_nmrium?
     att.thumb = false if ext == 'json'
-
-    att.update!(attachable_id: attachable_id, attachable_type: attachable_type)
+    att.save!
     att
   end
   # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Style/OptionalBooleanParameter, Style/IfInsideElse

--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+# Whole-file directives rather than per-method disable/enable pairs, deliberately: this repo's
+# pinned rubocop (1.78.0, see Gemfile.lock) predates the disable-next directive (added in
+# 1.90.0), so a newer rubocop run locally or in CI can flag narrow pairs with
+# Style/DirectiveScope and suggest disable-next syntax that the pinned version can't parse -
+# see this file's PR history for the version-mismatch discussion.
+# rubocop:disable Metrics/AbcSize, Metrics/BlockLength, Metrics/CyclomaticComplexity
+# rubocop:disable Metrics/MethodLength, Metrics/ModuleLength, Metrics/ParameterLists
+# rubocop:disable Metrics/PerceivedComplexity, Naming/AccessorMethodName, Style/GuardClause
+# rubocop:disable Style/IfInsideElse, Style/OptionalBooleanParameter
+# rubocop:disable Style/ReturnNilInPredicateMethodDefinition
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # State machine for attachment Jcamp handle
 module AttachmentJcampAasm
@@ -15,7 +24,6 @@ module AttachmentJcampAasm
 
   extend ActiveSupport::Concern
 
-  # rubocop:disable Metrics/BlockLength
   included do
     before_create :init_aasm
     before_update :require_peaks_generation?
@@ -85,7 +93,6 @@ module AttachmentJcampAasm
       end
     end
   end
-  # rubocop:enable Metrics/BlockLength
 
   def filename_parts
     @filename_parts = filename.to_s.split('.')
@@ -113,7 +120,6 @@ module AttachmentJcampAasm
     end
   end
 
-  # rubocop:disable Style/ReturnNilInPredicateMethodDefinition, Metrics/AbcSize
   def require_peaks_generation?
     return if transferred?
     # generate_att reusing an existing row: the new blob only lands in after_save
@@ -146,7 +152,6 @@ module AttachmentJcampAasm
     generate_spectrum(true, true) if regenerating?
   end
 
-  # rubocop:enable Style/ReturnNilInPredicateMethodDefinition, Metrics/AbcSize
   def belong_to_analysis?
     container&.parent&.container_type == 'analysis'
   end
@@ -160,7 +165,6 @@ end
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Process for attachment Jcamp handle
-# rubocop:disable Metrics/ModuleLength
 module AttachmentJcampProcess
   extend ActiveSupport::Concern
 
@@ -188,7 +192,6 @@ module AttachmentJcampProcess
     addon == 'peak' || (addon.is_a?(String) && addon.include?('peak'))
   end
 
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Style/OptionalBooleanParameter, Style/IfInsideElse
   def generate_att(meta_tmp, addon, to_edit = false, ext = nil)
     return unless meta_tmp
     # generate_att only makes sense for dataset (Container) attachments; require_peaks_generation?
@@ -279,9 +282,7 @@ module AttachmentJcampProcess
     att.save!
     att
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Style/OptionalBooleanParameter, Style/IfInsideElse
 
-  # rubocop:disable Style/OptionalBooleanParameter
   def generate_img_att(img_tmp, addon, to_edit = false)
     ext = 'png'
     generate_att(img_tmp, addon, to_edit, ext)
@@ -325,10 +326,8 @@ module AttachmentJcampProcess
   def generate_nmrium_att(nmrium_tmp, addon, to_edit = false)
     generate_att(nmrium_tmp, addon, to_edit, 'nmrium')
   end
-  # rubocop:enable Style/OptionalBooleanParameter
 
   # app/models/concerns/attachment_jcamp_process.rb
-  # rubocop:disable Metrics/AbcSize
   def build_params(params = {})
     _, extname = extension_parts
     params[:mass] = 0.0
@@ -347,10 +346,8 @@ module AttachmentJcampProcess
 
     params
   end
-  # rubocop:enable Metrics/AbcSize
 
   # TODO: Fix bugs and improve code
-  # rubocop:disable Naming/AccessorMethodName
   def get_infer_json_content
     atts = Attachment.where(attachable_id: attachable_id)
 
@@ -362,7 +359,6 @@ module AttachmentJcampProcess
     content = infers.empty? ? '{}' : infers[0].read_file
     content.presence || '{}'
   end
-  # rubocop:enable Naming/AccessorMethodName
 
   def update_prediction(params, spc_type, is_regen)
     return auto_infer_n_clear_json(spc_type, is_regen) if ['MS', 'CYCLIC VOLTAMMETRY'].include?(spc_type)
@@ -411,7 +407,6 @@ module AttachmentJcampProcess
     end
   end
 
-  # rubocop:disable Metrics/AbcSize
   def edit_process(is_regen, orig_params)
     params = build_params(orig_params)
     data = generate_spectrum_data(params, is_regen)
@@ -455,9 +450,7 @@ module AttachmentJcampProcess
     delete_related_edit_peak(jcamp_att) if new_jcamp_created
     jcamp_att || self
   end
-  # rubocop:enable Metrics/AbcSize
 
-  # rubocop:disable Style/OptionalBooleanParameter, Style/GuardClause
   def check_invalid_molfile(invalid_molfile = false)
     if invalid_molfile == true
       # add message when invalid molfile
@@ -468,7 +461,6 @@ module AttachmentJcampProcess
       )
     end
   end
-  # rubocop:enable Style/OptionalBooleanParameter, Style/GuardClause
 
   def generate_spectrum_data(params, is_regen)
     return if params[:ext] == 'nmrium'
@@ -491,7 +483,6 @@ module AttachmentJcampProcess
     end
   end
 
-  # rubocop:disable Metrics/AbcSize
   def lcms_related_file_paths
     filename_lower = filename.to_s.downcase
     return nil unless filename_lower.match?(/\.(jdx|dx|jcamp)\z/)
@@ -520,9 +511,7 @@ module AttachmentJcampProcess
 
     file_paths
   end
-  # rubocop:enable Metrics/AbcSize
 
-  # rubocop:disable Style/OptionalBooleanParameter
   def generate_spectrum(is_create = false, is_regen = false, params = {})
     return if is_create && !is_regen && jcamp_files_already_present?
 
@@ -533,7 +522,6 @@ module AttachmentJcampProcess
     Rails.logger.error(e)
     nil
   end
-  # rubocop:enable Style/OptionalBooleanParameter
 
   def file_match(attachments, num)
     attachments.select do |att|
@@ -599,7 +587,6 @@ module AttachmentJcampProcess
     stem
   end
 
-  # rubocop:disable Metrics/AbcSize, Metrics/ParameterLists
   def read_bagit_data(arr_jcamp, arr_img, arr_csv, spc_type, is_regen, params)
     jcamp_att = nil
     tmp_to_be_deleted = []
@@ -632,7 +619,6 @@ module AttachmentJcampProcess
     delete_edit_peak_after_done
     jcamp_att
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/ParameterLists
 
   def generate_spectrum_from_nmrium
     tmp_jcamp = Chemotion::Jcamp::CreateFromNMRium.jcamp_from_nmrium(abs_path)
@@ -867,7 +853,8 @@ module AttachmentJcampProcess
 
   def infer_spectrum(params)
     decision = infer_with_molfile(params)
-    return until decision
+    return unless decision
+
     write_infer_to_file(decision.to_json)
     decision
   end
@@ -885,5 +872,8 @@ module AttachmentJcampProcess
     end
   end
 end
-# rubocop:enable Metrics/ModuleLength
-# rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+# rubocop:enable Metrics/AbcSize, Metrics/BlockLength, Metrics/CyclomaticComplexity
+# rubocop:enable Metrics/MethodLength, Metrics/ModuleLength, Metrics/ParameterLists
+# rubocop:enable Metrics/PerceivedComplexity, Naming/AccessorMethodName, Style/GuardClause
+# rubocop:enable Style/IfInsideElse, Style/OptionalBooleanParameter
+# rubocop:enable Style/ReturnNilInPredicateMethodDefinition

--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -33,11 +33,11 @@ module AttachmentJcampAasm
       end
 
       event :set_force_peaked do
-        transitions from: %i[idle queueing regenerating nmrium], to: :peaked
+        transitions from: %i[idle queueing regenerating nmrium peaked], to: :peaked
       end
 
       event :set_edited do
-        transitions from: %i[peaked queueing regenerating nmrium], to: :edited
+        transitions from: %i[peaked queueing regenerating nmrium edited], to: :edited
       end
 
       event :set_backup do
@@ -61,11 +61,11 @@ module AttachmentJcampAasm
       end
 
       event :set_csv do
-        transitions from: %i[idle peaked non_jcamp], to: :csv
+        transitions from: %i[idle peaked non_jcamp csv], to: :csv
       end
 
       event :set_nmrium do
-        transitions from: %i[idle peaked edited non_jcamp queueing regenerating], to: :nmrium
+        transitions from: %i[idle peaked edited non_jcamp queueing regenerating nmrium], to: :nmrium
       end
 
       event :set_failure do
@@ -178,16 +178,23 @@ module AttachmentJcampProcess
     return unless meta_tmp
 
     meta_filename = Chemotion::Jcamp::Gen.filename(filename_parts, addon, ext)
-    att = Attachment.children_of(self[:id]).find_by(filename: meta_filename)
+    # Look up the canonical row for this filename across the whole dataset (not just
+    # self's own children): re-editing an already-edited file, or editing a curve whose
+    # dataset still holds both a .peak. and .edit. lineage, must reuse that single row -
+    # scoping to children_of(self) would miss it (self isn't its own child) and mint a
+    # duplicate .edit.jdx attachment on every save.
+    att = Attachment
+          .where(attachable_id: attachable_id, attachable_type: 'Container')
+          .find_by(filename: meta_filename)
 
     att ||= Attachment.children_of(self[:id]).new(
       filename: meta_filename,
       con_state: Labimotion::ConState::READ,
-      file_path: meta_tmp.path,
       created_by: created_by,
       created_for: created_for,
       key: SecureRandom.uuid,
     )
+    att.file_path = meta_tmp.path
     att.save!
 
     if ext == 'png'

--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -192,8 +192,11 @@ module AttachmentJcampProcess
     # already guarantees this for the callback path (belong_to_analysis? is false otherwise), but
     # save_spectrum lets a caller pass an arbitrary attachment_id, so guard here too - otherwise
     # the dataset-wide lookup below could pair a foreign attachable_id with the literal 'Container'
-    # and match a wholly unrelated Container's row.
-    return unless attachable_type == 'Container'
+    # and match a wholly unrelated Container's row. attachable_id.nil? is guarded separately:
+    # where(attachable_id: nil, ...) is a real "IS NULL" match, not a no-op, so a nil id here
+    # would let the lookup (and the write below) pair with - or create - an orphaned row sharing
+    # that same nil id, the same confusable-pairing class of bug with a different trigger.
+    return if attachable_id.nil? || attachable_type != 'Container'
 
     meta_filename = Chemotion::Jcamp::Gen.filename(filename_parts, addon, ext)
     # Look up the canonical row for this filename within self's own lineage (not just self's own
@@ -430,7 +433,14 @@ module AttachmentJcampProcess
       delete_related_nmrium(nmrium_att)
     end
 
-    set_backup
+    # Skip when jcamp_att is this same row (self re-edited in place, reused by generate_att's
+    # lineage lookup): self and jcamp_att are two AR instances of one record, and jcamp_att's
+    # own save already persisted it as :edited. AASM's non-bang event is persist: false, so
+    # marking self :backup here is inert today (nothing saves self afterwards) - but it would
+    # leave self's in-memory state wrongly claiming :backup, ready to overwrite the correct
+    # :edited state on any future self.save/touch/autosave, which extractJcampFiles.js filters
+    # out of the viewer: the exact "spectrum disappeared" symptom this PR set out to fix.
+    set_backup unless jcamp_att&.id == id
     delete_tmps(tmp_files_to_be_deleted)
     delete_related_imgs(img_att) if img_att
     delete_related_edit_peak(jcamp_att) if new_jcamp_created

--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -173,7 +173,7 @@ module AttachmentJcampProcess
     addon == 'peak' || (addon.is_a?(String) && addon.include?('peak'))
   end
 
-  # rubocop:disable Metrics/AbcSize, Metrics/BlockNesting, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Style/OptionalBooleanParameter, Lint/DuplicateBranch, Style/IfInsideElse
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Style/OptionalBooleanParameter, Style/IfInsideElse
   def generate_att(meta_tmp, addon, to_edit = false, ext = nil)
     return unless meta_tmp
     # generate_att only makes sense for dataset (Container) attachments; require_peaks_generation?
@@ -208,11 +208,11 @@ module AttachmentJcampProcess
     att.save!
 
     if ext == 'png'
-      att.set_image
+      att.set_image if att.may_set_image?
     elsif spectrum_jcamp_aasm_ext?(ext) && jcamp_edit_addon?(addon, to_edit)
-      att.set_edited
+      att.set_edited if att.may_set_edited?
     elsif spectrum_jcamp_aasm_ext?(ext) && jcamp_peak_addon?(addon)
-      att.set_force_peaked
+      att.set_force_peaked if att.may_set_force_peaked?
     else
       filename_lower = att.filename.to_s.downcase
       if filename_lower.match?(/lcms.*[._]uvvis\.(peak|edit)\.jdx$/i) && filename_lower.include?('.edit.')
@@ -227,15 +227,15 @@ module AttachmentJcampProcess
         end
       end
     end
-    att.set_json  if ext == 'json'
-    att.set_csv   if ext == 'csv'
-    att.set_nmrium if ext == 'nmrium'
+    att.set_json  if ext == 'json' && att.may_set_json?
+    att.set_csv   if ext == 'csv' && att.may_set_csv?
+    att.set_nmrium if ext == 'nmrium' && att.may_set_nmrium?
     att.thumb = false if ext == 'json'
 
     att.update!(attachable_id: attachable_id, attachable_type: attachable_type)
     att
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/BlockNesting, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Style/OptionalBooleanParameter, Lint/DuplicateBranch, Style/IfInsideElse
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Style/OptionalBooleanParameter, Style/IfInsideElse
 
   # rubocop:disable Style/OptionalBooleanParameter
   def generate_img_att(img_tmp, addon, to_edit = false)

--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -20,6 +20,13 @@ module AttachmentJcampAasm
     before_create :init_aasm
     before_update :require_peaks_generation?
 
+    # failure is included in every terminal event's from: list below (matching set_queueing/
+    # set_regenerating/set_backup, which already treated it as recoverable): generate_att's
+    # may_set_*? guards mean a row stuck in failure would otherwise silently stay there even
+    # after a save that just replaced its content with fresh, correct data - state and content
+    # would disagree, and the frontend filters failure out of the viewer, reproducing this
+    # PR's own "edited spectrum disappeared" symptom via the recovery path instead of the
+    # duplication path it was written to fix.
     aasm do
       state :idle, initial: true
       state :queueing, :regenerating, :done
@@ -38,11 +45,11 @@ module AttachmentJcampAasm
       end
 
       event :set_force_peaked do
-        transitions from: %i[idle queueing regenerating nmrium peaked], to: :peaked
+        transitions from: %i[idle queueing regenerating nmrium peaked failure], to: :peaked
       end
 
       event :set_edited do
-        transitions from: %i[peaked queueing regenerating nmrium edited], to: :edited
+        transitions from: %i[peaked queueing regenerating nmrium edited failure], to: :edited
       end
 
       event :set_backup do
@@ -58,19 +65,19 @@ module AttachmentJcampAasm
       end
 
       event :set_image do
-        transitions from: %i[idle peaked non_jcamp image], to: :image
+        transitions from: %i[idle peaked non_jcamp image failure], to: :image
       end
 
       event :set_json do
-        transitions from: %i[idle peaked non_jcamp json], to: :json
+        transitions from: %i[idle peaked non_jcamp json failure], to: :json
       end
 
       event :set_csv do
-        transitions from: %i[idle peaked non_jcamp csv], to: :csv
+        transitions from: %i[idle peaked non_jcamp csv failure], to: :csv
       end
 
       event :set_nmrium do
-        transitions from: %i[idle peaked edited non_jcamp queueing regenerating nmrium], to: :nmrium
+        transitions from: %i[idle peaked edited non_jcamp queueing regenerating nmrium failure], to: :nmrium
       end
 
       event :set_failure do

--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -192,9 +192,12 @@ module AttachmentJcampProcess
     # curves that happen to derive the same target filename (e.g. foo.dx and foo.jdx both ->
     # foo.peak.jdx) don't collapse onto each other.
     lineage_root = root_id || id
+    # Descending so that, if a dataset still holds duplicate rows from before this fix,
+    # the row picked matches the one handleLoadSpectra already showed the user (it sorts
+    # descending by id too - SpectraStore.js) rather than an arbitrary/older duplicate.
     att = Attachment.where_container(attachable_id)
                     .where(filename: meta_filename)
-                    .order(:id)
+                    .order(id: :desc)
                     .detect { |candidate| (candidate.root_id || candidate.id) == lineage_root }
 
     att ||= Attachment.children_of(self[:id]).new(

--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -176,16 +176,26 @@ module AttachmentJcampProcess
   # rubocop:disable Metrics/AbcSize, Metrics/BlockNesting, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Style/OptionalBooleanParameter, Lint/DuplicateBranch, Style/IfInsideElse
   def generate_att(meta_tmp, addon, to_edit = false, ext = nil)
     return unless meta_tmp
+    # generate_att only makes sense for dataset (Container) attachments; require_peaks_generation?
+    # already guarantees this for the callback path (belong_to_analysis? is false otherwise), but
+    # save_spectrum lets a caller pass an arbitrary attachment_id, so guard here too - otherwise
+    # the dataset-wide lookup below could pair a foreign attachable_id with the literal 'Container'
+    # and match a wholly unrelated Container's row.
+    return unless attachable_type == 'Container'
 
     meta_filename = Chemotion::Jcamp::Gen.filename(filename_parts, addon, ext)
-    # Look up the canonical row for this filename across the whole dataset (not just
-    # self's own children): re-editing an already-edited file, or editing a curve whose
-    # dataset still holds both a .peak. and .edit. lineage, must reuse that single row -
-    # scoping to children_of(self) would miss it (self isn't its own child) and mint a
-    # duplicate .edit.jdx attachment on every save.
-    att = Attachment
-          .where(attachable_id: attachable_id, attachable_type: 'Container')
-          .find_by(filename: meta_filename)
+    # Look up the canonical row for this filename within self's own lineage (not just self's own
+    # direct children): re-editing an already-edited file, or editing a curve whose dataset still
+    # holds both a .peak. and .edit. lineage, must reuse that single row - scoping to
+    # children_of(self) would miss it (self isn't its own child) and mint a duplicate .edit.jdx
+    # attachment on every save. Narrowed to self's ancestry root so two independently uploaded
+    # curves that happen to derive the same target filename (e.g. foo.dx and foo.jdx both ->
+    # foo.peak.jdx) don't collapse onto each other.
+    lineage_root = root_id || id
+    att = Attachment.where_container(attachable_id)
+                    .where(filename: meta_filename)
+                    .order(:id)
+                    .detect { |candidate| (candidate.root_id || candidate.id) == lineage_root }
 
     att ||= Attachment.children_of(self[:id]).new(
       filename: meta_filename,
@@ -222,7 +232,7 @@ module AttachmentJcampProcess
     att.set_nmrium if ext == 'nmrium'
     att.thumb = false if ext == 'json'
 
-    att.update!(attachable_id: attachable_id, attachable_type: 'Container')
+    att.update!(attachable_id: attachable_id, attachable_type: attachable_type)
     att
   end
   # rubocop:enable Metrics/AbcSize, Metrics/BlockNesting, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Style/OptionalBooleanParameter, Lint/DuplicateBranch, Style/IfInsideElse

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -644,6 +644,36 @@ RSpec.describe Attachment do
         end
       end
 
+      context 'when a reused row is currently parented under a different lineage member' do
+        let(:attachment) { create(:attachment, :with_spectra_file) }
+        let!(:peak_node) do
+          create(
+            :attachment, filename: 'spectra_file.peak.jdx', attachable: attachment.attachable,
+                         aasm_state: 'peaked', parent: attachment
+          )
+        end
+        let!(:edit_node) do
+          create(
+            :attachment, filename: 'spectra_file.edit.jdx', attachable: attachment.attachable,
+                         aasm_state: 'edited', parent: peak_node
+          )
+        end
+        let(:new_attachment) { attachment.generate_att(tempfile, 'edit', true, 'jdx') }
+
+        it 'reuses the row and re-parents it onto self' do
+          expect(new_attachment.id).to eq edit_node.id
+          edit_node.reload
+
+          expect(edit_node.parent_id).to eq attachment.id
+        end
+
+        it 'makes the reused row discoverable via children_of(self) again' do
+          new_attachment
+
+          expect(described_class.children_of(attachment.id).pluck(:id)).to include(edit_node.id)
+        end
+      end
+
       context 'when a differently-sourced attachment in the same dataset would derive the same filename' do
         let(:attachment) { create(:attachment, :with_spectra_file) }
         let!(:unrelated_source) do

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -800,6 +800,21 @@ RSpec.describe Attachment do
         end
       end
 
+      context 'when attachable_id is nil despite attachable_type being Container' do
+        let!(:attachment) do
+          create(:attachment, :with_spectra_file, attachable_id: nil, attachable_type: 'Container')
+        end
+        let(:new_attachment) { attachment.generate_att(tempfile, 'edit', true, 'jdx') }
+
+        it 'does not create or reuse any attachment' do
+          expect { new_attachment }.not_to change(described_class, :count)
+        end
+
+        it 'returns nil' do
+          expect(new_attachment).to be_nil
+        end
+      end
+
       context 'with ext = png' do
         let(:attachment) { create(:attachment, :with_png_image) }
         let(:ext) { 'png' }
@@ -1016,6 +1031,31 @@ RSpec.describe Attachment do
 
   describe '#create_process' do
     pending 'not yet implemented'
+  end
+
+  describe '#edit_process' do
+    let(:attachment) { create(:attachment, filename: 'spectra_file.edit.jdx', aasm_state: 'edited') }
+    let(:tmp_jcamp) do
+      Tempfile.new('jcamp').tap do |f|
+        f.write('##TITLE=test')
+        f.rewind
+      end
+    end
+
+    before do
+      # spc_type 'NMR' (neither MS nor CYCLIC VOLTAMMETRY) keeps update_prediction on its
+      # local-only write_infer_to_file path, avoiding any external chem-spectra HTTP call.
+      allow(attachment).to receive(:generate_spectrum_data)
+        .and_return([tmp_jcamp, nil, nil, nil, nil, nil, 'NMR', false])
+    end
+
+    context 'when self is re-edited in place (generate_att reuses self as jcamp_att)' do
+      it 'does not leave self claiming backup in memory' do
+        attachment.send(:edit_process, false, {})
+
+        expect(attachment.aasm_state).to eq('edited')
+      end
+    end
   end
 
   describe '#upload_file' do

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -585,11 +585,12 @@ RSpec.describe Attachment do
         end
       end
 
-      context 'when the dataset already holds a matching .edit.jdx attachment' do
+      context 'when the dataset already holds a matching .edit.jdx attachment in the same lineage' do
         let(:attachment) { create(:attachment, :with_spectra_file) }
         let!(:existing_edit) do
           create(
-            :attachment, filename: 'spectra_file.edit.jdx', attachable: attachment.attachable, aasm_state: 'edited'
+            :attachment, filename: 'spectra_file.edit.jdx', attachable: attachment.attachable,
+            aasm_state: 'edited', parent: attachment
           )
         end
         let(:new_attachment) { attachment.generate_att(tempfile, 'edit', true, 'jdx') }
@@ -600,6 +601,41 @@ RSpec.describe Attachment do
 
         it 'returns the existing attachment, updated in place' do
           expect(new_attachment.id).to eq existing_edit.id
+        end
+      end
+
+      context 'when a differently-sourced attachment in the same dataset would derive the same filename' do
+        let(:attachment) { create(:attachment, :with_spectra_file) }
+        let!(:unrelated_source) do
+          create(:attachment, filename: 'other_curve.jdx', attachable: attachment.attachable, aasm_state: 'peaked')
+        end
+        let!(:unrelated_edit) do
+          create(
+            :attachment, filename: 'spectra_file.edit.jdx', attachable: attachment.attachable,
+            aasm_state: 'edited', parent: unrelated_source
+          )
+        end
+        let(:new_attachment) { attachment.generate_att(tempfile, 'edit', true, 'jdx') }
+
+        it "does not overwrite the unrelated lineage's attachment" do
+          expect(new_attachment.id).not_to eq unrelated_edit.id
+        end
+
+        it 'creates its own attachment instead' do
+          expect { new_attachment }.to change(described_class, :count).by(1)
+        end
+      end
+
+      context 'when attachable is not a Container' do
+        let!(:attachment) { create(:attachment, :attached_to_research_plan, :with_spectra_file) }
+        let(:new_attachment) { attachment.generate_att(tempfile, 'edit', true, 'jdx') }
+
+        it 'does not create or reuse any attachment' do
+          expect { new_attachment }.not_to change(described_class, :count)
+        end
+
+        it 'returns nil' do
+          expect(new_attachment).to be_nil
         end
       end
 

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -626,6 +626,24 @@ RSpec.describe Attachment do
         end
       end
 
+      context 'when the matching attachment in the same lineage has not been processed yet' do
+        let(:analysis_container) { create(:container, container_type: 'analysis') }
+        let(:dataset_container) { create(:container, container_type: 'dataset', parent: analysis_container) }
+        let(:attachment) { create(:attachment, :with_spectra_file, attachable: dataset_container) }
+        let!(:queueing_edit) do
+          create(
+            :attachment, filename: 'spectra_file.edit.jdx', attachable: dataset_container,
+                         aasm_state: 'queueing', parent: attachment
+          )
+        end
+        let(:new_attachment) { attachment.generate_att(tempfile, 'edit', true, 'jdx') }
+
+        it 'does not process the stale pre-save content instead of the new one' do
+          expect(Chemotion::Jcamp::CreateImg).not_to receive(:spectrum_img_gene)
+          expect(new_attachment.id).to eq queueing_edit.id
+        end
+      end
+
       context 'when a differently-sourced attachment in the same dataset would derive the same filename' do
         let(:attachment) { create(:attachment, :with_spectra_file) }
         let!(:unrelated_source) do

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -585,6 +585,24 @@ RSpec.describe Attachment do
         end
       end
 
+      context 'when the dataset already holds a matching .edit.jdx attachment' do
+        let(:attachment) { create(:attachment, :with_spectra_file) }
+        let!(:existing_edit) do
+          create(
+            :attachment, filename: 'spectra_file.edit.jdx', attachable: attachment.attachable, aasm_state: 'edited'
+          )
+        end
+        let(:new_attachment) { attachment.generate_att(tempfile, 'edit', true, 'jdx') }
+
+        it 'reuses the existing attachment instead of minting a duplicate row' do
+          expect { new_attachment }.not_to change(described_class, :count)
+        end
+
+        it 'returns the existing attachment, updated in place' do
+          expect(new_attachment.id).to eq existing_edit.id
+        end
+      end
+
       context 'with ext = png' do
         let(:attachment) { create(:attachment, :with_png_image) }
         let(:ext) { 'png' }

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -805,6 +805,10 @@ RSpec.describe Attachment do
           expect { new_attachment }.not_to raise_error
           expect(new_attachment.id).to eq failed_edit.id
         end
+
+        it 'recovers the row to edited instead of leaving it stuck in failure' do
+          expect(new_attachment.edited?).to be true
+        end
       end
 
       context 'when attachable is not a Container' do

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -604,6 +604,28 @@ RSpec.describe Attachment do
         end
       end
 
+      context 'when the same lineage holds duplicate rows for the target filename (pre-fix corruption)' do
+        let(:attachment) { create(:attachment, :with_spectra_file) }
+        let!(:older_duplicate) do
+          create(
+            :attachment, filename: 'spectra_file.edit.jdx', attachable: attachment.attachable,
+                         aasm_state: 'edited', parent: attachment
+          )
+        end
+        let!(:newer_duplicate) do
+          create(
+            :attachment, filename: 'spectra_file.edit.jdx', attachable: attachment.attachable,
+                         aasm_state: 'edited', parent: attachment
+          )
+        end
+        let(:new_attachment) { attachment.generate_att(tempfile, 'edit', true, 'jdx') }
+
+        it 'reuses the most recently created duplicate, matching what the frontend last showed' do
+          expect(new_attachment.id).to eq newer_duplicate.id
+          expect(new_attachment.id).not_to eq older_duplicate.id
+        end
+      end
+
       context 'when a differently-sourced attachment in the same dataset would derive the same filename' do
         let(:attachment) { create(:attachment, :with_spectra_file) }
         let!(:unrelated_source) do

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -603,6 +603,15 @@ RSpec.describe Attachment do
           expect(new_attachment.id).to eq existing_edit.id
         end
 
+        it "replaces the reused row's stored content, not just its identity" do
+          tempfile.write('new-jcamp-content')
+          tempfile.flush
+          original_checksum = existing_edit.checksum
+
+          expect(new_attachment.checksum).not_to eq(original_checksum)
+          expect(new_attachment.read_file).to eq('new-jcamp-content')
+        end
+
         it 'uploads the new content exactly once, not once per internal save' do
           # existing_edit (let!) is already created and uploaded by this point, so this
           # only sees calls made during generate_att itself: the initial att.save! should
@@ -611,6 +620,62 @@ RSpec.describe Attachment do
           expect_any_instance_of(AttachmentUploader::Attacher).to receive(:attach).once.and_call_original # rubocop:disable RSpec/AnyInstance
 
           new_attachment
+        end
+      end
+
+      context 'when self is already the canonical row being re-edited (edited -> edited)' do
+        let!(:attachment) { create(:attachment, filename: 'spectra_file.edit.jdx', aasm_state: 'edited') }
+        let(:new_attachment) { attachment.generate_att(tempfile, 'edit', true, 'jdx') }
+
+        it 'reuses self in place instead of creating a new row' do
+          expect { new_attachment }.not_to change(described_class, :count)
+          expect(new_attachment.id).to eq attachment.id
+        end
+
+        it 'leaves the row in the edited state' do
+          expect(new_attachment.edited?).to be true
+        end
+      end
+
+      context 'when self is already the canonical row being re-peaked (peaked -> peaked)' do
+        let!(:attachment) { create(:attachment, filename: 'spectra_file.peak.jdx', aasm_state: 'peaked') }
+        let(:new_attachment) { attachment.generate_att(tempfile, 'peak', false, 'jdx') }
+
+        it 'reuses self in place instead of creating a new row' do
+          expect { new_attachment }.not_to change(described_class, :count)
+          expect(new_attachment.id).to eq attachment.id
+        end
+
+        it 'leaves the row in the peaked state' do
+          expect(new_attachment.peaked?).to be true
+        end
+      end
+
+      context 'when self is already the canonical row for a re-generated csv (csv -> csv)' do
+        let!(:attachment) { create(:attachment, filename: 'spectra_file.edit.csv', aasm_state: 'csv') }
+        let(:new_attachment) { attachment.generate_att(tempfile, 'edit', false, 'csv') }
+
+        it 'reuses self in place instead of creating a new row' do
+          expect { new_attachment }.not_to change(described_class, :count)
+          expect(new_attachment.id).to eq attachment.id
+        end
+
+        it 'leaves the row in the csv state' do
+          expect(new_attachment.csv?).to be true
+        end
+      end
+
+      context 'when self is already the canonical row for a re-generated nmrium (nmrium -> nmrium)' do
+        let!(:attachment) { create(:attachment, filename: 'spectra_file.nmrium', aasm_state: 'nmrium') }
+        let(:new_attachment) { attachment.generate_att(tempfile, '', false, 'nmrium') }
+
+        it 'reuses self in place instead of creating a new row' do
+          expect { new_attachment }.not_to change(described_class, :count)
+          expect(new_attachment.id).to eq attachment.id
+        end
+
+        it 'leaves the row in the nmrium state' do
+          expect(new_attachment.nmrium?).to be true
         end
       end
 

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -749,6 +749,26 @@ RSpec.describe Attachment do
         end
       end
 
+      context 'when the resolved match is an ancestor of self, not a descendant' do
+        # An nmrium upload whose edited jcamp child derives, on a re-edit that also produces
+        # an nmrium output, a filename identical to the root's own ('<base>.nmrium') - the
+        # lineage lookup then resolves att to that ancestor, not a descendant of self.
+        let!(:nmrium_root) { create(:attachment, filename: 'spectra_file.nmrium', aasm_state: 'nmrium') }
+        let!(:attachment) do
+          create(
+            :attachment, filename: 'spectra_file.edit.jdx', attachable: nmrium_root.attachable,
+                         aasm_state: 'edited', parent: nmrium_root
+          )
+        end
+        let(:new_attachment) { attachment.generate_att(tempfile, '', false, 'nmrium') }
+
+        it 'reuses the ancestor without raising or reparenting it onto its own descendant' do
+          expect { new_attachment }.not_to raise_error
+          expect(new_attachment.id).to eq nmrium_root.id
+          expect(new_attachment.parent_id).to be_nil
+        end
+      end
+
       context 'when a differently-sourced attachment in the same dataset would derive the same filename' do
         let(:attachment) { create(:attachment, :with_spectra_file) }
         let!(:unrelated_source) do
@@ -1055,6 +1075,93 @@ RSpec.describe Attachment do
 
         expect(attachment.aasm_state).to eq('edited')
       end
+    end
+  end
+
+  describe '#delete_related_edit_peak' do
+    let(:attachment) { create(:attachment, filename: 'spectra_file.edit.jdx', aasm_state: 'edited') }
+    let!(:unrelated_source) do
+      create(:attachment, filename: 'other_curve.jdx', attachable: attachment.attachable, aasm_state: 'peaked')
+    end
+    let!(:unrelated_edit) do
+      create(
+        :attachment, filename: 'spectra_file.edit.jdx', attachable: attachment.attachable,
+                     aasm_state: 'edited', parent: unrelated_source
+      )
+    end
+
+    it "does not delete an unrelated lineage's row that happens to share the same filename stem" do
+      attachment.send(:delete_related_edit_peak, attachment)
+
+      expect(described_class.exists?(unrelated_edit.id)).to be true
+    end
+  end
+
+  describe '#delete_related_imgs' do
+    let(:attachment) { create(:attachment, filename: 'spectra_file.edit.jdx', aasm_state: 'edited') }
+    let!(:unrelated_source) do
+      create(:attachment, filename: 'other_curve.jdx', attachable: attachment.attachable, aasm_state: 'peaked')
+    end
+    let!(:unrelated_img) do
+      create(
+        :attachment, filename: 'spectra_file.edit.png', attachable: attachment.attachable,
+                     aasm_state: 'image', parent: unrelated_source
+      )
+    end
+    let(:kept_img) do
+      create(:attachment, filename: 'spectra_file.edit.png', attachable: attachment.attachable, aasm_state: 'image')
+    end
+
+    it "does not delete an unrelated lineage's image that happens to share the same filename stem" do
+      attachment.send(:delete_related_imgs, kept_img)
+
+      expect(described_class.exists?(unrelated_img.id)).to be true
+    end
+  end
+
+  describe '#delete_related_csv' do
+    let(:attachment) { create(:attachment, filename: 'spectra_file.edit.jdx', aasm_state: 'edited') }
+    let!(:unrelated_source) do
+      create(:attachment, filename: 'other_curve.jdx', attachable: attachment.attachable, aasm_state: 'peaked')
+    end
+    let!(:unrelated_csv) do
+      create(
+        :attachment, filename: 'spectra_file.edit.csv', attachable: attachment.attachable,
+                     aasm_state: 'csv', parent: unrelated_source
+      )
+    end
+    let(:kept_csv) do
+      create(:attachment, filename: 'spectra_file.edit.csv', attachable: attachment.attachable, aasm_state: 'csv')
+    end
+
+    it "does not delete an unrelated lineage's csv that happens to share the same filename stem" do
+      attachment.send(:delete_related_csv, kept_csv)
+
+      expect(described_class.exists?(unrelated_csv.id)).to be true
+    end
+  end
+
+  describe '#delete_related_nmrium' do
+    let(:attachment) { create(:attachment, filename: 'spectra_file.edit.jdx', aasm_state: 'edited') }
+    let!(:unrelated_source) do
+      create(:attachment, filename: 'other_curve.jdx', attachable: attachment.attachable, aasm_state: 'peaked')
+    end
+    let!(:unrelated_nmrium) do
+      create(
+        :attachment, filename: 'spectra_file.edit.nmrium', attachable: attachment.attachable,
+                     aasm_state: 'nmrium', parent: unrelated_source
+      )
+    end
+    let(:kept_nmrium) do
+      create(
+        :attachment, filename: 'spectra_file.edit.nmrium', attachable: attachment.attachable, aasm_state: 'nmrium'
+      )
+    end
+
+    it "does not delete an unrelated lineage's nmrium file that happens to share the same filename stem" do
+      attachment.send(:delete_related_nmrium, kept_nmrium)
+
+      expect(described_class.exists?(unrelated_nmrium.id)).to be true
     end
   end
 

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -602,6 +602,16 @@ RSpec.describe Attachment do
         it 'returns the existing attachment, updated in place' do
           expect(new_attachment.id).to eq existing_edit.id
         end
+
+        it 'uploads the new content exactly once, not once per internal save' do
+          # existing_edit (let!) is already created and uploaded by this point, so this
+          # only sees calls made during generate_att itself: the initial att.save! should
+          # upload once; the AASM state-transition save and the final save (for att.thumb)
+          # must not re-run the full attach/create_derivatives/update_column pipeline.
+          expect_any_instance_of(AttachmentUploader::Attacher).to receive(:attach).once.and_call_original # rubocop:disable RSpec/AnyInstance
+
+          new_attachment
+        end
       end
 
       context 'when the same lineage holds duplicate rows for the target filename (pre-fix corruption)' do

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -590,7 +590,7 @@ RSpec.describe Attachment do
         let!(:existing_edit) do
           create(
             :attachment, filename: 'spectra_file.edit.jdx', attachable: attachment.attachable,
-            aasm_state: 'edited', parent: attachment
+                         aasm_state: 'edited', parent: attachment
           )
         end
         let(:new_attachment) { attachment.generate_att(tempfile, 'edit', true, 'jdx') }
@@ -612,7 +612,7 @@ RSpec.describe Attachment do
         let!(:unrelated_edit) do
           create(
             :attachment, filename: 'spectra_file.edit.jdx', attachable: attachment.attachable,
-            aasm_state: 'edited', parent: unrelated_source
+                         aasm_state: 'edited', parent: unrelated_source
           )
         end
         let(:new_attachment) { attachment.generate_att(tempfile, 'edit', true, 'jdx') }
@@ -623,6 +623,22 @@ RSpec.describe Attachment do
 
         it 'creates its own attachment instead' do
           expect { new_attachment }.to change(described_class, :count).by(1)
+        end
+      end
+
+      context 'when the matching attachment in the same lineage is stuck in a failure state' do
+        let(:attachment) { create(:attachment, :with_spectra_file) }
+        let!(:failed_edit) do
+          create(
+            :attachment, filename: 'spectra_file.edit.jdx', attachable: attachment.attachable,
+                         aasm_state: 'failure', parent: attachment
+          )
+        end
+        let(:new_attachment) { attachment.generate_att(tempfile, 'edit', true, 'jdx') }
+
+        it 'reuses the row without raising an invalid transition error' do
+          expect { new_attachment }.not_to raise_error
+          expect(new_attachment.id).to eq failed_edit.id
         end
       end
 


### PR DESCRIPTION
Look up the canonical row for this filename across the whole dataset (not just
self's own children): re-editing an already-edited file, or editing a curve whose
dataset still holds both a .peak. and .edit. lineage, must reuse that single row -
scoping to children_of(self) would miss it (self isn't its own child) and mint a
duplicate .edit.jdx attachment on every save.

Linted module AttachmentJcampAasm completely and moved all "rubocop:disable" to the whole file because of a rubocop version difference between github and ELN