### PR TITLE
fix(reporter): guard against blank ppm crashing gas-scheme DOCX export

### DIFF
--- a/app/models/concerns/reactable.rb
+++ b/app/models/concerns/reactable.rb
@@ -143,13 +143,13 @@ module Reactable
 
   def calculate_mole_gas_product(ppm, temperature, vessel_volume)
     ##  Mol Value = ppm*pressure*V/(0.0821*temp_in_K*1000000)
-    return nil if vessel_volume.nil? || ppm.nil? || temperature.nil?
+    return nil if vessel_volume.blank? || ppm.blank? || temperature.blank?
 
     temperature_in_kelvin = convert_temperature_to_kelvin(temperature)
 
     return nil if temperature_in_kelvin.nil?
 
-    ppm * vessel_volume / (IDEAL_GAS_CONSTANT * temperature_in_kelvin * PARTS_PER_MILLION_FACTOR)
+    ppm.to_f * vessel_volume.to_f / (IDEAL_GAS_CONSTANT * temperature_in_kelvin * PARTS_PER_MILLION_FACTOR)
   end
 
   def calculate_feedstock_moles(amount_liter, purity)

--- a/lib/reporter/docx/detail_reaction.rb
+++ b/lib/reporter/docx/detail_reaction.rb
@@ -332,7 +332,7 @@ module Reporter
         when 'ml'
           vessel_size['amount'] * 0.001
         when 'l'
-          vessel_size['amount']
+          vessel_size['amount'].to_f
         else
           0
         end

--- a/spec/concerns/reactable_spec.rb
+++ b/spec/concerns/reactable_spec.rb
@@ -112,6 +112,21 @@ RSpec.describe Reactable, type: :module do
         result = reactable.calculate_mole_gas_product(nil, { 'value' => 25, 'unit' => '°C' }, 1.0)
         expect(result).to be_nil
       end
+
+      it 'returns nil instead of raising if ppm is an empty string' do
+        result = reactable.calculate_mole_gas_product('', { 'value' => 25, 'unit' => '°C' }, 1.0)
+        expect(result).to be_nil
+      end
+
+      it 'returns nil instead of raising if ppm is an empty string and vessel volume is an integer' do
+        result = reactable.calculate_mole_gas_product('', { 'value' => 25, 'unit' => '°C' }, 2)
+        expect(result).to be_nil
+      end
+
+      it 'calculates correctly when ppm is a numeric string' do
+        result = reactable.calculate_mole_gas_product('100', { 'value' => 25, 'unit' => '°C' }, 1.0)
+        expect(result).to eq(4.085281893642546e-06)
+      end
     end
 
     describe '#calculate_feedstock_moles' do


### PR DESCRIPTION
## Problem

DOCX report generation (`Report#create_docx`) crashes for *some* reactions that use the gas-phase
reaction scheme, while other gas-scheme reactions export fine:

```
NoMethodError: undefined method `/' for "":String
  from app/models/concerns/reactable.rb:152:in `calculate_mole_gas_product'
  from lib/reporter/docx/detail_reaction.rb:418:in `calculate_amount_mmol'
  from lib/reporter/docx/detail_reaction.rb:437:in `assigned_amount'
  from lib/reporter/docx/detail_reaction.rb:541:in `material_hash'
  from lib/reporter/docx/detail_reaction.rb:724:in `block in products'
  ...
  from app/models/report.rb:94:in `create_docx'
```

## Root cause

`Reactable#calculate_mole_gas_product` guarded only against `nil`:

```ruby
return nil if vessel_volume.nil? || ppm.nil? || temperature.nil?

ppm * vessel_volume / (IDEAL_GAS_CONSTANT * temperature_in_kelvin * PARTS_PER_MILLION_FACTOR)
```

A gaseous product whose ppm field is cleared in the UI persists `gas_phase_data.part_per_million`
as an **empty string**, not `nil` — the frontend stores the raw input value verbatim, and the
JS-side calculation guards it with its own falsy check, so only the Ruby reporter path chokes on it.

Ruby's `String#*` on an empty string returns `""` for any integer multiplier, so
`ppm * vessel_volume` evaluates to `""` whenever `vessel_volume` is an `Integer` — which happens
when the reaction vessel size is recorded in **liters**, because `calculate_vessel_volume` passed
that amount through unconverted (the `ml` branch always coerces to `Float` via `* 0.001`). The
following division then raises the `NoMethodError` above.

That combination is exactly why some gas-scheme reactions fail and others don't: it needs both an
empty ppm on a gaseous product **and** a vessel size in `l`. With `ml` the same defect surfaces as a
`TypeError` instead.

`temperature` does not trigger this because `convert_temperature_to_kelvin` already coerces with
`.to_f`.

## Fix

- `app/models/concerns/reactable.rb` — guard with `blank?` instead of `nil?`, and coerce
  `ppm`/`vessel_volume` to `Float` before the arithmetic, mirroring the `.to_f` coercion already
  applied to `temperature`. `0` / `0.0` are not blank, so the previous behaviour for real values is
  unchanged; the guard only widens `nil` to "nil or empty".
- `lib/reporter/docx/detail_reaction.rb` — `calculate_vessel_volume`'s `'l'` branch returns
  `.to_f`, so the method's return type is a `Float` regardless of unit (this is what its own YARD
  example on the line above already documented: `#=> 2.0`).

The two non-reporter callers (`Reactable#update_gas_material` and
`Usecases::Reactions::UpdateMaterials#update_mole_gas_product`) both already treat a `nil` return as
"skip this material", so the widened guard is safe there — a blank ppm now yields a skipped
calculation instead of a raise.

## Testing

Three regression examples added to `spec/concerns/reactable_spec.rb`: empty-string ppm with a float
vessel volume, empty-string ppm with an **integer** vessel volume (the exact crashing shape), and a
numeric-string ppm that still calculates correctly.

```
$ bundle exec rspec spec/concerns/reactable_spec.rb
38 examples, 0 failures

$ bundle exec rspec spec/lib/reporter/docx/detail_reaction_spec.rb
17 examples, 0 failures
```

RuboCop is clean on the changed lines.

---

- [x] rather 1-story 1-commit than sub-atomic commits
- [x] commit title is meaningful
- [x] commit description is helpful
- [x] code is up-to-date with the latest developments of the target branch
- [x] added code is linted
- [x] tests are passing (at least locally)
- [ ] in case the changes are visible to the end-user, video or screenshots should be added — n/a, backend-only crash fix
- [x] testing coverage improvement is improved
- [ ] CHANGELOG — n/a, this repo only touches CHANGELOG.md at release prep
