### PR TITLE
fix(nmrium): pin the wrapper's origin allowlist so saving works on a self-hosted instance

### DIFF
--- a/.dockerenv.example
+++ b/.dockerenv.example
@@ -60,7 +60,12 @@ IMG_INDIGO=epmlsop/indigo-service:1.34.0-rc.1
 ## Rails at /nmrium/default/). Installing it is opt-in — see that service's
 ## comment for the command. .service-dependencies stays the source of truth
 ## for the version — keep the tag here in sync with its NMRIUMWRAPPER entry.
-IMG_NMRIUMWRAPPER=nfdi4chem/nmrium-react-wrapper:v1.1.0
+IMG_NMRIUMWRAPPER=nfdi4chem/nmrium-react-wrapper:v1.2.0
+## Origins allowed to drive the wrapper, space- or comma-separated and each with
+## its scheme (a scheme-less hostname is dropped on the wrapper side). Ports are
+## ignored, so one entry covers every port on that host. Left empty the wrapper
+## accepts messages from any origin — set it for anything but local development.
+#NMRIUM_ALLOWED_ORIGINS='https://eln.example.org https://1.eln.example.org'
 ## Keep the wrapper's sourcemaps, which are dropped by default: they multiply
 ## the installed size several times over and are only useful when debugging the
 ## wrapper itself, which this setup does not support.

--- a/.service-dependencies
+++ b/.service-dependencies
@@ -2,7 +2,7 @@
 CONVERTER=ComPlat/chemotion-converter-app@v1.9.3
 KETCHER=ptrxyz/chemotion-ketchersvc@main
 SPECTRA=ComPlat/chem-spectra-app@v1.5.1
-NMRIUMWRAPPER=NFDI4Chem/nmrium-react-wrapper@v1.1.0
+NMRIUMWRAPPER=NFDI4Chem/nmrium-react-wrapper@v1.2.0
 KETCHER2=epam/ketcher@v3.12.0
 CHEMLOCALLINK=Chemotion/ChemLocalLink@v2.0.1
 IMG_INDIGO=epmlsop/indigo-service:1.35.0-rc.2

--- a/app/javascript/src/components/nmriumWrapper/NMRiumDisplayer.js
+++ b/app/javascript/src/components/nmriumWrapper/NMRiumDisplayer.js
@@ -8,7 +8,7 @@ import UIFetcher from 'src/fetchers/UIFetcher';
 import Attachment from 'src/models/Attachment';
 import { SpectraOps } from 'src/utilities/quillToolbarSymbol';
 import { FN } from '@complat/react-spectra-editor';
-import { cleaningNMRiumData, isSpectrum2D } from 'src/utilities/SpectraHelper';
+import { cleaningNMRiumData, isSpectrum2D, spectrumName } from 'src/utilities/SpectraHelper';
 
 export default class NMRiumDisplayer extends React.Component {
   constructor(props) {
@@ -46,6 +46,7 @@ export default class NMRiumDisplayer extends React.Component {
     this.prepareAnalysisMetadata = this.prepareAnalysisMetadata.bind(this);
     this.prepareImageAttachment = this.prepareImageAttachment.bind(this);
     this.prepareNMRiumDataAttachment = this.prepareNMRiumDataAttachment.bind(this);
+    this.postToNMRium = this.postToNMRium.bind(this);
   }
 
   componentDidMount() {
@@ -170,17 +171,24 @@ export default class NMRiumDisplayer extends React.Component {
     }
   }
 
-  requestDataToBeSaved() {
+  // receiveMessage already refuses anything not from nmriumOrigin; this is the same
+  // check in the outbound direction, so the payload is only ever delivered to the frame
+  // we resolved from the configured wrapper url. Silently doing nothing without an
+  // origin is deliberate: it means loadWrapperHost has not resolved yet, and the caller
+  // is about to be re-run once the iframe loads.
+  postToNMRium(message) {
+    const { nmriumOrigin } = this.state;
     const iframe = this.iframeRef.current;
-    if (!iframe) return;
+    if (!iframe?.contentWindow || !nmriumOrigin) return;
 
-    iframe.contentWindow.postMessage(
-      {
-        type: 'nmr-wrapper:action-request',
-        data: { type: 'exportSpectraViewerAsBlob' },
-      },
-      '*'
-    );
+    iframe.contentWindow.postMessage(message, nmriumOrigin);
+  }
+
+  requestDataToBeSaved() {
+    this.postToNMRium({
+      type: 'nmr-wrapper:action-request',
+      data: { type: 'exportSpectraViewerAsBlob' },
+    });
   }
 
   handleCloseRequest(event, source) {
@@ -245,10 +253,10 @@ export default class NMRiumDisplayer extends React.Component {
           molecules: molfile ? [{ molfile }] : [],
         },
       };
-      this.iframeRef.current?.contentWindow.postMessage({ type: 'nmr-wrapper:load', data: payload }, '*');
+      this.postToNMRium({ type: 'nmr-wrapper:load', data: payload });
     } else if (zip?.url) {
 
-      this.iframeRef.current?.contentWindow.postMessage({ type: 'nmr-wrapper:load', data: { type: 'url', data: [`${zip.url}/file.zip`] } }, '*');
+      this.postToNMRium({ type: 'nmr-wrapper:load', data: { type: 'url', data: [`${zip.url}/file.zip`] } });
 
       const nmriumState = await this.waitForNMRiumDataWithSpectra(30000);
       if (!nmriumState) {
@@ -265,7 +273,7 @@ export default class NMRiumDisplayer extends React.Component {
 
       if (molfile) { cleaned.molecules = [{ molfile }]; }
 
-      this.iframeRef.current?.contentWindow.postMessage({ type: 'nmr-wrapper:load', data: { type: 'nmrium', data: cleaned } }, '*');
+      this.postToNMRium({ type: 'nmr-wrapper:load', data: { type: 'nmrium', data: cleaned } });
     } else {
       console.warn('No usable .nmrium or .jdx file for display.');
     }
@@ -321,7 +329,7 @@ export default class NMRiumDisplayer extends React.Component {
       this.setState({ fetchedSpectra: updatedSpectra });
 
       const payload = { type: 'file', data: fileList };
-      this.iframeRef.current?.contentWindow.postMessage({ type: 'nmr-wrapper:load', data: payload }, '*');
+      this.postToNMRium({ type: 'nmr-wrapper:load', data: payload });
     } catch (err) {
       console.error('Failed to parse/patch .nmrium:', err);
     }
@@ -342,9 +350,17 @@ export default class NMRiumDisplayer extends React.Component {
       || spectrum?.sourceSelector?.files?.find((file) => typeof file === 'string');
     const baseFromUrl = this.getFileBaseName(oldUrl);
     const baseFromInfo = this.getFileBaseName(spectrum?.info?.name);
+    // Last resort for a spectrum carrying neither a source url nor an info.name - the jcamp-loaded
+    // shape, where display.name is only the spectrum's uuid. spectrumName falls through to the raw
+    // JCAMP TITLE, which is already a stem ("X23827_10.processed_1"): it must not be run through
+    // getFileBaseName, which would read ".processed_1" as an extension and strip the curve away.
+    const nameFromSpectrum = spectrumName(spectrum);
+    const baseFromName = nameFromSpectrum ? nameFromSpectrum.toLowerCase() : '';
     const extFromUrl = this.getFileExtension(oldUrl);
     const extFromInfo = this.getFileExtension(spectrum?.info?.name);
-    const targetBase = baseFromUrl || baseFromInfo;
+    const targetBase = baseFromUrl || baseFromInfo || baseFromName;
+    // No extension is derived from the stem: it has none, and guessing one would only narrow the
+    // match away from the very attachment being looked for.
     const targetExt = extFromUrl || extFromInfo;
     if (!targetBase) return null;
 

--- a/app/javascript/src/utilities/SpectraHelper.js
+++ b/app/javascript/src/utilities/SpectraHelper.js
@@ -218,6 +218,30 @@ const isSpectrum2D = (spc) => (
   || spc?.display?.dimension === 2
 );
 
+// The raw JCAMP header keeps the source file's stem in TITLE, as a string or as an array of
+// repeats. It is the last place a spectrum's real name survives.
+const metaTitle = (spc) => {
+  const title = spc?.meta?.TITLE;
+  const value = Array.isArray(title)
+    ? title.find((entry) => typeof entry === 'string' && entry.trim())
+    : title;
+  return (typeof value === 'string' && value.trim()) ? value.trim() : null;
+};
+
+// The name to identify a spectrum by. NMRium defaults display.name to the spectrum's own id when
+// nothing set it - which is what a spectrum loaded straight from a jcamp ends up with - so a
+// display.name equal to the id names no file and must not be treated as one: buildSourceId would
+// key on a uuid, and findMatchingJcamp could not match the spectrum back to its attachment.
+const spectrumName = (spc) => {
+  const named = (spc?.display?.name && spc.display.name !== spc?.id) ? spc.display.name : null;
+  return named
+    || spc?.info?.name
+    || spc?.originalInfo?.name
+    || spc?.meta?.name
+    || metaTitle(spc)
+    || null;
+};
+
 const SOURCE_ID_PREFIX = 'nmrium-src-';
 const ARCHIVE_MARKER = '/file.zip/';
 const isAbsoluteUrl = (value) => typeof value === 'string' && /^https?:\/\//.test(value);
@@ -347,12 +371,9 @@ const cleaningNMRiumData = (nmriumData) => {
     // it, so we can't assume it's safe to lose. `info` itself must stay fully intact; NMRium relies
     // on it (e.g. dimension, isFid) to read `data`.
     if (is2DWithSource) {
-      const spectrumName = tmpSpc?.display?.name
-        || tmpSpc?.info?.name
-        || tmpSpc?.originalInfo?.name
-        || tmpSpc?.meta?.name;
-      if (spectrumName) {
-        tmpSpc.display = { ...tmpSpc.display, name: spectrumName };
+      const resolvedName = spectrumName(tmpSpc);
+      if (resolvedName) {
+        tmpSpc.display = { ...tmpSpc.display, name: resolvedName };
       }
       // info may be sparse on legacy spectra where dimension/isFid were only ever mirrored into
       // originalInfo/meta; backfill it before dropping the originalInfo duplicate. Only the two
@@ -386,7 +407,7 @@ const cleaningNMRiumData = (nmriumData) => {
       // If no URL can be resolved, leave `data` embedded: that's the same safe fallback this file
       // relied on before this was wired up, not a regression.
       const sourceUrl = resolveSpectrumSourceUrl(tmpSpc, root);
-      const sourceId = ensureSource(root, buildSourceId(spectrumName), sourceUrl, claimedSources);
+      const sourceId = ensureSource(root, buildSourceId(resolvedName), sourceUrl, claimedSources);
       if (sourceId) {
         // sourceSelector.files may address individual members *within* a shared source (e.g. one
         // experiment inside a multi-spectrum zip, all sharing one sources[] id); NMRium's reader
@@ -526,5 +547,6 @@ const inlineNotation = (layout, data, metadata) => {
 };
 
 export {
-  BuildSpcInfos, BuildSpcInfosForNMRDisplayer, JcampIds, isNMRKind, isSpectrum2D, cleaningNMRiumData, inlineNotation,
+  BuildSpcInfos, BuildSpcInfosForNMRDisplayer, JcampIds, isNMRKind, isSpectrum2D, spectrumName,
+  cleaningNMRiumData, inlineNotation,
 }; // eslint-disable-line

--- a/docker-compose.services.yml.example
+++ b/docker-compose.services.yml.example
@@ -74,6 +74,20 @@ services:
   #  - The first run pulls ~500 MB, but only ~75 MB lands in public/: the copy
   #    drops the nested per-release archives and the sourcemaps (the latter are
   #    kept with NMRIUM_SOURCEMAPS=1).
+  #  - NMRIUM_ALLOWED_ORIGINS is not optional for a self-hosted wrapper. The
+  #    wrapper validates the origin of every postMessage its parent sends against
+  #    an allowlist it fetches at runtime from
+  #    raw.githubusercontent.com/NFDI4Chem/nmrium-react-wrapper, and throws
+  #    "Invalid Origin <your eln>" for anything not on it. That list enumerates
+  #    other institutions' public ELNs, so a self-hosted instance is rejected by
+  #    default - and rejected specifically on save, because the list is empty
+  #    (and the check therefore skipped) for as long as that fetch is in flight,
+  #    which covers the initial load but not a later user action. The install
+  #    below repoints the wrapper at a list we write ourselves, so the origins
+  #    that may drive it are ours to declare and no egress to GitHub is needed.
+  #    Hostnames are matched exactly and wildcards are not supported, so a
+  #    multi-tenant deployment must list every subdomain it serves. An empty
+  #    list means the wrapper skips the check altogether.
   nmrium-assets:
     image: ${IMG_NMRIUMWRAPPER:-nfdi4chem/nmrium-react-wrapper:v1.1.0}
     # Write as the invoking user so public/nmrium is not left root-owned on the
@@ -90,6 +104,12 @@ services:
       # single variable to keep in sync with .service-dependencies.
       - IMG=${IMG_NMRIUMWRAPPER:-nfdi4chem/nmrium-react-wrapper:v1.1.0}
       - NMRIUM_SOURCEMAPS=${NMRIUM_SOURCEMAPS:-0}
+      # Space- or comma-separated origins allowed to drive the wrapper, e.g.
+      # "https://eln.example.org https://1.eln.example.org". Leaving it empty
+      # writes an empty list, which the wrapper reads as "no check" - fine for
+      # development, and the same effective behaviour a deployment already gets
+      # today whenever the GitHub fetch fails. Set it in production.
+      - NMRIUM_ALLOWED_ORIGINS=${NMRIUM_ALLOWED_ORIGINS:-}
     entrypoint: ["/bin/sh", "-c"]
     # A list, not a string: compose shell-splits a string command, which would
     # tear this script into separate arguments. `$$` escapes compose's own
@@ -117,6 +137,39 @@ services:
           # pattern cannot match the staging directory itself.
           find "$$tmp" -mindepth 1 -maxdepth 1 -type d -name 'v[0-9]*' -exec rm -rf {} +
           [ "$$NMRIUM_SOURCEMAPS" = "1" ] || find "$$tmp" -name '*.map' -delete
+
+          # Repoint the wrapper's origin allowlist at one we ship beside it (see
+          # the NMRIUM_ALLOWED_ORIGINS caveat above). A relative url resolves
+          # against the iframe's own origin, which for a self-hosted wrapper is
+          # the ELN's, so the list travels with the instance and no egress to
+          # GitHub is needed to open a spectrum.
+          #
+          # An empty list disables the check wrapper-side, so say so rather than
+          # letting a production deployment discover it later.
+          origins=$$(printf '%s' "$$NMRIUM_ALLOWED_ORIGINS" | tr ', ' '\n\n' | sed '/^$$/d' \
+            | sed 's/.*/"&"/' | paste -sd, -)
+          printf '[%s]' "$$origins" > "$$tmp/allowed-origins.json"
+          if [ -z "$$origins" ]; then
+            echo ">>> WARNING: NMRIUM_ALLOWED_ORIGINS is empty - the wrapper will accept"
+            echo ">>>          messages from any origin. Set it for a production deployment."
+          fi
+
+          # Fail the install rather than ship a wrapper that still reaches for
+          # GitHub: a future bundle may rename or inline this constant, and a
+          # silent no-op here would look like a working install right up until
+          # saving breaks in production.
+          hits=$$(grep -rl 'raw\.githubusercontent\.com/NFDI4Chem/nmrium-react-wrapper[^"'"'"']*allowed-origins\.json' "$$tmp/assets" | wc -l)
+          if [ "$$hits" -eq 0 ]; then
+            echo >&2 ">>> ERROR: allowed-origins url not found in the $$v bundle."
+            echo >&2 ">>> The wrapper changed how it loads its origin allowlist."
+            echo >&2 ">>> Re-check nmrium-assets in docker-compose.services.yml before deploying."
+            rm -rf "$$tmp"
+            exit 1
+          fi
+          find "$$tmp/assets" -type f -name '*.js' -exec sed -i \
+            's#https://raw\.githubusercontent\.com/NFDI4Chem/nmrium-react-wrapper/[^"'"'"'`]*allowed-origins\.json#./allowed-origins.json#g' {} +
+          echo ">>> Origin allowlist pinned to $$tmp/allowed-origins.json ($$hits file(s) patched)"
+
           mv "$$tmp" "/out/$$v"
         fi
         ln -sfn "$$v" /out/default

--- a/docker-compose.services.yml.example
+++ b/docker-compose.services.yml.example
@@ -85,11 +85,15 @@ services:
   #    which covers the initial load but not a later user action. The install
   #    below repoints the wrapper at a list we write ourselves, so the origins
   #    that may drive it are ours to declare and no egress to GitHub is needed.
-  #    Hostnames are matched exactly and wildcards are not supported, so a
-  #    multi-tenant deployment must list every subdomain it serves. An empty
-  #    list means the wrapper skips the check altogether.
+  #    Each entry must be a full origin, scheme included: the wrapper parses it
+  #    with `new URL()` and silently drops whatever fails, so a bare hostname
+  #    never makes it onto the list. It then compares hostnames only - scheme
+  #    and port are ignored, one entry covers every port on that host - and
+  #    wildcards are not supported, so a multi-tenant deployment must list every
+  #    subdomain it serves. An empty list means the wrapper skips the check
+  #    altogether.
   nmrium-assets:
-    image: ${IMG_NMRIUMWRAPPER:-nfdi4chem/nmrium-react-wrapper:v1.1.0}
+    image: ${IMG_NMRIUMWRAPPER:-nfdi4chem/nmrium-react-wrapper:v1.2.0}
     # Write as the invoking user so public/nmrium is not left root-owned on the
     # host. Matches the uid/gid the dev image is built with.
     user: "${uid:-1000}:${gid:-1000}"
@@ -102,10 +106,11 @@ services:
     environment:
       # The version subdirectory is derived from the image tag, so there is a
       # single variable to keep in sync with .service-dependencies.
-      - IMG=${IMG_NMRIUMWRAPPER:-nfdi4chem/nmrium-react-wrapper:v1.1.0}
+      - IMG=${IMG_NMRIUMWRAPPER:-nfdi4chem/nmrium-react-wrapper:v1.2.0}
       - NMRIUM_SOURCEMAPS=${NMRIUM_SOURCEMAPS:-0}
-      # Space- or comma-separated origins allowed to drive the wrapper, e.g.
-      # "https://eln.example.org https://1.eln.example.org". Leaving it empty
+      # Space- or comma-separated origins allowed to drive the wrapper, each
+      # with its scheme, e.g. "https://eln.example.org https://1.eln.example.org"
+      # - a scheme-less hostname is dropped on the wrapper side. Leaving it empty
       # writes an empty list, which the wrapper reads as "no check" - fine for
       # development, and the same effective behaviour a deployment already gets
       # today whenever the GitHub fetch fails. Set it in production.

--- a/spec/javascripts/packs/src/utilities/SpectraHelper.spec.js
+++ b/spec/javascripts/packs/src/utilities/SpectraHelper.spec.js
@@ -2,7 +2,7 @@ import expect from 'expect';
 import { FN } from '@complat/react-spectra-editor';
 import {
   isNMRKind, BuildSpcInfosForNMRDisplayer,
-  JcampIds, BuildSpcInfos, cleaningNMRiumData,
+  JcampIds, BuildSpcInfos, cleaningNMRiumData, spectrumName,
   inlineNotation,
 } from 'src/utilities/SpectraHelper';
 import Sample from 'src/models/Sample';
@@ -671,6 +671,29 @@ describe('SpectraHelper', () => {
         expect('info' in spectrum).toEqual(false);
       });
 
+      it('names a 2D spectrum from meta.TITLE when display.name is only its own uuid', () => {
+        // Real shape of a spectrum NMRium loaded straight from a jcamp: display.name defaults to
+        // the spectrum id, info carries no name, and the source file's stem survives only in the
+        // raw JCAMP TITLE - as an array of repeats.
+        const nmriumData = {
+          spectra: [{
+            id: '985335b4-3535-4098-b92c-fe4b20692cd1',
+            display: { name: '985335b4-3535-4098-b92c-fe4b20692cd1', dimension: 2 },
+            info: { dimension: 2, isFid: false },
+            meta: { TITLE: ['X23827_10.processed_1', 'X23827_10.processed_1'] },
+            source: { jcampURL: 'https://example.com/file.jdx' },
+            data: { rr: { z: [[1.0]] } },
+          }],
+        };
+        const cleanedNMRiumData = cleaningNMRiumData(nmriumData);
+        const [spectrum] = cleanedNMRiumData.spectra;
+        expect(spectrum.display.name).toEqual('X23827_10.processed_1');
+        expect(cleanedNMRiumData.sources).toEqual([
+          { id: 'nmrium-src-x23827-10-processed-1', entries: [{ relativePath: '/file.jdx', baseURL: 'https://example.com' }] },
+        ]);
+        expect(spectrum.selector).toEqual({ root: 'nmrium-src-x23827-10-processed-1' });
+      });
+
       it('does not drop the data matrix of a display-only 2D spectrum that has no source', () => {
         const nmriumData = {
           spectra: [{
@@ -683,6 +706,36 @@ describe('SpectraHelper', () => {
         expect(spectrum.data).toEqual({ rr: { z: [[1.0]] } });
         expect(spectrum.selector).toEqual(undefined);
       });
+    });
+  });
+
+  describe('.spectrumName()', () => {
+    it('prefers a real display.name', () => {
+      expect(spectrumName({ id: 'abc', display: { name: 'cosy.jdx' } })).toEqual('cosy.jdx');
+    });
+
+    it('ignores a display.name that is only the spectrum id', () => {
+      const uuid = '985335b4-3535-4098-b92c-fe4b20692cd1';
+      expect(spectrumName({ id: uuid, display: { name: uuid }, info: { name: 'cosy.jdx' } })).toEqual('cosy.jdx');
+    });
+
+    it('falls back to meta.TITLE, taking the first usable entry of an array', () => {
+      const uuid = '985335b4-3535-4098-b92c-fe4b20692cd1';
+      expect(spectrumName({
+        id: uuid,
+        display: { name: uuid },
+        meta: { TITLE: ['  ', 'X23827_10.processed_1'] },
+      })).toEqual('X23827_10.processed_1');
+    });
+
+    it('accepts a plain string meta.TITLE', () => {
+      expect(spectrumName({ meta: { TITLE: 'hsqc' } })).toEqual('hsqc');
+    });
+
+    it('returns null when nothing names the spectrum', () => {
+      const uuid = '985335b4-3535-4098-b92c-fe4b20692cd1';
+      expect(spectrumName({ id: uuid, display: { name: uuid }, meta: { TITLE: [] } })).toEqual(null);
+      expect(spectrumName(undefined)).toEqual(null);
     });
   });
 


### PR DESCRIPTION
## The bug

Saving a spectrum fails on a self-hosted NMRium wrapper. The console shows:

```
Uncaught Error: Invalid Origin https://<our eln>
    at NMRiumDisplayer.js:177   (requestDataToBeSaved -> postMessage)
```

The wrapper validates the origin of every `postMessage` its parent sends against an
allowlist it **fetches at runtime** from
`raw.githubusercontent.com/NFDI4Chem/nmrium-react-wrapper/main/src/allowed-origins.json`.
Read from the deployed bundle (`public/nmrium/v1.2.0/assets/index-i7TtJcfD.js`):

```js
L = `https://raw.githubusercontent.com/NFDI4Chem/nmrium-react-wrapper/main/src/allowed-origins.json`
// ...
if (!(i.length === 0 || i.includes(`*`)) && !a.has(E(c.origin)))
  throw Error(`Invalid Origin ${r}`);
// E = (e) => { try { return new URL(e).hostname } catch (e) { console.log(e); return null } }
```

Both the list entries and the incoming origin go through `E`, so the comparison is on
**hostname only** — scheme and port are ignored — an entry that does not parse as a URL is
silently dropped, and there is no wildcard support.

That list enumerates other institutions' public ELNs. A self-hosted deployment is rejected by
default — even though `config/spectra.yml` points the iframe at `/nmrium/default/`, making it
**same-origin with the page embedding it**.

It fails specifically on *save*, which is what made it confusing: the list is empty until the
fetch resolves, and an empty list skips the check entirely. The initial load gets through; a
later user action does not. For the same reason an instance whose egress to GitHub is blocked
appears to work — the fetch just never succeeds.

## What changed

**`docker-compose.services.yml.example`** — the `nmrium-assets` install step now writes an
`allowed-origins.json` beside the bundle and rewrites the constant to `./allowed-origins.json`.
A relative url resolves against the iframe's own origin, so the list ships with the instance and
opening a spectrum no longer depends on reaching GitHub. Origins come from a new
`NMRIUM_ALLOWED_ORIGINS`, space- or comma-separated and **each with its scheme** —
`https://eln.example.org`, not `eln.example.org`, which the wrapper drops without a word. Since
only the hostname is compared, one entry covers every port on that host, but a multi-tenant
deployment must still list every subdomain it serves.

The substitution **aborts the install** if it matches nothing. A future wrapper release may
rename or inline that constant, and a silent no-op would look like a working install right up
until saving breaks. An empty `NMRIUM_ALLOWED_ORIGINS` is allowed — it disables the check, which
is fine for development — but says so loudly.

Deployments carry their own `docker-compose.services.yml`; this updates the tracked `.example`,
so an existing instance needs to pick the change up.

**`.dockerenv.example`** — `NMRIUM_ALLOWED_ORIGINS` is documented here too, beside the existing
`IMG_NMRIUMWRAPPER` / `NMRIUM_SOURCEMAPS` entries. The variable is what a deployer has to set,
and it existed only inside the compose service, where nobody configuring an instance would find
it.

**Wrapper pinned to v1.2.0** — `.service-dependencies` (the source of truth), `.dockerenv.example`,
and both defaults in `docker-compose.services.yml.example` move from `v1.1.0`. v1.2.0 is the
version the fix was developed and verified against; leaving the pin behind would have shipped an
install path nothing exercises.

**`NMRiumDisplayer.js`** — `receiveMessage` already refuses anything not from `nmriumOrigin`,
but every outbound `postMessage` used `'*'`. They now go through one `postToNMRium` helper that
applies the same origin.

**`SpectraHelper.js` / `NMRiumDisplayer.js`** — a spectrum NMRium loaded straight from a jcamp
has `display.name` defaulted to its own id, no `info.name`, and `source.jcampURL` null. So
`findMatchingJcamp` could not match it back to its attachment and fell through to the *first*
jcamp in the dataset, and `buildSourceId` would key a `sources[]` entry on a uuid. The real name
survives in the raw JCAMP header as `meta.TITLE`. A shared `spectrumName` helper ignores a
`display.name` equal to the spectrum id and falls back to TITLE — which is already a stem, so it
must not go through `getFileBaseName`, which would read `.processed_1` as an extension and strip
the curve away.

## Verification

The install step was run end to end against the real v1.2.0 bundle:

| | result |
|---|---|
| normal install | 1 file patched, no residual GitHub reference, `L = './allowed-origins.json'`, list written from the env var |
| constant moved (simulated future release) | exits **1**, nothing installed, no staging directory left behind |
| empty `NMRIUM_ALLOWED_ORIGINS` | warns, writes `[]` |

Re-run after the version bump on a clean `public/nmrium`, from the pinned tag alone: v1.2.0 still
loads its allowlist from the GitHub url the rewrite targets, so the guard holds, and
`public/nmrium/default/allowed-origins.json` comes out as the origins given, with zero remaining
`raw.githubusercontent.com` references in the bundle.

The naming change was verified against a real `.nmrium` exported from production
(`display.name` a uuid, `info.name` absent, `meta.TITLE` an array): previously matched nothing,
now resolves to its own `…processed_1.jdx`.

JS specs: **725 passing, 0 failing** across the utilities and models suites, including six new
cases covering `spectrumName` and the uuid/`meta.TITLE` path. The full suite and eslint could not
be run locally — the dev container's `node_modules` predates `dd1852208d` — so both are left to CI.

## Still open, deliberately not in this PR

A 1D source-backed spectrum keeps its `data` since #3421, where `main` previously dropped it. On
a real exported file that is 2 479 054 of 2 585 504 bytes — 96% of the payload, a ~24× increase
per spectrum, against the Shrine upload cap #3421 cites as its own rationale. Reversing it means
changing a spec that asserts the current behaviour, so it belongs in its own change.
