### PR TITLE
fix(ui): keep sample tab title on one line with its icon

### DIFF
--- a/app/javascript/src/models/Sample.js
+++ b/app/javascript/src/models/Sample.js
@@ -579,7 +579,7 @@ export default class Sample extends Element {
     if (parts.length === 1) return parts[0];
 
     return (
-      <span className="d-flex gap-1 align-items-center">
+      <span className="d-inline-flex gap-1 align-items-center">
         {parts.map((part, i) => (
           <React.Fragment key={i}>
             {i > 0 && <span className="text-muted">|</span>}


### PR DESCRIPTION
## Problem

In the open-element tab bar, a sample tab rendered on two lines: the sample icon
sat alone on the first line and the label (short label | name | external label)
wrapped to the second line. Reaction and other tabs stayed on a single line.

## Cause

`Sample.title()` wrapped its label parts in a `d-flex` span. `display: flex` is
block-level, and the tab renders the title inline right after the icon
(`<span><ElementIcon className="me-1" />{title}</span>`). A block-level element after
the inline icon forces a line break, pushing the label onto a second line. Reaction
titles are plain strings, so they never triggered this.

## Fix

Change the wrapper from `d-flex` to `d-inline-flex` in `Sample.title()`. The label is
now inline and stays next to the icon on one line. The `|` separators and vertical
centering are unchanged.

This is safe in the other places `title()` is used (the samples list row and the
detail-card header), because there it already sits inside a flex container, where
`flex` and `inline-flex` behave identically (flex items are blockified regardless).

## Testing

Verified on the test server: sample tabs now render on a single line, matching
reaction tabs.