### PR TITLE
perf(ui_state): resolve load_report detail levels once per page, not per element

### DIFF
--- a/app/api/chemotion/element_api.rb
+++ b/app/api/chemotion/element_api.rb
@@ -120,6 +120,17 @@ module Chemotion
           samples = @collection.samples.by_ui_state(params[:sample])
           reactions = @collection.reactions.by_ui_state(params[:reaction])
 
+          # Every element in this report comes from the single resolved @collection, so its detail
+          # levels are computed once for the whole page instead of once per element (each instance
+          # fired 1-2 collection-membership queries). The report reflects the level granted on the
+          # collection it was run from: an owned collection (including the "All" view, which is an
+          # owned system collection) gives full access; a shared collection gives the share's level.
+          # An element also reachable at a higher level via another collection is rendered at this
+          # collection's level, the trade-off every list/index endpoint accepts (see
+          # ElementDetailLevelCalculator.for_collection). This can only lower detail, never leak,
+          # because the browsed collection's level never exceeds the element's best-available level.
+          detail_levels = ElementDetailLevelCalculator.for_collection(collection: @collection, user: current_user)
+
           if params[:loadType] == 'lists'
             sample_tags = selected_tags['sampleIds']
             reaction_tags = selected_tags['reactionIds']
@@ -127,7 +138,6 @@ module Chemotion
               if sample_tags && sample.id.in?(sample_tags)
                 { id: sample.id, in_browser_memory: true }
               else
-                detail_levels = ElementDetailLevelCalculator.new(user: current_user, element: sample).detail_levels
                 Entities::SampleEntity.represent(sample, detail_levels: detail_levels, displayed_in_list: true)
               end
             end
@@ -135,7 +145,6 @@ module Chemotion
               if reaction_tags && reaction.id.in?(reaction_tags)
                 { id: reaction.id, in_browser_memory: true }
               else
-                detail_levels = ElementDetailLevelCalculator.new(user: current_user, element: reaction).detail_levels
                 Entities::ReactionEntity.represent(reaction, detail_levels: detail_levels, displayed_in_list: true)
               end
             end
@@ -147,7 +156,6 @@ module Chemotion
               :container, :products, :purification_solvents, :reactants, :segments, :solvents, :starting_materials, :tag
             )
             result['samples'] = samples.map do |sample|
-              detail_levels = ElementDetailLevelCalculator.new(user: current_user, element: sample).detail_levels
               serialized_element = Entities::SampleEntity.represent(
                 sample,
                 detail_levels: detail_levels,
@@ -156,7 +164,6 @@ module Chemotion
               serialized_element
             end
             result['reactions'] = reactions.map do |reaction|
-              detail_levels = ElementDetailLevelCalculator.new(user: current_user, element: reaction).detail_levels
               serialized_element = Entities::ReactionEntity.represent(
                 reaction,
                 detail_levels: detail_levels,

--- a/spec/api/chemotion/element_api_spec.rb
+++ b/spec/api/chemotion/element_api_spec.rb
@@ -182,4 +182,89 @@ describe Chemotion::ElementAPI do
       expect(response).to have_http_status(:created)
     end
   end
+
+  describe 'POST /api/v1/ui_state/load_report detail levels' do
+    let(:own_collection) { create(:collection, user: user) }
+
+    def load_report(collection_id, sample_ids: [], reaction_ids: [], load_type: nil)
+      report = { currentCollection: { id: collection_id } }
+      report[:sample] = { checkedAll: false, checkedIds: sample_ids } if sample_ids.any?
+      report[:reaction] = { checkedAll: false, checkedIds: reaction_ids } if reaction_ids.any?
+      report[:loadType] = load_type if load_type
+      post '/api/v1/ui_state/load_report', params: report, as: :json
+    end
+
+    # ElementDetailLevelCalculator#user_collections_with_element probes each element's collection
+    # membership with `SELECT 1 AS one FROM collections INNER JOIN collections_<type> ...`. The old
+    # per-element instantiation fired this once (or more) per element; the batched for_collection
+    # call resolves the whole page from @collection, so the probe count must not grow with page size.
+    # Counts both sample and reaction probes so a regression on either loop is caught.
+    def count_membership_probes(&block)
+      count = 0
+      counter = lambda do |_name, _start, _finish, _id, payload|
+        sql = payload[:sql]
+        next unless sql.include?('1 AS one')
+
+        count += 1 if sql.include?('collections_samples') || sql.include?('collections_reactions')
+      end
+      ActiveSupport::Notifications.subscribed(counter, 'sql.active_record', &block)
+      count
+    end
+
+    it 'renders samples from an owned collection at full detail' do
+      own_sample = create(:sample, collections: [own_collection])
+      load_report(own_collection.id, sample_ids: [own_sample.id])
+
+      expect(response).to have_http_status(:created)
+      returned = parsed_json_response['samples'].first
+      # molfile is exposed at detail level >= 1; is_top_secret only at the owner level (10), where it
+      # is the real boolean rather than the '***' placeholder. Asserting both pins the owner level.
+      expect(returned['molfile']).to eq(own_sample.molfile)
+      expect(returned['is_top_secret']).to eq(own_sample.is_top_secret)
+    end
+
+    # Guards all four hoisted call sites: samples and reactions, in both the 'lists' and the
+    # non-'lists' (full report) branch. The invariant is that the probe count does not scale with
+    # page size, not that it is any particular value: a correct single-query design stays green,
+    # only a per-element N+1 fails.
+    [nil, 'lists'].each do |load_type|
+      it "resolves detail levels once per page, not once per element (no N+1, load_type=#{load_type.inspect})" do
+        samples = create_list(:sample, 3, collections: [own_collection])
+        reactions = create_list(:reaction, 3, collections: [own_collection])
+
+        one = count_membership_probes do
+          load_report(own_collection.id, sample_ids: [samples.first.id], reaction_ids: [reactions.first.id],
+                                         load_type: load_type)
+        end
+        many = count_membership_probes do
+          load_report(own_collection.id, sample_ids: samples.map(&:id), reaction_ids: reactions.map(&:id),
+                                         load_type: load_type)
+        end
+
+        expect(many).to eq(one)
+      end
+    end
+
+    # The report reflects the level granted on the collection it was run from, by design: even when
+    # the same element is fully accessible through another collection, a report drawn from a
+    # restricted share renders it at the share's (lower) level. This documents that intentional
+    # trade-off, and guards that a shared-collection report still redacts fields it should.
+    it 'renders a sample at the browsed shared collection\'s reduced level, not its best-available level' do
+      restricted_collection = create(:collection, user: other_user)
+      create(:collection_share, collection: restricted_collection, shared_with: user,
+                                permission_level: CollectionShare.permission_level(:read_elements),
+                                sample_detail_level: 0)
+      # The sample is also in the user's own collection, where it would render at full detail.
+      shared_sample = create(:sample, collections: [own_collection, restricted_collection])
+
+      load_report(restricted_collection.id, sample_ids: [shared_sample.id])
+
+      expect(response).to have_http_status(:created)
+      returned = parsed_json_response['samples'].first
+      # The requested sample is present but rendered at the share's level 0, so molfile (anonymised
+      # below level 1) is the '***' placeholder rather than the real structure.
+      expect(returned['id']).to eq(shared_sample.id)
+      expect(returned['molfile']).to eq('***')
+    end
+  end
 end


### PR DESCRIPTION
## What

`POST /api/v1/ui_state/load_report` built a fresh `ElementDetailLevelCalculator`
per element across four serialization loops. Each instance re-probed the
element's collection membership, so a report over N elements issued O(N)
extra `SELECT 1 AS one FROM collections INNER JOIN collections_samples ...`
queries (measured at ~9 per element).

The four call sites are replaced with a single
`ElementDetailLevelCalculator.for_collection(collection: @collection, user: current_user)`
hoisted above the loops, matching the nine list/index endpoints already
migrated (e.g. `sample_api.rb:76`).

## Detail-level trade-off (deliberate)

`for_collection` reports the detail level of the **collection the report was
run from**. If an element also belongs to another collection where the user
has higher access, the report renders it at the browsed collection's level,
not the higher one.

This is safe and intentional:
- It can only ever **lower** an element's detail, never leak: a browsed
  collection's level never exceeds the element's best-available level.
- Owned collections (including the "All" view, an owned system collection)
  resolve to full detail, identical to the old per-element result.
- It matches the contract every other list/index endpoint already accepts.

A user who needs fuller detail runs the report from the collection that grants
it. If the team instead wants "always show each element at its best-available
detail," that would require a cross-collection batched lookup — out of scope
for this change.

## Tests

- Owned-collection report renders at full detail (`molfile` not anonymised).
- N+1 guard: per-element membership probe count is 0 regardless of element
  count (reverting to the per-element calculator fails this — 9 probes for 1
  sample, 27 for 3).
- Shared-collection report renders the same sample at the share's reduced
  level even though it is fully accessible via another collection.

All specs pass; RuboCop clean on the changed code.