### PR TITLE
fix(mailer): harden SMTP settings (HELO domain, timeouts, value types)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -10,14 +10,20 @@ SMTP_PORT=587
 # login user name & password:
 SMTP_USERNAME='no-reply@sld.tld' 
 SMTP_PASSWORD='s3cr3tPW'
-# optional, HELO domain
+# HELO domain announced to the mail server; defaults to the PUBLIC_URL host.
+# Set it explicitly when the relay expects a specific name - relays that authenticate
+# their clients often answer a generic HELO slowly, or reject it.
 SMTP_DOMAIN='sld.tld'
 # detect STARTTLS
 SMTP_TLS=true
 # authentication type ('plain' 'login' (Base64 encoded) or 'cram_md5')
 SMTP_AUTH='plain'
-# how OpenSSL checks the certificate  ('none' or 'peer') 
+# how OpenSSL checks the certificate ('none' or 'peer'); any other value is ignored
 SMTP_SSL_MODE='none'
+# SMTP timeouts in seconds. The library default of 5s is too tight for an authenticated
+# remote relay (greylisting, recipient verification), which then fails with Net::ReadTimeout.
+# SMTP_OPEN_TIMEOUT=10
+# SMTP_READ_TIMEOUT=30
 
 # disable mail delivery
 # DISABLE_MAIL_DELIVERY='nomail'

--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -13,16 +13,36 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = { host: host, protocol: scheme, port: port }
   config.action_mailer.delivery_method = :smtp unless Rails.env.test?
+
+  # Accepted OpenSSL certificate check modes. Anything else (an empty value included) is
+  # ignored: Mail::SMTP#ssl_context would raise NameError on it.
+  smtp_ssl_mode = ENV['SMTP_SSL_MODE'].to_s.downcase
+  smtp_ssl_mode = nil unless %w[none peer].include?(smtp_ssl_mode)
+
+  # Fall back to the PUBLIC_URL host as HELO name, but only when it is a hostname: a bare
+  # IP is not a valid HELO argument and strict relays reject it.
+  smtp_domain = ENV['SMTP_DOMAIN'].presence
+  smtp_domain ||= host if host.to_s.include?('.') && !host.to_s.match?(/\A[\d.]+\z/)
+
+  # Blank settings are dropped rather than passed as nil: a nil value overrides the
+  # library default instead of falling back to it (Mail::SMTP does DEFAULTS.merge(settings)).
   config.action_mailer.smtp_settings = {
-    address: ENV.fetch('SMTP_ADDRESS', nil),
-    port: ENV.fetch('SMTP_PORT', nil),
-    user_name: ENV.fetch('SMTP_USERNAME', nil),
-    domain: ENV.fetch('SMTP_DOMAIN', nil),
-    password: ENV.fetch('SMTP_PASSWORD', nil),
-    authentication: ENV.fetch('SMTP_AUTH', nil) && ENV['SMTP_AUTH'].to_sym,
-    enable_starttls_auto: ENV.fetch('SMTP_TLS', nil) && ENV['SMTP_TLS'].include?('true'),
-    openssl_verify_mode: ENV.fetch('SMTP_SSL_MODE', nil),
-  }
+    address: ENV['SMTP_ADDRESS'].presence,
+    port: ENV['SMTP_PORT'].presence&.to_i,
+    user_name: ENV['SMTP_USERNAME'].presence,
+    # HELO domain. Without it the client announces itself as 'localhost', which
+    # authenticating relays commonly answer slowly or reject outright.
+    domain: smtp_domain,
+    password: ENV['SMTP_PASSWORD'].presence,
+    authentication: ENV['SMTP_AUTH'].presence&.to_sym,
+    enable_starttls_auto: ENV['SMTP_TLS'].presence && ENV['SMTP_TLS'].include?('true'),
+    openssl_verify_mode: smtp_ssl_mode,
+    # The mail gem defaults both timeouts to 5s, which an authenticated remote relay
+    # regularly exceeds (greylisting, recipient verification) - the delivery then fails
+    # with Net::ReadTimeout mid-session.
+    open_timeout: (ENV['SMTP_OPEN_TIMEOUT'].presence || 10).to_i,
+    read_timeout: (ENV['SMTP_READ_TIMEOUT'].presence || 30).to_i,
+  }.compact
 
   config.action_mailer.perform_deliveries = false if ENV['SMTP_ADDRESS'].blank? || ENV['DISABLE_MAIL_DELIVERY'].present?
 end


### PR DESCRIPTION
Ports ComPlat/chemotion_ELN#3474 from the `v3.x` maintenance line to `main`.

`config/initializers/mail.rb` on `main` was byte-identical to the v3.x pre-image, so this is an
unmodified cherry-pick of `9b87f8c` — reviewable directly against what landed on `v3.x`.

## Problem

Changing a user's e-mail address can 500. `Users::RegistrationsController#update` raises
`Net::ReadTimeout` from inside `Net::SMTP#rcptto`, reached through Devise's
`send_reconfirmation_instructions` → `deliver_now`.

It only affects installations that send through an **authenticated remote relay**
(`SMTP_USERNAME`/`SMTP_PASSWORD` set). An anonymous local relay never reproduces it.

## Cause

`config/initializers/mail.rb` builds `smtp_settings` straight from `ENV` and hands it to
`Mail::SMTP`, whose `initialize` does `DEFAULTS.merge(values)`. Two defects compound:

1. **A 5 second read timeout.** `Mail::SMTP::DEFAULTS` (mail 2.8.1) is `open_timeout: 5,
   read_timeout: 5`, and `build_smtp_session` applies them on top of net-smtp's own 30 s/60 s.
   The initializer set neither, so every SMTP command had a 5 s budget — and an authenticated
   relay routinely needs longer than that to answer `RCPT TO` (greylisting, recipient
   verification, rate limiting).
2. **`HELO localhost`.** Without `SMTP_DOMAIN`, `domain: nil` reaches `Net::SMTP#start`, which
   falls back to `helo ||= 'localhost'`. Relays that authenticate their clients commonly answer
   that slowly or reject it, and the added latency is what pushes `RCPT TO` past the ceiling above.

Separately, blank environment values were passed straight through. Because every key was always
present, a `nil` *overrode* the library default instead of falling back to it; `SMTP_PORT` was
handed over as a String; and an empty `SMTP_SSL_MODE` raised `NameError: uninitialized constant
OpenSSL::SSL::VERIFY_` inside `Mail::SMTP#ssl_context` at delivery time.

## Change

`config/initializers/mail.rb` — only the `smtp_settings` assignment:

- `open_timeout` / `read_timeout` default to 10 s / 30 s, configurable via `SMTP_OPEN_TIMEOUT`
  and `SMTP_READ_TIMEOUT`.
- `domain` falls back to the `PUBLIC_URL` host when `SMTP_DOMAIN` is unset — guarded so a bare IP
  is not used, since that is not a valid HELO argument either.
- The hash is `.compact`ed, so blank settings fall back to the library defaults instead of
  overriding them. `enable_starttls_auto: false` (from `SMTP_TLS=false`) survives and still
  disables STARTTLS; an unset `SMTP_TLS` leaves net-smtp's `:auto`, as before.
- `SMTP_PORT` is coerced to Integer; `SMTP_SSL_MODE` accepts only `none`/`peer` and is ignored
  otherwise.

`raise_delivery_errors`, `perform_deliveries` and the `return if Rails.env.test?` guard are
untouched. `.env.production.example` documents the HELO fallback, the two new timeout knobs and
the accepted `SMTP_SSL_MODE` values.

## Verification on `main`

Dev container, mail 2.8.1 / net-smtp 0.5.1 / Ruby 2.7.8. `smtp_settings` inspected across six env
combinations:

| Case | Result |
|---|---|
| Authenticated, no `SMTP_DOMAIN`, blank `SSL_MODE` | `port` → Integer, timeouts 10/30, no `nil` values, `openssl_verify_mode` key dropped |
| `PUBLIC_URL=https://eln.example.org` | `domain` → `eln.example.org` |
| `PUBLIC_URL=http://10.1.2.3:3000` | no `domain` key (bare IP is not a valid HELO argument) |
| `SMTP_TLS=false` | `enable_starttls_auto: false` survives `.compact` |
| No `SMTP_ADDRESS` | `perform_deliveries` still `false` |
| `SMTP_DOMAIN` + `SMTP_SSL_MODE=PEER` + custom timeouts | explicit domain wins, `"peer"`, 7/45 |

RuboCop clean. Full suite (`--exclude-pattern 'spec/features/**'`): 3246 examples, 17 failures,
coverage 70.22% (gate 57%) — all 17 reproduce identically on pristine `main` (datacollector sftp,
oauth_radar, admin_device sftp, metadata/radar, attachment paths) and are unrelated to this change.

## Out of scope

Delivery is still synchronous inside a Devise `after_commit`, so the `unconfirmed_email` change is
committed before the mailer runs, and `raise_delivery_errors = true` in production turns any SMTP
hiccup into a 500. Moving Devise notifications to `deliver_later` on the existing delayed_job
adapter, and rescuing in the controller, are the structural fixes — deliberately kept out of this
PR to keep it a clean port, and tracked separately.