### PR TITLE
fix(spectra): restore peak generation for derived jcamps, guard reused rows

### DIFF
--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -134,7 +134,13 @@ module AttachmentJcampAasm
     return if lcms_uvvis_raw?(filename_lower)
 
     typname, extname = extension_parts
-    return if peaked? || edited?
+    # :backup and :done are terminal for this callback. Since #3494 a reused row can be
+    # resolved in either state, and no AASM event fires for it in generate_att's dispatch
+    # block, so the trailing save! re-enters here. A peak/edit row would then fall through
+    # to generate_img_only, whose set_force_peaked is illegal from both states - and whose
+    # rescue calls set_failure, which is *also* illegal from them. The rescue would raise,
+    # aborting the save and rolling back the enclosing transaction. Return early instead.
+    return if peaked? || edited? || backup? || done?
     return unless FILE_EXT_SPECTRA.include?(extname.downcase)
 
     is_peak_edit = %w[peak edit].include?(typname)

--- a/app/models/concerns/attachment_jcamp_aasm.rb
+++ b/app/models/concerns/attachment_jcamp_aasm.rb
@@ -254,6 +254,13 @@ module AttachmentJcampProcess
     # re-run the full attach/create_derivatives/update_column pipeline and re-upload the
     # same blob - clear it so those saves are plain state/column updates instead.
     att.file_path = nil
+    # Same reason, same scope: the flag guarded *this* save only. It is a plain
+    # attr_accessor, so leaving it set would suppress require_peaks_generation? for every
+    # later save on this object too - including the final save! below, which is exactly
+    # where a freshly derived jcamp (a bagit curve, say) transitions out of :queueing and
+    # asks for its peak table. Left set, such a curve keeps the content it was created
+    # with, stays in :queueing, and is filtered out of the viewer entirely.
+    att.reattaching_derivative = false
 
     if ext == 'png'
       att.set_image if att.may_set_image?

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -444,6 +444,47 @@ RSpec.describe Attachment do
         end
       end
 
+      context 'when aasm_state is backup' do
+        it 'returns nil' do
+          attachment.aasm_state = :backup
+
+          expect(attachment.require_peaks_generation?).to be_nil
+        end
+      end
+
+      context 'when aasm_state is done' do
+        it 'returns nil' do
+          attachment.aasm_state = :done
+
+          expect(attachment.require_peaks_generation?).to be_nil
+        end
+      end
+
+      # Since #3494 generate_att can resolve a *reused* row that is already in :backup or
+      # :done. No AASM event fires for it in the dispatch block, so the trailing save!
+      # re-enters this callback with that state intact. Without the early return a peak row
+      # reaches generate_img_only, whose set_force_peaked is illegal from both states - and
+      # whose rescue calls set_failure, which is illegal from them too, so the rescue itself
+      # raises and takes the save (and the enclosing transaction) down with it.
+      %i[backup done].each do |reused_state|
+        context "when a .peak. row is reused in the #{reused_state} state" do
+          before do
+            attachment.filename = 'whatever.peak.jdx'
+            attachment.aasm_state = reused_state
+          end
+
+          it 'does not generate an image' do
+            expect(attachment).not_to receive(:generate_img_only)
+
+            attachment.require_peaks_generation?
+          end
+
+          it 'does not raise an illegal AASM transition' do
+            expect { attachment.require_peaks_generation? }.not_to raise_error
+          end
+        end
+      end
+
       context 'when filename has no spectra file extension' do
         it 'returns nil' do
           expect(attachment.require_peaks_generation?).to be_nil

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -623,6 +623,16 @@ RSpec.describe Attachment do
         end
       end
 
+      it 'leaves the reuse guard cleared, so later saves still generate peaks' do
+        # reattaching_derivative suppresses require_peaks_generation? for the one save it
+        # guards. It is a plain attr_accessor, so if generate_att leaves it set, every
+        # later save on the same object skips that callback too - including the final
+        # save! that a freshly derived jcamp relies on to leave :queueing and get its peak
+        # table. A curve stuck in :queueing is filtered out of the viewer, which reads as
+        # "the spectrum will not open".
+        expect(new_attachment.reattaching_derivative).to be_falsey
+      end
+
       context 'when self is already the canonical row being re-edited (edited -> edited)' do
         let!(:attachment) { create(:attachment, filename: 'spectra_file.edit.jdx', aasm_state: 'edited') }
         let(:new_attachment) { attachment.generate_att(tempfile, 'edit', true, 'jdx') }


### PR DESCRIPTION
## Symptom

Uploading a multi-curve archive stopped producing peak files, and the resulting analysis will not open in the spectra viewer until a regenerate is forced.

Two conversions of a **byte-identical** source `.DTA`, before and after:

| | before | after |
|---|---|---|
| `*.N_bagit.jdx` | 3 curves | 3 curves (**identical md5**) |
| `*.N_bagit.peak.jdx` | 3 | **0** |
| `*.N_bagit.peak.png` | 3 | **0** |

The source `.DTA`, `.zip` and all three `.jdx` files hash identically across the two runs — the only difference in the dataset is the missing peak derivatives. (The `.csv` files differ only in the analysis/dataset ID they embed.)

## Cause

`generate_att` sets `reattaching_derivative` before the save that attaches new content, so `require_peaks_generation?` skips a callback that would otherwise read the stale, pre-save file. That is correct for **that one save**.

But the flag is a plain `attr_accessor` and is never cleared, so it suppresses the callback for every later save on the same object — including `generate_att`'s own final `save!`:

```ruby
att.reattaching_derivative = true
att.save!                      # the save the guard is for
att.file_path = nil            # cleared, with a comment explaining exactly this hazard
...
att.save!                      # still guarded — and this is the one that matters
```

That final save is where a freshly derived jcamp leaves `:queueing` and asks for its peak table. Before #3494 the method ended in `att.update!(attachable_id:, attachable_type: 'Container')` — an update that ran the callback, and the guard did not exist:

```ruby
generate_spectrum(true, false) if queueing?
```

So a derived curve now keeps the state it was created with. `extractJcampFiles` filters `:queueing` out of the viewer, which is what *"the spectrum will not open"* looks like from the front end, and why a forced regenerate — which runs on a freshly loaded object with the flag unset — appears to fix it.

`file_path` has exactly the same lifetime problem and **is** cleared one line below the save, with a comment describing the hazard. The flag needed the same treatment.

## Fix

Clear the flag once the save it guards has completed, next to `file_path`. Both are per-save intent that must not outlive the save they describe. Every save except that first one behaves as it did before #3494.

## Second fix: the callback path the reset re-opens

Clearing the guard is correct and necessary, but it re-enables `require_peaks_generation?` on that trailing save — and that path is not safe for every *reused* row.

`require_peaks_generation?` returned early only for `:peaked` and `:edited`. Since #3494 `generate_att` can resolve a reused row already in `:backup` or `:done`, and no AASM event fires for it in the dispatch block, so the trailing save re-enters the callback with that state intact:

- a `.peak.`/`.edit.` row falls through to `generate_img_only`
- whose `set_force_peaked` is illegal from both states — `%i[idle queueing regenerating nmrium]`
- whose `rescue` then calls `set_failure`, illegal from them **too** — `%i[idle queueing regenerating failure nmrium]`

So the rescue itself raises `AASM::InvalidTransition` out of the `before_update` callback, aborting the save and rolling back the enclosing transaction.

Reachable by: upload a spectrum → save from the editor (`set_backup` retires the old `.peak.jdx` row) → force a regenerate.

Both added states are terminal for this callback, so an early return is the whole change. The non-peak branch was already a no-op for them (`generate_spectrum(true, false) if queueing?`), and revival is unaffected — `set_queueing` / `set_regenerating` both accept `backup` and `done`, so a revived row leaves those states before the guard is consulted.

```ruby
return if peaked? || edited? || backup? || done?
```

## Test plan

- [x] Regression spec added: after `generate_att`, the reuse guard is no longer set, so later saves still reach `require_peaks_generation?`.
- [x] 6 further examples for the guard: `returns nil` for `backup` and `done`, plus a `%i[backup done].each` pair asserting a `.peak.` row neither calls `generate_img_only` nor raises.
- [x] **Run locally** (`spec/models/attachment_spec.rb`, 131 examples). Reverting the guard makes all 4 reuse examples fail with exactly the predicted `AASM::InvalidTransition: Event 'set_failure' cannot transition from 'backup'` / `from 'done'`; restored, 4/4 pass. The single unrelated `#abs_path` failure (`tmp/uploads` vs `uploads`) reproduces with the change stashed and passes on CI.
- [x] `rubocop` clean on both changed files.
- [ ] Re-upload the affected archive and confirm the `.peak.jdx` / `.peak.png` derivatives reappear and the viewer opens without a forced regenerate.

## Note

A separate symptom was reported alongside this one: a white screen when opening the spectra editor *after* a regenerate. That is **not** explained by this fix and is not addressed here — it needs browser-side evidence. It may well be downstream of a half-generated dataset, in which case it should disappear once peak generation is restored; worth re-checking after this lands before investigating further.

refs: #3494
