### PR TITLE
perf(permissions): make permissions/status top-secret check set-based

### DIFF
--- a/app/api/chemotion/permission_api.rb
+++ b/app/api/chemotion/permission_api.rb
@@ -28,15 +28,20 @@ module Chemotion
             end
           end
 
-          # checking if the selected elements include any one element that is top secret
-          is_top_secret = false
-          is_top_secret ||= selected_elements[Sample].any?(&:is_top_secret?)
-          is_top_secret ||= selected_elements[Reaction].lazy.flat_map(&:samples).any?(&:is_top_secret?)
-          is_top_secret ||= selected_elements[Wellplate].lazy.flat_map(&:samples).any?(&:is_top_secret?)
-          is_top_secret ||= selected_elements[Screen].lazy
-                                                     .flat_map(&:wellplates)
-                                                     .flat_map(&:samples)
-                                                     .any?(&:is_top_secret?)
+          # Checking if the selection includes any top-secret sample. is_top_secret is a plain
+          # boolean column, so each element type is checked with a single EXISTS query
+          # (SELECT 1 ... LIMIT 1) instead of materialising every selected row and walking
+          # associations in Ruby (refs: #2783). Samples are reached directly and, for the container
+          # types, through their associated samples; the `||` chain stops at the first hit. An
+          # unselected type is the empty-array default, so where(id: []) short-circuits to no rows.
+          is_top_secret =
+            Sample.exists?(id: selected_elements[Sample], is_top_secret: true) ||
+            Reaction.where(id: selected_elements[Reaction])
+                    .joins(:samples).exists?(samples: { is_top_secret: true }) ||
+            Wellplate.where(id: selected_elements[Wellplate])
+                     .joins(:samples).exists?(samples: { is_top_secret: true }) ||
+            Screen.where(id: selected_elements[Screen])
+                  .joins(wellplates: :samples).exists?(samples: { is_top_secret: true })
 
           deletion_allowed = true
           sharing_allowed = true
@@ -51,10 +56,14 @@ module Chemotion
             # loop skipped (research_plan / cell_line / vessel / device_description / SBMM) would keep
             # the flag at its permissive default, and the UI would offer a Move/Remove/Delete the
             # server then refuses.
-            selected_elements.each_value do |scope|
-              next if scope.none?
+            # One policy per selected type, reused across every check below. ElementsPolicy
+            # memoizes its own/shared record-id lookups per instance, so building it once keeps
+            # the share pass from re-running those queries.
+            policies = selected_elements.values.reject(&:none?).map do |scope|
+              ElementsPolicy.new(current_user, scope)
+            end
 
-              policy = ElementsPolicy.new(current_user, scope)
+            policies.each do |policy|
               deletion_allowed &&= policy.destroy_all?
               remove_allowed &&= policy.remove_all?
               update_allowed &&= policy.update_all?
@@ -63,13 +72,7 @@ module Chemotion
             # permission for deletion includes permission for sharing,
             # so we have to check if the lower permissions for sharing are satisfied
             # when mass deletion is forbidden
-            unless deletion_allowed
-              selected_elements.each_value do |scope|
-                next if scope.none?
-
-                sharing_allowed &&= ElementsPolicy.new(current_user, scope).share_all?
-              end
-            end
+            policies.each { |policy| sharing_allowed &&= policy.share_all? } unless deletion_allowed
 
             # With nothing selected the loops above police nothing, leaving the permissive
             # defaults untouched. That stale "true" lingers in the client's PermissionStore and

--- a/spec/api/chemotion/permission_api_spec.rb
+++ b/spec/api/chemotion/permission_api_spec.rb
@@ -91,6 +91,79 @@ describe Chemotion::PermissionAPI do
       end
     end
 
+    # The top-secret flag must also be raised when the secret sample is not selected directly but
+    # is reachable through a selected reaction, wellplate, or screen. These exercise the joined
+    # EXISTS queries that replaced the per-element association walk (refs: #2783).
+    context 'when a top secret sample is reachable only through a selected container' do
+      let(:top_secret_sample) { create(:sample, is_top_secret: true, collections: [unshared_collection_of_user]) }
+
+      it 'detects it through a selected reaction' do
+        reaction = create(:reaction, collections: [unshared_collection_of_user])
+        reaction.products << top_secret_sample
+        post '/api/v1/permissions/status', params: {
+          currentCollection: { id: unshared_collection_of_user.id },
+          reaction: { checkedAll: false, checkedIds: [reaction.id], uncheckedIds: [] },
+        }
+
+        expect(parsed_json_response['is_top_secret']).to be true
+      end
+
+      it 'detects it through a selected screen (two association levels down)' do
+        wellplate = create(:wellplate, collections: [unshared_collection_of_user])
+        create(:well, wellplate: wellplate, sample: top_secret_sample)
+        screen = create(:screen, wellplates: [wellplate], collections: [unshared_collection_of_user])
+        post '/api/v1/permissions/status', params: {
+          currentCollection: { id: unshared_collection_of_user.id },
+          screen: { checkedAll: false, checkedIds: [screen.id], uncheckedIds: [] },
+        }
+
+        expect(parsed_json_response['is_top_secret']).to be true
+      end
+    end
+
+    # Regression guard: the top-secret check must issue a fixed number of queries no matter how many
+    # containers are selected. The old code walked `flat_map(&:samples)` one SELECT per reaction, so
+    # the count grew with the selection. On an own collection the sharing-policy block is skipped, so
+    # the query count isolates the top-secret check.
+    context 'when many containers are selected (N+1 guard)' do
+      # Count only the top-secret probe queries (they filter on samples.is_top_secret). The old code
+      # walked one SELECT per selected container, so this count grew with the selection; the joined
+      # EXISTS makes it exactly one, whatever the count.
+      def count_top_secret_probes(&block)
+        count = 0
+        counter = lambda do |_name, _start, _finish, _id, payload|
+          count += 1 if payload[:sql].include?('is_top_secret')
+        end
+        ActiveSupport::Notifications.subscribed(counter, 'sql.active_record', &block)
+        count
+      end
+
+      def post_status(element, records)
+        post '/api/v1/permissions/status', params: {
+          currentCollection: { id: unshared_collection_of_user.id },
+          element => { checkedAll: false, checkedIds: records.map(&:id), uncheckedIds: [] },
+        }
+      end
+
+      it 'probes for a top secret sample once through the reactions, whether 1 or 5 are selected' do
+        one = create_list(:reaction, 1, collections: [unshared_collection_of_user])
+        five = create_list(:reaction, 5, collections: [unshared_collection_of_user])
+
+        expect(count_top_secret_probes { post_status(:reaction, one) }).to eq(1)
+        expect(count_top_secret_probes { post_status(:reaction, five) }).to eq(1)
+      end
+
+      # The deepest path (screen -> wellplate -> well -> sample). The old code walked two nested
+      # flat_maps per screen; the single joined EXISTS must stay one query regardless of count.
+      it 'probes for a top secret sample once through the screens, whether 1 or 5 are selected' do
+        one = create_list(:screen, 1, collections: [unshared_collection_of_user])
+        five = create_list(:screen, 5, collections: [unshared_collection_of_user])
+
+        expect(count_top_secret_probes { post_status(:screen, one) }).to eq(1)
+        expect(count_top_secret_probes { post_status(:screen, five) }).to eq(1)
+      end
+    end
+
     context 'when requesting permission status for elements of a shared collection' do
       let(:sample) { create(:sample, collections: [shared_collection_of_other_user]) }
       let(:params) do


### PR DESCRIPTION
## What

Rewrites the `POST /api/v1/permissions/status` handler to stop loading and
iterating full element rows in Ruby. Two changes:

1. **Top-secret detection is now set-based.** The old code materialised every
   selected row and walked associations in Ruby:

   ```ruby
   is_top_secret ||= selected_elements[Sample].any?(&:is_top_secret?)
   is_top_secret ||= selected_elements[Reaction].lazy.flat_map(&:samples).any?(&:is_top_secret?)
   # ...wellplates, and screens two levels deep
   ```

   `any?` with a block cannot be pushed into SQL, so it loaded the whole
   relation; `flat_map(&:samples)` fired one `SELECT samples.*` per reaction and
   per wellplate (per wellplate *per screen* for the screen branch) — an N+1
   that grew with the size of the selection. `is_top_secret` is a plain boolean
   column, so each element type now resolves to a single `EXISTS` query
   (`SELECT 1 ... LIMIT 1`), joining through the container types where needed.
   The `||` chain still short-circuits on the first hit.

2. **`ElementsPolicy` is built once and reused.** The handler previously
   constructed a fresh `ElementsPolicy` per element type in each of two passes
   (destroy/remove/update, then share). Since `ElementsPolicy` memoises its
   own/shared record-id lookups per instance, the second pass re-ran those
   queries. The instances are now built once and reused across both passes.

## Why

Observed as an N+1 in production traces: whole sample rows loaded to test one
boolean, plus an unbatched association walk per selected container. The
sample-branch regression (single-column `pluck` replaced by block-form `any?`)
was introduced by #2783; the association walks are original 2015 behaviour.

## Behaviour

No functional change. Association coverage is identical (verified against the
generated SQL, including the soft-delete `deleted_at IS NULL` scopes carried
into every JOIN), and the policy result is unchanged (memoised lookups are a
deterministic function of the unchanged user/scope pair).

## Tests

- Correctness: top-secret detected through a selected reaction and through a
  selected screen (the deepest `screen → wellplate → well → sample` path).
- Regression guard: the top-secret probe stays a single query whether 1 or 5
  reactions/screens are selected — reverting to the association walk fails it.

All specs pass; RuboCop clean.