### PR TITLE
fix(polymers): stop writing empty PolymersList tags and stop exporting them

### DIFF
--- a/app/javascript/src/utilities/ketcherSurfaceChemistry/canvasOperations.js
+++ b/app/javascript/src/utilities/ketcherSurfaceChemistry/canvasOperations.js
@@ -81,6 +81,14 @@ const arrangePolymers = async (canvasData, editor) => {
   const listOfAtomsWithAlias = atomsWithAlias.map((a) => a.alias);
   const atomIndexList = atomsWithAlias.map((a) => a.atomIndex);
   const processString = await templateAliasesPrepare(listOfAtomsWithAlias, atomIndexList);
+  // Same guard as reAttachPolymerList (PolymersTemplates.js): an image on the canvas is not
+  // enough. When no atom resolves to a polymer template — no three-part alias, or a falsy
+  // templateId — templateAliasesPrepare returns ''. Appending the tag anyway writes an empty
+  // "> <PolymersList>" block that every backend reader then has to special-case as "not a
+  // polymer", and it persists in samples.molfile through collection export/import.
+  if (!processString.length) {
+    return canvasData.split('\n');
+  }
   return [...canvasData.split('\n'), KET_TAGS.polymerIdentifier, processString];
 };
 

--- a/lib/chemotion/molfile_polymer_support.rb
+++ b/lib/chemotion/molfile_polymer_support.rb
@@ -30,8 +30,18 @@ module Chemotion
       to_utf8(molfile).include?(TEXT_NODE_TAG)
     end
 
+    # True when the molfile carries a block that must survive CTAB trimming.
+    #
+    # The PolymersList half tests for *payload*, not the tag: Ketcher writes an empty
+    # "> <PolymersList>" block for ordinary structures, and preserving that on export would
+    # re-emit the empty tag into the SDF and carry it to whatever instance imports it. The
+    # TextNode half stays on tag presence -- TextNode blocks are written with an explicit
+    # "> </TextNode>" close and have no known empty-block emitter.
+    #
+    # @param molfile [String, nil]
+    # @return [Boolean]
     def has_polymer_or_textnode_blocks?(molfile)
-      has_polymers_list_tag?(molfile) || has_text_node_tag?(molfile)
+      has_polymer_content?(molfile) || has_text_node_tag?(molfile)
     end
 
     # True only when a PolymersList block carries a payload. Ketcher writes an empty

--- a/lib/export/export_sdf.rb
+++ b/lib/export/export_sdf.rb
@@ -135,8 +135,10 @@ module Export
       ">  <#{field}>\n#{value}\n\n"
     end
 
-    # Keep only the CTAB (up to and including "M  END") when molfile has no PolymersList/TextNode.
-    # When PolymersList or TextNode blocks are present, keep the full molfile including those blocks and $$$$.
+    # Keep only the CTAB (up to and including "M  END") unless the molfile carries a populated
+    # PolymersList block or a TextNode block, in which case the full molfile is kept including
+    # those blocks and $$$$. An *empty* "> <PolymersList>" block is not preserved: Ketcher emits
+    # one for ordinary structures, and exporting it would carry the tag to the importing instance.
     def validate_molfile(molfile)
       s = molfile.to_s
       return s.rstrip if Chemotion::MolfilePolymerSupport.has_polymer_or_textnode_blocks?(s)

--- a/spec/javascripts/packs/src/utilities/ketcherSurfaceChemistry/canvasOperations.spec.js
+++ b/spec/javascripts/packs/src/utilities/ketcherSurfaceChemistry/canvasOperations.spec.js
@@ -168,4 +168,40 @@ describe('canvasOperations — arrangePolymers', () => {
     assert.ok(Array.isArray(result));
     assert.ok(result.includes(KET_TAGS.polymerIdentifier));
   });
+
+  // An image on the canvas is not enough to make the structure a polymer. When nothing resolves
+  // to a template, the tag must be omitted entirely -- writing it with an empty payload leaves
+  // "> <PolymersList>" in samples.molfile, which the backend then has to treat as "not a polymer"
+  // and which survives collection export/import.
+  describe('empty payload', () => {
+    it('omits the tag when an image is present but no atom carries a polymer alias', async () => {
+      imagesListSetter([makeImageEntry()]);
+      const atoms = [{ alias: null }, { alias: 'not-a-polymer-alias' }];
+
+      const result = await arrangePolymers(CANVAS_DATA, makeEditor(atoms));
+
+      assert.deepStrictEqual(result, CANVAS_DATA.split('\n'));
+      assert.ok(!result.includes(KET_TAGS.polymerIdentifier), 'PolymersList header must be absent');
+    });
+
+    it('omits the tag when every alias parses to a falsy templateId', async () => {
+      imagesListSetter([makeImageEntry()]);
+      // "t_0_0" matches the three-part pattern but parseInt('0') is falsy, so
+      // templateAliasesPrepare skips it and returns ''.
+      const result = await arrangePolymers(CANVAS_DATA, makeEditor([{ alias: alias(0, 0) }]));
+
+      assert.deepStrictEqual(result, CANVAS_DATA.split('\n'));
+      assert.ok(!result.includes(KET_TAGS.polymerIdentifier), 'PolymersList header must be absent');
+    });
+
+    it('still appends the tag when at least one alias resolves', async () => {
+      imagesListSetter([makeImageEntry(), makeImageEntry()]);
+      const atoms = [{ alias: alias(0, 0) }, { alias: alias(95, 1) }];
+
+      const result = await arrangePolymers(CANVAS_DATA, makeEditor(atoms));
+
+      assert.ok(result.includes(KET_TAGS.polymerIdentifier), 'PolymersList header appended');
+      assert.ok(result[result.length - 1].includes('/95/'), `expected the resolved entry: ${result[result.length - 1]}`);
+    });
+  });
 });

--- a/spec/lib/chemotion/molfile_polymer_support_spec.rb
+++ b/spec/lib/chemotion/molfile_polymer_support_spec.rb
@@ -78,6 +78,30 @@ RSpec.describe Chemotion::MolfilePolymerSupport do
     end
   end
 
+  describe '.has_polymer_or_textnode_blocks?' do
+    # Drives Export::ExportSdf#validate_molfile: true keeps the full molfile, false trims to CTAB.
+    # The PolymersList half must key on payload, or an exported SDF re-emits Ketcher's empty tag.
+    it 'is true for a populated PolymersList block' do
+      expect(described_class.has_polymer_or_textnode_blocks?("#{ctab}> <PolymersList>\n0/95/1.00-1.00\n$$$$\n"))
+        .to be(true)
+    end
+
+    it 'is false for an empty PolymersList block' do
+      expect(described_class.has_polymer_or_textnode_blocks?("#{ctab}> <PolymersList>\n$$$$\n")).to be(false)
+    end
+
+    it 'is true for a TextNode block regardless of PolymersList payload' do
+      molfile = "#{ctab}> <PolymersList>\n> <TextNode>\n0#0ce7f3#t_95_0#label\n> </TextNode>\n$$$$\n"
+
+      expect(described_class.has_polymer_or_textnode_blocks?(molfile)).to be(true)
+    end
+
+    it 'is false for a plain molfile' do
+      expect(described_class.has_polymer_or_textnode_blocks?(ctab)).to be(false)
+      expect(described_class.has_polymer_or_textnode_blocks?(nil)).to be(false)
+    end
+  end
+
   describe '.normalize_for_open_babel' do
     # MOL is positional: line 1 is the title and may be empty. Padding must only ever append,
     # never prepend -- prepending corrupts a titled molfile, and the untitled case is preserved

--- a/spec/lib/export/export_sdf_spec.rb
+++ b/spec/lib/export/export_sdf_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Export::ExportSdf do
+  subject(:exporter) { described_class.new }
+
+  let(:ctab) do
+    <<~CTAB
+      null
+        Ketcher  6232611422D 1   1.00000     0.00000     0
+
+        1  0  0  0  0  0  0  0  0  0999 V2000
+          2.0250   -2.0250    0.0000 R#   0  0  0  0  0  0  0  0  0  0  0  0
+      M  END
+    CTAB
+  end
+
+  describe '#validate_molfile' do
+    it 'keeps the full molfile when the PolymersList block has a payload' do
+      molfile = "#{ctab}> <PolymersList>\n0/95/1.00-1.00\n$$$$\n"
+
+      expect(exporter.send(:validate_molfile, molfile)).to eq(molfile.rstrip)
+    end
+
+    it 'keeps the full molfile when a TextNode block is present' do
+      molfile = "#{ctab}> <TextNode>\n0#0ce7f3#t_95_0#label\n> </TextNode>\n$$$$\n"
+
+      expect(exporter.send(:validate_molfile, molfile)).to eq(molfile.rstrip)
+    end
+
+    # Ketcher emits an empty "> <PolymersList>" for ordinary structures. Preserving it here would
+    # write the tag into the exported SDF and carry it to whatever instance imports the file.
+    it 'trims an empty PolymersList block down to the CTAB' do
+      molfile = "#{ctab}> <PolymersList>\n$$$$\n"
+
+      expect(exporter.send(:validate_molfile, molfile)).to eq(ctab.rstrip)
+    end
+
+    it 'still keeps the molfile when an empty PolymersList is followed by a TextNode block' do
+      molfile = "#{ctab}> <PolymersList>\n> <TextNode>\n0#0ce7f3#t_95_0#label\n> </TextNode>\n$$$$\n"
+
+      expect(exporter.send(:validate_molfile, molfile)).to eq(molfile.rstrip)
+    end
+
+    it 'trims a plain molfile to the CTAB' do
+      expect(exporter.send(:validate_molfile, ctab)).to eq(ctab.rstrip)
+    end
+
+    it 'returns the molfile unchanged when it carries no end-of-CTAB marker' do
+      expect(exporter.send(:validate_molfile, "no ctab here\n")).to eq("no ctab here\n")
+    end
+
+    it 'returns an empty string for nil' do
+      expect(exporter.send(:validate_molfile, nil)).to eq('')
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to #3486, which fixed the **reader** side of the empty `> <PolymersList>` problem.
This closes the **writer** and **export** sides, so the ELN stops producing and propagating the
empty tag in the first place.

## 1. The writer stops emitting empty tags

`arrangePolymers` appended the tag whenever any image was on the canvas:

```js
const processString = await templateAliasesPrepare(listOfAtomsWithAlias, atomIndexList);
return [...canvasData.split('\n'), KET_TAGS.polymerIdentifier, processString];
```

When no atom resolves to a polymer template — no three-part alias, or a `templateId` that parses
falsy — `templateAliasesPrepare` returns `''`, and an ordinary structure was saved as:

```
M  END
> <PolymersList>

$$$$
```

The sibling writer `reAttachPolymerList` already guarded for exactly this
(`PolymersTemplates.js:94`); the two write paths simply disagreed. `arrangePolymers` now applies
the same guard and omits the tag entirely when the payload is empty.

## 2. SDF export stops preserving them

`has_polymer_or_textnode_blocks?` decides whether `ExportSdf#validate_molfile` keeps the full
molfile or trims to the CTAB. Its PolymersList half tested the *tag*, so an empty block survived
export into the SDF file and travelled to whatever instance imported it. It now tests for
payload via `has_polymer_content?`.

The TextNode half deliberately stays on tag presence: those blocks are written with an explicit
`> </TextNode>` close and have no known empty-block emitter.

## Verification

Run in the app container:

- `spec/lib/export/export_sdf_spec.rb` (new) + `spec/lib/chemotion/molfile_polymer_support_spec.rb` — **30 examples, 0 failures**
- Wider regression over `spec/lib/export/`, `spec/lib/import/`, `molfile_polymer_support_spec.rb`, `svg_renderer_spec.rb` — **264 examples, 0 failures**
- `canvasOperations.spec.js` — **11 passing**, including 3 new cases

Both new test groups were confirmed to fail against the unpatched source: without the writer
guard the molfile gains `'> <PolymersList>', ''`; without the predicate change
`validate_molfile` returns the molfile with `M  END\n> <PolymersList>\n$$$$` still attached.

RuboCop is clean on all changed files. (The four offences RuboCop reports in `export_sdf.rb` are
pre-existing and on untouched lines: 8, 19, 69, 151.)

## Not included

Two tidy-ups from the #3486 review are left out to keep this diff to the behavioural fix — the
now-dead `SvgRenderer.has_polymers_list_tag?` delegator (zero callers since #3486) and moving
`normalize_for_open_babel` out of `MolfilePolymerSupport` into `OpenBabelService`, which touches
call sites beyond this change.

Rows already carrying an empty tag stay as they are; readers tolerate them since #3486, but a
cleanup migration may still be worth it.
