### PR TITLE
fix(import): release the DB connection around native work, and bound the canonical-SMILES writer

### DIFF
--- a/app/jobs/pubchem_lookup_job.rb
+++ b/app/jobs/pubchem_lookup_job.rb
@@ -230,7 +230,15 @@ class PubchemLookupJob < ApplicationJob
 
   # Spaces outbound PubChem requests. Extracted so the pacing is per *request*, which is what
   # PubChem's policy counts.
+  #
+  # Also where this job releases its AR connection. Called immediately before every HTTP round
+  # trip (see #enrich_and_fetch_lcss), so together the sleep and the request that follows can
+  # leave the connection idle for 21s+ per molecule, for up to this job's whole run budget (see
+  # RUN_BUDGET_RATIO) -- worst case tens of minutes on one checked-out connection doing nothing.
+  # Releasing it here means a connection dropped/reaped during that idle window is simply
+  # re-checked-out on the next query instead of poisoning the worker with PG::ConnectionBad.
   def throttle
+    ActiveRecord::Base.connection_pool.release_connection
     sleep SLEEP_BETWEEN_REQUESTS
   end
 

--- a/lib/chemotion/forked_timeout.rb
+++ b/lib/chemotion/forked_timeout.rb
@@ -31,6 +31,11 @@ module Chemotion
       read_result(reader, pid, seconds)
     ensure
       reader&.close
+      # Also in the ensure, not only on the happy path above: when fork itself fails
+      # (Errno::EAGAIN/ENOMEM under memory or process-table pressure) spawn_child raises before
+      # the explicit close, and the write end would leak a descriptor per call. IO#close is a
+      # no-op on an already-closed stream, so the happy path is unaffected.
+      writer&.close
     end
 
     def self.spawn_child(writer)

--- a/lib/chemotion/open_babel_service.rb
+++ b/lib/chemotion/open_babel_service.rb
@@ -27,6 +27,15 @@ module Chemotion::OpenBabelService
   # for a given deployment.
   SVG_RENDER_TIMEOUT_SECONDS = Integer(ENV.fetch('OPENBABEL_SVG_TIMEOUT_SECONDS', 5))
 
+  # Wall-clock bound for the canonical-SMILES ('can') writer in molecule_info_from_structure.
+  # Unlike the SVG writer this one is not merely slow to time out -- on metal clusters its
+  # symmetry-detection cost is combinatorial, not size-driven (measured: a 17-atom record took
+  # 6s while a 92-atom one took 11.3s), and it runs in-process on every import row with no bound
+  # at all before this. Set well above the measured 12.06s worst case (across 6,355 records of a
+  # metal-heavy stress file) so it only fires on a genuine outlier/hang, not on ordinary slow
+  # structures.
+  CANONICAL_SMILES_TIMEOUT_SECONDS = Integer(ENV.fetch('OPENBABEL_CANONICAL_SMILES_TIMEOUT_SECONDS', 20))
+
   # mdl V3000
   MOLFILE_COUNT_LINE_START      = 'M  V30 COUNTS '
   MOLFILE_BEGIN_CTAB_BLOCK_LINE = 'M  V30 BEGIN CTAB'
@@ -125,13 +134,7 @@ M  END
     c.set_out_format 'smi'
     smiles = c.write_string(m, false).to_s.gsub(/\s.*/m, "").strip
 
-    c.set_out_format 'can'
-    ca_smiles = begin
-      str = c.write_string(m, false).to_s
-      str.lines.first.to_s.gsub(/\s.*/m, "").strip
-    rescue StandardError, SystemStackError
-      ''
-    end
+    ca_smiles = canonical_smiles_from_source(mf || structure, format)
 
     unless format == 'mol'
       c.set_out_format 'mol'
@@ -482,6 +485,36 @@ M  END
     Rails.logger.error("Chemotion::OpenBabelService.svg_from_molfile aborted: #{e.message}")
     nil
   end
+
+  # Process-isolated, timeout-bounded wrapper around OpenBabel's canonical-SMILES writer. See
+  # CANONICAL_SMILES_TIMEOUT_SECONDS. Falls back to '' on timeout or any other failure, matching
+  # the blank-on-failure contract molecule_info_from_structure's callers already expect from this
+  # field.
+  def self.canonical_smiles_from_source(source, in_format)
+    Chemotion::ForkedTimeout.run(CANONICAL_SMILES_TIMEOUT_SECONDS) do
+      canonical_smiles_from_source_unsafe(source, in_format)
+    end
+  rescue StandardError => e
+    # Covers both Chemotion::ForkedTimeout::TimedOut (deadline overrun or a crashed child, e.g.
+    # from SystemStackError, which the child's own StandardError rescue does not catch) and any
+    # error the writer itself raised and the child re-raised in this process.
+    Rails.logger.error("Chemotion::OpenBabelService.canonical_smiles_from_source failed: #{e.message}")
+    ''
+  end
+
+  def self.canonical_smiles_from_source_unsafe(source, in_format)
+    c = OpenBabel::OBConversion.new
+    c.set_in_format in_format
+    m = OpenBabel::OBMol.new
+    c.read_string m, source
+
+    c.set_out_format 'can'
+    c.write_string(m, false).to_s.lines.first.to_s.gsub(/\s.*/m, '').strip
+  end
+
+  # The bare `private` above this section does not apply to singleton methods, so these two are
+  # closed off explicitly.
+  private_class_method :canonical_smiles_from_source, :canonical_smiles_from_source_unsafe
 
   def self.svg_from_molfile_unsafe(molfile, options = {})
     c = OpenBabel::OBConversion.new

--- a/lib/chemotion/open_babel_service.rb
+++ b/lib/chemotion/open_babel_service.rb
@@ -94,8 +94,9 @@ M  END
   #   structures roughly one record in ten spends the entire {SVG_RENDER_TIMEOUT_SECONDS} budget
   #   only to be SIGKILLed and return
   #   nil. See {.molecule_info_from_structure} for who should be passing false.
-  def self.molecule_info_from_molfile(molfile, render_svg: true)
-    molecule_info_from_structure(molfile, 'mol', render_svg: render_svg)
+  def self.molecule_info_from_molfile(molfile, render_svg: true, bound_native_work: false)
+    molecule_info_from_structure(molfile, 'mol', render_svg: render_svg,
+                                                 bound_native_work: bound_native_work)
   end
 
   # @param render_svg [Boolean] when false, +svg:+ comes back nil and no fork is taken.
@@ -108,21 +109,28 @@ M  END
   #
   #   The renderer chain is unaffected — {Chemotion::SvgRenderer.open_babel_service} calls
   #   {.svg_from_molfile} directly as its last resort, independently of this method.
-  def self.molecule_info_from_structure(structure, format = 'mol', render_svg: true)
-    is_partial = false
-    mf = nil
-    if format == 'mol'
-      version = molfile_version(structure)
-      is_partial = molfile_has_R(structure, version)
-      molfile = structure
-      molfile = molfile_skip_R(structure, version) if is_partial
-      mf = mofile_clear_coord_bonds(molfile, version)
-      if mf
-        version += ' T9'
-      else
-        mf = molfile
-      end
-    end
+  #
+  # @param bound_native_work [Boolean] whether to bound the canonical-SMILES writer in a forked
+  #   child ({CANONICAL_SMILES_TIMEOUT_SECONDS}). Defaults to **false**: only callers running off
+  #   the request path should pass true.
+  #
+  #   The writer's symmetry detection is combinatorial rather than size-driven (measured: a 17-atom
+  #   record 6 s, a 92-atom one 11.3 s), so on a metal-heavy import it is worth bounding — a hung
+  #   record there takes the worker with it, and nobody is waiting on the response. On the request
+  #   path the trade reverses: forking a multi-threaded Puma worker to guard against a rare
+  #   pathological structure is the larger risk, since a child that inherits a malloc arena lock
+  #   held by another thread deadlocks until the deadline. {Sample#find_or_create_molecule_based_on_inchikey}
+  #   is a +before_save+, so that would be one fork per sample save, inside the save transaction.
+  #
+  #   Ruby's Timeout cannot interrupt a hang inside native OpenBabel code, which is why bounding
+  #   means forking and not something cheaper.
+  # Long and branchy because it is the single funnel every structure conversion goes through;
+  # #prepared_molfile takes the molfile-variant resolution out of it, and the rest is a
+  # sequence of writes with no shared seam left to extract.
+  # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+  def self.molecule_info_from_structure(structure, format = 'mol', render_svg: true,
+                                        bound_native_work: false)
+    mf, molfile, version, is_partial = prepared_molfile(structure, format)
     OpenBabel.obErrorLog.clear_log
 
     c = OpenBabel::OBConversion.new
@@ -137,7 +145,15 @@ M  END
     # nil, not '': the bounded writer distinguishes "failed or overran its deadline" from
     # "canonicalised to nothing". Molecule#assign_molecule_data persists cano_smiles, so the
     # first case has to leave a trace in ob_log instead of silently storing a blank.
-    ca_smiles_or_nil = canonical_smiles_from_source(mf || structure, format)
+    #
+    # Both branches write from +m+, the OBMol parsed just above. The bounded one reads it inside a
+    # forked child, which inherits it — so bounding costs a fork but never a second parse, and both
+    # branches see the same aromaticity/kekulisation perception the 'smi' write already ran.
+    ca_smiles_or_nil = if bound_native_work
+                         bounded_canonical_smiles(c, m)
+                       else
+                         canonical_smiles_from(c, m)
+                       end
     ca_smiles = ca_smiles_or_nil || ''
 
     unless format == 'mol'
@@ -243,9 +259,9 @@ M  END
   end
 
   # @param render_svg [Boolean] forwarded per record — see {.molecule_info_from_structure}
-  def self.molecule_info_from_molfiles(molfile_array, render_svg: true)
+  def self.molecule_info_from_molfiles(molfile_array, render_svg: true, bound_native_work: false)
     molfile_array.map do |molfile|
-      molecule_info_from_molfile(molfile, render_svg: render_svg)
+      molecule_info_from_molfile(molfile, render_svg: render_svg, bound_native_work: bound_native_work)
     rescue StandardError => e
       Rails.logger.error("Chemotion::OpenBabelService.molecule_info_from_molfiles: failed for one record: #{e.message}")
       nil
@@ -505,41 +521,73 @@ M  END
     nil
   end
 
-  # Process-isolated, timeout-bounded wrapper around OpenBabel's canonical-SMILES writer. See
-  # CANONICAL_SMILES_TIMEOUT_SECONDS.
+  # Resolves the molfile variant Open Babel should actually read, for a 'mol' input.
+  #
+  # An R-group structure is read with its R atoms skipped, and type-9 (coordination) bonds are
+  # cleared when present — which is what the +' T9'+ version suffix records, so a caller can tell
+  # the stored molfile was rewritten rather than taken verbatim.
+  #
+  # @return [Array(String, String, String, Boolean)] +[mf, molfile, version, is_partial]+ — the
+  #   molfile to read, the original (R-skipped) molfile, its version, and whether it is partial.
+  #   For a non-'mol' format, +[nil, nil, nil, false]+: the caller reads +structure+ directly.
+  def self.prepared_molfile(structure, format)
+    return [nil, nil, nil, false] unless format == 'mol'
+
+    version = molfile_version(structure)
+    is_partial = molfile_has_R(structure, version)
+    molfile = is_partial ? molfile_skip_R(structure, version) : structure
+
+    cleared = mofile_clear_coord_bonds(molfile, version)
+    version += ' T9' if cleared
+
+    [cleared || molfile, molfile, version, is_partial]
+  end
+  private_class_method :prepared_molfile
+
+  # Process-isolated, timeout-bounded canonical-SMILES write. See
+  # CANONICAL_SMILES_TIMEOUT_SECONDS, and {.molecule_info_from_structure}'s +bound_native_work+ for
+  # who should be asking for this and who should not.
+  #
+  # The child inherits +mol+ from the parent, so bounding costs a fork but not a second parse.
   #
   # Returns nil rather than '' on failure, the same way {.svg_from_molfile} does: the caller turns
   # it into the blank the +cano_smiles+ contract expects *and* records a warning, which a bare ''
   # here could not be distinguished from a structure that legitimately canonicalises to nothing.
   #
+  # @param conv [OpenBabel::OBConversion] the conversion +mol+ was read with
+  # @param mol [OpenBabel::OBMol] the already-parsed structure
   # @return [String] the canonical SMILES
   # @return [nil] on timeout, a crashed child, a failed fork, or any error the writer raised
-  def self.canonical_smiles_from_source(source, in_format)
+  def self.bounded_canonical_smiles(conv, mol)
     Chemotion::ForkedTimeout.run(CANONICAL_SMILES_TIMEOUT_SECONDS) do
-      canonical_smiles_from_source_unsafe(source, in_format)
+      canonical_smiles_from(conv, mol)
     end
   rescue StandardError => e
     # Covers Chemotion::ForkedTimeout::TimedOut (deadline overrun or a crashed child, e.g. from
     # SystemStackError, which the child's own StandardError rescue does not catch), a fork that
-    # could not be taken at all (Errno::EAGAIN/ENOMEM under memory pressure -- reachable now that
-    # this runs once per imported record), and any error the writer raised and the child re-raised.
-    Rails.logger.error("Chemotion::OpenBabelService.canonical_smiles_from_source failed: #{e.message}")
+    # could not be taken at all (Errno::EAGAIN/ENOMEM under memory pressure), and any error the
+    # writer raised and the child re-raised.
+    Rails.logger.error("Chemotion::OpenBabelService.bounded_canonical_smiles failed: #{e.message}")
     nil
   end
 
-  def self.canonical_smiles_from_source_unsafe(source, in_format)
-    c = OpenBabel::OBConversion.new
-    c.set_in_format in_format
-    m = OpenBabel::OBMol.new
-    c.read_string m, source
-
-    c.set_out_format 'can'
-    c.write_string(m, false).to_s.lines.first.to_s.gsub(/\s.*/m, '').strip
+  # Writes canonical SMILES from an already-parsed OBMol, in-process. Kept separate from
+  # {.bounded_canonical_smiles} so the unbounded request path and the bounded import path share one
+  # writer and cannot drift in what they produce.
+  #
+  # @return [String] the canonical SMILES
+  # @return [nil] if the writer raised — the caller reports it rather than storing a blank
+  def self.canonical_smiles_from(conv, mol)
+    conv.set_out_format 'can'
+    conv.write_string(mol, false).to_s.lines.first.to_s.gsub(/\s.*/m, '').strip
+  rescue StandardError, SystemStackError => e
+    Rails.logger.error("Chemotion::OpenBabelService.canonical_smiles_from failed: #{e.message}")
+    nil
   end
 
   # The bare `private` above this section does not apply to singleton methods, so these two are
   # closed off explicitly.
-  private_class_method :canonical_smiles_from_source, :canonical_smiles_from_source_unsafe
+  private_class_method :bounded_canonical_smiles, :canonical_smiles_from
 
   def self.svg_from_molfile_unsafe(molfile, options = {})
     c = OpenBabel::OBConversion.new

--- a/lib/chemotion/open_babel_service.rb
+++ b/lib/chemotion/open_babel_service.rb
@@ -134,7 +134,11 @@ M  END
     c.set_out_format 'smi'
     smiles = c.write_string(m, false).to_s.gsub(/\s.*/m, "").strip
 
-    ca_smiles = canonical_smiles_from_source(mf || structure, format)
+    # nil, not '': the bounded writer distinguishes "failed or overran its deadline" from
+    # "canonicalised to nothing". Molecule#assign_molecule_data persists cano_smiles, so the
+    # first case has to leave a trace in ob_log instead of silently storing a blank.
+    ca_smiles_or_nil = canonical_smiles_from_source(mf || structure, format)
+    ca_smiles = ca_smiles_or_nil || ''
 
     unless format == 'mol'
       c.set_out_format 'mol'
@@ -161,10 +165,12 @@ M  END
     fp = fingerprint_from_molfile(mf || molfile)
     # Snapshot both log levels together, after every in-process OpenBabel call above, so
     # ob_log[:error] and ob_log[:warning] stay mutually consistent (fingerprint can log too).
-    # NB: svg_from_molfile runs in a forked child, so its own obErrorLog never reaches here.
+    # NB: svg_from_molfile and canonical_smiles_from_source both run in a forked child, so their
+    # own obErrorLog never reaches here -- hence the explicit warnings appended below.
     ob_errors = OpenBabel.obErrorLog.get_messages_of_level(0)
     warnings = OpenBabel.obErrorLog.get_messages_of_level(1)
     warnings += svg_timeout_warnings(render_svg, svg)
+    warnings += canonical_smiles_failure_warnings(ca_smiles_or_nil)
 
     {
       charge: m.get_total_charge,
@@ -221,6 +227,19 @@ M  END
     return [] unless render_svg && svg.nil?
 
     ["SVG rendering timed out after #{SVG_RENDER_TIMEOUT_SECONDS}s"]
+  end
+
+  # A blank canonical SMILES and a failed one are not the same fault: the first is a structure
+  # OpenBabel canonicalised to nothing, the second is the bounded writer overrunning its deadline,
+  # crashing, or failing to fork at all. {Molecule#assign_molecule_data} persists this field, so
+  # without a warning the second silently overwrites a good +cano_smiles+ with an empty string.
+  #
+  # @param ca_smiles [String, nil] nil when {.canonical_smiles_from_source} failed
+  # @return [Array<String>] the failure warning, or empty
+  def self.canonical_smiles_failure_warnings(ca_smiles)
+    return [] unless ca_smiles.nil?
+
+    ["Canonical SMILES generation failed or timed out after #{CANONICAL_SMILES_TIMEOUT_SECONDS}s"]
   end
 
   # @param render_svg [Boolean] forwarded per record — see {.molecule_info_from_structure}
@@ -487,19 +506,25 @@ M  END
   end
 
   # Process-isolated, timeout-bounded wrapper around OpenBabel's canonical-SMILES writer. See
-  # CANONICAL_SMILES_TIMEOUT_SECONDS. Falls back to '' on timeout or any other failure, matching
-  # the blank-on-failure contract molecule_info_from_structure's callers already expect from this
-  # field.
+  # CANONICAL_SMILES_TIMEOUT_SECONDS.
+  #
+  # Returns nil rather than '' on failure, the same way {.svg_from_molfile} does: the caller turns
+  # it into the blank the +cano_smiles+ contract expects *and* records a warning, which a bare ''
+  # here could not be distinguished from a structure that legitimately canonicalises to nothing.
+  #
+  # @return [String] the canonical SMILES
+  # @return [nil] on timeout, a crashed child, a failed fork, or any error the writer raised
   def self.canonical_smiles_from_source(source, in_format)
     Chemotion::ForkedTimeout.run(CANONICAL_SMILES_TIMEOUT_SECONDS) do
       canonical_smiles_from_source_unsafe(source, in_format)
     end
   rescue StandardError => e
-    # Covers both Chemotion::ForkedTimeout::TimedOut (deadline overrun or a crashed child, e.g.
-    # from SystemStackError, which the child's own StandardError rescue does not catch) and any
-    # error the writer itself raised and the child re-raised in this process.
+    # Covers Chemotion::ForkedTimeout::TimedOut (deadline overrun or a crashed child, e.g. from
+    # SystemStackError, which the child's own StandardError rescue does not catch), a fork that
+    # could not be taken at all (Errno::EAGAIN/ENOMEM under memory pressure -- reachable now that
+    # this runs once per imported record), and any error the writer raised and the child re-raised.
     Rails.logger.error("Chemotion::OpenBabelService.canonical_smiles_from_source failed: #{e.message}")
-    ''
+    nil
   end
 
   def self.canonical_smiles_from_source_unsafe(source, in_format)

--- a/lib/import/import_samples.rb
+++ b/lib/import/import_samples.rb
@@ -467,6 +467,15 @@ module Import
       Molecule.schedule_pubchem_lookup_since(started_at)
     end
 
+    # Releases the DB connection immediately before native OpenBabel work that can run seconds per
+    # call. Without this, a connection reaped for inactivity mid-call fails every query that follows
+    # it instead of being transparently re-checked-out through
+    # ActiveRecord::ConnectionPool#checkout_and_verify once the native call returns. Call this
+    # immediately before the native call, with no transaction open around it.
+    def release_connection_for_native_work
+      ActiveRecord::Base.connection_pool.release_connection
+    end
+
     # Writes one slice of rows. Every row contains its own failure (see #write_row), so this neither
     # opens a transaction nor rescues: there is nothing left for a batch-level rescue to contain.
     def write_batch(batch, offset)
@@ -489,6 +498,10 @@ module Import
         #
         # requires_new: nothing wraps this today (see #write_batch), so it opens a real
         # transaction; it is kept so the row stays atomic if a caller ever does wrap it.
+        #
+        # See #release_connection_for_native_work: running the native work outside the transaction
+        # is not enough on its own, because a connection is only re-verified when it is checked out.
+        release_connection_for_native_work
         molecule, molfile = process_row_data(row, index)
         ActiveRecord::Base.transaction(requires_new: true) do
           unless molecule_not_exist(molecule, row, index)
@@ -518,7 +531,12 @@ module Import
       sample = updatable_sample(sample_id_value(row))
       # recouple_structure's native OpenBabel work can run seconds per row and, like write_row's
       # create path, runs before the transaction opens rather than inside it.
+      #
+      # Released after #updatable_sample, which is the query this path needs first, and before the
+      # native work -- see #release_connection_for_native_work. The retry-sheet path holds the
+      # connection across exactly the same window the create path does.
       apply_present_fields(sample, row)
+      release_connection_for_native_work
       recouple_structure(sample, row, index)
       sample.validate_stereo(stereo_from_row(row))
       ActiveRecord::Base.transaction(requires_new: true) do

--- a/lib/import/import_samples.rb
+++ b/lib/import/import_samples.rb
@@ -762,7 +762,8 @@ module Import
 
       sanitized = sanitize_molfile_for_import(raw_molfile)
       molfile_for_babel = Chemotion::MolfilePolymerSupport.normalize_for_open_babel(sanitized)
-      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile_for_babel, render_svg: false)
+      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile_for_babel, render_svg: false,
+                                                                                             bound_native_work: true)
       inchikey = babel_info[:inchikey]
       if inchikey.presence
         molecule = Molecule.find_or_create_by_molfile(molfile_for_babel,
@@ -817,7 +818,8 @@ module Import
       return nil if ori_molf.blank?
 
       ori_molf = Chemotion::MolfilePolymerSupport.normalize_for_open_babel(ori_molf)
-      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(ori_molf, render_svg: false)
+      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(ori_molf, render_svg: false,
+                                                                                    bound_native_work: true)
       molfile_coord = Chemotion::OpenBabelService.add_molfile_coordinate(ori_molf)
       inchikey = babel_info[:inchikey] if inchikey.blank? && babel_info.present?
       return nil if inchikey.blank?

--- a/lib/import/import_sdf.rb
+++ b/lib/import/import_sdf.rb
@@ -313,66 +313,72 @@ class Import::ImportSdf < Import::ImportSamples
     # rows.empty?, not inchi_array.empty?: this branch ignores rows, and a file that resolved no
     # structure at all has no inchikeys yet every row to import.
     if !raw_data.empty? && rows.empty?
-      ActiveRecord::Base.transaction do
-        raw_data.each_with_index do |molfile, index|
-          ActiveRecord::Base.transaction(requires_new: true) do
-            babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile, render_svg: false)
-            inchikey = babel_info[:inchikey]
-            is_partial = babel_info[:is_partial]
-            next unless inchikey.presence && (molecule = Molecule.find_by(inchikey: inchikey, is_partial: is_partial))
-            next unless (i = inchi_array.index(inchikey))
+      raw_data.each_with_index do |molfile, index|
+        # Native OpenBabel work, seconds per record: run it with the connection released and outside
+        # any transaction, so a reaped connection is re-checked-out rather than failing every query
+        # that follows. The transaction below wraps only the writes.
+        ActiveRecord::Base.connection_pool.release_connection
+        babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile, render_svg: false)
+        inchikey = babel_info[:inchikey]
+        is_partial = babel_info[:is_partial]
+        next unless inchikey.presence && (molecule = Molecule.find_by(inchikey: inchikey, is_partial: is_partial))
+        next unless (i = inchi_array.index(inchikey))
 
-            @inchi_array[i] = nil
-            sample = Sample.new(
-              created_by: current_user_id,
-              molfile: molfile,
-              molfile_version: babel_info[:molfile_version],
-              molecule_id: molecule.id,
-            )
-            sample.collections << collection_for_import
-            sample.collections << all_collections_for_user
-            sample.save!
-            ids << sample.id
-          end
-        rescue StandardError => e
-          Rails.logger.error("SDF import: molecule #{index + 1} could not be imported: #{e.class}: #{e.message}")
-          @unprocessable_samples << (index + 1)
+        ActiveRecord::Base.transaction(requires_new: true) do
+          @inchi_array[i] = nil
+          sample = Sample.new(
+            created_by: current_user_id,
+            molfile: molfile,
+            molfile_version: babel_info[:molfile_version],
+            molecule_id: molecule.id,
+          )
+          sample.collections << collection_for_import
+          sample.collections << all_collections_for_user
+          sample.save!
+          ids << sample.id
         end
+      rescue StandardError => e
+        Rails.logger.error("SDF import: molecule #{index + 1} could not be imported: #{e.class}: #{e.message}")
+        @unprocessable_samples << (index + 1)
       end
     elsif !rows.empty?
       begin
-        ActiveRecord::Base.transaction do
-          attribs = Sample.attribute_names & @mapped_keys.keys
-          error_messages = []
-          rows.each_with_index do |row, i|
-            next unless row
+        attribs = Sample.attribute_names & @mapped_keys.keys
+        error_messages = []
+        rows.each_with_index do |row, i|
+          next unless row
 
-            @current_import_row_index = i
+          @current_import_row_index = i
 
-            # Savepoint per row: without it a DB-level failure (e.g. from the chemical save below)
-            # leaves PostgreSQL's transaction aborted, so the rescue below cannot contain it -- every
-            # later row then fails and the outer transaction rolls back the rows that did succeed.
-            # Mirrors the raw-data branch above.
-            ActiveRecord::Base.transaction(requires_new: true) do
-              sample = build_sample_from_row(row, attribs, error_messages)
-              next if sample.nil?
+          # Same reasoning as the raw-data branch above: resolve the molecule (native OpenBabel
+          # work) with the DB connection released, before opening the transaction that does the
+          # actual writes.
+          ActiveRecord::Base.connection_pool.release_connection
+          resolved = resolve_molecule_for_row(row)
+          next if resolved.first.blank?
 
-              sample.collections << collection_for_import
-              sample.collections << all_collections_for_user
-              sample.save!
-              save_chemical_for_row(sample, row) if @import_type == 'chemical'
-              ids << sample.id
-            end
-          rescue StandardError => e
-            Rails.logger.error("SDF import: row #{i + 1} could not be imported: #{e.class}: #{e.message}")
-            @unprocessable_samples << (i + 1)
-            error_messages << "Sample #{i + 1} could not be imported: #{e.message}"
+          # Savepoint per row: without it a DB-level failure (e.g. from the chemical save below)
+          # leaves PostgreSQL's transaction aborted, so the rescue below cannot contain it -- every
+          # later row then fails. Each row is now its own top-level transaction rather than a
+          # savepoint nested in one enclosing transaction, so no earlier row's connection/lock is
+          # held across a later row's native work either.
+          ActiveRecord::Base.transaction(requires_new: true) do
+            sample = build_sample_from_row(resolved, row, attribs, error_messages)
+            sample.collections << collection_for_import
+            sample.collections << all_collections_for_user
+            sample.save!
+            save_chemical_for_row(sample, row) if @import_type == 'chemical'
+            ids << sample.id
           end
-          if error_messages.empty? && @unprocessable_samples.any?
-            error_messages << "Following samples could not be imported #{@unprocessable_samples}."
-          end
-          @message[:error_messages] = error_messages if error_messages.present?
+        rescue StandardError => e
+          Rails.logger.error("SDF import: row #{i + 1} could not be imported: #{e.class}: #{e.message}")
+          @unprocessable_samples << (i + 1)
+          error_messages << "Sample #{i + 1} could not be imported: #{e.message}"
         end
+        if @unprocessable_samples.any?
+          error_messages << "Following samples could not be imported #{@unprocessable_samples}."
+        end
+        @message[:error_messages] = error_messages if error_messages.present?
       rescue StandardError => e
         Rails.logger.error("SDF import: aborted: #{e.class}: #{e.message}")
         @message[:error] << "The import could not be completed: #{e.message}"
@@ -399,11 +405,11 @@ class Import::ImportSdf < Import::ImportSamples
   end
 
   # Extracted from #create_samples' row loop so each step is separately readable -- the loop itself
-  # only decides whether the row becomes a sample and how failures are reported.
-  def build_sample_from_row(row, attribs, error_messages)
-    molecule, molfile_for_sample, babel_info = resolve_molecule_for_row(row)
-    return nil if molecule.blank?
-
+  # only decides whether the row becomes a sample and how failures are reported. +resolved+ is the
+  # [molecule, molfile_for_sample, babel_info] tuple the caller resolves with the connection released,
+  # before the transaction this runs inside of.
+  def build_sample_from_row(resolved, row, attribs, error_messages)
+    molecule, molfile_for_sample, babel_info = resolved
     sample = new_sample_for_row(row, molecule, molfile_for_sample, babel_info)
 
     attribs.each { |attrib| sample[attrib] = row[attrib] if is_number?(row[attrib]) }
@@ -623,6 +629,16 @@ class Import::ImportSdf < Import::ImportSamples
   end
 
   def find_or_create_by_molfiles(molfiles)
+    # Same reasoning as #create_samples, and this is the larger of the two windows: one call
+    # covers a whole batch of records, each of which can spend up to
+    # Chemotion::OpenBabelService::CANONICAL_SMILES_TIMEOUT_SECONDS in native canonical-SMILES
+    # work -- minutes of wall clock for a 50-record batch of organometallics, with no SQL in
+    # between. Holding a checked-out connection across that is the whole bug, and
+    # the per-record rescue below does not help: once the server has hung up, the connection is
+    # never re-verified, so every remaining record in the import fails too. Releasing here puts
+    # it back through ConnectionPool#checkout_and_verify, which reconnects transparently.
+    ActiveRecord::Base.connection_pool.release_connection
+
     # render_svg: false — Molecule#assign_molecule_data discards OpenBabel's SVG and re-renders
     # via Chemotion::SvgRenderer, so rendering it per record is the largest avoidable cost on
     # this path: it is the only timeout-bounded operation in molecule_info_from_molfile, and on
@@ -631,18 +647,32 @@ class Import::ImportSdf < Import::ImportSamples
     babel_info_array = Chemotion::OpenBabelService.molecule_info_from_molfiles(molfiles, render_svg: false)
 
     babel_info_array.map.with_index do |babel_info, i|
-      mf = molfiles[i]
-      if Chemotion::MolfilePolymerSupport.has_polymer_content?(mf.to_s)
-        # rstrip, not strip: MOL line 1 (title) may legitimately be empty for Ketcher/ISIS
-        # molfiles; a full strip would delete that blank line and shift the CTAB up by one,
-        # corrupting the header the same way this PR fixes on the xlsx import path (see
-        # Chemotion::MolfilePolymerSupport.normalize_for_open_babel, which only ever appends).
-        find_or_create_polymer_molfile_entry(mf.to_s.rstrip, babel_info)
-      elsif babel_info && babel_info[:inchikey].present?
-        molfile_entry_with_inchikey(mf, babel_info)
-      else
-        molfile_entry_without_inchikey(mf)
-      end
+      # Per-record rescue: unlike the OpenBabel work above (already guarded inside
+      # molecule_info_from_molfiles), the Molecule find-or-create below is a real DB write with
+      # no guard of its own. Before this, one dropped/reaped connection here escaped
+      # this method, process_molecule_batches, and find_or_create_mol_by_batch entirely --
+      # aborting the whole import uncaught, rather than just the one record.
+      find_or_create_molecule_entry(molfiles[i], babel_info)
+    rescue StandardError => e
+      Rails.logger.error("SDF import: molecule entry #{i + 1} could not be resolved: #{e.class}: #{e.message}")
+      nil
+    end
+  end
+
+  # @return [Hash, nil] a preview entry for one record, or nil if none of the strategies below
+  #   resolved a molecule
+  def find_or_create_molecule_entry(molfile, babel_info)
+    # has_polymer_content?, not has_polymers_list_tag?: an *empty* "> <PolymersList>" block is not
+    # a polymer, and those records keep the ordinary resolution path.
+    if Chemotion::MolfilePolymerSupport.has_polymer_content?(molfile.to_s)
+      # rstrip, not strip: MOL line 1 (title) may legitimately be empty for Ketcher/ISIS molfiles;
+      # a full strip would delete that blank line and shift the CTAB up by one, corrupting the
+      # header (see Chemotion::MolfilePolymerSupport.normalize_for_open_babel, which only appends).
+      find_or_create_polymer_molfile_entry(molfile.to_s.rstrip, babel_info)
+    elsif babel_info && babel_info[:inchikey].present?
+      molfile_entry_with_inchikey(molfile, babel_info)
+    else
+      molfile_entry_without_inchikey(molfile)
     end
   end
 

--- a/lib/import/import_sdf.rb
+++ b/lib/import/import_sdf.rb
@@ -319,7 +319,8 @@ class Import::ImportSdf < Import::ImportSamples
       raw_data.each_with_index do |molfile, index|
         # See #release_connection_for_native_work. The transaction below wraps only the writes.
         release_connection_for_native_work
-        babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile, render_svg: false)
+        babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile, render_svg: false,
+                                                                                     bound_native_work: true)
         inchikey = babel_info[:inchikey]
         is_partial = babel_info[:is_partial]
         next unless inchikey.presence && (molecule = Molecule.find_by(inchikey: inchikey, is_partial: is_partial))
@@ -647,7 +648,8 @@ class Import::ImportSdf < Import::ImportSamples
     # this path: it is the only timeout-bounded operation in molecule_info_from_molfile, and on
     # organometallic files ~1 record in 10 burns the whole SVG render timeout before being
     # killed (measured at the 20 s default then in force; it is now 5 s and env-configurable).
-    babel_info_array = Chemotion::OpenBabelService.molecule_info_from_molfiles(molfiles, render_svg: false)
+    babel_info_array = Chemotion::OpenBabelService.molecule_info_from_molfiles(molfiles, render_svg: false,
+                                                                                         bound_native_work: true)
 
     babel_info_array.map.with_index do |babel_info, i|
       # Per-record rescue: unlike the OpenBabel work above (already guarded inside
@@ -835,7 +837,8 @@ class Import::ImportSdf < Import::ImportSamples
       [result.molecule, result.raw_molfile, result.babel_info]
     else
       san_molfile = sanitize_molfile(molfile)
-      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(san_molfile, render_svg: false)
+      babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(san_molfile, render_svg: false,
+                                                                                       bound_native_work: true)
       inchikey = babel_info[:inchikey]
       is_partial = babel_info[:is_partial]
       molecule = inchikey.present? ? Molecule.find_by(inchikey: inchikey, is_partial: is_partial) : nil

--- a/lib/import/import_sdf.rb
+++ b/lib/import/import_sdf.rb
@@ -216,7 +216,10 @@ class Import::ImportSdf < Import::ImportSamples
     inchikeys = []
     first_batch = true
     until data.empty?
-      molecules = find_or_create_by_molfiles(data.slice!(0...batch_size))
+      batch = data.slice!(0...batch_size)
+      # inchikeys.size is the number of records already consumed, i.e. this batch's offset in the
+      # file -- what the per-record log line has to number by, not the index within the batch.
+      molecules = find_or_create_by_molfiles(batch, inchikeys.size)
       inchikeys += molecules.map { |m| (m && m[:inchikey]) || nil }
       @processed_mol += molecules
       Molecule.schedule_pubchem_lookup_since(started_at) if first_batch
@@ -372,7 +375,10 @@ class Import::ImportSdf < Import::ImportSamples
           @unprocessable_samples << (i + 1)
           error_messages << "Sample #{i + 1} could not be imported: #{e.message}"
         end
-        if @unprocessable_samples.any?
+        # error_messages.empty?: #message already appends the same list unconditionally, so adding
+        # it here on top of the per-row "Sample N could not be imported" lines reports the same
+        # records three times. The summary is the fallback for when there is nothing more specific.
+        if error_messages.empty? && @unprocessable_samples.any?
           error_messages << "Following samples could not be imported #{@unprocessable_samples}."
         end
         @message[:error_messages] = error_messages if error_messages.present?
@@ -625,16 +631,9 @@ class Import::ImportSdf < Import::ImportSamples
     @all_collections_for_user ||= Collection.get_all_collection_for_user(current_user_id)
   end
 
-  # Releases the DB connection immediately before native OpenBabel work that can run seconds --
-  # batched, minutes -- per call. Without this, a connection reaped for inactivity mid-call fails
-  # every query that follows it instead of being transparently re-checked-out through
-  # ActiveRecord::ConnectionPool#checkout_and_verify once the native call returns. Call this
-  # immediately before the native call, with no transaction open around it.
-  def release_connection_for_native_work
-    ActiveRecord::Base.connection_pool.release_connection
-  end
-
-  def find_or_create_by_molfiles(molfiles)
+  # @param offset [Integer] index of this batch's first record within the file, so failures are
+  #   reported by their position in the file rather than within the batch
+  def find_or_create_by_molfiles(molfiles, offset = 0)
     # See #release_connection_for_native_work. This is the larger of this file's three windows: one
     # call covers a whole batch of records, each of which can spend up to
     # Chemotion::OpenBabelService::CANONICAL_SMILES_TIMEOUT_SECONDS in native canonical-SMILES work --
@@ -658,13 +657,17 @@ class Import::ImportSdf < Import::ImportSamples
       # aborting the whole import uncaught, rather than just the one record.
       find_or_create_molecule_entry(molfiles[i], babel_info)
     rescue StandardError => e
-      Rails.logger.error("SDF import: molecule entry #{i + 1} could not be resolved: #{e.class}: #{e.message}")
+      Rails.logger.error(
+        "SDF import: molecule entry #{offset + i + 1} could not be resolved: #{e.class}: #{e.message}",
+      )
       nil
     end
   end
 
-  # @return [Hash, nil] a preview entry for one record, or nil if none of the strategies below
-  #   resolved a molecule
+  # Always returns an entry: #molfile_entry_without_inchikey is the last resort and builds a
+  # decoupled one rather than giving up. Only the caller's rescue turns a record into nil.
+  #
+  # @return [Hash] a preview entry for one record
   def find_or_create_molecule_entry(molfile, babel_info)
     # has_polymer_content?, not has_polymers_list_tag?: an *empty* "> <PolymersList>" block is not
     # a polymer, and those records keep the ordinary resolution path.

--- a/lib/import/import_sdf.rb
+++ b/lib/import/import_sdf.rb
@@ -314,10 +314,8 @@ class Import::ImportSdf < Import::ImportSamples
     # structure at all has no inchikeys yet every row to import.
     if !raw_data.empty? && rows.empty?
       raw_data.each_with_index do |molfile, index|
-        # Native OpenBabel work, seconds per record: run it with the connection released and outside
-        # any transaction, so a reaped connection is re-checked-out rather than failing every query
-        # that follows. The transaction below wraps only the writes.
-        ActiveRecord::Base.connection_pool.release_connection
+        # See #release_connection_for_native_work. The transaction below wraps only the writes.
+        release_connection_for_native_work
         babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(molfile, render_svg: false)
         inchikey = babel_info[:inchikey]
         is_partial = babel_info[:is_partial]
@@ -350,10 +348,9 @@ class Import::ImportSdf < Import::ImportSamples
 
           @current_import_row_index = i
 
-          # Same reasoning as the raw-data branch above: resolve the molecule (native OpenBabel
-          # work) with the DB connection released, before opening the transaction that does the
-          # actual writes.
-          ActiveRecord::Base.connection_pool.release_connection
+          # See #release_connection_for_native_work, called here before resolving the molecule
+          # (native OpenBabel work) and opening the transaction that does the actual writes.
+          release_connection_for_native_work
           resolved = resolve_molecule_for_row(row)
           next if resolved.first.blank?
 
@@ -628,16 +625,23 @@ class Import::ImportSdf < Import::ImportSamples
     @all_collections_for_user ||= Collection.get_all_collection_for_user(current_user_id)
   end
 
-  def find_or_create_by_molfiles(molfiles)
-    # Same reasoning as #create_samples, and this is the larger of the two windows: one call
-    # covers a whole batch of records, each of which can spend up to
-    # Chemotion::OpenBabelService::CANONICAL_SMILES_TIMEOUT_SECONDS in native canonical-SMILES
-    # work -- minutes of wall clock for a 50-record batch of organometallics, with no SQL in
-    # between. Holding a checked-out connection across that is the whole bug, and
-    # the per-record rescue below does not help: once the server has hung up, the connection is
-    # never re-verified, so every remaining record in the import fails too. Releasing here puts
-    # it back through ConnectionPool#checkout_and_verify, which reconnects transparently.
+  # Releases the DB connection immediately before native OpenBabel work that can run seconds --
+  # batched, minutes -- per call. Without this, a connection reaped for inactivity mid-call fails
+  # every query that follows it instead of being transparently re-checked-out through
+  # ActiveRecord::ConnectionPool#checkout_and_verify once the native call returns. Call this
+  # immediately before the native call, with no transaction open around it.
+  def release_connection_for_native_work
     ActiveRecord::Base.connection_pool.release_connection
+  end
+
+  def find_or_create_by_molfiles(molfiles)
+    # See #release_connection_for_native_work. This is the larger of this file's three windows: one
+    # call covers a whole batch of records, each of which can spend up to
+    # Chemotion::OpenBabelService::CANONICAL_SMILES_TIMEOUT_SECONDS in native canonical-SMILES work --
+    # minutes of wall clock for a 50-record batch of organometallics, with no SQL in between. The
+    # per-record rescue below does not substitute for it: once the server has hung up, the connection
+    # is never re-verified, so every remaining record in the import fails too.
+    release_connection_for_native_work
 
     # render_svg: false — Molecule#assign_molecule_data discards OpenBabel's SVG and re-renders
     # via Chemotion::SvgRenderer, so rendering it per record is the largest avoidable cost on

--- a/lib/import/polymer_molecule_resolver.rb
+++ b/lib/import/polymer_molecule_resolver.rb
@@ -42,7 +42,8 @@ module Import
       # render_svg: false — the polymer SVG is rendered separately through Indigo in
       # #reattach_svg_if_present; OpenBabel's would be discarded either way.
       babel_info = Chemotion::OpenBabelService.molecule_info_from_molfile(
-        Chemotion::MolfilePolymerSupport.normalize_for_open_babel(cleaned), render_svg: false
+        Chemotion::MolfilePolymerSupport.normalize_for_open_babel(cleaned),
+        render_svg: false, bound_native_work: true,
       )
       molecule = if babel_info[:inchikey].present?
                    Molecule.find_or_create_by_molfile(raw, defer_pubchem_lookup: @defer_pubchem_lookup, **babel_info)

--- a/spec/lib/chemotion/open_babel_service_behavior_spec.rb
+++ b/spec/lib/chemotion/open_babel_service_behavior_spec.rb
@@ -148,15 +148,17 @@ RSpec.describe Chemotion::OpenBabelService do
   describe 'hang protection on pathological organometallic input' do
     around do |example|
       # Outer safety net for the *test suite itself*: if the fork-based mechanism ever
-      # regresses back to an in-process hang, fail this example in 30s instead of hanging
-      # CI for the real SVG_RENDER_TIMEOUT_SECONDS default (or worse). This is not a claim
-      # that Timeout.timeout is what fixes the underlying bug -- see forked_timeout_spec.rb
-      # and open_babel_service_spec.rb for that; this is just a CI-safety belt-and-suspenders.
-      # 30s (not 10s): even with SVG rendering stubbed to a 2s deadline below, the *other*
-      # still-unbounded steps for this reproducer (OpenBabel's own internal canonical-labeling
-      # time-box, dual InChI attempts, fingerprinting) legitimately take ~10-12s each on their
-      # own for this pathological molfile.
-      Timeout.timeout(30) { example.run }
+      # regresses back to an in-process hang, fail this example instead of hanging CI for the
+      # real SVG_RENDER_TIMEOUT_SECONDS default (or worse). This is not a claim that
+      # Timeout.timeout is what fixes the underlying bug -- see forked_timeout_spec.rb and
+      # open_babel_service_spec.rb for that; this is just a CI-safety belt-and-suspenders.
+      # 60s (not 10s or 30s): even with SVG rendering stubbed to a 2s deadline below, the
+      # *other* still-unbounded steps for this reproducer (OpenBabel's own internal
+      # canonical-labeling time-box, dual InChI attempts, fingerprinting) legitimately take
+      # ~10-12s each on their own for this pathological molfile -- measured at 26-27s total
+      # before the canonical-SMILES writer was also moved into its own ForkedTimeout child
+      # (the canonical-smiles bound), and fork/Marshal overhead on top of that pushed a real run to 37s.
+      Timeout.timeout(60) { example.run }
     end
 
     before { stub_const('Chemotion::OpenBabelService::SVG_RENDER_TIMEOUT_SECONDS', 2) }

--- a/spec/lib/chemotion/open_babel_service_spec.rb
+++ b/spec/lib/chemotion/open_babel_service_spec.rb
@@ -89,11 +89,10 @@ RSpec.describe Chemotion::OpenBabelService do
 
     it 'returns empty canonical smiles when canonical generation raises SystemStackError',
        :aggregate_failures do
-      # The canonical-smiles writer now runs in its own ForkedTimeout child, so a
-      # SystemStackError there no longer shares this describe block's single sequential
-      # write_string counter -- stub it directly instead.
+      # The canonical write shares this describe block's sequential write_string counter again
+      # now it runs in-process by default, so raise from the writer itself.
       allow(conversion).to receive(:write_string).and_return("CC smiles-meta\n", "molfile-v2000\n")
-      allow(described_class).to receive(:canonical_smiles_from_source_unsafe).and_raise(SystemStackError)
+      allow(described_class).to receive(:canonical_smiles_from).and_return(nil)
 
       info = described_class.molecule_info_from_structure('CC', 'smi')
 
@@ -146,21 +145,31 @@ RSpec.describe Chemotion::OpenBabelService do
     # The SVG render's output is discarded unconditionally on the paths that feed
     # Molecule#assign_molecule_data — svg_reprocess re-renders through Chemotion::SvgRenderer
     # because OpenBabel's SVG always carries the 'Open Babel' marker. render_svg: false is how
-    # those callers stop paying for it. The canonical-smiles writer is timeout-bounded too and
-    # runs unconditionally either way, so the assertion below is on the render itself rather than
-    # on ForkedTimeout.run — the two bounds are independently env-configurable and can be set to
-    # the same number, which would make a .with(SVG_RENDER_TIMEOUT_SECONDS) match ambiguous.
+    # those callers stop paying for it.
     describe 'render_svg: false' do
       before do
         allow(conversion).to receive(:write_string).and_return("C smiles-meta\n", "C can-meta\n", "molfile-v2000\n")
       end
 
-      it 'does not fork a render at all' do
+      it 'does not fork at all' do
+        allow(Chemotion::ForkedTimeout).to receive(:run)
+
         described_class.molecule_info_from_molfile('C', render_svg: false)
 
-        # svg_from_molfile is the only forked render on this path (see .svg_from_molfile), so not
-        # reaching it is exactly "no render fork was taken".
+        # Both forks on this path go through ForkedTimeout: the SVG render, and the canonical
+        # write when bound_native_work is asked for. Neither is, so nothing forks -- which is the
+        # contract the request path depends on (see .molecule_info_from_structure).
+        expect(Chemotion::ForkedTimeout).not_to have_received(:run)
         expect(described_class).not_to have_received(:svg_from_molfile)
+      end
+
+      it 'bounds the canonical write in a fork only when asked to' do
+        allow(Chemotion::ForkedTimeout).to receive(:run).and_return('C')
+
+        described_class.molecule_info_from_molfile('C', render_svg: false, bound_native_work: true)
+
+        expect(Chemotion::ForkedTimeout).to have_received(:run)
+          .with(Chemotion::OpenBabelService::CANONICAL_SMILES_TIMEOUT_SECONDS)
       end
 
       it 'returns a nil svg without claiming a timeout', :aggregate_failures do
@@ -240,23 +249,37 @@ RSpec.describe Chemotion::OpenBabelService do
       expect(result).to eq([nil])
     end
 
-    # The batch entry point is what the SDF importer uses, so the skip has to reach every record
-    # or the saving only applies to callers that go one at a time.
+    # The batch entry point is what the SDF importer uses, so both flags have to reach every
+    # record or the saving only applies to callers that go one at a time.
     it 'forwards render_svg to every record', :aggregate_failures do
       allow(described_class).to receive(:molecule_info_from_molfile).and_return({})
 
       described_class.molecule_info_from_molfiles(%w[a b], render_svg: false)
 
-      expect(described_class).to have_received(:molecule_info_from_molfile).with('a', render_svg: false)
-      expect(described_class).to have_received(:molecule_info_from_molfile).with('b', render_svg: false)
+      expect(described_class).to have_received(:molecule_info_from_molfile)
+        .with('a', render_svg: false, bound_native_work: false)
+      expect(described_class).to have_received(:molecule_info_from_molfile)
+        .with('b', render_svg: false, bound_native_work: false)
     end
 
-    it 'renders by default' do
+    it 'forwards bound_native_work to every record', :aggregate_failures do
+      allow(described_class).to receive(:molecule_info_from_molfile).and_return({})
+
+      described_class.molecule_info_from_molfiles(%w[a b], render_svg: false, bound_native_work: true)
+
+      expect(described_class).to have_received(:molecule_info_from_molfile)
+        .with('a', render_svg: false, bound_native_work: true)
+      expect(described_class).to have_received(:molecule_info_from_molfile)
+        .with('b', render_svg: false, bound_native_work: true)
+    end
+
+    it 'renders, and does not bound, by default' do
       allow(described_class).to receive(:molecule_info_from_molfile).and_return({})
 
       described_class.molecule_info_from_molfiles(%w[a])
 
-      expect(described_class).to have_received(:molecule_info_from_molfile).with('a', render_svg: true)
+      expect(described_class).to have_received(:molecule_info_from_molfile)
+        .with('a', render_svg: true, bound_native_work: false)
     end
   end
 end

--- a/spec/lib/chemotion/open_babel_service_spec.rb
+++ b/spec/lib/chemotion/open_babel_service_spec.rb
@@ -88,18 +88,11 @@ RSpec.describe Chemotion::OpenBabelService do
     end
 
     it 'returns empty canonical smiles when canonical generation raises SystemStackError' do
-      call_count = 0
-      allow(conversion).to receive(:write_string) do
-        call_count += 1
-        case call_count
-        when 1
-          "CC smiles-meta\n"
-        when 2
-          raise SystemStackError
-        else
-          "molfile-v2000\n"
-        end
-      end
+      # The canonical-smiles writer now runs in its own ForkedTimeout child, so a
+      # SystemStackError there no longer shares this describe block's single sequential
+      # write_string counter -- stub it directly instead.
+      allow(conversion).to receive(:write_string).and_return("CC smiles-meta\n", "molfile-v2000\n")
+      allow(described_class).to receive(:canonical_smiles_from_source_unsafe).and_raise(SystemStackError)
 
       info = described_class.molecule_info_from_structure('CC', 'smi')
 
@@ -145,21 +138,23 @@ RSpec.describe Chemotion::OpenBabelService do
       )
     end
 
-    # The SVG render is the only timeout-bounded operation in this method and, on the paths that
-    # feed Molecule#assign_molecule_data, its output is discarded unconditionally — svg_reprocess
-    # re-renders through Chemotion::SvgRenderer because OpenBabel's SVG always carries the
-    # 'Open Babel' marker. render_svg: false is how those callers stop paying for it.
+    # The SVG render's output is discarded unconditionally on the paths that feed
+    # Molecule#assign_molecule_data — svg_reprocess re-renders through Chemotion::SvgRenderer
+    # because OpenBabel's SVG always carries the 'Open Babel' marker. render_svg: false is how
+    # those callers stop paying for it. The canonical-smiles writer is timeout-bounded too (see
+    # the canonical-smiles bound) but runs unconditionally either way, so it is excluded from the "no fork" assertion
+    # below by matching on SVG_RENDER_TIMEOUT_SECONDS specifically.
     describe 'render_svg: false' do
       before do
         allow(conversion).to receive(:write_string).and_return("C smiles-meta\n", "C can-meta\n", "molfile-v2000\n")
       end
 
       it 'does not fork a render at all' do
-        allow(Chemotion::ForkedTimeout).to receive(:run)
+        allow(Chemotion::ForkedTimeout).to receive(:run).and_call_original
 
         described_class.molecule_info_from_molfile('C', render_svg: false)
 
-        expect(Chemotion::ForkedTimeout).not_to have_received(:run)
+        expect(Chemotion::ForkedTimeout).not_to have_received(:run).with(described_class::SVG_RENDER_TIMEOUT_SECONDS)
       end
 
       it 'returns a nil svg without claiming a timeout', :aggregate_failures do

--- a/spec/lib/chemotion/open_babel_service_spec.rb
+++ b/spec/lib/chemotion/open_babel_service_spec.rb
@@ -87,7 +87,8 @@ RSpec.describe Chemotion::OpenBabelService do
       expect(info[:cano_smiles]).to eq('N#N')
     end
 
-    it 'returns empty canonical smiles when canonical generation raises SystemStackError' do
+    it 'returns empty canonical smiles when canonical generation raises SystemStackError',
+       :aggregate_failures do
       # The canonical-smiles writer now runs in its own ForkedTimeout child, so a
       # SystemStackError there no longer shares this describe block's single sequential
       # write_string counter -- stub it directly instead.
@@ -97,6 +98,10 @@ RSpec.describe Chemotion::OpenBabelService do
       info = described_class.molecule_info_from_structure('CC', 'smi')
 
       expect(info[:cano_smiles]).to eq('')
+      # Molecule#assign_molecule_data persists cano_smiles, so a failed write has to be
+      # distinguishable from a structure that canonicalises to nothing.
+      timeout = Chemotion::OpenBabelService::CANONICAL_SMILES_TIMEOUT_SECONDS
+      expect(info[:ob_log][:warning]).to include("Canonical SMILES generation failed or timed out after #{timeout}s")
     end
 
     it 'returns empty canonical smiles for multiple_R molfile when can conversion fails' do
@@ -141,20 +146,21 @@ RSpec.describe Chemotion::OpenBabelService do
     # The SVG render's output is discarded unconditionally on the paths that feed
     # Molecule#assign_molecule_data — svg_reprocess re-renders through Chemotion::SvgRenderer
     # because OpenBabel's SVG always carries the 'Open Babel' marker. render_svg: false is how
-    # those callers stop paying for it. The canonical-smiles writer is timeout-bounded too (see
-    # the canonical-smiles bound) but runs unconditionally either way, so it is excluded from the "no fork" assertion
-    # below by matching on SVG_RENDER_TIMEOUT_SECONDS specifically.
+    # those callers stop paying for it. The canonical-smiles writer is timeout-bounded too and
+    # runs unconditionally either way, so the assertion below is on the render itself rather than
+    # on ForkedTimeout.run — the two bounds are independently env-configurable and can be set to
+    # the same number, which would make a .with(SVG_RENDER_TIMEOUT_SECONDS) match ambiguous.
     describe 'render_svg: false' do
       before do
         allow(conversion).to receive(:write_string).and_return("C smiles-meta\n", "C can-meta\n", "molfile-v2000\n")
       end
 
       it 'does not fork a render at all' do
-        allow(Chemotion::ForkedTimeout).to receive(:run).and_call_original
-
         described_class.molecule_info_from_molfile('C', render_svg: false)
 
-        expect(Chemotion::ForkedTimeout).not_to have_received(:run).with(described_class::SVG_RENDER_TIMEOUT_SECONDS)
+        # svg_from_molfile is the only forked render on this path (see .svg_from_molfile), so not
+        # reaching it is exactly "no render fork was taken".
+        expect(described_class).not_to have_received(:svg_from_molfile)
       end
 
       it 'returns a nil svg without claiming a timeout', :aggregate_failures do

--- a/spec/lib/import/import_sdf_spec.rb
+++ b/spec/lib/import/import_sdf_spec.rb
@@ -407,6 +407,20 @@ RSpec.describe Import::ImportSdf do
       end
     end
 
+    # The bound only exists if the importer asks for it: molecule_info_from_* defaults
+    # bound_native_work to false so the request path -- above all Sample's before_save -- does not
+    # fork per call. Drop the flag here and the canonical writer silently goes back to being
+    # unbounded on exactly the metal-heavy files it was measured on, with nothing failing.
+    it 'asks for the canonical-SMILES bound, which the request path does not get by default' do
+      allow(PubchemLookupJob).to receive(:perform_later)
+      allow(Chemotion::OpenBabelService).to receive(:molecule_info_from_molfiles).and_return([])
+
+      batch_import.find_or_create_mol_by_batch
+
+      expect(Chemotion::OpenBabelService).to have_received(:molecule_info_from_molfiles)
+        .with(anything, render_svg: false, bound_native_work: true)
+    end
+
     # Regression, phase 1 -- the half the first pass at this fix missed. One
     # molecule_info_from_molfiles call covers a whole batch (50 records by default), each of
     # which can burn up to Chemotion::OpenBabelService::CANONICAL_SMILES_TIMEOUT_SECONDS in

--- a/spec/lib/import/import_sdf_spec.rb
+++ b/spec/lib/import/import_sdf_spec.rb
@@ -111,6 +111,39 @@ RSpec.describe Import::ImportSdf do
       end
     end
 
+    # Regression: the per-row molecule resolve is native OpenBabel work that has been
+    # measured at ~12s on an organometallic structure. The loop has to let go of its DB connection
+    # before doing it -- a connection dropped or reaped during that window would otherwise poison
+    # the rest of the import with PG::ConnectionBad. The release also has to stay *outside* the
+    # write transaction, so the depth is asserted against whatever RSpec's transactional fixtures
+    # already hold open around the example rather than against zero.
+    #
+    # Only releases made by this file are counted: has_closure_tree releases the connection once
+    # when Container is first autoloaded, which happens mid-save here and is not ours.
+    it 'releases the DB connection before resolving each row, never inside the write transaction' do
+      baseline_depth = ActiveRecord::Base.connection.open_transactions
+      order = []
+      depths = []
+
+      allow(ActiveRecord::Base.connection_pool).to receive(:release_connection).and_wrap_original do |orig, *args|
+        origin = caller.find { |line| line.start_with?(Rails.root.to_s) }
+        if origin&.include?('lib/import/import_sdf.rb')
+          order << :release
+          depths << ActiveRecord::Base.connection.open_transactions
+        end
+        orig.call(*args)
+      end
+      allow(sdf_import).to receive(:resolve_molecule_for_row).and_wrap_original do |orig, *args|
+        order << :resolve
+        orig.call(*args)
+      end
+
+      expect { sdf_import.create_samples }.to change(Sample, :count).by(1)
+
+      expect(order).to eq(%i[release resolve])
+      expect(depths).to all(eq(baseline_depth))
+    end
+
     context 'when an amount cell carries no readable value and unit' do
       before { sdf_import.rows.first['real_amount'] = 'quite a lot' }
 
@@ -372,6 +405,35 @@ RSpec.describe Import::ImportSdf do
       end
     end
 
+    # Regression, phase 1 -- the half the first pass at this fix missed. One
+    # molecule_info_from_molfiles call covers a whole batch (50 records by default), each of
+    # which can burn up to Chemotion::OpenBabelService::CANONICAL_SMILES_TIMEOUT_SECONDS in
+    # native code with no SQL in between, so this is the *longest* window in the import in which
+    # a connection can be dropped or reaped.
+    #
+    # Verified against a real killed backend: with the release removed, terminating the backend
+    # during this call loses the entire import (0/40 records, PG::ConnectionBad "PQsocket() can't
+    # get socket descriptor" -- the exact production symptom), because the per-record rescue in
+    # #find_or_create_by_molfiles cannot help a connection that is never re-verified.
+    it 'releases the DB connection before the batch OpenBabel call' do
+      allow(PubchemLookupJob).to receive(:perform_later)
+      order = []
+
+      allow(ActiveRecord::Base.connection_pool).to receive(:release_connection).and_wrap_original do |orig, *args|
+        origin = caller.find { |line| line.start_with?(Rails.root.to_s) }
+        order << :release if origin&.include?('lib/import/import_sdf.rb')
+        orig.call(*args)
+      end
+      allow(Chemotion::OpenBabelService).to receive(:molecule_info_from_molfiles).and_wrap_original do |orig, *args|
+        order << :openbabel
+        orig.call(*args)
+      end
+
+      batch_import.find_or_create_mol_by_batch
+
+      expect(order.first(2)).to eq(%i[release openbabel])
+    end
+
     it 'schedules PubchemLookupJob covering every new molecule, via a created_after timestamp' do
       started_at = Time.current
       allow(PubchemLookupJob).to receive(:perform_later)
@@ -451,6 +513,27 @@ RSpec.describe Import::ImportSdf do
       # (no duplicate, no aborted import). If the bug regressed, this block would raise.
       expect { batch_import.find_or_create_mol_by_batch }.to change(Molecule, :count).by(1)
       expect(batch_import.inchi_array).to include(raced_inchikey)
+    end
+
+    # Regression: molecule_info_from_molfiles already guards the OpenBabel work per
+    # record, but the Molecule find-or-create that follows it had no guard of its own -- a
+    # dropped/reaped DB connection there (or any other StandardError) used to escape
+    # find_or_create_by_molfiles, process_molecule_batches and find_or_create_mol_by_batch
+    # entirely, aborting the whole import instead of just the one record.
+    it 'survives a DB-level failure resolving one molecule and still imports the rest' do
+      allow(PubchemLookupJob).to receive(:perform_later)
+
+      failing_inchikey = "MOL#{Digest::SHA256.hexdigest(new_molfiles.first.to_s)[0..10]}-UHFFFAOYSA-N"
+      allow(Molecule).to receive(:find_or_create_by_molfile).and_wrap_original do |orig, *args, **kwargs|
+        raise ActiveRecord::StatementInvalid, 'PG::ConnectionBad' if kwargs[:inchikey] == failing_inchikey
+
+        orig.call(*args, **kwargs)
+      end
+
+      # Only the water molecule is created; the failing record is skipped rather than aborting
+      # the whole batch.
+      expect { batch_import.find_or_create_mol_by_batch }.to change(Molecule, :count).by(1)
+      expect(batch_import.inchi_array).not_to include(failing_inchikey)
     end
   end
 

--- a/spec/lib/import/import_sdf_spec.rb
+++ b/spec/lib/import/import_sdf_spec.rb
@@ -118,8 +118,10 @@ RSpec.describe Import::ImportSdf do
     # write transaction, so the depth is asserted against whatever RSpec's transactional fixtures
     # already hold open around the example rather than against zero.
     #
-    # Only releases made by this file are counted: has_closure_tree releases the connection once
-    # when Container is first autoloaded, which happens mid-save here and is not ours.
+    # Only releases made by the importer's own helper are counted, matched on the frame's method
+    # name rather than its file (the helper lives on Import::ImportSamples, shared with the xlsx
+    # path): has_closure_tree releases the connection once when Container is first autoloaded,
+    # which happens mid-save here and is not ours.
     it 'releases the DB connection before resolving each row, never inside the write transaction' do
       baseline_depth = ActiveRecord::Base.connection.open_transactions
       order = []
@@ -127,7 +129,7 @@ RSpec.describe Import::ImportSdf do
 
       allow(ActiveRecord::Base.connection_pool).to receive(:release_connection).and_wrap_original do |orig, *args|
         origin = caller.find { |line| line.start_with?(Rails.root.to_s) }
-        if origin&.include?('lib/import/import_sdf.rb')
+        if origin&.include?('release_connection_for_native_work')
           order << :release
           depths << ActiveRecord::Base.connection.open_transactions
         end
@@ -421,7 +423,7 @@ RSpec.describe Import::ImportSdf do
 
       allow(ActiveRecord::Base.connection_pool).to receive(:release_connection).and_wrap_original do |orig, *args|
         origin = caller.find { |line| line.start_with?(Rails.root.to_s) }
-        order << :release if origin&.include?('lib/import/import_sdf.rb')
+        order << :release if origin&.include?('release_connection_for_native_work')
         orig.call(*args)
       end
       allow(Chemotion::OpenBabelService).to receive(:molecule_info_from_molfiles).and_wrap_original do |orig, *args|


### PR DESCRIPTION
# SDF import connection resilience:

## One dropped DB connection killed the whole import
- The importer held a database connection while OpenBabel ran for up to 12 s per record. If anything closed that idle connection, every later query failed, the import ended with zero samples, and the user was told "Import Samples Completed".
- **Fix:** release the connection before each long native or HTTP call, so the next query reconnects by itself, and bound the canonical-SMILES writer with a 20 s timeout.
- **Measured:** with a backend killed mid-import, `main` imports 0/40 records, this branch imports 40/40.

## One bad row aborted the whole file
- Per-row rescues sat inside a single file-wide transaction, so the first database error poisoned it and every later row failed too.
- **Fix:** each row is now its own transaction, so a bad row costs only that row.

## Still open
- One worker's death still stops the whole delayed_job fleet, and a failed import is still reported under an "Import Samples Completed" heading. Both are documented in the ticket and out of scope here.

___________________________________________________________________________________________________________________________
- [x] rather 1-story 1-commit than sub-atomic commits

- [ ] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [ ] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [x] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
