### PR TITLE
fix: keep the line break at the end of a saved template

### DIFF
--- a/app/javascript/src/apps/userSettings/TextTemplates.js
+++ b/app/javascript/src/apps/userSettings/TextTemplates.js
@@ -9,6 +9,9 @@ import UserActions from 'src/stores/alt/actions/UserActions';
 import UserStore from 'src/stores/alt/stores/UserStore';
 import TextTemplateActions from 'src/stores/alt/actions/TextTemplateActions';
 
+// the editor keeps one closing line break of its own; save strips it, so add it back here
+const asEditorValue = (data) => ({ ...data, ops: [...(data?.ops || []), { insert: '\n' }] });
+
 function TemplateListItem({ name, selected, onSelect, onRemove, readOnly }) {
   return (
     <div
@@ -46,6 +49,7 @@ class TemplateEditPanel extends React.Component {
       name: props.template?.name ?? '',
       text: props.template?.data?.text ?? '',
       icon: props.template?.data?.icon ?? '',
+      editorValue: asEditorValue(props.template?.data),
     };
 
     this.reactQuillRef = React.createRef();
@@ -58,6 +62,7 @@ class TemplateEditPanel extends React.Component {
         name: template?.name ?? '',
         text: template?.data?.text ?? '',
         icon: template?.data?.icon ?? '',
+        editorValue: asEditorValue(template?.data),
       });
     }
   }
@@ -87,7 +92,7 @@ class TemplateEditPanel extends React.Component {
 
   render() {
     const { template, readOnly } = this.props;
-    const { name, text, icon } = this.state;
+    const { name, text, icon, editorValue } = this.state;
 
     const previewTemplate = {
       ...template,
@@ -161,7 +166,7 @@ class TemplateEditPanel extends React.Component {
               <Form.Label className="fw-medium text-muted small text-uppercase mb-1">Content</Form.Label>
               <QuillEditor
                 ref={this.reactQuillRef}
-                value={template.data}
+                value={editorValue}
                 onChange={() => {}}
                 disabled={readOnly}
               />


### PR DESCRIPTION
A blank line at the end of a text template was lost on save, and each further save ate one more line.
Fix: add the break back on load, so save and load cancel out.

## Note on location

The issue says Admin → Text Templates. That tab existed in v3.1.2 but is gone in v4; the editor now lives in user settings (profile → Text Templates). Fixed there.

-------

- [x] rather 1-story 1-commit than sub-atomic commits

- [x] commit title is meaningful =>  git history search

- [x] commit description is helpful => helps the reviewer to understand the changes

- [x] code is up-to-date with the latest developments of the target branch (rebased to it or whatever) => :fast_forward:-merge for linear history is favoured

- [x] added code is linted

- [ ] tests are passing (at least locally): we still have some random test failure on CI. thinking of asking spec/examples.txt to be commited

- [ ] in case the changes are visible to the end-user,  video or screenshots should be added to the PR => helps  with user testing

- [ ] testing coverage improvement is improved.

- [ ] CHANGELOG :  add a bullet point on top (optional: reference to github issue/PR )

- [ ] parallele PR for documentation  on docusaurus  if the feature/fix is tagged for a release
