### PR TITLE
fix(mixtures): propagate stock concentration on drop and stop total-conc value clipping

### DIFF
--- a/app/api/entities/sample_entity.rb
+++ b/app/api/entities/sample_entity.rb
@@ -58,8 +58,8 @@ module Entities
       expose! :location,                unless: :displayed_in_list
       expose! :melting_point,           unless: :displayed_in_list
       expose! :metrics
-      expose! :molarity_unit,           unless: :displayed_in_list
-      expose! :molarity_value,          unless: :displayed_in_list
+      expose! :molarity_unit
+      expose! :molarity_value
       expose! :name
       expose! :parent_id,               unless: :displayed_in_list
       expose! :pubchem_tag,                                         anonymize_with: nil

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,6 +47,7 @@
 @import "components/ReactionVariation";
 @import "components/Report";
 @import "components/ReorderableList";
+@import "components/SampleComponentsGroup";
 @import "components/SampleName";
 @import "components/SearchInput";
 @import "components/TextRangeWithAddon";

--- a/app/assets/stylesheets/components/SampleComponentsGroup.scss
+++ b/app/assets/stylesheets/components/SampleComponentsGroup.scss
@@ -1,0 +1,37 @@
+// Mixture components table. Every numeric field carries a unit button, so the row
+// needs a minimum width to show all values. When the detail panel is narrower than
+// that, the wrapper scrolls horizontally instead of clipping individual fields.
+.sample-scheme-wrapper {
+  overflow-x: auto;
+}
+
+.sample-scheme {
+  min-width: 800px;
+
+  .numeral-input-with-units .btn {
+    padding-left: 0.2rem;
+    padding-right: 0.2rem;
+  }
+
+  // Column widths (was a colgroup with inline widths).
+  .col-drag { width: 4%; }
+  .col-name { width: 7%; }
+  .col-delete { width: 2%; }
+  .col-stock-density { width: 13%; }
+  .col-volume { width: 14%; }
+  .col-amount { width: 14%; }
+  .col-ratio { width: 8%; }
+  .col-ref { width: 2%; }
+  .col-total-conc { width: 16%; }
+  .col-purity { width: 4%; }
+
+  // Total concentration cell: lock button next to a growing input.
+  .total-conc-cell {
+    vertical-align: top;
+  }
+
+  .total-conc-input {
+    display: flex;
+    align-items: center;
+  }
+}

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleComponent.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleComponent.js
@@ -585,24 +585,27 @@ class SampleComponent extends Component {
     const isConcentrationLocked = lockedComponents.includes(material.id);
 
     return (
-      <td style={{ verticalAlign: 'top', display: 'flex', alignItems: 'center' }}>
-        {this.renderLockButton(
-          material,
-          isConcentrationLocked,
-          () => this.handleConcentrationLockToggle(material, isConcentrationLocked)
-        )}
+      <td className="total-conc-cell">
+        <div className="total-conc-input">
+          {this.renderLockButton(
+            material,
+            isConcentrationLocked,
+            () => this.handleConcentrationLockToggle(material, isConcentrationLocked)
+          )}
 
-        <NumeralInputWithUnitsCompo
-          key={material.id}
-          value={material.concn}
-          unit="mol/l"
-          metricPrefix={metricMolConc}
-          metricPrefixes={metricPrefixesMolConc}
-          precision={4}
-          disabled={!permitOn(sample) || isConcentrationLocked}
-          onChange={(e) => this.handleAmountChange(e, material.concn, 'targetConc', isConcentrationLocked)}
-          onMetricsChange={this.handleMetricsChange}
-        />
+          <NumeralInputWithUnitsCompo
+            key={material.id}
+            className="flex-grow-1"
+            value={material.concn}
+            unit="mol/l"
+            metricPrefix={metricMolConc}
+            metricPrefixes={metricPrefixesMolConc}
+            precision={4}
+            disabled={!permitOn(sample) || isConcentrationLocked}
+            onChange={(e) => this.handleAmountChange(e, material.concn, 'targetConc', isConcentrationLocked)}
+            onMetricsChange={this.handleMetricsChange}
+          />
+        </div>
       </td>
     );
   }

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleComponentsGroup.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleComponentsGroup.js
@@ -159,19 +159,19 @@ class SampleComponentsGroup extends React.Component {
     };
 
     return (
-      <div>
+      <div className="sample-scheme-wrapper">
         <table width="100%" className="sample-scheme">
           <colgroup>
-            <col style={{ width: '4%' }} />
-            <col style={{ width: '7%' }} />
-            <col style={{ width: '2%' }} />
-            <col style={{ width: '17%' }} />
-            <col style={{ width: '14%' }} />
-            <col style={{ width: '14%' }} />
-            <col style={{ width: '6%' }} />
-            <col style={{ width: '2%' }} />
-            <col style={{ width: '14%' }} />
-            {enableComponentPurity && <col style={{ width: '4%' }} />}
+            <col className="col-drag" />
+            <col className="col-name" />
+            <col className="col-delete" />
+            <col className="col-stock-density" />
+            <col className="col-volume" />
+            <col className="col-amount" />
+            <col className="col-ratio" />
+            <col className="col-ref" />
+            <col className="col-total-conc" />
+            {enableComponentPurity && <col className="col-purity" />}
           </colgroup>
           <thead>
           <tr>

--- a/spec/api/entities/sample_entity_spec.rb
+++ b/spec/api/entities/sample_entity_spec.rb
@@ -291,8 +291,6 @@ describe Entities::SampleEntity do
           :imported_readout,
           :location,
           :melting_point,
-          :molarity_unit,
-          :molarity_value,
           :parent_id,
           :reaction_description,
           :real_amount_unit,
@@ -302,6 +300,15 @@ describe Entities::SampleEntity do
           :solvent,
           :target_amount_unit,
           :target_amount_value,
+        )
+      end
+
+      # molarity is kept in list mode (like density) so a sample dragged from the
+      # list into a mixture propagates its stock concentration to the component.
+      it 'still exposes molarity so mixture drops carry the stock concentration' do
+        expect(grape_entity_as_hash).to include(
+          molarity_unit: sample.molarity_unit,
+          molarity_value: sample.molarity_value,
         )
       end
     end


### PR DESCRIPTION
## Summary

Two related fixes for liquid mixture components when a component has a molarity (stock concentration):

1. **Stock concentration not propagated when dropping a sample.** Dragging a sample that has a molarity into a liquid mixture left the Stock field empty, and because of that the Amount, Total conc., and Ratio all stayed blank.
2. **Total conc. value was clipped** in the components table (e.g. `100 mmol/l` showed as `10`), and there was no room to show longer values without squeezing the other columns.

## 1. Stock concentration propagation (backend)

**Root cause:** a sample dragged from the collection list is serialized in list mode (`displayed_in_list`), where `SampleEntity` exposed `density` but hid `molarity_value` / `molarity_unit`. So the dropped sample arrived with molarity `0`. The drop path (`Sample.buildChildWithoutCounter`) copies `molarity_value` into the new component's `starting_molarity_value`, so the stock came through as `0`. With no stock and no density, every dependent liquid calculation (amount, total conc, ratio) stayed at `0`.

**Fix:** expose `molarity_value` and `molarity_unit` unconditionally in `SampleEntity`, matching how `density` is already always exposed.

- `app/api/entities/sample_entity.rb`
- `spec/api/entities/sample_entity_spec.rb` — updated the list-mode expectation and added a check that molarity is present in list mode.

> Note: this fixes newly dropped samples. Mixtures already saved with a blank stock will need the stock re-entered, since the bad value is persisted on those components.

## 2. Total conc. column layout (frontend)

**Root cause:** the Total conc. `<td>` used `display: flex`, which drops the cell out of the table's column-width sharing and collapses it to its content, so the number was clipped. More broadly, every numeric field carries a wide unit button, so the whole row needs more width than a narrow panel provides.

**Fix:**
- Total conc. cell is a normal table cell again, with the lock button and a growing input in an inner flex wrapper so the value uses the available width.
- The table has a minimum width and its wrapper scrolls horizontally when the panel is narrower, so no column clips instead of columns stealing width from each other.
- All the related styling was moved out of inline styles into a new stylesheet.

- `app/javascript/.../propertiesTab/SampleComponent.js`
- `app/javascript/.../propertiesTab/SampleComponentsGroup.js`
- `app/assets/stylesheets/components/SampleComponentsGroup.scss` (new), imported in `application.scss`

## Testing

- `sample_entity_spec.rb` passes (molarity exposed in both detail and list mode).
- Frontend change is layout-only; verified the calculation flow at the model level (a component built with a stock molarity computes amount/total conc/ratio on volume entry). Visual check of the table widths still recommended before merge.