### PR TITLE
fix(pubchem): stop LCSS misses re-queueing forever, and guard Fault responses

### DIFF
--- a/db/migrate/20260825120000_backfill_pubchem_lcss_sentinels.rb
+++ b/db/migrate/20260825120000_backfill_pubchem_lcss_sentinels.rb
@@ -10,8 +10,17 @@ class BackfillPubchemLcssSentinels < ActiveRecord::Migration[6.1]
   #    selects on -- matches a JSON null exactly as it matches a missing key. So the molecule never
   #    left the pending scope and was re-asked on every sweep, indefinitely. The convention the code
   #    uses now is `false`, meaning "asked, PubChem has none": it reads back through `->>` as the
-  #    string 'false' and clears the scope. Rewriting these needs no network call, because the
-  #    answer is already known.
+  #    string 'false' and clears the scope. Rewriting these needs no network call.
+  #
+  #    A JSON null does not only mean "PubChem has none", though: get_lcss_from_cid also returns
+  #    nil on a timeout, a 5xx or any rescued exception, and Molecule#pubchem_lcss stored that
+  #    verbatim too. Those molecules are marked answered here without ever having been answered.
+  #    That is deliberate, because it is what the fixed code already does at runtime -- `lcss ||
+  #    false` collapses a transient failure to the same sentinel -- so the migration matches
+  #    application behaviour rather than introducing a new loss. Distinguishing the two would
+  #    need the :not_found/:unavailable outcome split that fetch_record_from_inchikey already
+  #    carries for the inchikey path, extended to LCSS; until then a molecule whose lookup
+  #    merely failed is recoverable by clearing its key, exactly as branch 2 below does.
   #
   # 2. A Fault body stored as GHS data. PubChem answers an unknown cid on the pug_view endpoint with
   #    HTTP 200 and a `{"Fault": ...}` body, and get_lcss_from_cid stored that body as if it were a

--- a/db/migrate/20260825120000_backfill_pubchem_lcss_sentinels.rb
+++ b/db/migrate/20260825120000_backfill_pubchem_lcss_sentinels.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class BackfillPubchemLcssSentinels < ActiveRecord::Migration[6.1]
+  # Repairs the two bad shapes of `element_tags.taggable_data->'pubchem_lcss'` that the PubChem
+  # client fix shipping alongside this migration stops producing. Neither shape self-heals, so the
+  # code fix alone leaves the existing rows broken.
+  #
+  # 1. A JSON null. Molecule#pubchem_lcss stored the client's nil verbatim, and
+  #    `taggable_data->>'pubchem_lcss' is null` -- the predicate PubchemLookupJob#pending_scope
+  #    selects on -- matches a JSON null exactly as it matches a missing key. So the molecule never
+  #    left the pending scope and was re-asked on every sweep, indefinitely. The convention the code
+  #    uses now is `false`, meaning "asked, PubChem has none": it reads back through `->>` as the
+  #    string 'false' and clears the scope. Rewriting these needs no network call, because the
+  #    answer is already known.
+  #
+  # 2. A Fault body stored as GHS data. PubChem answers an unknown cid on the pug_view endpoint with
+  #    HTTP 200 and a `{"Fault": ...}` body, and get_lcss_from_cid stored that body as if it were a
+  #    classification. It is truthy, so these molecules were never in the pending scope and the
+  #    Fault was being handed to the UI as safety data. The key is deleted rather than set to
+  #    `false`: most of these are PUGVIEW.NotFound and will settle to `false` on the next sweep, but
+  #    a Fault can also be transient (a busy server), and those deserve a real answer rather than a
+  #    permanent "no". Re-asking is bounded by the pubchem_checked_at TTL pending_scope already
+  #    applies, so this does not put the whole set back into every sweep.
+  #
+  # Both statements are idempotent: a second run matches nothing, because neither `false` nor an
+  # absent key satisfies its WHERE. jsonb_typeof is used instead of the `?` containment operator so
+  # the SQL carries no character the adapter could read as a bind placeholder; a missing key yields
+  # SQL NULL from `->`, whose jsonb_typeof is NULL rather than the string 'null', so a molecule that
+  # was never asked is untouched.
+
+  def up
+    say_with_time 'rewriting JSON-null pubchem_lcss values to false' do
+      execute(<<~SQL.squish)
+        UPDATE element_tags
+        SET taggable_data = jsonb_set(taggable_data, '{pubchem_lcss}', 'false'::jsonb),
+            updated_at = now()
+        WHERE taggable_type = 'Molecule'
+          AND jsonb_typeof(taggable_data->'pubchem_lcss') = 'null'
+      SQL
+    end
+
+    say_with_time 'clearing PubChem Fault bodies stored as pubchem_lcss' do
+      execute(<<~SQL.squish)
+        UPDATE element_tags
+        SET taggable_data = taggable_data - 'pubchem_lcss',
+            updated_at = now()
+        WHERE taggable_type = 'Molecule'
+          AND jsonb_typeof(taggable_data->'pubchem_lcss') = 'object'
+          AND (taggable_data->'pubchem_lcss')->>'Fault' IS NOT NULL
+      SQL
+    end
+  end
+
+  def down
+    # Irreversible. A `false` written here is indistinguishable from one written by the application,
+    # and the deleted Fault bodies were never valid data to restore.
+    say 'BackfillPubchemLcssSentinels is not reversible (the previous values were not valid data).'
+  end
+end

--- a/lib/chemotion/pubchem_service.rb
+++ b/lib/chemotion/pubchem_service.rb
@@ -34,66 +34,91 @@ module Chemotion::PubchemService
   end
 
   def self.interpret_record(record, as_array = false)
+    compounds = compounds_in(record)
+    return as_array ? [] : empty_result if compounds.nil?
+
+    results = compounds.filter_map { |rec| compound_result(rec) }
+
+    as_array ? results : results[0]
+  end
+
+  # @param record [Object] a parsed record, a JSON string, or an HTTParty response
+  # @return [Array, nil] the PC_Compounds entries, or nil when the record carries none
+  def self.compounds_in(record)
     record = JSON.parse(record) if record.is_a?(String)
-    result = {
+    return nil unless record && record['PC_Compounds']
+
+    Array(record['PC_Compounds'])
+  end
+
+  # A malformed entry -- one that is not a Hash at all, an absent or wrongly typed id, missing
+  # props, a props entry with no urn -- must degrade to the same nil-filled result a Fault
+  # produces, not raise up through PubchemLookupJob. Every read goes through dig_hash for that
+  # reason; see its note on why Hash#dig alone is not enough.
+  #
+  # @param rec [Object] one PC_Compounds entry
+  # @return [Hash, nil] the interpreted result, or nil for an entry that is not a Hash
+  def self.compound_result(rec)
+    return unless rec.is_a?(Hash)
+
+    result = empty_result
+    result[:cid] = dig_hash(rec, 'id', 'id', 'cid')
+    Array(rec['props']).each { |prop| apply_prop(result, prop) }
+    result
+  end
+
+  # Built fresh per call rather than shared: apply_prop mutates +names+ in place.
+  #
+  # @return [Hash] the nil-filled shape every caller sees when PubChem has nothing to say
+  def self.empty_result
+    {
       cid: nil,         # optional
       iupac_name: nil,
       names: [],
       topological: nil, # optional
-      log_p: nil        # optional
+      log_p: nil,       # optional
     }
+  end
 
-    results=[]
+  # Walks +keys+ only while each level is genuinely a Hash.
+  #
+  # Hash#dig guards a *missing* key but still raises TypeError when an intermediate value is
+  # present and not diggable (+{'id' => 'unknown'}.dig('id', 'id')+), which is exactly the shape
+  # a malformed PubChem record arrives in.
+  #
+  # @param hash [Object] any value; a non-Hash yields nil rather than raising
+  # @return [Object, nil] the nested value, or nil if any level is absent or not a Hash
+  def self.dig_hash(hash, *keys)
+    keys.reduce(hash) do |node, key|
+      return nil unless node.is_a?(Hash)
 
-    unless record && record['PC_Compounds']
-      return result unless as_array
-      return results
+      node[key]
     end
+  end
 
-    record['PC_Compounds'].each do |rec|
-      result = {
-        cid: nil,         # optional
-        iupac_name: nil,
-        names: [],
-        topological: nil, # optional
-        log_p: nil        # optional
-      }
+  # Folds one PC_Compounds property into +result+, in place. A property whose urn carries no
+  # label is skipped: it identifies nothing, and PubChem sends no such entry for a well-formed
+  # record.
+  #
+  # @param result [Hash] mutated in place
+  # @param prop [Object] one entry of the record's +props+; anything malformed is ignored
+  # @return [void]
+  def self.apply_prop(result, prop)
+    label = dig_hash(prop, 'urn', 'label')
+    return if label.nil?
 
-      # dig, not chained [], and Array(...) below: a malformed PC_Compounds record (empty id,
-      # missing props) must degrade to the same nil-filled result a Fault produces, not raise
-      # NoMethodError up through PubchemLookupJob.
-      result[:cid] = rec.dig('id', 'id', 'cid')
-
-      Array(rec['props']).each do |prop|
-        if (prop['urn']['label'] == 'IUPAC Name' && prop['urn']['name'] == 'Preferred')
-          result[:iupac_name] = prop['value']['sval'].to_s
-        end
-
-        if (prop['urn']['label'] == 'IUPAC Name')
-          result[:names] << prop['value']['sval'].to_s
-          result[:names].uniq!
-        end
-
-        if (prop['urn']['label'] == 'Topoligical')
-          result[:topological] = prop['value']['fval'].to_s
-        end
-
-        if (prop['urn']['label'] == 'Log P')
-          result[:log_p] = prop['value']['fval'].to_s
-        end
-
-        if (prop['urn']['label'] == 'InChIKey')
-          result[:inchikey] = prop['value']['sval'].to_s
-        end
-      end
-
-      results << result
-    end
-
-    if !as_array
-      results[0]
-    else
-      results
+    case label
+    when 'IUPAC Name'
+      sval = dig_hash(prop, 'value', 'sval').to_s
+      result[:iupac_name] = sval if dig_hash(prop, 'urn', 'name') == 'Preferred'
+      result[:names] << sval
+      result[:names].uniq!
+    when 'Topoligical'
+      result[:topological] = dig_hash(prop, 'value', 'fval').to_s
+    when 'Log P'
+      result[:log_p] = dig_hash(prop, 'value', 'fval').to_s
+    when 'InChIKey'
+      result[:inchikey] = dig_hash(prop, 'value', 'sval').to_s
     end
   end
 

--- a/lib/chemotion/pubchem_service.rb
+++ b/lib/chemotion/pubchem_service.rb
@@ -59,9 +59,12 @@ module Chemotion::PubchemService
         log_p: nil        # optional
       }
 
-      result[:cid] = rec['id']['id']['cid']
+      # dig, not chained [], and Array(...) below: a malformed PC_Compounds record (empty id,
+      # missing props) must degrade to the same nil-filled result a Fault produces, not raise
+      # NoMethodError up through PubchemLookupJob.
+      result[:cid] = rec.dig('id', 'id', 'cid')
 
-      rec['props'].each do |prop|
+      Array(rec['props']).each do |prop|
         if (prop['urn']['label'] == 'IUPAC Name' && prop['urn']['name'] == 'Preferred')
           result[:iupac_name] = prop['value']['sval'].to_s
         end

--- a/lib/pub_chem.rb
+++ b/lib/pub_chem.rb
@@ -188,8 +188,26 @@ module PubChem
     fault = result['Fault'] || result[:Fault]
     return false unless fault
 
-    Rails.logger.warn "PubChem API error: #{fault['Code'] || fault[:Code]} - #{fault['Message'] || fault[:Message]}"
+    code = fault['Code'] || fault[:Code]
+    message = fault['Message'] || fault[:Message]
+    log_fault(code, message)
     true
+  end
+
+  # "Not found" is PubChem's routine answer, not an error: for the pug_view endpoint it is the
+  # only way it says "no data for this cid", and a PubchemLookupJob sweep asks about in-house
+  # compounds PubChem has never heard of. Logging one warn per molecule per sweep for that
+  # buries the faults that do warrant attention (throttling, server errors), so the expected
+  # codes drop to info and everything else keeps warn.
+  BENIGN_FAULT_CODES = %w[PUGVIEW.NotFound PUGREST.NotFound].freeze
+
+  def self.log_fault(code, message)
+    line = "PubChem API error: #{code} - #{message}"
+    if BENIGN_FAULT_CODES.include?(code)
+      Rails.logger.info line
+    else
+      Rails.logger.warn line
+    end
   end
 
   def self.extract_smiles_property(result)

--- a/lib/pub_chem.rb
+++ b/lib/pub_chem.rb
@@ -11,12 +11,21 @@ module PubChem
     (Rails.env.test? && 'http://') || 'https://'
   end
 
+  # A 200 carrying a Fault body is PubChem's way of answering "no" for several of these endpoints
+  # (get_lcss_from_cid's PUGVIEW.NotFound is the one with live user impact); success?
+  # alone does not catch it. Centralizes the "genuinely usable response" check every raw-body
+  # method below needs, so a future change to what counts as safe only has to be made once.
+  # @return [HTTParty::Response, nil] +resp+ unchanged, or nil if it failed or carried a Fault
+  def self.safe_response(resp)
+    resp if resp.success? && !fault_response?(resp.parsed_response)
+  end
+
   def self.get_record_from_molfile(molfile)
     @auth = { username: '', password: '' }
     options = { timeout: 10, headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
                 body: { 'sdf' => molfile } }
 
-    HTTParty.post(http_s + PUBCHEM_HOST + '/rest/pug/compound/sdf/record/JSON', options)
+    safe_response(HTTParty.post("#{http_s}#{PUBCHEM_HOST}/rest/pug/compound/sdf/record/JSON", options))
   rescue StandardError => e
     Rails.logger.error ["with molfile: #{molfile}", e.message, *e.backtrace].join($INPUT_RECORD_SEPARATOR)
     nil
@@ -74,7 +83,8 @@ module PubChem
       headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
       body: { 'inchikey' => "#{inchikeys.join(',')}" },
     }
-    HTTParty.post(http_s + PUBCHEM_HOST + '/rest/pug/compound/inchikey/property/InChIKey/JSON', options).body
+    resp = HTTParty.post("#{http_s}#{PUBCHEM_HOST}/rest/pug/compound/inchikey/property/InChIKey/JSON", options)
+    safe_response(resp)&.body
   rescue StandardError => e
     Rails.logger.error ["with inchikey: #{inchikeys}", e.message, *e.backtrace].join($INPUT_RECORD_SEPARATOR)
     nil
@@ -84,32 +94,19 @@ module PubChem
     @auth = { username: '', password: '' }
     options = { timeout: 10, headers: { 'Content-Type' => 'text/json' } }
 
-    HTTParty.get(http_s + PUBCHEM_HOST + '/rest/pug/compound/inchikey/' + inchikey + '/record/SDF', options).body
+    resp = HTTParty.get("#{http_s}#{PUBCHEM_HOST}/rest/pug/compound/inchikey/#{inchikey}/record/SDF", options)
+    safe_response(resp)&.body
   rescue StandardError => e
     Rails.logger.error ["with inchikey: #{inchikey}", e.message, *e.backtrace].join($INPUT_RECORD_SEPARATOR)
-    nil
-  end
-
-  def self.get_molfiles_by_inchikeys(inchikeys)
-    options = {
-      timeout: 10,
-      headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
-      body: { 'inchikey' => "#{inchikeys.join(',')}" },
-    }
-    HTTParty.post(http_s + '/rest/pug/compound/inchikey/record/SDF', options).body
-  rescue StandardError => e
-    Rails.logger.error "[PubChemError] of [get_molfiles_by_inchikeys] with inchikey [#{inchikeys}], exception [#{e.backtrace}]"
     nil
   end
 
   def self.get_molfile_by_smiles(smiles)
     @auth = { username: '', password: '' }
     options = { timeout: 10, headers: { 'Content-Type' => 'text/json' } }
-    encoded_smiles = URI.encode(smiles, '[]/()+-.@#=\\')
+    encoded_smiles = URI::DEFAULT_PARSER.escape(smiles, %r{[\[\]/()+.@#=\\-]})
     response = HTTParty.get(http_s + PUBCHEM_HOST + '/rest/pug/compound/smiles/' + encoded_smiles + '/record/SDF', options)
-    return nil unless response.success?
-
-    response.body
+    safe_response(response)&.body
   rescue StandardError => e
     Rails.logger.error ["with smiles: #{smiles}", e.message, *e.backtrace].join($INPUT_RECORD_SEPARATOR)
     nil
@@ -119,7 +116,8 @@ module PubChem
     @auth = { username: '', password: '' }
     options = { timeout: 10, headers: { 'Content-Type' => 'text/json' } }
 
-    HTTParty.get(http_s + PUBCHEM_HOST + '/rest/pug/compound/inchikey/' + inchikey + '/xrefs/RN/JSON', options).body
+    resp = HTTParty.get("#{http_s}#{PUBCHEM_HOST}/rest/pug/compound/inchikey/#{inchikey}/xrefs/RN/JSON", options)
+    safe_response(resp)&.body
   rescue StandardError => e
     Rails.logger.error ["with inchikey: #{inchikey}", e.message, *e.backtrace].join($INPUT_RECORD_SEPARATOR)
     nil
@@ -181,10 +179,16 @@ module PubChem
     extract_smiles_property(result)
   end
 
+  # Accepts either string- or symbol-keyed JSON (JSON.parse without and with symbolize_names:
+  # respectively -- both are in use across this module's callers), and anything that is not a
+  # Hash at all (a raw SDF/molfile body, say), which is never a Fault.
   def self.fault_response?(result)
-    return false unless result['Fault']
+    return false unless result.is_a?(Hash)
 
-    Rails.logger.warn "PubChem API error: #{result['Fault']['Code']} - #{result['Fault']['Message']}"
+    fault = result['Fault'] || result[:Fault]
+    return false unless fault
+
+    Rails.logger.warn "PubChem API error: #{fault['Code'] || fault[:Code]} - #{fault['Message'] || fault[:Message]}"
     true
   end
 
@@ -200,7 +204,9 @@ module PubChem
   #   the cid arrives from +element_tags.taggable_data+, where a value written as a JSON string
   #   deserialises to a String — under the old +is_a? Integer+ guard that silently disabled LCSS
   #   for the molecule, with nothing to show for it.
-  # @return [Hash, nil] parsed GHS classification, or nil when there is none or the fetch fails
+  # @return [Hash, nil] parsed GHS classification, or nil when there is none, the cid does not
+  #   resolve (PubChem answers a 200 with a Fault body for this endpoint, not a 404),
+  #   or the fetch fails
   def self.get_lcss_from_cid(cid)
     cid = Integer(cid, exception: false) unless cid.is_a?(Integer)
     return nil unless cid
@@ -211,7 +217,10 @@ module PubChem
       resp = HTTParty.get(page, options)
       return nil unless resp.success?
 
-      JSON.parse resp, symbolize_names: true
+      result = JSON.parse(resp.body, symbolize_names: true)
+      return nil if fault_response?(result)
+
+      result
     rescue StandardError => e
       Rails.logger.error ["with cid: #{cid}", e.message, *e.backtrace].join($INPUT_RECORD_SEPARATOR)
       nil

--- a/lib/tasks/data/ver_20170215133510_molecule.rake
+++ b/lib/tasks/data/ver_20170215133510_molecule.rake
@@ -4,9 +4,13 @@ namespace :data do
     Molecule.all.each_slice(50) do |molecules|
       # Populate Molecule - PubChem tag
       pubchem_cids = nil
-      iks = molecules.map(&:inchikey)
-      pubchem_json = JSON.parse(PubChem.get_cids_from_inchikeys(iks))
-      pubchem_list = pubchem_json["PropertyTable"]["Properties"]
+      # nil when the request failed or PubChem answered with a Fault, which it does for a
+      # throttled batch. Skip that slice rather than passing nil to JSON.parse, which would
+      # abort the whole run on the first bad batch.
+      body = PubChem.get_cids_from_inchikeys(molecules.map(&:inchikey))
+      pubchem_list = body.presence && JSON.parse(body).dig('PropertyTable', 'Properties')
+      next if pubchem_list.blank?
+
       molecule_pubchem = pubchem_list.map { |pub|
         {
           id: Molecule.find_by(inchikey: pub["InChIKey"]).id,

--- a/spec/db/migrate/20260825120000_backfill_pubchem_lcss_sentinels_spec.rb
+++ b/spec/db/migrate/20260825120000_backfill_pubchem_lcss_sentinels_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 load Rails.root.join('db/migrate/20260825120000_backfill_pubchem_lcss_sentinels.rb').to_s
 
-# rubocop:disable-next-line RSpec/DescribeClass
+# rubocop:disable-next RSpec/DescribeClass
 RSpec.describe 'migration 20260825120000: BackfillPubchemLcssSentinels' do
   # Writes taggable_data straight through update_column: the point of each example is the raw JSON
   # shape on the row, which Molecule#pubchem_lcss would normalise away if it were involved.

--- a/spec/db/migrate/20260825120000_backfill_pubchem_lcss_sentinels_spec.rb
+++ b/spec/db/migrate/20260825120000_backfill_pubchem_lcss_sentinels_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+load Rails.root.join('db/migrate/20260825120000_backfill_pubchem_lcss_sentinels.rb').to_s
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'migration 20260825120000: BackfillPubchemLcssSentinels' do
+  # Writes taggable_data straight through update_column: the point of each example is the raw JSON
+  # shape on the row, which Molecule#pubchem_lcss would normalise away if it were involved.
+  def tag_with(lcss_json)
+    molecule = create(:molecule)
+    molecule.tag.update_column(:taggable_data, JSON.parse(lcss_json)) # rubocop:disable Rails/SkipsModelValidations
+    molecule.tag
+  end
+
+  def stored_lcss(tag)
+    tag.reload.taggable_data['pubchem_lcss']
+  end
+
+  describe 'a JSON null, which never leaves PubchemLookupJob pending scope' do
+    let!(:tag) { tag_with('{"pubchem_lcss": null, "pubchem_cid": 962}') }
+
+    it 'becomes false, the "asked, PubChem has none" sentinel' do
+      described_class_up
+
+      expect(stored_lcss(tag)).to be(false)
+    end
+
+    it 'no longer matches the pending predicate the sweep selects on' do
+      described_class_up
+
+      expect(pending_lcss_tag_ids).not_to include(tag.id)
+    end
+
+    it 'keeps the rest of taggable_data' do
+      described_class_up
+
+      expect(tag.reload.taggable_data['pubchem_cid']).to eq(962)
+    end
+  end
+
+  describe 'a Fault body stored as if it were GHS data' do
+    let!(:tag) do
+      tag_with('{"pubchem_lcss": {"Fault": {"Code": "PUGVIEW.NotFound", "Message": "No data found"}}}')
+    end
+
+    # Deleted rather than set to false: a Fault can be transient, so these get one more real
+    # question rather than a permanent "PubChem has none".
+    it 'has the key removed so the molecule is asked once more' do
+      described_class_up
+
+      expect(tag.reload.taggable_data).not_to have_key('pubchem_lcss')
+    end
+  end
+
+  describe 'values the migration must not touch' do
+    let!(:real_data) { tag_with('{"pubchem_lcss": {"Record": {"Section": []}}}') }
+    let!(:already_false) { tag_with('{"pubchem_lcss": false}') }
+    let!(:never_asked) { tag_with('{"pubchem_cid": 962}') }
+
+    it 'leaves a real classification alone' do
+      described_class_up
+
+      expect(stored_lcss(real_data)).to eq({ 'Record' => { 'Section' => [] } })
+    end
+
+    it 'leaves an existing false alone' do
+      described_class_up
+
+      expect(stored_lcss(already_false)).to be(false)
+    end
+
+    it 'does not invent a value for a molecule that was never asked' do
+      described_class_up
+
+      expect(never_asked.reload.taggable_data).not_to have_key('pubchem_lcss')
+    end
+  end
+
+  describe 'running twice' do
+    let!(:null_tag) { tag_with('{"pubchem_lcss": null}') }
+    let!(:fault_tag) { tag_with('{"pubchem_lcss": {"Fault": {"Code": "PUGVIEW.NotFound"}}}') }
+
+    it 'is idempotent' do
+      described_class_up
+      described_class_up
+
+      expect([stored_lcss(null_tag), fault_tag.reload.taggable_data.key?('pubchem_lcss')])
+        .to eq([false, false])
+    end
+  end
+
+  # The predicate PubchemLookupJob#pending_scope selects on. Asserted directly against Postgres so
+  # the migration is measured against the same `->>` semantics that caused the stall, not against a
+  # Ruby-side reading of the column.
+  def pending_lcss_tag_ids
+    ElementTag.where(taggable_type: 'Molecule')
+              .where("taggable_data->>'pubchem_lcss' is null")
+              .pluck(:id)
+  end
+
+  def described_class_up
+    BackfillPubchemLcssSentinels.new.up
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/db/migrate/20260825120000_backfill_pubchem_lcss_sentinels_spec.rb
+++ b/spec/db/migrate/20260825120000_backfill_pubchem_lcss_sentinels_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 load Rails.root.join('db/migrate/20260825120000_backfill_pubchem_lcss_sentinels.rb').to_s
 
-# rubocop:disable RSpec/DescribeClass
+# rubocop:disable-next-line RSpec/DescribeClass
 RSpec.describe 'migration 20260825120000: BackfillPubchemLcssSentinels' do
   # Writes taggable_data straight through update_column: the point of each example is the raw JSON
   # shape on the row, which Molecule#pubchem_lcss would normalise away if it were involved.
@@ -104,4 +104,3 @@ RSpec.describe 'migration 20260825120000: BackfillPubchemLcssSentinels' do
     BackfillPubchemLcssSentinels.new.up
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/lib/chemotion/pubchem_service_spec.rb
+++ b/spec/lib/chemotion/pubchem_service_spec.rb
@@ -66,5 +66,48 @@ RSpec.describe Chemotion::PubchemService do
 
       expect(described_class.interpret_record(fault_record, true)).to eq([])
     end
+
+    # Hash#dig guards a missing key but still raises TypeError on an intermediate value that is
+    # present and not diggable, so the id is type-checked and not merely dug.
+    it 'does not raise on a record whose id is not a hash' do
+      malformed = { 'PC_Compounds' => [{ 'id' => 'unknown', 'props' => [] }] }
+
+      expect { described_class.interpret_record(malformed) }.not_to raise_error
+      expect(described_class.interpret_record(malformed)[:cid]).to be_nil
+    end
+
+    # The realistic malformed shape: the record resolves, but one property carries no urn.
+    it 'skips a props entry with no urn instead of raising' do
+      malformed = {
+        'PC_Compounds' => [{
+          'id' => { 'id' => { 'cid' => 962 } },
+          'props' => [
+            { 'value' => { 'sval' => 'orphan' } },
+            { 'urn' => { 'label' => 'InChIKey' }, 'value' => { 'sval' => 'XLYOFNOQVPJJNP-UHFFFAOYSA-N' } },
+          ],
+        }],
+      }
+
+      result = described_class.interpret_record(malformed)
+
+      expect(result[:inchikey]).to eq('XLYOFNOQVPJJNP-UHFFFAOYSA-N')
+    end
+
+    it 'reads a labelled props entry with no value as an empty string rather than raising' do
+      malformed = {
+        'PC_Compounds' => [{
+          'id' => { 'id' => { 'cid' => 962 } },
+          'props' => [{ 'urn' => { 'label' => 'IUPAC Name', 'name' => 'Preferred' } }],
+        }],
+      }
+
+      expect(described_class.interpret_record(malformed)[:iupac_name]).to eq('')
+    end
+
+    it 'skips a PC_Compounds entry that is not a hash' do
+      malformed = { 'PC_Compounds' => ['nonsense', { 'id' => { 'id' => { 'cid' => 7 } }, 'props' => [] }] }
+
+      expect(described_class.interpret_record(malformed, true).map { |r| r[:cid] }).to eq([7])
+    end
   end
 end

--- a/spec/lib/chemotion/pubchem_service_spec.rb
+++ b/spec/lib/chemotion/pubchem_service_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# interpret_record's nil-hash-on-Fault contract was previously asserted only in a comment
+# (app/models/molecule.rb:473-477), with no spec exercising it directly.
+RSpec.describe Chemotion::PubchemService do
+  describe '.interpret_record' do
+    let(:empty_result) { { cid: nil, iupac_name: nil, names: [], topological: nil, log_p: nil } }
+
+    it 'returns the nil-filled hash for a Fault body' do
+      fault_record = { 'Fault' => { 'Code' => 'PUGREST.NotFound', 'Message' => 'No CID found' } }
+
+      expect(described_class.interpret_record(fault_record)).to eq(empty_result)
+    end
+
+    it 'returns the nil-filled hash for a nil record' do
+      expect(described_class.interpret_record(nil)).to eq(empty_result)
+    end
+
+    it 'parses a record given as a JSON string' do
+      record = { 'PC_Compounds' => [{ 'id' => { 'id' => { 'cid' => 42 } }, 'props' => [] }] }.to_json
+
+      expect(described_class.interpret_record(record)[:cid]).to eq(42)
+    end
+
+    # A malformed PC_Compounds entry (missing id, or props not an array) must degrade to the
+    # same nil-filled shape a Fault produces, not raise NoMethodError up through
+    # PubchemLookupJob -- exactly the realistic failure mode for a record that does resolve but
+    # is shaped unexpectedly.
+    it 'does not raise on a record with an empty id' do
+      malformed = { 'PC_Compounds' => [{ 'id' => {}, 'props' => [] }] }
+
+      expect { described_class.interpret_record(malformed) }.not_to raise_error
+      expect(described_class.interpret_record(malformed)[:cid]).to be_nil
+    end
+
+    it 'does not raise on a record with no props at all' do
+      malformed = { 'PC_Compounds' => [{ 'id' => { 'id' => { 'cid' => 1 } } }] }
+
+      expect { described_class.interpret_record(malformed) }.not_to raise_error
+      expect(described_class.interpret_record(malformed)[:cid]).to eq(1)
+    end
+
+    it 'extracts cid, iupac_name, names and inchikey from a well-formed record', :aggregate_failures do
+      record = {
+        'PC_Compounds' => [{
+          'id' => { 'id' => { 'cid' => 962 } },
+          'props' => [
+            { 'urn' => { 'label' => 'IUPAC Name', 'name' => 'Preferred' }, 'value' => { 'sval' => 'water' } },
+            { 'urn' => { 'label' => 'InChIKey' }, 'value' => { 'sval' => 'XLYOFNOQVPJJNP-UHFFFAOYSA-N' } },
+          ],
+        }],
+      }
+
+      result = described_class.interpret_record(record)
+
+      expect(result[:cid]).to eq(962)
+      expect(result[:iupac_name]).to eq('water')
+      expect(result[:names]).to eq(['water'])
+      expect(result[:inchikey]).to eq('XLYOFNOQVPJJNP-UHFFFAOYSA-N')
+    end
+
+    it 'returns an empty array for a Fault body when as_array is true' do
+      fault_record = { 'Fault' => { 'Code' => 'PUGREST.NotFound' } }
+
+      expect(described_class.interpret_record(fault_record, true)).to eq([])
+    end
+  end
+end

--- a/spec/lib/chemotion/pubchem_service_spec.rb
+++ b/spec/lib/chemotion/pubchem_service_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Chemotion::PubchemService do
     it 'skips a PC_Compounds entry that is not a hash' do
       malformed = { 'PC_Compounds' => ['nonsense', { 'id' => { 'id' => { 'cid' => 7 } }, 'props' => [] }] }
 
-      expect(described_class.interpret_record(malformed, true).map { |r| r[:cid] }).to eq([7])
+      expect(described_class.interpret_record(malformed, true).pluck(:cid)).to eq([7])
     end
   end
 end

--- a/spec/lib/pub_chem_spec.rb
+++ b/spec/lib/pub_chem_spec.rb
@@ -85,6 +85,78 @@ RSpec.describe 'PubChem' do
     end
   end
 
+  # The contract safe_response introduces: a Fault body on a 200, or any non-2xx, must reach the
+  # caller as nil rather than as a body it will parse as data.
+  describe '.safe_response gate on the raw-body methods' do
+    let(:fault_body) { { Fault: { Code: 'PUGREST.NotFound', Message: 'No CID found' } }.to_json }
+
+    def stub_get(success:, body:)
+      allow(HTTParty).to receive(:get).and_return(
+        instance_double(HTTParty::Response, success?: success, body: body, parsed_response: JSON.parse(body)),
+      )
+    end
+
+    def stub_post(success:, body:)
+      allow(HTTParty).to receive(:post).and_return(
+        instance_double(HTTParty::Response, success?: success, body: body, parsed_response: JSON.parse(body)),
+      )
+    end
+
+    it 'returns nil from get_molfile_by_inchikey for a 200 carrying a Fault' do
+      stub_get(success: true, body: fault_body)
+
+      expect(PubChem.get_molfile_by_inchikey('KEY')).to be_nil
+    end
+
+    it 'returns nil from get_xref_by_inchikey for a failed response' do
+      stub_get(success: false, body: fault_body)
+
+      expect(PubChem.get_xref_by_inchikey('KEY')).to be_nil
+    end
+
+    it 'returns nil from get_cids_from_inchikeys for a 200 carrying a Fault' do
+      stub_post(success: true, body: fault_body)
+
+      expect(PubChem.get_cids_from_inchikeys(%w[KEY])).to be_nil
+    end
+
+    it 'returns nil from get_record_from_molfile for a 200 carrying a Fault' do
+      stub_post(success: true, body: fault_body)
+
+      expect(PubChem.get_record_from_molfile('molfile')).to be_nil
+    end
+
+    # A molfile body is not JSON and not a Hash, so the Fault check must let it through
+    # untouched rather than treating an unparseable body as a failure.
+    it 'passes a plain SDF body through' do
+      allow(HTTParty).to receive(:get).and_return(
+        instance_double(HTTParty::Response, success?: true, body: 'SDF', parsed_response: 'SDF'),
+      )
+
+      expect(PubChem.get_molfile_by_inchikey('KEY')).to eq('SDF')
+    end
+  end
+
+  # Not found is PubChem's routine "no data" answer; logging one warn per molecule per sweep
+  # for it would bury the faults that do warrant attention.
+  describe '.fault_response? log level' do
+    it 'logs an expected not-found at info' do
+      allow(Rails.logger).to receive(:info)
+
+      PubChem.fault_response?({ 'Fault' => { 'Code' => 'PUGVIEW.NotFound', 'Message' => 'No data found' } })
+
+      expect(Rails.logger).to have_received(:info).with(/PUGVIEW.NotFound/)
+    end
+
+    it 'keeps warn for an unexpected fault code' do
+      allow(Rails.logger).to receive(:warn)
+
+      PubChem.fault_response?({ 'Fault' => { 'Code' => 'PUGREST.ServerBusy', 'Message' => 'Too busy' } })
+
+      expect(Rails.logger).to have_received(:warn).with(/PUGREST.ServerBusy/)
+    end
+  end
+
   describe 'most_occurance' do
     it 'returns the most common element' do
       target = [1, 2, 3, 4, 5, 1, 2, 3, 1]

--- a/spec/lib/pub_chem_spec.rb
+++ b/spec/lib/pub_chem_spec.rb
@@ -71,6 +71,18 @@ RSpec.describe 'PubChem' do
 
       expect(HTTParty).not_to have_received(:get)
     end
+
+    # PubChem answers an unknown cid with HTTP 200 and a Fault body, not a 404 -- so success?
+    # alone does not catch it, and the caller (Molecule#pubchem_lcss) used to store the Fault
+    # hash itself as if it were real GHS data.
+    it 'returns nil for a 200 response carrying a Fault body' do
+      fault_body = { Fault: { Code: 'PUGVIEW.NotFound', Message: 'No data found' } }.to_json
+      allow(HTTParty).to receive(:get).and_return(
+        instance_double(HTTParty::Response, success?: true, body: fault_body),
+      )
+
+      expect(PubChem.get_lcss_from_cid(962)).to be_nil
+    end
   end
 
   describe 'most_occurance' do

--- a/spec/models/molecule_spec.rb
+++ b/spec/models/molecule_spec.rb
@@ -308,18 +308,32 @@ RSpec.describe Molecule, type: :model do
       expect(persisted_molfile_sha).to eq(molfile_sha)
     end
 
-    it 'updates LCSS when molecule.pubchem_lcss is requested' do
+    # Previously asserted `be_nil` against a molecule with no pubchem_cid at all, which passes
+    # vacuously: #pubchem_lcss returns early on a blank cid without touching taggable_data, so the
+    # assertion held regardless of what PubChem would have said. Stubs the network call instead of
+    # relying on a real request, and asserts the actual `false`-not-nil storage convention
+    # documented at #pubchem_lcss (a stored JSON null reads back as SQL NULL through `->>`, so it
+    # would never leave PubchemLookupJob's pending scope).
+    it 'stores false, not nil, when PubChem has no LCSS data for the cid' do
       molecule.save!
       persisted_molecule = described_class.last
+      persisted_molecule.tag.taggable_data['pubchem_cid'] = 123_456_789
+      allow(Chemotion::PubchemService).to receive(:lcss_from_cid).with(123_456_789).and_return(nil)
 
-      # lcss is updated as nil because cid 123456789 has no PubChem lcss
       persisted_molecule.pubchem_lcss
-      expect(persisted_molecule.tag.taggable_data['pubchem_lcss']).to be_nil
 
-      # lcss is updated with value because cid 643785 has PubChem lcss
+      expect(persisted_molecule.tag.taggable_data['pubchem_lcss']).to be(false)
+    end
+
+    it 'stores the LCSS data PubChem returns for the cid' do
+      molecule.save!
+      persisted_molecule = described_class.last
       persisted_molecule.tag.taggable_data['pubchem_cid'] = 643_785
+      allow(Chemotion::PubchemService).to receive(:lcss_from_cid).with(643_785).and_return({ 'ghs' => 'data' })
+
       persisted_molecule.pubchem_lcss
-      expect(persisted_molecule.tag.taggable_data['pubchem_lcss']).not_to be_nil
+
+      expect(persisted_molecule.tag.taggable_data['pubchem_lcss']).to eq({ 'ghs' => 'data' })
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,7 +107,7 @@ RSpec.configure do |config|
         )
     end
 
-    error_body = "<<~BODY
+    error_body = <<~BODY
       Status: 400
       Code: PUGREST.BadRequest
       Message: Unable to standardize the given structure - perhaps some special characters need to be escaped or data
@@ -120,7 +120,7 @@ RSpec.configure do |config|
       Detail: Record 1: Error: Unable to convert input into a compound object
       Detail:
       Detail:
-    BODY"
+    BODY
 
     bad_smiles.each_value do |entry|
       smiles_end_point = "http://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/smiles/#{entry['smiles']}/record/SDF"


### PR DESCRIPTION
# PubChem Fault handling and the LCSS backfill

## The problem

`Molecule#pubchem_lcss` stored the client's `nil` verbatim. A JSON null in
`taggable_data['pubchem_lcss']` matches `->>'pubchem_lcss' is null` — the predicate
`PubchemLookupJob#pending_scope` selects on — exactly as a missing key does, so those molecules
never left the pending scope and were re-asked on every sweep, indefinitely. Measured on a
production-data copy: **12,658 molecules, 23% of all molecule tags**, permanently stuck.

Around that, the client had no guard against PubChem's `Fault` bodies:

- `get_lcss_from_cid` checked only `success?`. Every Fault observed in practice arrives with a
  **404 or 400**, so `success?` does catch them today — but the endpoint's error contract is not
  guaranteed, and nothing between the status check and the store would stop a non-record body
  from being written as a molecule's GHS classification.
- Four other raw-body methods (`get_record_from_molfile`, `get_cids_from_inchikeys`,
  `get_molfile_by_inchikey`, `get_xref_by_inchikey`) checked **neither** `success?` nor `Fault`,
  so an error page could be parsed as a record.
- `interpret_record` assumed the shape of a `PC_Compounds` record and raised on a malformed one,
  failing the whole enrichment job rather than that molecule.
- `URI.encode` was still in use; it was removed in Ruby 3.

## The fix

- One `safe_response` gate: a response is usable only if `success?` **and** not a `Fault`. Every
  raw-body method returns `nil` instead of a Fault body. `get_lcss_from_cid` checks for a Fault
  after parsing, so a Fault can never be stored regardless of the status it arrives with.
- `interpret_record` reads every nested value through a `dig_hash` helper that walks only while
  each level is a Hash, so a malformed record — a non-Hash entry, a wrongly typed `id`, missing
  `props`, a props entry with no `urn` — degrades to the same nil-filled result a Fault produces
  instead of raising `NoMethodError`/`TypeError` up through `PubchemLookupJob`. The per-property
  branch moves to `apply_prop` and the duplicated literal to `empty_result`.
- `fault_response?` logs the expected not-found codes at `info` and everything else at `warn`:
  "not found" is PubChem's routine answer, and with five call sites now routed through this
  method a sweep would otherwise log one warning per molecule.
- `URI.encode` becomes `URI::DEFAULT_PARSER.escape` (verified character-for-character
  equivalent). `get_molfiles_by_inchikeys` is deleted: it had a broken URL and no callers.
- `ver_20170215133510_molecule.rake` skips a slice when `get_cids_from_inchikeys` returns nil,
  rather than passing nil to `JSON.parse`.

## The backfill (`20260825120000`)

The code fix stops producing bad values but cannot repair the stored ones, so the migration does:

- **A JSON null** becomes `false`, the "asked, PubChem has none" sentinel, with no network call.
  Note that a null also records a timeout or a 5xx, not only a genuine miss; collapsing both is
  deliberate, because `lcss || false` in `Molecule#pubchem_lcss` already does the same at
  runtime.
- **A stored Fault body** is truthy, so such a molecule would never be in the pending scope and
  would keep serving a Fault as safety data. The key is deleted so it gets asked once more with
  the corrected client, rate-limited by the existing `pubchem_checked_at` TTL. No such rows have
  been observed in production data — this branch is a safety net for an instance that has them,
  and a no-op otherwise.

Both statements are idempotent and the migration is not reversible: the previous values were not
valid data.

### Validated against a production-data copy

Run inside a rolled-back transaction on a database carrying production data:

| check | result |
|---|---|
| JSON-null rows rewritten | 12,658 |
| Fault-body rows cleared | 0 |
| real `Record` classifications altered | 0 |
| rows where any other `taggable_data` key changed | 0 |
| rows with no `pubchem_lcss` key touched | 0 |
| second run of both statements | 0, 0 (idempotent) |
| pending scope | 44,404 → 31,746 rows |

~0.3 s per statement over 54k rows.

## Tests

`spec/lib/chemotion/pubchem_service_spec.rb` (new) covers the nil-on-Fault contract and the
malformed-record shapes; `spec/lib/pub_chem_spec.rb` the Fault detection, the `safe_response`
gate on the raw-body methods, and both log levels; `spec/db/migrate/20260825120000_..._spec.rb`
the backfill, including what it must not touch — asserted against the real Postgres `->>`
predicate rather than a Ruby-side read of the column. The LCSS model spec previously asserted
against a molecule with no cid at all, so it passed regardless of what PubChem answered; it now
stubs the call and asserts the real `false`-not-nil storage convention. A broken heredoc in
`spec/spec_helper.rb` (a quoted string containing the literal `<<~BODY`) is repaired.

167 examples, 0 failures across the affected spec files; rubocop clean on every touched file.
