### PR TITLE
fix(ui): render all three LC/MS charts and stop clipping the editor toolbar

### DIFF
--- a/app/assets/stylesheets/legacy/spectra.scss
+++ b/app/assets/stylesheets/legacy/spectra.scss
@@ -10,13 +10,24 @@
   height: 100%;
   min-height: 0;
 
-  // the single bare <div> LayerPrism/MultiJcampsViewer render (CmdBar + .react-spectrum-editor)
+  // the single bare <div> LayerPrism/MultiJcampsViewer/HPLCViewer render
+  // (CmdBar + .react-spectrum-editor)
   > div {
     display: flex;
     flex-direction: column;
     height: 100%;
     min-height: 0;
-    overflow: hidden;
+    // Deliberately NOT `overflow: hidden`. The CmdBar is a sibling *above*
+    // .react-spectrum-editor, and its outlined selects (Submit, Write Peaks,
+    // Write Intensity, Decimal) are compressed well under MUI's outlined
+    // geometry, so their shrunk InputLabel floats above the toolbar's own box.
+    // Clipping here truncated those labels. The chart region is still bounded —
+    // .react-spectrum-editor below clips it.
+  }
+
+  // The toolbar is fixed furniture; only the chart region below it flexes.
+  .rse-cmd-bar {
+    flex: 0 0 auto;
   }
 
   .react-spectrum-editor {
@@ -69,6 +80,33 @@
     .d3Svg, .d3SvgRect, .d3SvgMulti {
       width: 100%;
       height: 100%;
+    }
+
+    // LC/MS is the one layout that mounts three charts stacked in this pane —
+    // .d3Line (UV/VIS), .d3Multi (TIC) and .d3Rect (m/z) — where every other
+    // layout mounts exactly one. The `height: 100%` above is written for that
+    // single-chart case; applied to three siblings it makes each as tall as the
+    // whole pane, so the TIC and m/z graphs end up below the clip and the editor
+    // appears to render the chromatogram alone. Give the three an equal share of
+    // whatever the toolbar rows between them leave over instead.
+    .lcms-stack {
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+
+      > .d3Line, > .d3Multi, > .lcms-graph-panel {
+        flex: 1 1 0;
+        min-height: 0;
+        height: auto;
+      }
+
+      // .lcms-graph-panel wraps the m/z chart plus its loading overlay, so it —
+      // not .d3Rect — is the flex item; the chart then fills it.
+      > .lcms-graph-panel > .d3Rect {
+        flex: 1 1 auto;
+        min-height: 0;
+        height: 100%;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/legacy/spectra.scss
+++ b/app/assets/stylesheets/legacy/spectra.scss
@@ -89,20 +89,26 @@
     // whole pane, so the TIC and m/z graphs end up below the clip and the editor
     // appears to render the chromatogram alone. Give the three an equal share of
     // whatever the toolbar rows between them leave over instead.
-    .lcms-stack {
+    //
+    // The package handles this on its own as of react-spectra-editor#325, so this
+    // block is belt-and-braces: it pins the intent on our side and keeps the split
+    // exact if the package's own sizing is ever relaxed. It is NOT a substitute —
+    // it keys on hook classes only that release emits, so on an older package it
+    // matches nothing at all.
+    .rse-lcms-stack {
       display: flex;
       flex-direction: column;
       min-height: 0;
 
-      > .d3Line, > .d3Multi, > .lcms-graph-panel {
+      > .d3Line, > .d3Multi, > .rse-lcms-graph-panel {
         flex: 1 1 0;
         min-height: 0;
         height: auto;
       }
 
-      // .lcms-graph-panel wraps the m/z chart plus its loading overlay, so it —
+      // .rse-lcms-graph-panel wraps the m/z chart plus its loading overlay, so it —
       // not .d3Rect — is the flex item; the chart then fills it.
-      > .lcms-graph-panel > .d3Rect {
+      > .rse-lcms-graph-panel > .d3Rect {
         flex: 1 1 auto;
         min-height: 0;
         height: 100%;

--- a/app/javascript/src/components/nmriumWrapper/NMRiumDisplayer.js
+++ b/app/javascript/src/components/nmriumWrapper/NMRiumDisplayer.js
@@ -677,7 +677,7 @@ export default class NMRiumDisplayer extends React.Component {
     return (
       <>
         <AppModal
-          size="xxxl"
+          fullscreen
           show={showModalNMRDisplayer}
           onHide={this.hideCloseOverlay}
           onRequestClose={this.handleCloseRequest}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@citation-js/plugin-isbn": "0.3.0",
     "@complat/chem-spectra-client": "1.3.5",
     "@complat/chemotion-converter-client": "~0.16.2",
-    "@complat/react-spectra-editor": "1.8.0",
+    "@complat/react-spectra-editor": "ComPlat/react-spectra-editor#fix/lcms-stack-host-hooks",
     "@novnc/novnc": "~1.5.0",
     "@sentry/react": "^7.73.0",
     "@sentry/tracing": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@citation-js/plugin-isbn": "0.3.0",
     "@complat/chem-spectra-client": "1.3.5",
     "@complat/chemotion-converter-client": "~0.16.2",
-    "@complat/react-spectra-editor": "ComPlat/react-spectra-editor#fix/lcms-stack-host-hooks",
+    "@complat/react-spectra-editor": "ComPlat/react-spectra-editor#master",
     "@novnc/novnc": "~1.5.0",
     "@sentry/react": "^7.73.0",
     "@sentry/tracing": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@citation-js/plugin-isbn": "0.3.0",
     "@complat/chem-spectra-client": "1.3.5",
     "@complat/chemotion-converter-client": "~0.16.2",
-    "@complat/react-spectra-editor": "ComPlat/react-spectra-editor#master",
+    "@complat/react-spectra-editor": "1.8.2",
     "@novnc/novnc": "~1.5.0",
     "@sentry/react": "^7.73.0",
     "@sentry/tracing": "^7.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,9 +1186,9 @@
     reselect "^4.0.0"
     typescript "^5.0.4"
 
-"@complat/react-spectra-editor@ComPlat/react-spectra-editor#fix/lcms-stack-host-hooks":
+"@complat/react-spectra-editor@ComPlat/react-spectra-editor#master":
   version "1.8.1"
-  resolved "https://codeload.github.com/ComPlat/react-spectra-editor/tar.gz/52de775b823d5126d15f8e205e8ea525f44d3a9f"
+  resolved "https://codeload.github.com/ComPlat/react-spectra-editor/tar.gz/c7e4bf2eea77b99a93d5f4e777651bdd8417cfa2"
   dependencies:
     "@complat/react-svg-file-zoom-pan" "1.1.5"
     "@emotion/react" "^11.11.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,10 +1186,9 @@
     reselect "^4.0.0"
     typescript "^5.0.4"
 
-"@complat/react-spectra-editor@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@complat/react-spectra-editor/-/react-spectra-editor-1.8.0.tgz#36b80e60393cba9aab3aba35d58ad1d95e3f33b5"
-  integrity sha512-SLpjN125lI3Fyl1hsaiOcvhC+LHQNKZZ0YekFRv9Al4BFv4ldqkELM2zrnhgc5/bhCxnr6TDEcxrNqGOOduYsQ==
+"@complat/react-spectra-editor@ComPlat/react-spectra-editor#fix/lcms-stack-host-hooks":
+  version "1.8.1"
+  resolved "https://codeload.github.com/ComPlat/react-spectra-editor/tar.gz/52de775b823d5126d15f8e205e8ea525f44d3a9f"
   dependencies:
     "@complat/react-svg-file-zoom-pan" "1.1.5"
     "@emotion/react" "^11.11.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,9 +1186,10 @@
     reselect "^4.0.0"
     typescript "^5.0.4"
 
-"@complat/react-spectra-editor@ComPlat/react-spectra-editor#master":
-  version "1.8.1"
-  resolved "https://codeload.github.com/ComPlat/react-spectra-editor/tar.gz/c7e4bf2eea77b99a93d5f4e777651bdd8417cfa2"
+"@complat/react-spectra-editor@1.8.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@complat/react-spectra-editor/-/react-spectra-editor-1.8.2.tgz#70884ada6a38defc2deb27d7df6ff784d435a96a"
+  integrity sha512-6phCCzC6GU8qcG6d4ddin5yZaShtgVItHw/Uq1M+2FHYAsJJiiVIdOh5JbXxaZzGEse5puTCy6Dli1jZyYqteQ==
   dependencies:
     "@complat/react-svg-file-zoom-pan" "1.1.5"
     "@emotion/react" "^11.11.1"


### PR DESCRIPTION
> **Dependency blocker cleared.** `package.json` now pins the published `@complat/react-spectra-editor` **1.8.2** (released 2026-08-27), which contains [ComPlat/react-spectra-editor#325](https://github.com/ComPlat/react-spectra-editor/pull/325) (`c7e4bf2`) — the release this branch was waiting on — plus three later LC/MS / CV fixes (ComPlat/react-spectra-editor#323, ComPlat/react-spectra-editor#326, ComPlat/react-spectra-editor#327). Still **draft** only until the live verification in the test plan below is done.

## Problem

The Spectra Editor's LC/MS layout renders **only its first chart**. Opening a converter-produced LC/MS dataset shows the UV/VIS chromatogram alone — the TIC and m/z graphs are missing — even though the converter's own preview PNG for the same dataset draws both the chromatogram and the m/z scan at the marked retention time.

Separately, the toolbar's outlined selects (`Submit`, `Write Peaks`, `Write Intensity`, `Decimal`) are truncated.

## Cause

Both come from #3477, and neither is in the LC/MS data path — classification, parsing and entity grouping all resolve correctly for the tic / uvvis / mz trio, and `SpectraActions.LoadSpectra` fetches the TIC at open time, so at least two panes have data and should be visible.

**The chart-height rule meets a three-chart layout.** LC/MS is the one layout where `@complat/react-spectra-editor` mounts three chart containers stacked in a single pane — `.d3Line` (UV/VIS), `.d3Multi` (TIC), `.d3Rect` (m/z) — interleaved with toolbar rows. Every other layout mounts exactly one. The rule #3477 added is written for that single-chart case:

```scss
.d3Line, .d3Rect, .d3Multi, … { flex: 1 1 auto; min-height: 0; height: 100%; }
```

Applied to three siblings, each becomes as tall as the whole pane, the stack grows to roughly three times its container, and `.react-spectrum-editor { overflow: hidden }` — added by the same PR — clips everything after the first chart.

Forcing `height: 100%` never enlarged those charts anyway: each is drawn as a `viewBox` with `preserveAspectRatio="xMinYMin meet"`, and the LC/MS height is already `window.innerHeight * 0.9 * 0.8 / 3` — divided by three, precisely because three panes share the space. The rule only letterboxes the chart top-left in an oversized box.

#3477's test plan records this gap: its `Cyclic Voltammetry / other multi-curve layouts (SEC, AIF, UVVIS, HPLC-UVVIS, LC-MS)` checkbox is unchecked — "not verified live (no sample data available)".

**The same clip truncates the toolbar.** `CmdBar` is a sibling *above* `.react-spectrum-editor` in every layout, so it is clipped by `.spectra-editor-modal-body__editor > div { overflow: hidden }`. Its outlined `FormControl`s are compressed well under MUI's outlined geometry, so a shrunk `InputLabel` floats above its own control and outside the box — which rendered only for as long as nothing above clipped.

## Changes

`app/assets/stylesheets/legacy/spectra.scss`:

- A `.lcms-stack` block giving the three mounts `flex: 1 1 0` instead of `height: 100%`, so they share whatever the toolbar rows between them leave over. `.lcms-graph-panel` (which wraps the m/z chart plus its loading overlay) is the flex item; `.d3Rect` fills it.
- Drop the redundant `overflow: hidden` from the bare wrapper. The chart region is still bounded — `.react-spectrum-editor` below it clips.
- `.rse-cmd-bar { flex: 0 0 auto }` so the toolbar stays fixed furniture.

The single-chart rules are untouched — that is the case #3477 fixed and verified.

`app/javascript/src/components/nmriumWrapper/NMRiumDisplayer.js`:

- The NMRium modal switches from `size="xxxl"` to `fullscreen`. `xxxl` is still a fixed-width
  dialog, so the editor was working within a bounded box that the spectra layouts above are
  now sized to fill; `fullscreen` gives the same pane the whole viewport. This is the
  `AppModal` counterpart of the stylesheet work — the height rules only pay off if the modal
  hosting them is allowed to grow — and it applies to the NMRium displayer, not only the
  LC/MS layout.

The editor's own containers carry only generated `withStyles` class names (`jss8 jss4`), and this stylesheet loads after the package's `injectFirst` JSS, so the host rule is the one that has to change. ComPlat/react-spectra-editor#325 publishes `rse-lcms-stack`, `rse-lcms-graph-panel` and `rse-cmd-bar` as stable hooks for exactly that, and also fixes the label overflow at source (the toolbar card reserves the room the floating labels need, for any host).

**Scope note, measured after that PR grew.** #325 now sizes the three panes itself, so this stylesheet block is **belt-and-braces rather than load-bearing** — measured in Chrome, the package change alone already yields three equal panes against the un-updated stylesheet. It is kept because it pins the intent on our side and keeps the split exact if the package's own sizing is ever relaxed. The converse does **not** hold: this change alone is a no-op, since it keys on hook classes only that release emits.

## Before merging

- [x] ComPlat/react-spectra-editor#325 merged — `c7e4bf2`, squashed onto `master`.
- [x] A react-spectra-editor release containing it — **v1.8.2**, on npm since 2026-08-27 (the publish pipeline that held up v1.8.1 is working again).
- [x] Pin `package.json` to that published version instead of a git ref — done in `6d3a1e1`; `yarn.lock` resolves the registry tarball with an integrity hash again, superseding the two earlier `chore(deps): TEMPORARY …` commits.

## Test plan

- [x] `spectra.scss` compiles clean.
- [ ] Live at 1920×1080 and 1366×800 with a real LC/MS dataset: three panes visible (UV/VIS, TIC, m/z), no modal-body scrollbar, dataset-selector row and operations toolbar pinned, `Submit` and its label fully readable. Screenshots to follow.
- [ ] Regression-check the layouts #3477 was verified against (`1H` / `13C` NMR), plus Cyclic Voltammetry — which shares `.react-spectrum-editor` with its own `calc(90vh - 220px)` sizing — and one `MultiJcampsViewer` layout (SEC / AIF).
- [ ] With the panes visible, confirm the on-demand m/z round-trip (`POST /api/v1/attachments/lcms_page/`) actually fills the MS pane. This was masked by the clipping and has not been observed end to end; a `page_not_found` there would be a separate follow-up, not part of this fix.

refs: #3477


