### PR TITLE
fix(fetchers): restore pagination defaults in preparedCollectionParams

### DIFF
--- a/app/javascript/src/utilities/FetcherHelper.js
+++ b/app/javascript/src/utilities/FetcherHelper.js
@@ -67,8 +67,19 @@ const classifyString = (str) => upperFirst(camelCase(str));
 const filteredSearchParams = (params) => new URLSearchParams(omitBy(params, isNil));
 
 const preparedCollectionParams = (id, params) => {
+  // Re-inject the pagination defaults the removed BaseFetcher.fetchByCollectionId used to
+  // supply, so callers passing {} (e.g. split-as-subsamples/subwellplates, vessel-template
+  // mutations) still get the configured page size instead of the endpoints' small defaults.
+  // Loaded at call-time (not a static import) to avoid a module-init import
+  // cycle: FetcherHelper is pulled in by every fetcher, and UIStore transitively
+  // imports those fetchers. Same pattern as VesselUtilities.js.
+  const UIStore = require('src/stores/alt/stores/UIStore').default;
+  const page = params?.page ?? 1;
+  const perPage = params?.perPage ?? params?.per_page ?? UIStore.getState().number_of_results;
   const collectionParams = {
     ...params,
+    page,
+    per_page: perPage,
     collection_id: id,
     from_date: (params?.fromDate ? dateToUnixTimestamp(params.fromDate) : null),
     to_date: (params?.toDate ? dateToUnixTimestamp(params.toDate) : null)

--- a/spec/javascripts/utils/FetcherHelper.spec.js
+++ b/spec/javascripts/utils/FetcherHelper.spec.js
@@ -2,8 +2,27 @@ import expect from 'expect';
 import base64 from 'base-64';
 
 import {
-    parseBase64ToArrayBuffer
-} from '../../../app/javascript/src/utilities/FetcherHelper';
+  parseBase64ToArrayBuffer,
+  preparedCollectionParams,
+} from 'src/utilities/FetcherHelper';
+
+// A value distinct from the endpoints' small defaults (7 / 5) and from the
+// store's built-in default (15), so the assertions prove the value really
+// comes from UIStore rather than any hard-coded fallback.
+const CONFIGURED_PER_PAGE = 25;
+
+// preparedCollectionParams reads UIStore.number_of_results via a call-time
+// require('...').default (a deliberate lazy load that breaks a module-init
+// import cycle). The real UIStore drags in a module graph that does not load
+// under the plain mocha/babel runner, so we stub it in the require cache,
+// keyed by the same resolved path FetcherHelper's require() will hit.
+const uiStorePath = require.resolve('src/stores/alt/stores/UIStore');
+require.cache[uiStorePath] = {
+  id: uiStorePath,
+  filename: uiStorePath,
+  loaded: true,
+  exports: { default: { getState: () => ({ number_of_results: CONFIGURED_PER_PAGE }) } },
+};
 
 describe('parseBase64ToArrayBuffer', () => {
   it('return array buffer', () => {
@@ -14,5 +33,42 @@ describe('parseBase64ToArrayBuffer', () => {
     const encodedValue = base64.encode(stringToTest);
     const parsedBuffer = parseBase64ToArrayBuffer(encodedValue);
     expect(parsedBuffer).toEqual(originalBuffer);
+  });
+});
+
+describe('preparedCollectionParams', () => {
+  const collectionId = 42;
+
+  it('injects page=1 and per_page from UIStore.number_of_results when params is empty', () => {
+    const params = preparedCollectionParams(collectionId, {});
+    expect(params.get('page')).toEqual('1');
+    expect(params.get('per_page')).toEqual(String(CONFIGURED_PER_PAGE));
+  });
+
+  it('injects the same defaults when params is omitted entirely', () => {
+    // The split-as-subwellplates flow calls the fetcher with no params object.
+    const params = preparedCollectionParams(collectionId);
+    expect(params.get('page')).toEqual('1');
+    expect(params.get('per_page')).toEqual(String(CONFIGURED_PER_PAGE));
+  });
+
+  it('preserves an explicit snake_case per_page over the default', () => {
+    const params = preparedCollectionParams(collectionId, { per_page: 5 });
+    expect(params.get('per_page')).toEqual('5');
+  });
+
+  it('preserves an explicit camelCase perPage over the default', () => {
+    const params = preparedCollectionParams(collectionId, { perPage: 7 });
+    expect(params.get('per_page')).toEqual('7');
+  });
+
+  it('preserves an explicit page over the default', () => {
+    const params = preparedCollectionParams(collectionId, { page: 3 });
+    expect(params.get('page')).toEqual('3');
+  });
+
+  it('sets collection_id from the id argument', () => {
+    const params = preparedCollectionParams(collectionId, {});
+    expect(params.get('collection_id')).toEqual(String(collectionId));
   });
 });


### PR DESCRIPTION
## What

Re-inject the `page` / `per_page` defaults inside `preparedCollectionParams`, so
collection-list fetchers that are called without explicit pagination fall back to
the configured page size (`number_of_results`, default 15) instead of the
endpoints' small defaults (samples 7, vessels 5).

## Why

PR #3294 (rework fetchers) deleted `BaseFetcher.fetchByCollectionId`, which had
always injected `page = page || 1` and `per_page = per_page || number_of_results`.
The replacement `preparedCollectionParams` injected neither. Callers that pass
`{}` therefore silently fell through to the endpoints' small defaults and their
lists shrank. Normal collection click/refresh still passed `per_page`, so the
regression was limited to these flows:

- **Split as subsamples** (`ElementStore.handleSplitAsSubsamples`) - passes `{}`,
  sample list capped at 7.
- **Split as subwellplates** (`ElementStore.handleSplitAsSubwellplates`) - passes
  `{}` / nothing, so both the wellplates list (capped at 5) and the samples list
  (capped at 7) shrank.
- **Vessel-template mutations** (`VesselTemplateDetails.syncTemplateAndInstances`,
  called from create / bulk-create / update / delete instance and update template)
  - vessel instance list capped at 5.

## How

Centralized fix inside `preparedCollectionParams`, mirroring the deleted
`BaseFetcher` behavior, rather than patching each call site:

- `page` defaults to `1`, `per_page` defaults to `UIStore.number_of_results`.
- Both are only filled in when the caller omits them (`??`), so explicit values
  and the normal collection flow are unchanged. Handles both `perPage` and
  `per_page` input.
- `UIStore` is loaded at call-time via `require('...').default` rather than a
  static import. A static import closed a module-init cycle
  (`UserStore → UserActions → UsersFetcher → FetcherHelper → UIStore`) and crashed
  the app with `Cannot access '__WEBPACK_DEFAULT_EXPORT__' before initialization`.
  Same call-time pattern already used in `VesselUtilities.js`.
- Adds a `preparedCollectionParams` regression suite (spec/javascripts/utils/FetcherHelper.spec.js)
  covering default injection and explicit-value precedence.

## Manual QA

For each flow, watch the `/api/v1/...` request in DevTools:
- **Before:** no `per_page` param, list capped at 7 (samples/wellplates) or 5 (vessels).
- **After:** `per_page=15`, full set shown.

1. Split as subsamples -> `/api/v1/samples` carries `per_page=15`.
2. Split as subwellplates -> both `/api/v1/wellplates` and `/api/v1/samples` carry `per_page=15`.
3. Vessel-template create/update/delete instance + update template -> `/api/v1/vessels` carries `per_page=15`.
4. Control: normal collection click still respects an explicit page-size setting (e.g. set to 25 -> `per_page=25`).

Refs: N3 from the PR ELN#3294 rework-fetchers regression tracker.