### PR TITLE
fix(reaction): stop solvent volumes collapsing to 0 / n.d. on reference-amount change

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
@@ -1760,7 +1760,15 @@ export default class ReactionDetailsScheme extends React.Component {
           }
         }
 
-        if ((materialGroup === 'starting_materials' || materialGroup === 'reactants') && !sample.reference && !lockEquivColumn) {
+        // Solvents are included here so that editing a solvent volume (Eq unlocked) derives
+        // its equivalent from the real amount (amount_mol / reference.amount_mol). Otherwise
+        // the updated-sample branch above leaves it as amount_g / maxAmount, which is NaN for
+        // a solvent (no maxAmount); the next locked scale-up then multiplies NaN by the
+        // reference and shows the volume as "n.d.". This block is skipped while Eq is locked,
+        // so the solvent still scales from its (now valid) equivalent under lock.
+        if ((materialGroup === 'starting_materials'
+          || materialGroup === 'reactants'
+          || materialGroup === 'solvents') && !sample.reference && !lockEquivColumn) {
           // eslint-disable-next-line no-param-reassign
           if (referenceMaterial.amount_mol > 0) {
             sample.equivalent = sample.amount_mol / referenceMaterial.amount_mol;

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.spec.js
@@ -199,6 +199,108 @@ describe('ReactionDetailsScheme#updatedSamplesForAmountChange — polymer produc
   });
 });
 
+// Regression tests for the solvent volume calculation:
+// - Eq unlocked: a solvent's volume stays fixed; only its (derived) equivalent updates.
+// - Eq locked: a solvent's volume scales with the reference (equivalent * ref.amount_mol).
+// The historical glitch: editing a solvent volume set its equivalent via amount_g / maxAmount
+// (NaN, because a solvent has no maxAmount), and the correction block excluded solvents, so
+// the first locked scale-up multiplied NaN by the reference and showed the volume as "n.d.".
+// The correction block now includes solvents, so the equivalent is always a valid
+// amount_mol / reference.amount_mol ratio before it is used to scale.
+describe('ReactionDetailsScheme#updatedSamplesForAmountChange — solvent volume', () => {
+  let gasStoreStub;
+
+  const buildCtx = ({ lockEquivColumn = false } = {}) => ({
+    props: {
+      reaction: {
+        referenceMaterial: { amount_value: 200, amount_mol: 0.1, coefficient: 1 },
+        updateReferenceAmountForLockedEquivalents: sinon.stub(),
+      },
+    },
+    state: { lockEquivColumn },
+  });
+
+  const makeSolvent = (overrides = {}) => ({
+    id: 'solv-1',
+    amount_value: 0.01,
+    amount_unit: 'l',
+    amount_l: 0.01,
+    amount_g: 1.58,
+    amount_mol: 0.02,
+    coefficient: 1,
+    gas_type: 'off',
+    reference: false,
+    setAmountAndNormalizeToGram: sinon.spy(),
+    ...overrides,
+  });
+
+  const updatedReference = { id: 'ref-1', gas_type: 'off', amount_mol: 0.1 };
+
+  beforeEach(() => {
+    gasStoreStub = sinon.stub(GasPhaseReactionStore, 'getState').returns({ reactionVesselSizeValue: 0 });
+  });
+
+  afterEach(() => {
+    gasStoreStub.restore();
+  });
+
+  it('scales a solvent volume from its equivalent when Eq is locked and the reference changes', () => {
+    const ctx = buildCtx({ lockEquivColumn: true });
+    const solvent = makeSolvent({ equivalent: 0.5 });
+
+    ReactionDetailsScheme.prototype.updatedSamplesForAmountChange.call(
+      ctx,
+      [solvent],
+      updatedReference,
+      'solvents'
+    );
+
+    // equivalent (0.5) * reference amount_mol (0.1) = 0.05 mol
+    expect(solvent.setAmountAndNormalizeToGram.calledOnce).toBe(true);
+    const arg = solvent.setAmountAndNormalizeToGram.firstCall.args[0];
+    expect(arg.unit).toBe('mol');
+    expect(Math.abs(arg.value - 0.05) < 1e-9).toBe(true);
+  });
+
+  it('keeps a solvent volume fixed but refreshes its equivalent when Eq is unlocked and the reference changes', () => {
+    const ctx = buildCtx({ lockEquivColumn: false });
+    const solvent = makeSolvent({ equivalent: 999 });
+
+    const result = ReactionDetailsScheme.prototype.updatedSamplesForAmountChange.call(
+      ctx,
+      [solvent],
+      updatedReference,
+      'solvents'
+    );
+
+    expect(solvent.setAmountAndNormalizeToGram.called).toBe(false);
+    expect(result[0].amount_value).toBe(0.01);
+    // amount_mol (0.02) / reference amount_mol (0.1) = 0.2
+    expect(Math.abs(result[0].equivalent - 0.2) < 1e-9).toBe(true);
+  });
+
+  it('derives a valid equivalent (not NaN) when a solvent volume is edited while Eq is unlocked', () => {
+    // Reproduces the "n.d." glitch at its source: without the fix the equivalent is set to
+    // amount_g / maxAmount = NaN (a solvent has no maxAmount), which the next locked
+    // scale-up turns into "n.d.".
+    const ctx = buildCtx({ lockEquivColumn: false });
+    const solvent = makeSolvent({ equivalent: NaN, maxAmount: undefined });
+
+    const result = ReactionDetailsScheme.prototype.updatedSamplesForAmountChange.call(
+      ctx,
+      [solvent],
+      solvent, // the solvent itself is the updated sample (its own volume was edited)
+      'solvents'
+    );
+
+    expect(Number.isNaN(result[0].equivalent)).toBe(false);
+    expect(Math.abs(result[0].equivalent - 0.2) < 1e-9).toBe(true);
+    // Volume stays fixed while unlocked.
+    expect(solvent.setAmountAndNormalizeToGram.called).toBe(false);
+    expect(result[0].amount_value).toBe(0.01);
+  });
+});
+
 // Regression tests for the second polymer code path:
 // calculateEquivalentForProduct must route polymer products through checkMassPolymer
 // instead of the MW-based equivalent formula (which gives 0 when amount_g is null).


### PR DESCRIPTION
## Problem

In a reaction with a starting material and a solvent, changing the reference
amount with **equivalents locked** made the solvent volume render as `n.d.`.

## Steps to reproduce
1. Starting material = 700 mg (reference); add a solvent at 10 mL.
2. Lock the equivalents.
3. Change the starting material 700 mg → 350 mg. **Solvent volume → `n.d.`**

## Intended behaviour

- **Equivalents unlocked:** the solvent volume stays fixed; only its derived
  equivalent updates.
- **Equivalents locked:** the solvent volume scales with the reference.

## Root cause

When a solvent volume is edited (equivalents unlocked), the "updated sample"
branch of `updatedSamplesForAmountChange` sets the equivalent to
`amount_g / maxAmount`. A solvent has no `maxAmount`, so the equivalent becomes
`NaN`. The equivalent-correction block right below, which recomputes
`amount_mol / reference.amount_mol`, only ran for `starting_materials` and
`reactants`, so the solvent kept its `NaN` equivalent. The next locked reference
change then computed `NaN × reference.amount_mol`, which renders as `n.d.`.

Re-entering the volume while unlocked and changing the reference eventually hit a
different branch that set a valid equivalent, which is why the manual workaround
"fixed" it.

## Fix

Include `solvents` in the equivalent-correction block so a solvent volume edit
always leaves a valid `amount_mol / reference.amount_mol` equivalent before it is
ever used to scale. One condition change; no change to the locked/unlocked
behaviour otherwise.

## Tests

`ReactionDetailsScheme.spec.js` adds a `solvent volume` block covering:
- locked reference change → solvent scales (`equivalent × reference.amount_mol`),
- unlocked reference change → volume fixed, equivalent refreshed,
- unlocked volume edit → equivalent is a valid number, not `NaN` (the glitch).

## Manual QA

- [ ] Original reaction, dropdown solvent: 700→350 mg locked → 10 mL becomes 5 mL, not `n.d.`; 350→700 returns to 10 mL.
- [ ] Same with a custom (non-dropdown) solvent that has a density.
- [ ] Equivalents unlocked: changing the reference leaves the solvent volume unchanged.
- [ ] Regression: a normal reactant/starting material still scales under lock.

## Known limitation (out of scope)

A custom solvent with **neither density nor molarity** still cannot scale, because
its volume cannot be converted to moles at all (equivalent → 0). That is a separate,
deeper limitation, not this glitch.
