### PR TITLE
style(popover): add close button to layout settings popovers

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/ElementDetailSortTab.js
+++ b/app/javascript/src/apps/mydb/elements/details/ElementDetailSortTab.js
@@ -8,7 +8,7 @@ import React, {
   useState,
 } from 'react';
 import PropTypes from 'prop-types';
-import { Popover } from 'react-bootstrap';
+import { CloseButton, Popover } from 'react-bootstrap';
 import { List } from 'immutable';
 import { isEmpty, set } from 'lodash';
 import UserStore from 'src/stores/alt/stores/UserStore';
@@ -148,9 +148,12 @@ export default function ElementDetailSortTab({
   const allCollection = isAllCollection(currentCollection);
   if (!isOwnCollection && !allCollection) { return null; }
 
-  const popoverSettings = (
+  const popoverSettings = ({ close }) => (
     <Popover>
-      <Popover.Header>Tab Layout</Popover.Header>
+      <Popover.Header className="d-flex justify-content-between align-items-center">
+        Tab Layout
+        <CloseButton onClick={close} />
+      </Popover.Header>
       <Popover.Body>
         <TabLayoutEditor
           visible={visible}
@@ -165,9 +168,7 @@ export default function ElementDetailSortTab({
   return (
     <ConfigOverlayButton
       popoverSettings={popoverSettings}
-      onToggle={(show) => {
-        if (!show) updateLayout();
-      }}
+      onClose={updateLayout}
     />
   );
 }

--- a/app/javascript/src/apps/mydb/elements/details/reactions/ReactionSchemeGraphic.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/ReactionSchemeGraphic.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import {
-  Popover, ButtonGroup, Button, OverlayTrigger, Tooltip,
+  Popover, ButtonGroup, Button, CloseButton, OverlayTrigger, Tooltip,
   ButtonToolbar
 } from 'react-bootstrap';
 import PropTypes from 'prop-types';
@@ -126,10 +126,11 @@ export default function ReactionSchemeGraphic({
     );
   };
 
-  const popoverSettings = (
+  const popoverSettings = ({ close }) => (
     <Popover>
-      <Popover.Header>
+      <Popover.Header className="d-flex justify-content-between align-items-center">
         Graphic Settings
+        <CloseButton onClick={close} />
       </Popover.Header>
       {!isInteractionReaction && (
         <>
@@ -179,7 +180,6 @@ export default function ReactionSchemeGraphic({
           key={isInteractionReaction ? 'interaction' : 'standard'}
           popperConfig={popperConfigAboveToolbar}
           popoverSettings={popoverSettings}
-          onToggle={() => {}}
           wrapperClassName=""
         />
         {onRefresh && (

--- a/app/javascript/src/apps/mydb/elements/list/ElementsTableSettings.js
+++ b/app/javascript/src/apps/mydb/elements/list/ElementsTableSettings.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Popover, Form } from 'react-bootstrap';
+import { CloseButton, Popover, Form } from 'react-bootstrap';
 
 import TabLayoutEditor from 'src/apps/mydb/elements/tabLayout/TabLayoutEditor';
 import ConfigOverlayButton from 'src/components/common/ConfigOverlayButton';
@@ -46,7 +46,7 @@ export default class ElementsTableSettings extends React.Component {
       tableSchemePreviews: true
     }
 
-    this.onToggleTabLayoutContainer = this.onToggleTabLayoutContainer.bind(this);
+    this.onTabLayoutClose = this.onTabLayoutClose.bind(this);
     this.handleToggleSampleExt = this.handleToggleSampleExt.bind(this);
     this.handleToggleSampleShortLabel = this.handleToggleSampleShortLabel.bind(this);
     this.handleToggleSampleName = this.handleToggleSampleName.bind(this);
@@ -112,19 +112,17 @@ export default class ElementsTableSettings extends React.Component {
     }
   }
 
-  onToggleTabLayoutContainer(show) {
-    if (!show) {
-      clearTimeout(this._saveLabelTimeout);
-      this._saveLabelTimeout = null;
+  onTabLayoutClose() {
+    clearTimeout(this._saveLabelTimeout);
+    this._saveLabelTimeout = null;
 
-      this.updateLayout();
+    this.updateLayout();
 
-      if (this.state.currentType == "sample" || this.state.currentType == "reaction") {
-        const show_previews = UIStore.getState().showPreviews;
-        const cur_previews = this.state.tableSchemePreviews;
-        if (cur_previews != show_previews) {
-          UIActions.toggleShowPreviews(cur_previews);
-        }
+    if (this.state.currentType === 'sample' || this.state.currentType === 'reaction') {
+      const { showPreviews } = UIStore.getState();
+      const curPreviews = this.state.tableSchemePreviews;
+      if (curPreviews !== showPreviews) {
+        UIActions.toggleShowPreviews(curPreviews);
       }
     }
   }
@@ -206,7 +204,7 @@ export default class ElementsTableSettings extends React.Component {
     const otherLabelChecked = showSampleExternalLabel || showSampleName;
     const shortLabelDisabled = !otherLabelChecked;
     const shortLabelChecked = shortLabelDisabled ? true : showSampleShortLabel;
-    const popoverSettings = (
+    const popoverSettings = ({ close }) => (
       <Popover className="d-flex popover-multi">
         {showSettings && (
           <div className="popover-multi-item">
@@ -225,7 +223,7 @@ export default class ElementsTableSettings extends React.Component {
                       type="checkbox"
                       onChange={this.handleToggleSampleExt}
                       checked={showSampleExternalLabel}
-                      label="Show sample external name on title"
+                      label="Show sample external label"
                     />
                     <Form.Check
                       type="checkbox"
@@ -247,8 +245,9 @@ export default class ElementsTableSettings extends React.Component {
           </div>
         )}
         <div className="popover-multi-item">
-          <Popover.Header>
+          <Popover.Header className="d-flex justify-content-between align-items-center">
             Tab Layout
+            <CloseButton onClick={close} />
           </Popover.Header>
           <Popover.Body>
             <TabLayoutEditor
@@ -265,7 +264,7 @@ export default class ElementsTableSettings extends React.Component {
     );
 
     return (
-      <ConfigOverlayButton popoverSettings={popoverSettings} onToggle={this.onToggleTabLayoutContainer} />
+      <ConfigOverlayButton popoverSettings={popoverSettings} onClose={this.onTabLayoutClose} />
     );
   }
 }

--- a/app/javascript/src/apps/mydb/inbox/InboxModal.js
+++ b/app/javascript/src/apps/mydb/inbox/InboxModal.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import Draggable from 'react-draggable';
 import {
-  Badge, Button, Pagination, OverlayTrigger, Tooltip, Dropdown, DropdownButton, Card,
+  Badge, Button, CloseButton, Pagination, OverlayTrigger, Tooltip, Dropdown, DropdownButton, Card,
   ButtonToolbar
 } from 'react-bootstrap';
 import InboxStore from 'src/stores/alt/stores/InboxStore';
@@ -314,7 +314,7 @@ export default class InboxModal extends React.Component {
       >
         <DropdownButton
           title="Size"
-          variant="info"
+          variant="light"
           size="sm"
           onSelect={(size) => this.handleSizingIconClick(size)}
         >
@@ -357,7 +357,7 @@ export default class InboxModal extends React.Component {
     return (
       <OverlayTrigger placement="bottom" overlay={sortTooltip}>
         <Button
-          variant="success"
+          variant="light"
           size="xsm"
           onClick={this.changeSortColumn}
         >
@@ -390,7 +390,7 @@ export default class InboxModal extends React.Component {
         >
           <Card className="cursor">
             <Card.Header
-              className="cursor handle draggable text-bg-primary"
+              className="cursor handle draggable border-gray-600 bg-gray-300"
               id="draggableInbox"
               onMouseDown={this.handleMouseDown}
             >
@@ -402,12 +402,12 @@ export default class InboxModal extends React.Component {
                     onClick={() => this.onClickInbox()}
                   >
                     <i className="fa fa-inbox" />
-                    <span className="ms-2 me-1 fw-bold text-white">Inbox</span>
+                    <span className="ms-2 me-1 fw-bold">Inbox</span>
                   </button>
                   {
                     numberOfAttachments > 0
                     && (
-                      <Badge bg="light" className="mx-1 text-primary">{numberOfAttachments}</Badge>
+                      <Badge bg="warning" className="mx-1">{numberOfAttachments}</Badge>
                     )
                   }
                 </div>
@@ -416,19 +416,16 @@ export default class InboxModal extends React.Component {
                   {collectorAddress && this.collectorAddressInfoButton()}
                   {this.renderSizingIcon()}
                   <Button
-                    variant="success"
+                    variant="light"
                     size="xsm"
                     onClick={() => this.refreshInbox()}
                   >
                     <i className="fa fa-refresh" />
                   </Button>
-                  <Button
-                    variant="danger"
-                    size="xsm"
+                  <CloseButton
+                    className="ms-2"
                     onClick={InboxActions.toggleInboxModal}
-                  >
-                    <i className="fa fa-close" />
-                  </Button>
+                  />
                 </ButtonToolbar>
               </div>
             </Card.Header>

--- a/app/javascript/src/components/common/ConfigOverlayButton.js
+++ b/app/javascript/src/components/common/ConfigOverlayButton.js
@@ -1,20 +1,29 @@
-import React from "react";
+import React, { useState } from 'react';
 import { OverlayTrigger, Button } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 
 export default function ConfigOverlayButton({
-  popoverSettings, onToggle, wrapperClassName, popperConfig,
+  popoverSettings, onClose, wrapperClassName, popperConfig,
 }) {
-  const defaultClassName = "position-absolute top-0 end-0";
+  const defaultClassName = 'position-absolute top-0 end-0';
   const className = wrapperClassName !== undefined ? wrapperClassName : defaultClassName;
+  const [show, setShow] = useState(false);
+
+  // Fire onClose on the true -> false edge only, so the popover persists its
+  // changes exactly once whether it is dismissed via the x or via rootClose.
+  const handleToggle = (next) => {
+    if (show && !next) { onClose?.(); }
+    setShow(next);
+  };
 
   return (
     <div className={className}>
       <OverlayTrigger
         trigger="click"
         placement="left"
-        overlay={popoverSettings}
-        onToggle={onToggle}
+        overlay={popoverSettings({ close: () => handleToggle(false) })}
+        show={show}
+        onToggle={handleToggle}
         rootClose
         popperConfig={popperConfig}
       >
@@ -30,8 +39,14 @@ export default function ConfigOverlayButton({
 }
 
 ConfigOverlayButton.propTypes = {
-  popoverSettings: PropTypes.element.isRequired,
-  onToggle: PropTypes.func.isRequired,
+  popoverSettings: PropTypes.func.isRequired,
+  onClose: PropTypes.func,
   wrapperClassName: PropTypes.string,
   popperConfig: PropTypes.object,
+};
+
+ConfigOverlayButton.defaultProps = {
+  onClose: undefined,
+  wrapperClassName: undefined,
+  popperConfig: undefined,
 };


### PR DESCRIPTION
The fa-sliders settings popover could only be dismissed by clicking outside, which is also the moment the accumulated changes get persisted. There was no explicit "close & apply" affordance, so a popover that behaves like a modal did not read like one.

ConfigOverlayButton is now a controlled OverlayTrigger: it owns the show state and fires onClose on the true -> false edge only, so the popover persists exactly once whether it is dismissed via the x or via rootClose. popoverSettings becomes a render prop receiving { close }, letting each call site put a CloseButton in its Popover.Header.

Also restyles the Inbox card to the neutral/light scheme from the same upstream change, and fixes the sample checkbox wording: the flag toggles Sample#external_label, not a name ("Show sample external name on title" -> "Show sample external label").

Ports #3031 (merged to v3.x only) to main; ElementDetailSortTab and ElementsTableSettings have diverged since, so their local behaviour (hooks rewrite, checkbox mutual exclusion, debounced label save) is kept.

Closes #3509
refs: #3031
