### PR TITLE
fix  PG dropped connection on sdf import and pubchem faults

### DIFF
--- a/app/jobs/pubchem_lookup_job.rb
+++ b/app/jobs/pubchem_lookup_job.rb
@@ -230,7 +230,16 @@ class PubchemLookupJob < ApplicationJob
 
   # Spaces outbound PubChem requests. Extracted so the pacing is per *request*, which is what
   # PubChem's policy counts.
+  #
+  # Also where this job releases its AR connection. Called immediately before every HTTP round
+  # trip (see #enrich_and_fetch_lcss), so together the sleep and the request that follows can
+  # leave the connection idle for 21s+ per molecule, for up to this job's whole run budget (see
+  # RUN_BUDGET_RATIO) -- worst case tens of minutes on one checked-out connection doing nothing.
+  # Releasing it here means a connection dropped/reaped during that idle window is simply
+  # re-checked-out on the next query instead of poisoning the worker with PG::ConnectionBad. See
+  # #626.
   def throttle
+    ActiveRecord::Base.connection_pool.release_connection
     sleep SLEEP_BETWEEN_REQUESTS
   end
 

--- a/lib/chemotion/open_babel_service.rb
+++ b/lib/chemotion/open_babel_service.rb
@@ -27,6 +27,15 @@ module Chemotion::OpenBabelService
   # for a given deployment.
   SVG_RENDER_TIMEOUT_SECONDS = Integer(ENV.fetch('OPENBABEL_SVG_TIMEOUT_SECONDS', 5))
 
+  # Wall-clock bound for the canonical-SMILES ('can') writer in molecule_info_from_structure.
+  # Unlike the SVG writer this one is not merely slow to time out -- on metal clusters its
+  # symmetry-detection cost is combinatorial, not size-driven (see #626: a 17-atom record took
+  # 6s while a 92-atom one took 11.3s), and it runs in-process on every import row with no bound
+  # at all before this. Set well above the measured 12.06s worst case (across 6,355 records of a
+  # metal-heavy stress file) so it only fires on a genuine outlier/hang, not on ordinary slow
+  # structures.
+  CANONICAL_SMILES_TIMEOUT_SECONDS = Integer(ENV.fetch('OPENBABEL_CANONICAL_SMILES_TIMEOUT_SECONDS', 20))
+
   # mdl V3000
   MOLFILE_COUNT_LINE_START      = 'M  V30 COUNTS '
   MOLFILE_BEGIN_CTAB_BLOCK_LINE = 'M  V30 BEGIN CTAB'
@@ -125,13 +134,7 @@ M  END
     c.set_out_format 'smi'
     smiles = c.write_string(m, false).to_s.gsub(/\s.*/m, "").strip
 
-    c.set_out_format 'can'
-    ca_smiles = begin
-      str = c.write_string(m, false).to_s
-      str.lines.first.to_s.gsub(/\s.*/m, "").strip
-    rescue StandardError, SystemStackError
-      ''
-    end
+    ca_smiles = canonical_smiles_from_source(mf || structure, format)
 
     unless format == 'mol'
       c.set_out_format 'mol'
@@ -480,6 +483,36 @@ M  END
     Rails.logger.error("Chemotion::OpenBabelService.svg_from_molfile aborted: #{e.message}")
     nil
   end
+
+  # Process-isolated, timeout-bounded wrapper around OpenBabel's canonical-SMILES writer. See
+  # CANONICAL_SMILES_TIMEOUT_SECONDS. Falls back to '' on timeout or any other failure, matching
+  # the blank-on-failure contract molecule_info_from_structure's callers already expect from this
+  # field.
+  def self.canonical_smiles_from_source(source, in_format)
+    Chemotion::ForkedTimeout.run(CANONICAL_SMILES_TIMEOUT_SECONDS) do
+      canonical_smiles_from_source_unsafe(source, in_format)
+    end
+  rescue StandardError => e
+    # Covers both Chemotion::ForkedTimeout::TimedOut (deadline overrun or a crashed child, e.g.
+    # from SystemStackError, which the child's own StandardError rescue does not catch) and any
+    # error the writer itself raised and the child re-raised in this process.
+    Rails.logger.error("Chemotion::OpenBabelService.canonical_smiles_from_source failed: #{e.message}")
+    ''
+  end
+
+  def self.canonical_smiles_from_source_unsafe(source, in_format)
+    c = OpenBabel::OBConversion.new
+    c.set_in_format in_format
+    m = OpenBabel::OBMol.new
+    c.read_string m, source
+
+    c.set_out_format 'can'
+    c.write_string(m, false).to_s.lines.first.to_s.gsub(/\s.*/m, '').strip
+  end
+
+  # The bare `private` above this section does not apply to singleton methods, so these two are
+  # closed off explicitly.
+  private_class_method :canonical_smiles_from_source, :canonical_smiles_from_source_unsafe
 
   def self.svg_from_molfile_unsafe(molfile, options = {})
     c = OpenBabel::OBConversion.new

--- a/lib/chemotion/pubchem_service.rb
+++ b/lib/chemotion/pubchem_service.rb
@@ -59,9 +59,12 @@ module Chemotion::PubchemService
         log_p: nil        # optional
       }
 
-      result[:cid] = rec['id']['id']['cid']
+      # dig, not chained [], and Array(...) below: a malformed PC_Compounds record (empty id,
+      # missing props) must degrade to the same nil-filled result a Fault produces, not raise
+      # NoMethodError up through PubchemLookupJob. See #627.
+      result[:cid] = rec.dig('id', 'id', 'cid')
 
-      rec['props'].each do |prop|
+      Array(rec['props']).each do |prop|
         if (prop['urn']['label'] == 'IUPAC Name' && prop['urn']['name'] == 'Preferred')
           result[:iupac_name] = prop['value']['sval'].to_s
         end

--- a/lib/import/import_sdf.rb
+++ b/lib/import/import_sdf.rb
@@ -269,64 +269,72 @@ class Import::ImportSdf < Import::ImportSamples
     ids = []
     read_data if raw_data.empty? && rows.empty?
     if !raw_data.empty? && inchi_array.empty?
-      ActiveRecord::Base.transaction do
-        raw_data.each_with_index do |molfile, index|
-          ActiveRecord::Base.transaction(requires_new: true) do
-            babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile, render_svg: false)
-            inchikey = babel_info[:inchikey]
-            is_partial = babel_info[:is_partial]
-            next unless inchikey.presence && (molecule = Molecule.find_by(inchikey: inchikey, is_partial: is_partial))
-            next unless (i = inchi_array.index(inchikey))
+      raw_data.each_with_index do |molfile, index|
+        # OpenBabel's canonical-SMILES/InChI work is native and can run for several seconds on an
+        # organometallic structure (measured up to ~12s, see #626). Do it -- and release the DB
+        # connection around it -- before opening a transaction, so a dropped/reaped connection is
+        # simply re-checked-out on the next query instead of leaving a transaction idle for
+        # seconds at a time. The transaction below wraps only the actual DB writes.
+        ActiveRecord::Base.connection_pool.release_connection
+        babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile, render_svg: false)
+        inchikey = babel_info[:inchikey]
+        is_partial = babel_info[:is_partial]
+        next unless inchikey.presence && (molecule = Molecule.find_by(inchikey: inchikey, is_partial: is_partial))
+        next unless (i = inchi_array.index(inchikey))
 
-            @inchi_array[i] = nil
-            sample = Sample.new(
-              created_by: current_user_id,
-              molfile: molfile,
-              molfile_version: babel_info[:molfile_version],
-              molecule_id: molecule.id,
-            )
-            sample.collections << Collection.find(collection_id)
-            sample.collections << Collection.get_all_collection_for_user(current_user_id)
-            sample.save!
-            ids << sample.id
-          end
-        rescue StandardError => e
-          Rails.logger.error("SDF import: molecule #{index + 1} could not be imported: #{e.class}: #{e.message}")
-          @unprocessable_samples << (index + 1)
+        ActiveRecord::Base.transaction(requires_new: true) do
+          @inchi_array[i] = nil
+          sample = Sample.new(
+            created_by: current_user_id,
+            molfile: molfile,
+            molfile_version: babel_info[:molfile_version],
+            molecule_id: molecule.id,
+          )
+          sample.collections << Collection.find(collection_id)
+          sample.collections << Collection.get_all_collection_for_user(current_user_id)
+          sample.save!
+          ids << sample.id
         end
+      rescue StandardError => e
+        Rails.logger.error("SDF import: molecule #{index + 1} could not be imported: #{e.class}: #{e.message}")
+        @unprocessable_samples << (index + 1)
       end
     elsif !rows.empty?
       begin
-        ActiveRecord::Base.transaction do
-          attribs = Sample.attribute_names & @mapped_keys.keys
-          error_messages = []
-          rows.each_with_index do |row, i|
-            next unless row
+        attribs = Sample.attribute_names & @mapped_keys.keys
+        error_messages = []
+        rows.each_with_index do |row, i|
+          next unless row
 
-            # Savepoint per row: without it a DB-level failure (e.g. from the chemical save below)
-            # leaves PostgreSQL's transaction aborted, so the rescue below cannot contain it -- every
-            # later row then fails and the outer transaction rolls back the rows that did succeed.
-            # Mirrors the raw-data branch above.
-            ActiveRecord::Base.transaction(requires_new: true) do
-              sample = build_sample_from_row(row, attribs, error_messages)
-              next if sample.nil?
+          # Same reasoning as the raw-data branch above: resolve the molecule (native OpenBabel
+          # work) with the DB connection released, before opening the transaction that does the
+          # actual writes.
+          ActiveRecord::Base.connection_pool.release_connection
+          resolved = resolve_molecule_for_row(row)
+          next if resolved.first.blank?
 
-              sample.collections << Collection.find(collection_id)
-              sample.collections << Collection.get_all_collection_for_user(current_user_id)
-              sample.save!
-              save_chemical_for_row(sample, row) if @import_type == 'chemical'
-              ids << sample.id
-            end
-          rescue StandardError => e
-            Rails.logger.error("SDF import: row #{i + 1} could not be imported: #{e.class}: #{e.message}")
-            @unprocessable_samples << (i + 1)
-            error_messages << "Sample #{i + 1} could not be imported: #{e.message}"
+          # Savepoint per row: without it a DB-level failure (e.g. from the chemical save below)
+          # leaves PostgreSQL's transaction aborted, so the rescue below cannot contain it -- every
+          # later row then fails. Each row is now its own top-level transaction rather than a
+          # savepoint nested in one enclosing transaction, so no earlier row's connection/lock is
+          # held across a later row's native work either.
+          ActiveRecord::Base.transaction(requires_new: true) do
+            sample = build_sample_from_row(resolved, row, attribs, error_messages)
+            sample.collections << Collection.find(collection_id)
+            sample.collections << Collection.get_all_collection_for_user(current_user_id)
+            sample.save!
+            save_chemical_for_row(sample, row) if @import_type == 'chemical'
+            ids << sample.id
           end
-          if error_messages.empty? && @unprocessable_samples.any?
-            error_messages << "Following samples could not be imported #{@unprocessable_samples}."
-          end
-          @message[:error_messages] = error_messages if error_messages.present?
+        rescue StandardError => e
+          Rails.logger.error("SDF import: row #{i + 1} could not be imported: #{e.class}: #{e.message}")
+          @unprocessable_samples << (i + 1)
+          error_messages << "Sample #{i + 1} could not be imported: #{e.message}"
         end
+        if @unprocessable_samples.any?
+          error_messages << "Following samples could not be imported #{@unprocessable_samples}."
+        end
+        @message[:error_messages] = error_messages if error_messages.present?
       rescue StandardError => e
         Rails.logger.error("SDF import: aborted: #{e.class}: #{e.message}")
         @message[:error] << "The import could not be completed: #{e.message}"
@@ -351,11 +359,11 @@ class Import::ImportSdf < Import::ImportSamples
   end
 
   # Extracted from #create_samples' row loop so each step is separately readable -- the loop itself
-  # only decides whether the row becomes a sample and how failures are reported.
-  def build_sample_from_row(row, attribs, error_messages)
-    molecule, molfile_for_sample, babel_info = resolve_molecule_for_row(row)
-    return nil if molecule.blank?
-
+  # only decides whether the row becomes a sample and how failures are reported. +resolved+ is
+  # [molecule, molfile_for_sample, babel_info] from #resolve_molecule_for_row, resolved in the
+  # caller -- native OpenBabel work -- before the transaction this runs inside of. See #626.
+  def build_sample_from_row(resolved, row, attribs, error_messages)
+    molecule, molfile_for_sample, babel_info = resolved
     sample = Sample.new(
       created_by: current_user_id,
       molfile: molfile_for_sample,
@@ -517,6 +525,16 @@ class Import::ImportSdf < Import::ImportSamples
   end
 
   def find_or_create_by_molfiles(molfiles)
+    # Same reasoning as #create_samples, and this is the larger of the two windows: one call
+    # covers a whole batch of records, each of which can spend up to
+    # Chemotion::OpenBabelService::CANONICAL_SMILES_TIMEOUT_SECONDS in native canonical-SMILES
+    # work -- minutes of wall clock for a 50-record batch of organometallics, with no SQL in
+    # between. Holding a checked-out connection across that is exactly what #626 is about, and
+    # the per-record rescue below does not help: once the server has hung up, the connection is
+    # never re-verified, so every remaining record in the import fails too. Releasing here puts
+    # it back through ConnectionPool#checkout_and_verify, which reconnects transparently.
+    ActiveRecord::Base.connection_pool.release_connection
+
     # render_svg: false — Molecule#assign_molecule_data discards OpenBabel's SVG and re-renders
     # via Chemotion::SvgRenderer, so rendering it per record is the largest avoidable cost on
     # this path: it is the only timeout-bounded operation in molecule_info_from_molfile, and on
@@ -525,14 +543,27 @@ class Import::ImportSdf < Import::ImportSamples
     babel_info_array = Chemotion::OpenBabelService.molecule_info_from_molfiles(molfiles, render_svg: false)
 
     babel_info_array.map.with_index do |babel_info, i|
-      mf = molfiles[i]
-      if Chemotion::MolfilePolymerSupport.has_polymers_list_tag?(mf.to_s)
-        find_or_create_polymer_molfile_entry(mf.to_s.strip, babel_info)
-      elsif babel_info && babel_info[:inchikey].present?
-        molfile_entry_with_inchikey(mf, babel_info)
-      else
-        molfile_entry_without_inchikey(mf)
-      end
+      # Per-record rescue: unlike the OpenBabel work above (already guarded inside
+      # molecule_info_from_molfiles), the Molecule find-or-create below is a real DB write with
+      # no guard of its own. Before this, one dropped/reaped connection here (see #626) escaped
+      # this method, process_molecule_batches, and find_or_create_mol_by_batch entirely --
+      # aborting the whole import uncaught, rather than just the one record.
+      find_or_create_molecule_entry(molfiles[i], babel_info)
+    rescue StandardError => e
+      Rails.logger.error("SDF import: molecule entry #{i + 1} could not be resolved: #{e.class}: #{e.message}")
+      nil
+    end
+  end
+
+  # @return [Hash, nil] a preview entry for one record, or nil if none of the strategies below
+  #   resolved a molecule
+  def find_or_create_molecule_entry(molfile, babel_info)
+    if Chemotion::MolfilePolymerSupport.has_polymers_list_tag?(molfile.to_s)
+      find_or_create_polymer_molfile_entry(molfile.to_s.strip, babel_info)
+    elsif babel_info && babel_info[:inchikey].present?
+      molfile_entry_with_inchikey(molfile, babel_info)
+    else
+      molfile_entry_without_inchikey(molfile)
     end
   end
 

--- a/lib/pub_chem.rb
+++ b/lib/pub_chem.rb
@@ -11,12 +11,21 @@ module PubChem
     (Rails.env.test? && 'http://') || 'https://'
   end
 
+  # A 200 carrying a Fault body is PubChem's way of answering "no" for several of these endpoints
+  # (get_lcss_from_cid's PUGVIEW.NotFound is the one with live user impact -- see #627); success?
+  # alone does not catch it. Centralizes the "genuinely usable response" check every raw-body
+  # method below needs, so a future change to what counts as safe only has to be made once.
+  # @return [HTTParty::Response, nil] +resp+ unchanged, or nil if it failed or carried a Fault
+  def self.safe_response(resp)
+    resp if resp.success? && !fault_response?(resp.parsed_response)
+  end
+
   def self.get_record_from_molfile(molfile)
     @auth = { username: '', password: '' }
     options = { timeout: 10, headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
                 body: { 'sdf' => molfile } }
 
-    HTTParty.post(http_s + PUBCHEM_HOST + '/rest/pug/compound/sdf/record/JSON', options)
+    safe_response(HTTParty.post("#{http_s}#{PUBCHEM_HOST}/rest/pug/compound/sdf/record/JSON", options))
   rescue StandardError => e
     Rails.logger.error ["with molfile: #{molfile}", e.message, *e.backtrace].join($INPUT_RECORD_SEPARATOR)
     nil
@@ -74,7 +83,8 @@ module PubChem
       headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
       body: { 'inchikey' => "#{inchikeys.join(',')}" },
     }
-    HTTParty.post(http_s + PUBCHEM_HOST + '/rest/pug/compound/inchikey/property/InChIKey/JSON', options).body
+    resp = HTTParty.post("#{http_s}#{PUBCHEM_HOST}/rest/pug/compound/inchikey/property/InChIKey/JSON", options)
+    safe_response(resp)&.body
   rescue StandardError => e
     Rails.logger.error ["with inchikey: #{inchikeys}", e.message, *e.backtrace].join($INPUT_RECORD_SEPARATOR)
     nil
@@ -84,32 +94,19 @@ module PubChem
     @auth = { username: '', password: '' }
     options = { timeout: 10, headers: { 'Content-Type' => 'text/json' } }
 
-    HTTParty.get(http_s + PUBCHEM_HOST + '/rest/pug/compound/inchikey/' + inchikey + '/record/SDF', options).body
+    resp = HTTParty.get("#{http_s}#{PUBCHEM_HOST}/rest/pug/compound/inchikey/#{inchikey}/record/SDF", options)
+    safe_response(resp)&.body
   rescue StandardError => e
     Rails.logger.error ["with inchikey: #{inchikey}", e.message, *e.backtrace].join($INPUT_RECORD_SEPARATOR)
-    nil
-  end
-
-  def self.get_molfiles_by_inchikeys(inchikeys)
-    options = {
-      timeout: 10,
-      headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
-      body: { 'inchikey' => "#{inchikeys.join(',')}" },
-    }
-    HTTParty.post(http_s + '/rest/pug/compound/inchikey/record/SDF', options).body
-  rescue StandardError => e
-    Rails.logger.error "[PubChemError] of [get_molfiles_by_inchikeys] with inchikey [#{inchikeys}], exception [#{e.backtrace}]"
     nil
   end
 
   def self.get_molfile_by_smiles(smiles)
     @auth = { username: '', password: '' }
     options = { timeout: 10, headers: { 'Content-Type' => 'text/json' } }
-    encoded_smiles = URI.encode(smiles, '[]/()+-.@#=\\')
+    encoded_smiles = URI::DEFAULT_PARSER.escape(smiles, %r{[\[\]/()+.@#=\\-]})
     response = HTTParty.get(http_s + PUBCHEM_HOST + '/rest/pug/compound/smiles/' + encoded_smiles + '/record/SDF', options)
-    return nil unless response.success?
-
-    response.body
+    safe_response(response)&.body
   rescue StandardError => e
     Rails.logger.error ["with smiles: #{smiles}", e.message, *e.backtrace].join($INPUT_RECORD_SEPARATOR)
     nil
@@ -119,7 +116,8 @@ module PubChem
     @auth = { username: '', password: '' }
     options = { timeout: 10, headers: { 'Content-Type' => 'text/json' } }
 
-    HTTParty.get(http_s + PUBCHEM_HOST + '/rest/pug/compound/inchikey/' + inchikey + '/xrefs/RN/JSON', options).body
+    resp = HTTParty.get("#{http_s}#{PUBCHEM_HOST}/rest/pug/compound/inchikey/#{inchikey}/xrefs/RN/JSON", options)
+    safe_response(resp)&.body
   rescue StandardError => e
     Rails.logger.error ["with inchikey: #{inchikey}", e.message, *e.backtrace].join($INPUT_RECORD_SEPARATOR)
     nil
@@ -181,10 +179,16 @@ module PubChem
     extract_smiles_property(result)
   end
 
+  # Accepts either string- or symbol-keyed JSON (JSON.parse without and with symbolize_names:
+  # respectively -- both are in use across this module's callers), and anything that is not a
+  # Hash at all (a raw SDF/molfile body, say), which is never a Fault.
   def self.fault_response?(result)
-    return false unless result['Fault']
+    return false unless result.is_a?(Hash)
 
-    Rails.logger.warn "PubChem API error: #{result['Fault']['Code']} - #{result['Fault']['Message']}"
+    fault = result['Fault'] || result[:Fault]
+    return false unless fault
+
+    Rails.logger.warn "PubChem API error: #{fault['Code'] || fault[:Code]} - #{fault['Message'] || fault[:Message]}"
     true
   end
 
@@ -200,7 +204,9 @@ module PubChem
   #   the cid arrives from +element_tags.taggable_data+, where a value written as a JSON string
   #   deserialises to a String — under the old +is_a? Integer+ guard that silently disabled LCSS
   #   for the molecule, with nothing to show for it.
-  # @return [Hash, nil] parsed GHS classification, or nil when there is none or the fetch fails
+  # @return [Hash, nil] parsed GHS classification, or nil when there is none, the cid does not
+  #   resolve (PubChem answers a 200 with a Fault body for this endpoint, not a 404 -- see #627),
+  #   or the fetch fails
   def self.get_lcss_from_cid(cid)
     cid = Integer(cid, exception: false) unless cid.is_a?(Integer)
     return nil unless cid
@@ -211,7 +217,10 @@ module PubChem
       resp = HTTParty.get(page, options)
       return nil unless resp.success?
 
-      JSON.parse resp, symbolize_names: true
+      result = JSON.parse(resp.body, symbolize_names: true)
+      return nil if fault_response?(result)
+
+      result
     rescue StandardError => e
       Rails.logger.error ["with cid: #{cid}", e.message, *e.backtrace].join($INPUT_RECORD_SEPARATOR)
       nil

--- a/spec/lib/chemotion/open_babel_service_behavior_spec.rb
+++ b/spec/lib/chemotion/open_babel_service_behavior_spec.rb
@@ -148,15 +148,17 @@ RSpec.describe Chemotion::OpenBabelService do
   describe 'hang protection on pathological organometallic input' do
     around do |example|
       # Outer safety net for the *test suite itself*: if the fork-based mechanism ever
-      # regresses back to an in-process hang, fail this example in 30s instead of hanging
-      # CI for the real SVG_RENDER_TIMEOUT_SECONDS default (or worse). This is not a claim
-      # that Timeout.timeout is what fixes the underlying bug -- see forked_timeout_spec.rb
-      # and open_babel_service_spec.rb for that; this is just a CI-safety belt-and-suspenders.
-      # 30s (not 10s): even with SVG rendering stubbed to a 2s deadline below, the *other*
-      # still-unbounded steps for this reproducer (OpenBabel's own internal canonical-labeling
-      # time-box, dual InChI attempts, fingerprinting) legitimately take ~10-12s each on their
-      # own for this pathological molfile.
-      Timeout.timeout(30) { example.run }
+      # regresses back to an in-process hang, fail this example instead of hanging CI for the
+      # real SVG_RENDER_TIMEOUT_SECONDS default (or worse). This is not a claim that
+      # Timeout.timeout is what fixes the underlying bug -- see forked_timeout_spec.rb and
+      # open_babel_service_spec.rb for that; this is just a CI-safety belt-and-suspenders.
+      # 60s (not 10s or 30s): even with SVG rendering stubbed to a 2s deadline below, the
+      # *other* still-unbounded steps for this reproducer (OpenBabel's own internal
+      # canonical-labeling time-box, dual InChI attempts, fingerprinting) legitimately take
+      # ~10-12s each on their own for this pathological molfile -- measured at 26-27s total
+      # before the canonical-SMILES writer was also moved into its own ForkedTimeout child
+      # (see #626), and fork/Marshal overhead on top of that pushed a real run to 37s.
+      Timeout.timeout(60) { example.run }
     end
 
     before { stub_const('Chemotion::OpenBabelService::SVG_RENDER_TIMEOUT_SECONDS', 2) }

--- a/spec/lib/chemotion/open_babel_service_spec.rb
+++ b/spec/lib/chemotion/open_babel_service_spec.rb
@@ -88,18 +88,11 @@ RSpec.describe Chemotion::OpenBabelService do
     end
 
     it 'returns empty canonical smiles when canonical generation raises SystemStackError' do
-      call_count = 0
-      allow(conversion).to receive(:write_string) do
-        call_count += 1
-        case call_count
-        when 1
-          "CC smiles-meta\n"
-        when 2
-          raise SystemStackError
-        else
-          "molfile-v2000\n"
-        end
-      end
+      # The canonical-smiles writer now runs in its own ForkedTimeout child (see #626), so a
+      # SystemStackError there no longer shares this describe block's single sequential
+      # write_string counter -- stub it directly instead.
+      allow(conversion).to receive(:write_string).and_return("CC smiles-meta\n", "molfile-v2000\n")
+      allow(described_class).to receive(:canonical_smiles_from_source_unsafe).and_raise(SystemStackError)
 
       info = described_class.molecule_info_from_structure('CC', 'smi')
 
@@ -145,21 +138,23 @@ RSpec.describe Chemotion::OpenBabelService do
       )
     end
 
-    # The SVG render is the only timeout-bounded operation in this method and, on the paths that
-    # feed Molecule#assign_molecule_data, its output is discarded unconditionally — svg_reprocess
-    # re-renders through Chemotion::SvgRenderer because OpenBabel's SVG always carries the
-    # 'Open Babel' marker. render_svg: false is how those callers stop paying for it.
+    # The SVG render's output is discarded unconditionally on the paths that feed
+    # Molecule#assign_molecule_data — svg_reprocess re-renders through Chemotion::SvgRenderer
+    # because OpenBabel's SVG always carries the 'Open Babel' marker. render_svg: false is how
+    # those callers stop paying for it. The canonical-smiles writer is timeout-bounded too (see
+    # #626) but runs unconditionally either way, so it is excluded from the "no fork" assertion
+    # below by matching on SVG_RENDER_TIMEOUT_SECONDS specifically.
     describe 'render_svg: false' do
       before do
         allow(conversion).to receive(:write_string).and_return("C smiles-meta\n", "C can-meta\n", "molfile-v2000\n")
       end
 
       it 'does not fork a render at all' do
-        allow(Chemotion::ForkedTimeout).to receive(:run)
+        allow(Chemotion::ForkedTimeout).to receive(:run).and_call_original
 
         described_class.molecule_info_from_molfile('C', render_svg: false)
 
-        expect(Chemotion::ForkedTimeout).not_to have_received(:run)
+        expect(Chemotion::ForkedTimeout).not_to have_received(:run).with(described_class::SVG_RENDER_TIMEOUT_SECONDS)
       end
 
       it 'returns a nil svg without claiming a timeout', :aggregate_failures do

--- a/spec/lib/chemotion/pubchem_service_spec.rb
+++ b/spec/lib/chemotion/pubchem_service_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# interpret_record's nil-hash-on-Fault contract was previously asserted only in a comment
+# (app/models/molecule.rb:473-477), with no spec exercising it directly. See #627.
+RSpec.describe Chemotion::PubchemService do
+  describe '.interpret_record' do
+    let(:empty_result) { { cid: nil, iupac_name: nil, names: [], topological: nil, log_p: nil } }
+
+    it 'returns the nil-filled hash for a Fault body' do
+      fault_record = { 'Fault' => { 'Code' => 'PUGREST.NotFound', 'Message' => 'No CID found' } }
+
+      expect(described_class.interpret_record(fault_record)).to eq(empty_result)
+    end
+
+    it 'returns the nil-filled hash for a nil record' do
+      expect(described_class.interpret_record(nil)).to eq(empty_result)
+    end
+
+    it 'parses a record given as a JSON string' do
+      record = { 'PC_Compounds' => [{ 'id' => { 'id' => { 'cid' => 42 } }, 'props' => [] }] }.to_json
+
+      expect(described_class.interpret_record(record)[:cid]).to eq(42)
+    end
+
+    # A malformed PC_Compounds entry (missing id, or props not an array) must degrade to the
+    # same nil-filled shape a Fault produces, not raise NoMethodError up through
+    # PubchemLookupJob -- exactly the realistic failure mode for a record that does resolve but
+    # is shaped unexpectedly.
+    it 'does not raise on a record with an empty id' do
+      malformed = { 'PC_Compounds' => [{ 'id' => {}, 'props' => [] }] }
+
+      expect { described_class.interpret_record(malformed) }.not_to raise_error
+      expect(described_class.interpret_record(malformed)[:cid]).to be_nil
+    end
+
+    it 'does not raise on a record with no props at all' do
+      malformed = { 'PC_Compounds' => [{ 'id' => { 'id' => { 'cid' => 1 } } }] }
+
+      expect { described_class.interpret_record(malformed) }.not_to raise_error
+      expect(described_class.interpret_record(malformed)[:cid]).to eq(1)
+    end
+
+    it 'extracts cid, iupac_name, names and inchikey from a well-formed record', :aggregate_failures do
+      record = {
+        'PC_Compounds' => [{
+          'id' => { 'id' => { 'cid' => 962 } },
+          'props' => [
+            { 'urn' => { 'label' => 'IUPAC Name', 'name' => 'Preferred' }, 'value' => { 'sval' => 'water' } },
+            { 'urn' => { 'label' => 'InChIKey' }, 'value' => { 'sval' => 'XLYOFNOQVPJJNP-UHFFFAOYSA-N' } },
+          ],
+        }],
+      }
+
+      result = described_class.interpret_record(record)
+
+      expect(result[:cid]).to eq(962)
+      expect(result[:iupac_name]).to eq('water')
+      expect(result[:names]).to eq(['water'])
+      expect(result[:inchikey]).to eq('XLYOFNOQVPJJNP-UHFFFAOYSA-N')
+    end
+
+    it 'returns an empty array for a Fault body when as_array is true' do
+      fault_record = { 'Fault' => { 'Code' => 'PUGREST.NotFound' } }
+
+      expect(described_class.interpret_record(fault_record, true)).to eq([])
+    end
+  end
+end

--- a/spec/lib/import/import_sdf_spec.rb
+++ b/spec/lib/import/import_sdf_spec.rb
@@ -111,6 +111,39 @@ RSpec.describe Import::ImportSdf do
       end
     end
 
+    # Regression for #626: the per-row molecule resolve is native OpenBabel work that has been
+    # measured at ~12s on an organometallic structure. The loop has to let go of its DB connection
+    # before doing it -- a connection dropped or reaped during that window would otherwise poison
+    # the rest of the import with PG::ConnectionBad. The release also has to stay *outside* the
+    # write transaction, so the depth is asserted against whatever RSpec's transactional fixtures
+    # already hold open around the example rather than against zero.
+    #
+    # Only releases made by this file are counted: has_closure_tree releases the connection once
+    # when Container is first autoloaded, which happens mid-save here and is not ours.
+    it 'releases the DB connection before resolving each row, never inside the write transaction' do
+      baseline_depth = ActiveRecord::Base.connection.open_transactions
+      order = []
+      depths = []
+
+      allow(ActiveRecord::Base.connection_pool).to receive(:release_connection).and_wrap_original do |orig, *args|
+        origin = caller.find { |line| line.start_with?(Rails.root.to_s) }
+        if origin&.include?('lib/import/import_sdf.rb')
+          order << :release
+          depths << ActiveRecord::Base.connection.open_transactions
+        end
+        orig.call(*args)
+      end
+      allow(sdf_import).to receive(:resolve_molecule_for_row).and_wrap_original do |orig, *args|
+        order << :resolve
+        orig.call(*args)
+      end
+
+      expect { sdf_import.create_samples }.to change(Sample, :count).by(1)
+
+      expect(order).to eq(%i[release resolve])
+      expect(depths).to all(eq(baseline_depth))
+    end
+
     context 'when an amount cell carries no readable value and unit' do
       before { sdf_import.rows.first['real_amount'] = 'quite a lot' }
 
@@ -192,6 +225,35 @@ RSpec.describe Import::ImportSdf do
       end
     end
 
+    # Regression for #626, phase 1 -- the half the first pass at this fix missed. One
+    # molecule_info_from_molfiles call covers a whole batch (50 records by default), each of
+    # which can burn up to Chemotion::OpenBabelService::CANONICAL_SMILES_TIMEOUT_SECONDS in
+    # native code with no SQL in between, so this is the *longest* window in the import in which
+    # a connection can be dropped or reaped.
+    #
+    # Verified against a real killed backend: with the release removed, terminating the backend
+    # during this call loses the entire import (0/40 records, PG::ConnectionBad "PQsocket() can't
+    # get socket descriptor" -- the exact production symptom), because the per-record rescue in
+    # #find_or_create_by_molfiles cannot help a connection that is never re-verified.
+    it 'releases the DB connection before the batch OpenBabel call' do
+      allow(PubchemLookupJob).to receive(:perform_later)
+      order = []
+
+      allow(ActiveRecord::Base.connection_pool).to receive(:release_connection).and_wrap_original do |orig, *args|
+        origin = caller.find { |line| line.start_with?(Rails.root.to_s) }
+        order << :release if origin&.include?('lib/import/import_sdf.rb')
+        orig.call(*args)
+      end
+      allow(Chemotion::OpenBabelService).to receive(:molecule_info_from_molfiles).and_wrap_original do |orig, *args|
+        order << :openbabel
+        orig.call(*args)
+      end
+
+      batch_import.find_or_create_mol_by_batch
+
+      expect(order.first(2)).to eq(%i[release openbabel])
+    end
+
     it 'schedules PubchemLookupJob covering every new molecule, via a created_after timestamp' do
       started_at = Time.current
       allow(PubchemLookupJob).to receive(:perform_later)
@@ -271,6 +333,27 @@ RSpec.describe Import::ImportSdf do
       # (no duplicate, no aborted import). If the bug regressed, this block would raise.
       expect { batch_import.find_or_create_mol_by_batch }.to change(Molecule, :count).by(1)
       expect(batch_import.inchi_array).to include(raced_inchikey)
+    end
+
+    # Regression for #626: molecule_info_from_molfiles already guards the OpenBabel work per
+    # record, but the Molecule find-or-create that follows it had no guard of its own -- a
+    # dropped/reaped DB connection there (or any other StandardError) used to escape
+    # find_or_create_by_molfiles, process_molecule_batches and find_or_create_mol_by_batch
+    # entirely, aborting the whole import instead of just the one record.
+    it 'survives a DB-level failure resolving one molecule and still imports the rest' do
+      allow(PubchemLookupJob).to receive(:perform_later)
+
+      failing_inchikey = "MOL#{Digest::SHA256.hexdigest(new_molfiles.first.to_s)[0..10]}-UHFFFAOYSA-N"
+      allow(Molecule).to receive(:find_or_create_by_molfile).and_wrap_original do |orig, *args, **kwargs|
+        raise ActiveRecord::StatementInvalid, 'PG::ConnectionBad' if kwargs[:inchikey] == failing_inchikey
+
+        orig.call(*args, **kwargs)
+      end
+
+      # Only the water molecule is created; the failing record is skipped rather than aborting
+      # the whole batch.
+      expect { batch_import.find_or_create_mol_by_batch }.to change(Molecule, :count).by(1)
+      expect(batch_import.inchi_array).not_to include(failing_inchikey)
     end
   end
 

--- a/spec/lib/pub_chem_spec.rb
+++ b/spec/lib/pub_chem_spec.rb
@@ -71,6 +71,18 @@ RSpec.describe 'PubChem' do
 
       expect(HTTParty).not_to have_received(:get)
     end
+
+    # PubChem answers an unknown cid with HTTP 200 and a Fault body, not a 404 -- so success?
+    # alone does not catch it, and the caller (Molecule#pubchem_lcss) used to store the Fault
+    # hash itself as if it were real GHS data. See #627.
+    it 'returns nil for a 200 response carrying a Fault body' do
+      fault_body = { Fault: { Code: 'PUGVIEW.NotFound', Message: 'No data found' } }.to_json
+      allow(HTTParty).to receive(:get).and_return(
+        instance_double(HTTParty::Response, success?: true, body: fault_body),
+      )
+
+      expect(PubChem.get_lcss_from_cid(962)).to be_nil
+    end
   end
 
   describe 'most_occurance' do

--- a/spec/models/molecule_spec.rb
+++ b/spec/models/molecule_spec.rb
@@ -308,18 +308,32 @@ RSpec.describe Molecule, type: :model do
       expect(persisted_molfile_sha).to eq(molfile_sha)
     end
 
-    it 'updates LCSS when molecule.pubchem_lcss is requested' do
+    # Previously asserted `be_nil` against a molecule with no pubchem_cid at all, which passes
+    # vacuously: #pubchem_lcss returns early on a blank cid without touching taggable_data, so the
+    # assertion held regardless of what PubChem would have said. Stubs the network call instead of
+    # relying on a real request, and asserts the actual `false`-not-nil storage convention
+    # documented at #pubchem_lcss (a stored JSON null reads back as SQL NULL through `->>`, so it
+    # would never leave PubchemLookupJob's pending scope -- see #627).
+    it 'stores false, not nil, when PubChem has no LCSS data for the cid' do
       molecule.save!
       persisted_molecule = described_class.last
+      persisted_molecule.tag.taggable_data['pubchem_cid'] = 123_456_789
+      allow(Chemotion::PubchemService).to receive(:lcss_from_cid).with(123_456_789).and_return(nil)
 
-      # lcss is updated as nil because cid 123456789 has no PubChem lcss
       persisted_molecule.pubchem_lcss
-      expect(persisted_molecule.tag.taggable_data['pubchem_lcss']).to be_nil
 
-      # lcss is updated with value because cid 643785 has PubChem lcss
+      expect(persisted_molecule.tag.taggable_data['pubchem_lcss']).to be(false)
+    end
+
+    it 'stores the LCSS data PubChem returns for the cid' do
+      molecule.save!
+      persisted_molecule = described_class.last
       persisted_molecule.tag.taggable_data['pubchem_cid'] = 643_785
+      allow(Chemotion::PubchemService).to receive(:lcss_from_cid).with(643_785).and_return({ 'ghs' => 'data' })
+
       persisted_molecule.pubchem_lcss
-      expect(persisted_molecule.tag.taggable_data['pubchem_lcss']).not_to be_nil
+
+      expect(persisted_molecule.tag.taggable_data['pubchem_lcss']).to eq({ 'ghs' => 'data' })
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,7 +107,7 @@ RSpec.configure do |config|
         )
     end
 
-    error_body = "<<~BODY
+    error_body = <<~BODY
       Status: 400
       Code: PUGREST.BadRequest
       Message: Unable to standardize the given structure - perhaps some special characters need to be escaped or data
@@ -120,7 +120,7 @@ RSpec.configure do |config|
       Detail: Record 1: Error: Unable to convert input into a compound object
       Detail:
       Detail:
-    BODY"
+    BODY
 
     bad_smiles.each_value do |entry|
       smiles_end_point = "http://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/smiles/#{entry['smiles']}/record/SDF"


### PR DESCRIPTION
# SDF import and PubChem fixes:


## One dropped DB connection killed the whole import
- The importer held a database connection while OpenBabel ran for up to 12 s per record. If anything closed that idle connection, every later query failed, the import ended with zero samples, and the user was told "Import Samples Completed".
- **Fix:** release the connection before each long native or HTTP call, so the next query reconnects by itself, and bound the canonical-SMILES writer with a 20 s timeout.
- **Measured:** with a backend killed mid-import, `main` imports 0/40 records, this branch imports 40/40.

## One bad row aborted the whole file
- Per-row rescues sat inside a single file-wide transaction, so the first database error poisoned it and every later row failed too.
- **Fix:** each row is now its own transaction, so a bad row costs only that row.

## PubChem errors were stored as chemical data
- PubChem answers "not found" with HTTP 200 and a `Fault` body, which was saved verbatim as GHS safety data. Four other endpoints checked nothing at all.
- **Fix:** treat a `Fault` as no data everywhere, stop assuming the record shape, drop dead code, and add the missing specs.
______________________________________________________________________________________________________________
- [ ] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [ ] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [ ] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
