### PR TITLE
refactor(mixtures): improve reference amount handling

### DIFF
--- a/app/assets/stylesheets/components/SampleComponentsGroup.scss
+++ b/app/assets/stylesheets/components/SampleComponentsGroup.scss
@@ -25,6 +25,18 @@
   .col-total-conc { width: 16%; }
   .col-purity { width: 4%; }
 
+  // Delete cell sits at the end of each row. Give the trash button some room on
+  // its left (it would otherwise butt against the previous column) and trim the
+  // button padding so it stays compact, matching the reaction scheme.
+  .component-delete-cell {
+    vertical-align: top;
+    padding-left: 0.5rem;
+  }
+
+  .component-delete-btn.btn {
+    padding: 0.15rem 0.4rem;
+  }
+
   // Total concentration cell: lock button next to a growing input.
   .total-conc-cell {
     vertical-align: top;

--- a/app/javascript/src/apps/mydb/elements/details/NumeralInputWithUnitsCompo.js
+++ b/app/javascript/src/apps/mydb/elements/details/NumeralInputWithUnitsCompo.js
@@ -106,6 +106,11 @@ export default class NumeralInputWithUnitsCompo extends Component {
   }
 
   _handleInputValueBlur() {
+    // Let the parent flush any pending (e.g. debounced) onChange before we reset the
+    // display to props.value below. This runs first so a value still sitting in a
+    // debounce is committed to the model on blur instead of being dropped.
+    if (this.props.onBlur) this.props.onBlur();
+
     const { value } = this.props;
     const { metricPrefix } = this.state;
     this.setState({
@@ -312,6 +317,7 @@ export default class NumeralInputWithUnitsCompo extends Component {
 NumeralInputWithUnitsCompo.propTypes = {
   className: PropTypes.string,
   onChange: PropTypes.func,
+  onBlur: PropTypes.func,
   onMetricsChange: PropTypes.func,
   unit: PropTypes.string,
   units: PropTypes.array,
@@ -332,6 +338,7 @@ NumeralInputWithUnitsCompo.propTypes = {
 
 NumeralInputWithUnitsCompo.defaultProps = {
   className: '',
+  onBlur: null,
   unit: 'n',
   value: 0,
   units: [],

--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/Material.js
@@ -144,6 +144,12 @@ class Material extends Component {
     }
   }
 
+  componentWillUnmount() {
+    // Drop any pending debounced amount edit so it can't fire after unmount.
+    // Blur already flushes real edits, so cancelling here loses nothing.
+    this.debounceHandleAmountUnitChange.cancel();
+  }
+
   handleMaterialClick(sample) {
     const { reaction } = this.props;
     const isSbmm = isSbmmSample(sample);
@@ -1160,6 +1166,7 @@ class Material extends Component {
               || material.gas_type === 'gas'
             }
             onChange={(e) => this.debounceHandleAmountUnitChange(e, material.amount_g, material.amountType)}
+            onBlur={() => this.debounceHandleAmountUnitChange.flush()}
             onMetricsChange={this.handleMetricsChange}
             active={material.amount_unit === 'g'}
             isError={material.error_mass}

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleComponent.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleComponent.js
@@ -176,6 +176,9 @@ class SampleComponent extends Component {
 
   componentWillUnmount() {
     ComponentStore.unlisten(this.onComponentStoreChange);
+    // Drop any pending debounced amount edit so it can't fire after unmount.
+    // Blur already flushes real edits, so cancelling here loses nothing.
+    this.debounceHandleAmountChange.cancel();
   }
 
   /**
@@ -467,6 +470,7 @@ class SampleComponent extends Component {
           precision={3}
           disabled={!permitOn(sample)}
           onChange={(e) => this.debounceHandleAmountChange(e, material.amount_l, '', false)}
+          onBlur={() => this.debounceHandleAmountChange.flush()}
           onMetricsChange={this.handleMetricsChange}
           variant="light"
           active={material.amount_unit === 'l'}
@@ -504,6 +508,7 @@ class SampleComponent extends Component {
             precision={4}
             disabled={!permitOn(sample) || lockAmountColumnSolids}
             onChange={(e) => this.debounceHandleAmountChange(e, material.amount_g, '', lockAmountColumnSolids)}
+            onBlur={() => this.debounceHandleAmountChange.flush()}
             onMetricsChange={this.handleMetricsChange}
             active={material.amount_unit === 'g'}
             isError={material.error_mass}
@@ -545,6 +550,7 @@ class SampleComponent extends Component {
               precision={4}
               disabled={!permitOn(sample)}
               onChange={(e) => this.debounceHandleAmountChange(e, material.amount_mol, '', false)}
+              onBlur={() => this.debounceHandleAmountChange.flush()}
               onMetricsChange={this.handleMetricsChange}
               variant="light"
               active={material.amount_unit === 'mol'}

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleComponent.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleComponent.js
@@ -15,6 +15,7 @@ import { permitCls, permitOn } from 'src/components/common/uis';
 import ElementActions from 'src/stores/alt/actions/ElementActions';
 import { aviatorNavigation } from 'src/utilities/routesUtils';
 import SvgWithPopover from 'src/components/common/SvgWithPopover';
+import DeleteButton from 'src/components/common/DeleteButton';
 import ComponentStore from 'src/stores/alt/stores/ComponentStore';
 import ComponentActions from 'src/stores/alt/actions/ComponentActions';
 import { StoreContext } from 'src/stores/mobx/RootStore';
@@ -550,6 +551,25 @@ class SampleComponent extends Component {
   }
 
   /**
+   * Renders the delete button cell for a component row.
+   * @param {Object} material - The material object
+   * @returns {JSX.Element} The delete button cell
+   */
+  renderDeleteButton(material) {
+    const { sample, deleteMaterial } = this.props;
+
+    return (
+      <td className="component-delete-cell">
+        <DeleteButton
+          className="component-delete-btn"
+          disabled={!permitOn(sample)}
+          onClick={() => deleteMaterial(material)}
+        />
+      </td>
+    );
+  }
+
+  /**
    * Renders the ratio input for a component.
    * @param {Object} material - The material object
    * @returns {JSX.Element} The ratio input cell
@@ -713,7 +733,7 @@ class SampleComponent extends Component {
    */
   mixtureComponent(props, style) {
     const {
-      sample, material, deleteMaterial, connectDragSource, connectDropTarget, activeTab, enableComponentPurity
+      sample, material, connectDragSource, connectDropTarget, activeTab, enableComponentPurity
     } = props;
     const metricMol = getMetricMol(material);
     const metricMolConc = getMetricMolConc(material);
@@ -729,17 +749,6 @@ class SampleComponent extends Component {
 
         <td style={{ width: '10%', maxWidth: '50px', cursor: 'pointer' }}>
           {this.materialNameWithIupac(material)}
-        </td>
-
-        <td style={{ verticalAlign: 'top' }}>
-          <Button
-            disabled={!permitOn(sample)}
-            variant="danger"
-            size="sm"
-            onClick={() => deleteMaterial(material)}
-          >
-            <i className="fa fa-trash-o" />
-          </Button>
         </td>
 
         {activeTab === 'concentration' && this.componentStartingConc(material, metricMolConc, metricPrefixesMolConc)}
@@ -767,6 +776,8 @@ class SampleComponent extends Component {
             </td>
           )
         }
+
+        {this.renderDeleteButton(material)}
       </tr>
     );
   }
@@ -779,7 +790,7 @@ class SampleComponent extends Component {
    */
   solidComponent(props, style) {
     const {
-      sample, material, deleteMaterial, connectDragSource, connectDropTarget, enableComponentPurity
+      sample, material, connectDragSource, connectDropTarget, enableComponentPurity
     } = props;
     const metricPrefixes = ['m', 'n', 'u'];
     const metric = (material.metrics && material.metrics.length > 2 && metricPrefixes.indexOf(material.metrics[0]) > -1) ? material.metrics[0] : 'm';
@@ -799,16 +810,6 @@ class SampleComponent extends Component {
           {this.materialNameWithIupac(material)}
         </td>
 
-        <td style={{ verticalAlign: 'top' }}>
-          <Button
-            disabled={!permitOn(sample)}
-            variant="danger"
-            size="sm"
-            onClick={() => deleteMaterial(material)}
-          >
-            <i className="fa fa-trash-o" />
-          </Button>
-        </td>
         <td />
 
         <td
@@ -837,6 +838,8 @@ class SampleComponent extends Component {
             </td>
           )
         }
+
+        {this.renderDeleteButton(material)}
       </tr>
     );
   }

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleComponent.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleComponent.js
@@ -8,6 +8,7 @@ import {
 } from 'react-bootstrap';
 import { DragSource, DropTarget } from 'react-dnd';
 import { compose } from 'redux';
+import { debounce } from 'lodash';
 import { DragDropItemTypes } from 'src/utilities/DndConst';
 import NumeralInputWithUnitsCompo from 'src/apps/mydb/elements/details/NumeralInputWithUnitsCompo';
 import Sample from 'src/models/Sample';
@@ -156,6 +157,10 @@ class SampleComponent extends Component {
 
     this.onComponentStoreChange = this.onComponentStoreChange.bind(this);
     this.handleAmountChange = this.handleAmountChange.bind(this);
+    // Debounce amount/volume/mass edits so multi-digit typing (e.g. "10") settles before
+    // the value propagates to the model, matching the reaction scheme (Material.js).
+    // The input shows the typed text immediately; only the model update waits.
+    this.debounceHandleAmountChange = debounce(this.handleAmountChange, 500);
     this.handleMetricsChange = this.handleMetricsChange.bind(this);
     this.handleDensityChange = this.handleDensityChange.bind(this);
     this.handlePurityChange = this.handlePurityChange.bind(this);
@@ -461,7 +466,7 @@ class SampleComponent extends Component {
           metricPrefixes={metricPrefixes}
           precision={3}
           disabled={!permitOn(sample)}
-          onChange={(e) => this.handleAmountChange(e, material.amount_l, '', false)}
+          onChange={(e) => this.debounceHandleAmountChange(e, material.amount_l, '', false)}
           onMetricsChange={this.handleMetricsChange}
           variant="light"
           active={material.amount_unit === 'l'}
@@ -498,7 +503,7 @@ class SampleComponent extends Component {
             metricPrefixes={metricPrefixes}
             precision={4}
             disabled={!permitOn(sample) || lockAmountColumnSolids}
-            onChange={(e) => this.handleAmountChange(e, material.amount_g, '', lockAmountColumnSolids)}
+            onChange={(e) => this.debounceHandleAmountChange(e, material.amount_g, '', lockAmountColumnSolids)}
             onMetricsChange={this.handleMetricsChange}
             active={material.amount_unit === 'g'}
             isError={material.error_mass}
@@ -539,7 +544,7 @@ class SampleComponent extends Component {
               metricPrefixes={metricPrefixesMol}
               precision={4}
               disabled={!permitOn(sample)}
-              onChange={(e) => this.handleAmountChange(e, material.amount_mol, '', false)}
+              onChange={(e) => this.debounceHandleAmountChange(e, material.amount_mol, '', false)}
               onMetricsChange={this.handleMetricsChange}
               variant="light"
               active={material.amount_unit === 'mol'}

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleComponentsGroup.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleComponentsGroup.js
@@ -164,7 +164,6 @@ class SampleComponentsGroup extends React.Component {
           <colgroup>
             <col className="col-drag" />
             <col className="col-name" />
-            <col className="col-delete" />
             <col className="col-stock-density" />
             <col className="col-volume" />
             <col className="col-amount" />
@@ -172,12 +171,12 @@ class SampleComponentsGroup extends React.Component {
             <col className="col-ref" />
             <col className="col-total-conc" />
             {enableComponentPurity && <col className="col-purity" />}
+            <col className="col-delete" />
           </colgroup>
           <thead>
           <tr>
             <th/>
             <th>{headers.group}</th>
-            <th/>
             {materialGroup === 'solid' && <th/>}
             {materialGroup === 'solid' && (
               <th style={{padding: '3px 3px'}}>
@@ -216,6 +215,7 @@ class SampleComponentsGroup extends React.Component {
               </OverlayTrigger>
             </th>
             {enableComponentPurity && <th>{headers.purity}</th>}
+            <th/>
           </tr>
           </thead>
           <tbody>

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsComponents.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsComponents.js
@@ -333,8 +333,9 @@ export default class SampleDetailsComponents extends React.Component {
     const isReferenceComponent = referenceComponent && referenceComponent.id === sampleID;
 
     if (isReferenceComponent) {
-      // Reference changed → refresh every component ratio
-      sample.updateMixtureComponentEquivalent();
+      // Reference amount changed → fill/scale the other components from it. The amount
+      // input is debounced (SampleComponent), so this fires once with the settled value.
+      sample.updateMixtureComponentsFromReferenceAmount();
     } else if (referenceComponent) {
       // Non-reference changed → only update its own equivalent against the reference
       currentComponent.updateRatioFromReference(referenceComponent);

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsComponents.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleDetailsComponents.js
@@ -360,8 +360,18 @@ export default class SampleDetailsComponents extends React.Component {
 
     currentComponent.handleDensityChange(amount, lockColumn);
 
-    // update components ratio
-    sample.updateMixtureComponentEquivalent();
+    const referenceComponent = sample.reference_component;
+    const isReferenceComponent = referenceComponent && referenceComponent.id === sampleID;
+
+    if (isReferenceComponent) {
+      // A density edit can give the reference an amount (volume + density), just like a
+      // reference amount change → fill/scale the other components from it so a typed ratio
+      // on an amount-less component fills in its amount instead of collapsing to 0.
+      sample.updateMixtureComponentsFromReferenceAmount();
+    } else {
+      // Non-reference (or no reference set) → recompute ratios from amounts.
+      sample.updateMixtureComponentEquivalent();
+    }
 
     // update sample total mass for the reaction scheme
     sample.calculateTotalMixtureMass();

--- a/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
+++ b/app/javascript/src/apps/mydb/elements/details/samples/propertiesTab/SampleForm.js
@@ -93,9 +93,9 @@ export default class SampleForm extends React.Component {
 
     return (
       <Form.Check
-        className={className}
+        className={`${className} d-inline-flex align-items-center gap-2`}
         style={{ margin: 0 }}
-        type="checkbox"
+        type="switch"
         id={id}
         checked={isChecked}
         onChange={() => this.handleToggle(key)}

--- a/app/javascript/src/models/Component.js
+++ b/app/javascript/src/models/Component.js
@@ -543,6 +543,33 @@ export default class Component extends Sample {
     this.calculateTargetConcentration(totalVolume);
   }
 
+  /**
+   * Re-applies an already-set ratio after the reference amount changes, deriving
+   * amount = ratio * referenceMoles and refreshing volume/mass and concentration.
+   *
+   * Unlike updateRatio, there is no early return when the ratio is unchanged: the
+   * caller is reacting to a reference-amount change, so the amount must be
+   * recomputed even though the equivalent stays the same (e.g. a ratio typed while
+   * the reference had no amount must now produce a real amount).
+   * @param {number} ratio - The existing equivalent ratio to keep.
+   * @param {number} referenceMoles - Amount in mol of the reference component.
+   * @param {number} totalVolume - Total mixture volume.
+   */
+  updateAmountFromRatio(ratio, referenceMoles, totalVolume) {
+    const purity = this.purity || 1.0;
+
+    this.amount_mol = ratio * referenceMoles;
+    this.equivalent = ratio;
+
+    if (this.material_group === 'liquid') {
+      this.calculateVolumeForLiquid(purity);
+    } else if (this.material_group === 'solid') {
+      this.calculateMassFromAmount(purity);
+    }
+
+    this.calculateTargetConcentration(totalVolume);
+  }
+
   // Case 1(Solids): Mass given -> Calculate Amount
 
   /**

--- a/app/javascript/src/models/Sample.js
+++ b/app/javascript/src/models/Sample.js
@@ -2441,15 +2441,71 @@ export default class Sample extends Element {
 
     // Set equivalent for each component
     this.components.forEach((component, index) => {
-      if (!referenceMol || Number.isNaN(referenceMol)) {
-        component.equivalent = index === referenceIndex ? 1 : 'n.d';
-      } else if (index === referenceIndex) {
+      if (index === referenceIndex) {
         component.equivalent = 1;
+      } else if (!referenceMol || Number.isNaN(referenceMol)) {
+        // The reference has no amount, so the ratio cannot be derived from amounts.
+        // Preserve a user-entered numeric ratio; only fall back to 'n.d' when the
+        // component has no meaningful ratio yet.
+        const currentEq = component.equivalent;
+        const hasNumericEq = typeof currentEq === 'number' && !Number.isNaN(currentEq);
+        component.equivalent = hasNumericEq ? currentEq : 'n.d';
       } else {
         const currentMol = component.amount_mol ?? 0;
         component.equivalent = currentMol && !Number.isNaN(currentMol)
           ? currentMol / referenceMol
           : 0;
+      }
+    });
+  }
+
+  /**
+   * Recomputes non-reference components after the reference component's own amount
+   * changes.
+   *
+   * Per non-reference component:
+   * - has a typed ratio (numeric equivalent > 0) but NO amount yet → fill the amount
+   *   from the ratio: amount_mol = ratio * referenceAmount, ratio kept. This is the
+   *   case where a ratio was typed while the reference had no amount.
+   * - already has an amount → keep the amount fixed and re-derive the ratio from it
+   *   (matching updateMixtureComponentEquivalent), so a later reference change updates
+   *   the ratio rather than the amount the user already established.
+   *
+   * Falls back to updateMixtureComponentEquivalent when there is no usable reference
+   * amount to scale from.
+   */
+  updateMixtureComponentsFromReferenceAmount() {
+    if (!this.hasComponents()) return;
+
+    const referenceComponent = this.reference_component;
+    const referenceMol = referenceComponent?.amount_mol ?? 0;
+
+    // Without a reference amount, ratios cannot be scaled into amounts; defer to the
+    // ratio-preserving path.
+    if (!referenceComponent || !referenceMol || Number.isNaN(referenceMol)) {
+      this.updateMixtureComponentEquivalent();
+      return;
+    }
+
+    const totalVolume = this.amount_l;
+
+    this.components.forEach((component) => {
+      if (component.id === referenceComponent.id) {
+        component.equivalent = 1;
+        return;
+      }
+
+      const eq = component.equivalent;
+      const hasTypedRatio = typeof eq === 'number' && !Number.isNaN(eq) && eq > 0;
+      const currentMol = component.amount_mol ?? 0;
+      // Fill the amount from the ratio only when the component has a typed ratio and no
+      // amount yet. Once it has an amount, keep the amount and re-derive the ratio.
+      const isRatioDriven = hasTypedRatio && !currentMol;
+
+      if (isRatioDriven) {
+        component.updateAmountFromRatio(eq, referenceMol, totalVolume);
+      } else {
+        component.updateRatioFromReference(referenceComponent);
       }
     });
   }

--- a/app/javascript/src/models/Sample.js
+++ b/app/javascript/src/models/Sample.js
@@ -817,25 +817,44 @@ export default class Sample extends Element {
   }
 
   /**
-   * Updates each component's amount (in mol) based on total mixture mass.
-   * Uses the component's relative molecular weight (relMw) and equivalent (eq) values.
+   * Updates each component's amount (in mol) from the mixture's total mass, using
+   * each component's ratio (equivalent) and its own molar mass.
+   *
+   * The total mass is split across components in proportion to their ratios:
+   *   amount_mol_i = (ratio_i * totalMass) / Σ_j (ratio_j * molar_mass_j)
+   * which keeps the component mole ratios equal to their ratios and conserves the
+   * total mass (Σ amount_mol_i * molar_mass_i === totalMass).
+   *
+   * This is self-contained (ratios + molar masses only), so it also works when the
+   * components have no prior amounts, i.e. when a mass is first entered on a mixture
+   * used as a reaction material.
    * @returns {void}
    */
   updateComponentAmounts() {
     const totalMassG = Number(this.amount_g);
     if (!Number.isFinite(totalMassG) || totalMassG < 0) return;
 
-    (this.components || []).forEach((component) => {
-      const relMw = Number(component.relative_molecular_weight);
-      if (!Number.isFinite(relMw) || relMw <= 0) return;
+    const components = this.components || [];
 
+    const ratioOf = (component) => {
       const isRef = !!component.reference;
-      const eq = Number.isFinite(component.equivalent)
-        ? component.equivalent
-        : (isRef ? 1 : 0);
+      return Number.isFinite(component.equivalent) ? component.equivalent : (isRef ? 1 : 0);
+    };
 
-      const totalMoles = totalMassG / relMw;
-      component.amount_mol = isRef ? totalMoles : totalMoles * eq;
+    // Weighted molar-mass sum: Σ (ratio_j * molar_mass_j).
+    const weightedMolarMass = components.reduce((sum, component) => {
+      const molarMass = Number(component.molecule_molecular_weight);
+      if (!Number.isFinite(molarMass) || molarMass <= 0) return sum;
+      return sum + (ratioOf(component) * molarMass);
+    }, 0);
+
+    if (!(weightedMolarMass > 0)) return;
+
+    components.forEach((component) => {
+      const molarMass = Number(component.molecule_molecular_weight);
+      if (!Number.isFinite(molarMass) || molarMass <= 0) return;
+
+      component.amount_mol = (ratioOf(component) * totalMassG) / weightedMolarMass;
     });
   }
 

--- a/app/javascript/src/models/Sample.js
+++ b/app/javascript/src/models/Sample.js
@@ -817,17 +817,22 @@ export default class Sample extends Element {
   }
 
   /**
-   * Updates each component's amount (in mol) from the mixture's total mass, using
-   * each component's ratio (equivalent) and its own molar mass.
+   * Updates each component's amount (in mol) from the mixture's total mass, using its
+   * ratio (equivalent) and its own molar mass.
    *
    * The total mass is split across components in proportion to their ratios:
    *   amount_mol_i = (ratio_i * totalMass) / Σ_j (ratio_j * molar_mass_j)
    * which keeps the component mole ratios equal to their ratios and conserves the
    * total mass (Σ amount_mol_i * molar_mass_i === totalMass).
    *
+   * The split is only performed when every component has a KNOWN ratio and a usable molar
+   * mass. An 'n.d' (unknown) ratio means the composition is unknown, not zero, so the
+   * amounts are left unchanged rather than silently assigning that component 0 moles and
+   * reallocating its share to the others.
+   *
    * This is self-contained (ratios + molar masses only), so it also works when the
-   * components have no prior amounts, i.e. when a mass is first entered on a mixture
-   * used as a reaction material.
+   * components have no prior amounts, i.e. when a mass is first entered on a mixture used
+   * as a reaction material.
    * @returns {void}
    */
   updateComponentAmounts() {
@@ -835,26 +840,33 @@ export default class Sample extends Element {
     if (!Number.isFinite(totalMassG) || totalMassG < 0) return;
 
     const components = this.components || [];
+    if (components.length === 0) return;
 
     const ratioOf = (component) => {
       const isRef = !!component.reference;
       return Number.isFinite(component.equivalent) ? component.equivalent : (isRef ? 1 : 0);
     };
+    const molarMassOf = (component) => Number(component.molecule_molecular_weight);
+
+    // Bail when any component's composition is unknown: an 'n.d' (non-numeric) ratio or a
+    // missing/invalid molar mass makes the distribution indeterminate, so we must not
+    // silently assign that component 0 moles and reallocate its share to the others.
+    const hasUnknownComposition = components.some((component) => {
+      const ratioKnown = !!component.reference || Number.isFinite(component.equivalent);
+      const molarMass = molarMassOf(component);
+      return !ratioKnown || !Number.isFinite(molarMass) || molarMass <= 0;
+    });
+    if (hasUnknownComposition) return;
 
     // Weighted molar-mass sum: Σ (ratio_j * molar_mass_j).
-    const weightedMolarMass = components.reduce((sum, component) => {
-      const molarMass = Number(component.molecule_molecular_weight);
-      if (!Number.isFinite(molarMass) || molarMass <= 0) return sum;
-      return sum + (ratioOf(component) * molarMass);
-    }, 0);
-
-    if (!(weightedMolarMass > 0)) return;
+    const weighted = components.reduce(
+      (sum, component) => sum + (ratioOf(component) * molarMassOf(component)),
+      0
+    );
+    if (!(weighted > 0)) return;
 
     components.forEach((component) => {
-      const molarMass = Number(component.molecule_molecular_weight);
-      if (!Number.isFinite(molarMass) || molarMass <= 0) return;
-
-      component.amount_mol = (ratioOf(component) * totalMassG) / weightedMolarMass;
+      component.amount_mol = (ratioOf(component) * totalMassG) / weighted;
     });
   }
 

--- a/spec/javascripts/packs/src/models/Sample.spec.js
+++ b/spec/javascripts/packs/src/models/Sample.spec.js
@@ -314,6 +314,59 @@ describe('Sample', async () => {
     });
   });
 
+  describe('Sample.updateComponentAmounts()', () => {
+    // icosane (ref, ratio 1, MW 282.55) + octane (ratio 2, MW 114.23)
+    const buildMixture = (totalMassG) => {
+      const s = new Sample();
+      s.sample_type = 'Mixture';
+
+      const ref = new Component({});
+      ref.reference = true;
+      ref.material_group = 'solid';
+      ref.molecule = { molecular_weight: 282.55 };
+      ref.equivalent = 1;
+      ref.component_properties = {};
+
+      const other = new Component({});
+      other.reference = false;
+      other.material_group = 'solid';
+      other.molecule = { molecular_weight: 114.23 };
+      other.equivalent = 2;
+      other.component_properties = {};
+
+      s.initialComponents([ref, other]);
+      s.amount_value = totalMassG;
+      s.amount_unit = 'g';
+      return { s, ref, other };
+    };
+
+    it('distributes the total mass into component amounts by ratio and molar mass', () => {
+      const { s, ref, other } = buildMixture(1); // 1 g total
+      const denom = (1 * 282.55) + (2 * 114.23); // Σ ratio * molar mass
+      s.updateComponentAmounts();
+      expect(ref.amount_mol).toBeCloseTo(1 / denom, 9);
+      expect(other.amount_mol).toBeCloseTo(2 / denom, 9);
+    });
+
+    it('conserves the total mass across the components', () => {
+      const { s, ref, other } = buildMixture(0.5); // 0.5 g total
+      s.updateComponentAmounts();
+      const massBack = (ref.amount_mol * 282.55) + (other.amount_mol * 114.23);
+      expect(massBack).toBeCloseTo(0.5, 9);
+    });
+
+    it('works from zero prior amounts (no dependence on relative_molecular_weight)', () => {
+      const { s, ref, other } = buildMixture(1);
+      // Components start with no amounts / no relative MW, as when a mass is first
+      // entered on a mixture reaction material.
+      expect(ref.amount_mol == null || ref.amount_mol === 0).toBe(true);
+      s.updateComponentAmounts();
+      expect(ref.amount_mol).toBeGreaterThan(0);
+      expect(other.amount_mol).toBeGreaterThan(0);
+      expect(other.amount_mol).toBeCloseTo(ref.amount_mol * 2, 9);
+    });
+  });
+
   describe('Sample.calculateRequiredTotalVolume()', () => {
     let sample;
     let referenceComponent;

--- a/spec/javascripts/packs/src/models/Sample.spec.js
+++ b/spec/javascripts/packs/src/models/Sample.spec.js
@@ -217,6 +217,103 @@ describe('Sample', async () => {
     });
   });
 
+  describe('Sample.updateMixtureComponentEquivalent()', () => {
+    const buildMixture = () => {
+      const s = new Sample();
+      s.sample_type = 'Mixture';
+      const ref = new Component({});
+      ref.reference = true;
+      ref.component_properties = {};
+      const other = new Component({});
+      other.reference = false;
+      other.component_properties = {};
+      s.initialComponents([ref, other]);
+      return { s, ref, other };
+    };
+
+    it('keeps a user-entered ratio when the reference has no amount', () => {
+      const { s, other } = buildMixture();
+      // Reference has amount_mol 0 (no values entered anywhere).
+      other.equivalent = 2;
+      s.updateMixtureComponentEquivalent();
+      expect(other.equivalent).toBe(2);
+    });
+
+    it("marks a non-reference component with no ratio as 'n.d' when the reference has no amount", () => {
+      const { s, other } = buildMixture();
+      other.equivalent = 'n.d';
+      s.updateMixtureComponentEquivalent();
+      expect(other.equivalent).toBe('n.d');
+    });
+
+    it('derives the ratio from amounts when the reference has an amount', () => {
+      const { s, ref, other } = buildMixture();
+      ref.amount_mol = 2;
+      other.amount_mol = 1;
+      s.updateMixtureComponentEquivalent();
+      expect(other.equivalent).toBeCloseTo(0.5, 6);
+    });
+  });
+
+  describe('Sample.updateMixtureComponentsFromReferenceAmount()', () => {
+    const buildMixture = () => {
+      const s = new Sample();
+      s.sample_type = 'Mixture';
+      const ref = new Component({});
+      ref.reference = true;
+      ref.material_group = 'liquid';
+      ref.component_properties = {};
+      const other = new Component({});
+      other.reference = false;
+      other.material_group = 'liquid';
+      other.component_properties = {};
+      s.initialComponents([ref, other]);
+      return { s, ref, other };
+    };
+
+    it('fills in the amount from the ratio when the component has no amount yet', () => {
+      const { s, ref, other } = buildMixture();
+      // User typed a ratio while the reference had no amount; component amount is 0.
+      other.equivalent = 2;
+      other.amount_mol = 0;
+      // Now the reference amount is entered.
+      ref.amount_mol = 10;
+      s.updateMixtureComponentsFromReferenceAmount();
+      expect(other.equivalent).toBe(2);
+      expect(other.amount_mol).toBeCloseTo(20, 6);
+    });
+
+    it('keeps an existing amount fixed and re-derives its ratio when the reference amount changes', () => {
+      const { s, ref, other } = buildMixture();
+      // Component already has its own amount (20 mmol) and ratio 2 vs reference 10 mmol.
+      other.equivalent = 2;
+      other.amount_mol = 20;
+      // Change reference 10 -> 20 mmol; amount stays 20, ratio re-derived (20/20 = 1).
+      ref.amount_mol = 20;
+      s.updateMixtureComponentsFromReferenceAmount();
+      expect(other.amount_mol).toBeCloseTo(20, 6);
+      expect(other.equivalent).toBeCloseTo(1, 6);
+    });
+
+    it('re-derives the ratio (and keeps the amount) for a component with no ratio yet', () => {
+      const { s, ref, other } = buildMixture();
+      other.equivalent = 'n.d';
+      other.amount_mol = 4;
+      ref.amount_mol = 8;
+      s.updateMixtureComponentsFromReferenceAmount();
+      expect(other.amount_mol).toBeCloseTo(4, 6);
+      expect(other.equivalent).toBeCloseTo(0.5, 6);
+    });
+
+    it('preserves a typed ratio when the reference still has no amount', () => {
+      const { s, ref, other } = buildMixture();
+      other.equivalent = 3;
+      ref.amount_mol = 0;
+      s.updateMixtureComponentsFromReferenceAmount();
+      expect(other.equivalent).toBe(3);
+    });
+  });
+
   describe('Sample.calculateRequiredTotalVolume()', () => {
     let sample;
     let referenceComponent;

--- a/spec/javascripts/packs/src/models/Sample.spec.js
+++ b/spec/javascripts/packs/src/models/Sample.spec.js
@@ -312,6 +312,26 @@ describe('Sample', async () => {
       s.updateMixtureComponentsFromReferenceAmount();
       expect(other.equivalent).toBe(3);
     });
+
+    it('materialises a ratio-driven amount when the reference amount appears via a density edit', () => {
+      const { s, ref, other } = buildMixture();
+      // Reference is a liquid with a volume but no amount yet; the other component has a
+      // typed ratio and no amount.
+      ref.material_group = 'liquid';
+      ref.molecule = { molecular_weight: 100 };
+      ref.amount_l = 0.001; // 1 mL
+      ref.amount_mol = 0;
+      other.equivalent = 2;
+      other.amount_mol = 0;
+
+      // Density edit derives the reference amount from volume + density.
+      ref.handleDensityChange({ value: 0.8, unit: 'g/ml' }, false);
+      expect(ref.amount_mol).toBeGreaterThan(0);
+
+      s.updateMixtureComponentsFromReferenceAmount();
+      expect(other.equivalent).toBe(2);
+      expect(other.amount_mol).toBeCloseTo(ref.amount_mol * 2, 9);
+    });
   });
 
   describe('Sample.updateComponentAmounts()', () => {
@@ -364,6 +384,14 @@ describe('Sample', async () => {
       expect(ref.amount_mol).toBeGreaterThan(0);
       expect(other.amount_mol).toBeGreaterThan(0);
       expect(other.amount_mol).toBeCloseTo(ref.amount_mol * 2, 9);
+    });
+
+    it('does not mutate amounts when a ratio is unknown (n.d)', () => {
+      const { s, ref, other } = buildMixture(1);
+      other.equivalent = 'n.d'; // composition unknown, not zero
+      s.updateComponentAmounts();
+      expect(ref.amount_mol == null || ref.amount_mol === 0).toBe(true);
+      expect(other.amount_mol == null || other.amount_mol === 0).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Improvements to how mixture samples behave, both in the sample detail (Properties tab) and when a mixture is used as a reaction material.

Three related changes:

1. **Ratio (equivalent) now persists and can drive amounts.** Previously a ratio typed
   on a non-reference component was silently reset to `n.d.` on save when the reference
   component had no amount, because the ratio was always re-derived from amounts.
2. **Entering a mass on a mixture distributes it across the components.** A mixture used
   as a reaction material now splits an entered mass into each component's
   `amount_mol` from the ratios and molar masses.
3. **Component-row UI cleanup.** Delete button moved to the end of each row and the
   "Enable purity" control is now a toggle switch.

## Details

### 1. Ratio persistence and ratio-driven amounts
- `Sample.updateMixtureComponentEquivalent()` no longer force-overwrites a non-reference
  ratio to `'n.d'` when the reference has no amount. A user-entered numeric ratio is kept;
  only untouched components fall back to `'n.d'`.
- New `Sample.updateMixtureComponentsFromReferenceAmount()`: when the reference amount is
  entered/changed, a component that has a typed ratio **but no amount yet** gets its
  amount filled in as `ratio × referenceAmount` (ratio preserved). Components that already
  have their own amount are left untouched and only have their ratio re-derived, so
  directly-entered amounts are never rescaled.
- New `Component.updateAmountFromRatio()` re-applies an existing ratio to compute the
  amount (no early-return guard, unlike `updateRatio`).

### 2. Mass-to-component distribution
- `Sample.updateComponentAmounts()` rewritten to be self-contained:
  `amount_mol_i = (ratio_i × totalMass) / Σ_j(ratio_j × molar_mass_j)`.
  The previous implementation divided by each component's `relative_molecular_weight`,
  which is derived from existing amounts and is `0` before any amount is entered, so mass
  entry produced nothing. The new formula uses ratios and molar masses only, conserves
  total mass (`Σ amount_mol_i × molar_mass_i === totalMass`), and keeps the mole ratios
  equal to the entered ratios. The reaction Scheme already calls this via
  `updateMixtureComponentAmounts()` on amount change.

### 3. UI
- Delete button moved from just after the component name to the end of each row (matches
  the reaction scheme), with left spacing and tighter padding.
- "Enable purity" checkbox is now a Bootstrap toggle switch.

## Testing
- Added unit specs in `spec/javascripts/packs/src/models/Sample.spec.js` covering:
  - ratio preserved with a zero-amount reference; `n.d.` for untouched components; ratio
    derived when the reference has an amount;
  - reference-amount entry fills a zero-amount ratio-driven component; existing amounts are
    not rescaled;
  - mass distributed by ratio × molar mass; mass conserved; works from zero prior amounts.
- Full JS suite passing locally (1708 examples).

## Checklist
- [x] added code is linted
- [x] tests are passing locally