### PR TITLE
feat(ui): configurable workshop guide title and optional alternate logo asset

### DIFF
--- a/app/api/chemotion/public_api.rb
+++ b/app/api/chemotion/public_api.rb
@@ -48,9 +48,13 @@ module Chemotion
       end
 
       namespace :workshop_guide do
-        desc 'Whether workshop wiki content has been synced (see `rake workshop_guide:sync`)'
+        desc 'Whether workshop wiki content has been synced (see `rake workshop_guide:sync`), ' \
+             'and the display title configured via WORKSHOP_GUIDE_TITLE'
         get 'available' do
-          { available: Rails.public_path.join('workshop', 'home.md').file? }
+          {
+            available: Rails.public_path.join('workshop', 'home.md').file?,
+            title: ENV.fetch('WORKSHOP_GUIDE_TITLE', 'Workshop Guide'),
+          }
         end
       end
 

--- a/app/api/chemotion/public_api.rb
+++ b/app/api/chemotion/public_api.rb
@@ -2,6 +2,11 @@
 
 module Chemotion
   class PublicAPI < Grape::API
+    # Candidate filenames for an instance-provided logo under public/logos, in preference
+    # order. Fixed list rather than a glob: the path is echoed back to the browser, so it
+    # must never be influenced by request input.
+    ALTERNATE_LOGO_FILES = %w[chemotion-alternate.svg chemotion-alternate.png].freeze
+
     helpers do
       def send_notification(attachment, user, status, has_error = false)
         data_args = { filename: attachment.filename, comment: 'the file has been updated' }
@@ -46,6 +51,15 @@ module Chemotion
         desc 'Whether workshop wiki content has been synced (see `rake workshop_guide:sync`)'
         get 'available' do
           { available: Rails.public_path.join('workshop', 'home.md').file? }
+        end
+      end
+
+      namespace :logo do
+        desc 'Path of the instance-provided logo under public/logos, or null when there is none. ' \
+             'Resolved server-side so stock instances do not log a 404 for the absent file.'
+        get 'alternate' do
+          name = ALTERNATE_LOGO_FILES.find { |file| Rails.public_path.join('logos', file).file? }
+          { src: name && "/logos/#{name}" }
         end
       end
 

--- a/app/assets/stylesheets/components/WorkshopGuide.scss
+++ b/app/assets/stylesheets/components/WorkshopGuide.scss
@@ -21,6 +21,7 @@
     font-size: 0.875rem;
     font-weight: 600;
     color: #4f5659;
+    white-space: nowrap;
   }
 }
 

--- a/app/javascript/src/components/common/ChemotionLogo.js
+++ b/app/javascript/src/components/common/ChemotionLogo.js
@@ -1,9 +1,45 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+
+// An instance can drop an alternate logo into public/logos; the server reports whether
+// one is there. Resolved once per page load and shared by every mount, because
+// ChemotionLogo renders in both navigation bars, the workshop FAB and the sidebar --
+// which remounts whenever it is collapsed or expanded.
+//
+// Deliberately not probed by requesting the (expectedly absent) file directly: a 404
+// does not throw, but the browser still logs the failed resource load to the console on
+// every stock instance. The endpoint always answers 200, so "no alternate" stays silent.
+let alternateSrcPromise = null;
+
+const fetchAlternateLogoSrc = () => {
+  alternateSrcPromise ||= fetch('/api/v1/public/logo/alternate')
+    .then((res) => (res.ok ? res.json() : { src: null }))
+    .then(({ src }) => src || null)
+    .catch(() => null);
+  return alternateSrcPromise;
+};
 
 const ChemotionLogo = ({ collapsed }) => {
+  const [alternateSrc, setAlternateSrc] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchAlternateLogoSrc().then((src) => { if (!cancelled) { setAlternateSrc(src); } });
+    return () => { cancelled = true; };
+  }, []);
+
   const height = '52';
   const width = collapsed ? '52' : '87';
   const scaledSize = '34';
+
+  if (alternateSrc) {
+    return (
+      <img
+        src={alternateSrc}
+        alt="Chemotion Logo"
+        style={{ height: collapsed ? Number(scaledSize) : Number(height), width: 'auto', maxWidth: '100%' }}
+      />
+    );
+  }
 
   const styles = {
     blue: {

--- a/app/javascript/src/components/workshopGuide/WorkshopGuideDrawer.js
+++ b/app/javascript/src/components/workshopGuide/WorkshopGuideDrawer.js
@@ -2,19 +2,28 @@ import React, { useEffect, useState } from 'react';
 
 import ChemotionLogo from 'src/components/common/ChemotionLogo';
 import WorkshopContent from 'src/components/workshopGuide/WorkshopContent';
-import { fetchWorkshopAvailability } from 'src/components/workshopGuide/workshopGuideFetch';
+import {
+  fetchWorkshopAvailability,
+  workshopDefaultTitle,
+} from 'src/components/workshopGuide/workshopGuideFetch';
 
 // The drawer auto-hides itself if no workshop content is checked out, so the
 // feature is implicitly off on non-workshop instances (just don't run the rake
 // sync task).
 export default function WorkshopGuideDrawer() {
   const [available, setAvailable] = useState(false);
+  const [title, setTitle] = useState(workshopDefaultTitle);
   const [open, setOpen] = useState(false);
   const [openedOnce, setOpenedOnce] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
-    fetchWorkshopAvailability().then((ok) => { if (!cancelled) setAvailable(ok); });
+    fetchWorkshopAvailability().then(({ available: ok, title: t }) => {
+      if (!cancelled) {
+        setAvailable(ok);
+        setTitle(t);
+      }
+    });
     return () => { cancelled = true; };
   }, []);
 
@@ -32,22 +41,22 @@ export default function WorkshopGuideDrawer() {
       <button
         type="button"
         className="workshop-guide-fab"
-        title={open ? 'Hide Workshop Guide' : 'Show Workshop Guide'}
-        aria-label="Workshop Guide"
+        title={open ? `Hide ${title}` : `Show ${title}`}
+        aria-label={title}
         onClick={toggle}
       >
         <ChemotionLogo collapsed />
-        <span className="workshop-guide-fab__label">Workshop&nbsp;Guide</span>
+        <span className="workshop-guide-fab__label">{title}</span>
       </button>
       {openedOnce && (
         <div
           className={`workshop-guide-drawer${open ? '' : ' workshop-guide-drawer--hidden'}`}
           role="dialog"
-          aria-label="Workshop Guide"
+          aria-label={title}
           aria-hidden={!open}
         >
           <div className="workshop-guide-drawer__header">
-            <strong>Workshop Guide</strong>
+            <strong>{title}</strong>
             <button
               type="button"
               className="workshop-guide-drawer__close"

--- a/app/javascript/src/components/workshopGuide/WorkshopGuideInline.js
+++ b/app/javascript/src/components/workshopGuide/WorkshopGuideInline.js
@@ -8,7 +8,7 @@ export default function WorkshopGuideInline() {
 
   useEffect(() => {
     let cancelled = false;
-    fetchWorkshopAvailability().then((ok) => { if (!cancelled) setAvailable(ok); });
+    fetchWorkshopAvailability().then(({ available: ok }) => { if (!cancelled) setAvailable(ok); });
     return () => { cancelled = true; };
   }, []);
 

--- a/app/javascript/src/components/workshopGuide/workshopGuideFetch.js
+++ b/app/javascript/src/components/workshopGuide/workshopGuideFetch.js
@@ -5,24 +5,30 @@
 const BASE = '/workshop';
 const SIDEBAR = `${BASE}/_sidebar.md`;
 const DEFAULT_SLUG = 'home';
+const DEFAULT_TITLE = 'Workshop Guide';
 
 const cacheBust = () => `?_=${Date.now()}`;
 
 export const workshopBase = BASE;
 export const workshopDefaultSlug = DEFAULT_SLUG;
+export const workshopDefaultTitle = DEFAULT_TITLE;
 
 // Availability must not be probed by requesting the (expectedly missing) static
 // file directly: a 404 fetch response doesn't throw, but the browser still logs
 // the failed resource load to the console on every non-workshop instance. This
 // endpoint always answers 200, so the "feature disabled" case stays silent.
+//
+// Also carries the display title (server-configured via WORKSHOP_GUIDE_TITLE,
+// see `rake workshop_guide:sync`) so instances can rebrand the guide without
+// touching frontend code.
 export async function fetchWorkshopAvailability() {
   try {
     const res = await fetch('/api/v1/public/workshop_guide/available');
-    if (!res.ok) return false;
-    const { available } = await res.json();
-    return !!available;
+    if (!res.ok) return { available: false, title: DEFAULT_TITLE };
+    const { available, title } = await res.json();
+    return { available: !!available, title: title || DEFAULT_TITLE };
   } catch (e) {
-    return false;
+    return { available: false, title: DEFAULT_TITLE };
   }
 }
 

--- a/lib/tasks/workshop_guide.rake
+++ b/lib/tasks/workshop_guide.rake
@@ -7,6 +7,10 @@
 #               With no content present both widgets render nothing, so the
 #               app is the usual ELN.
 # public/workshop is gitignored, so the content is a runtime checkout only.
+#
+# The drawer's title defaults to "Workshop Guide" and can be rebranded per
+# instance via the WORKSHOP_GUIDE_TITLE env var on the app server (read at
+# request time by the public workshop_guide/available API, not by this task).
 namespace :workshop_guide do
   desc 'Clone or update the Chemotion workshop wiki into public/workshop. ' \
        'Configure via env: WORKSHOP_GUIDE_REPO (required, the git URL of a ' \

--- a/spec/api/chemotion/public_api_spec.rb
+++ b/spec/api/chemotion/public_api_spec.rb
@@ -93,4 +93,64 @@ describe Chemotion::PublicAPI do
       end
     end
   end
+
+  describe 'GET /api/v1/public/logo/alternate' do
+    subject(:execute_request) { get('/api/v1/public/logo/alternate') }
+
+    let(:logos_dir) { Rails.public_path.join('logos') }
+    let(:candidates) { Chemotion::PublicAPI::ALTERNATE_LOGO_FILES.map { |name| logos_dir.join(name) } }
+
+    # public/logos also holds committed assets, so every candidate is moved aside for the
+    # duration of the example and put back afterwards -- never simply deleted.
+    around do |example|
+      backups = candidates.select(&:exist?).to_h { |path| [path, Rails.root.join("tmp/#{path.basename}.bak")] }
+      backups.each { |path, backup| FileUtils.mv(path, backup) }
+      begin
+        example.run
+      ensure
+        candidates.each { |path| FileUtils.rm_f(path) }
+        backups.each { |path, backup| FileUtils.mv(backup, path) }
+      end
+    end
+
+    def write_logo(name)
+      FileUtils.mkdir_p(logos_dir)
+      FileUtils.touch(logos_dir.join(name))
+    end
+
+    context 'when no alternate logo is present' do
+      before { execute_request }
+
+      # 200 with a null src, not a 404: the client must be able to ask without the browser
+      # logging a failed resource load on every stock instance.
+      it 'responds 200 with a null src' do
+        expect(response).to have_http_status :ok
+        expect(parsed_json_response).to eq({ 'src' => nil })
+      end
+    end
+
+    context 'when a PNG alternate logo is present' do
+      before do
+        write_logo('chemotion-alternate.png')
+        execute_request
+      end
+
+      it 'responds 200 with the public path of the file' do
+        expect(response).to have_http_status :ok
+        expect(parsed_json_response).to eq({ 'src' => '/logos/chemotion-alternate.png' })
+      end
+    end
+
+    context 'when both an SVG and a PNG are present' do
+      before do
+        write_logo('chemotion-alternate.svg')
+        write_logo('chemotion-alternate.png')
+        execute_request
+      end
+
+      it 'prefers the SVG' do
+        expect(parsed_json_response).to eq({ 'src' => '/logos/chemotion-alternate.svg' })
+      end
+    end
+  end
 end

--- a/spec/api/chemotion/public_api_spec.rb
+++ b/spec/api/chemotion/public_api_spec.rb
@@ -66,15 +66,23 @@ describe Chemotion::PublicAPI do
       end
     end
 
+    # The title is read from the process environment at request time, so an ambient
+    # WORKSHOP_GUIDE_TITLE -- the dev container sets one -- would otherwise leak into the
+    # default-title expectations below. The configured context overrides this stub.
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('WORKSHOP_GUIDE_TITLE', 'Workshop Guide').and_return('Workshop Guide')
+    end
+
     context 'when workshop content has not been synced' do
       before do
         FileUtils.rm_f(home_md)
         execute_request
       end
 
-      it 'responds 200 with available: false' do
+      it 'responds 200 with available: false and the default title' do
         expect(response).to have_http_status :ok
-        expect(parsed_json_response).to eq({ 'available' => false })
+        expect(parsed_json_response).to eq({ 'available' => false, 'title' => 'Workshop Guide' })
       end
     end
 
@@ -87,9 +95,23 @@ describe Chemotion::PublicAPI do
 
       after { FileUtils.rm_f(home_md) }
 
-      it 'responds 200 with available: true' do
+      it 'responds 200 with available: true and the default title' do
         expect(response).to have_http_status :ok
-        expect(parsed_json_response).to eq({ 'available' => true })
+        expect(parsed_json_response).to eq({ 'available' => true, 'title' => 'Workshop Guide' })
+      end
+    end
+
+    context 'when WORKSHOP_GUIDE_TITLE is configured' do
+      before do
+        FileUtils.rm_f(home_md)
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with('WORKSHOP_GUIDE_TITLE', 'Workshop Guide').and_return('Summer School Guide')
+        execute_request
+      end
+
+      it 'responds 200 with the configured title' do
+        expect(response).to have_http_status :ok
+        expect(parsed_json_response).to eq({ 'available' => false, 'title' => 'Summer School Guide' })
       end
     end
   end
@@ -103,7 +125,7 @@ describe Chemotion::PublicAPI do
     # public/logos also holds committed assets, so every candidate is moved aside for the
     # duration of the example and put back afterwards -- never simply deleted.
     around do |example|
-      backups = candidates.select(&:exist?).to_h { |path| [path, Rails.root.join("tmp/#{path.basename}.bak")] }
+      backups = candidates.select(&:exist?).index_with { |path| Rails.root.join("tmp/#{path.basename}.bak") }
       backups.each { |path, backup| FileUtils.mv(path, backup) }
       begin
         example.run


### PR DESCRIPTION
Two small display settings that an instance can adjust without patching or rebuilding the
frontend. Both default to today's behaviour, so a stock instance is unchanged.

## Workshop guide drawer title

The drawer and its floating button were hard-coded to `Workshop Guide` — in the visible
label, the button tooltip, and both `aria-label`s. An instance running the drawer for
something other than a workshop had no way to say so.

The title now comes from the `WORKSHOP_GUIDE_TITLE` env var, read at request time by
`GET /api/v1/public/workshop_guide/available` and returned alongside the availability
flag. It defaults to `Workshop Guide`, which is also the client's fallback when the
request fails.

`fetchWorkshopAvailability()` accordingly resolves to `{ available, title }` instead of a
bare boolean; both call sites are updated. The button label gets `white-space: nowrap` so
a longer title doesn't wrap under the logo.

## Alternate logo asset

`ChemotionLogo` draws a built-in inline SVG. If `chemotion-alternate.svg` (or `.png`) is
present under `public/logos`, the component renders that file instead. No such file is
shipped in this PR.

Presence is resolved through a new `GET /api/v1/public/logo/alternate` rather than by the
browser requesting the file directly. A missing static asset doesn't throw on `fetch`, but
the browser still logs the failed resource load to the console — which is the same reason
the workshop guide already checks availability through the API rather than by requesting
`home.md`. The endpoint answers `200` with `{"src": null}` when there is nothing, so the
absent case stays silent. The answer is memoised per page load, because `ChemotionLogo`
mounts in both navigation bars, the workshop FAB, and the sidebar — which remounts every
time it is collapsed or expanded.

The candidate filenames are a fixed list on the API class, never derived from request
input, so the returned path can't be steered by a caller.

## Testing

`spec/api/chemotion/public_api_spec.rb` — **10 examples, 0 failures** (app container).
Covers the new endpoint's three cases (absent → null src, PNG present, SVG preferred over
PNG) and the title default/override.

The two pre-existing "default title" examples were reading the ambient
`WORKSHOP_GUIDE_TITLE` from the environment, so they failed on any machine that sets one
(the dev container does). They now stub the lookup, so the default is actually asserted
rather than inherited.

RuboCop is clean on both changed Ruby files. The two offences it still reports in
`public_api.rb` are pre-existing and on untouched lines (11, 146).
