### PR TITLE
fix(attachments): don't wire non-previewable attachments into ImageModal

### DIFF
--- a/app/javascript/src/apps/mydb/elements/list/AttachmentList.js
+++ b/app/javascript/src/apps/mydb/elements/list/AttachmentList.js
@@ -12,20 +12,33 @@ import mime from 'mime-types';
 import SpinnerPencilIcon from 'src/components/common/SpinnerPencilIcon';
 import Dropzone from 'src/components/common/Dropzone';
 import Utils from 'src/utilities/Functions';
-import ImageModal from 'src/components/common/ImageModal';
+import ImageModal, { fileIconClass } from 'src/components/common/ImageModal';
 import ThirdPartyAppFetcher from 'src/fetchers/ThirdPartyAppFetcher';
 import UIStore from 'src/stores/alt/stores/UIStore';
 import EditorFetcher from 'src/fetchers/EditorFetcher';
 import { StoreContext } from 'src/stores/mobx/RootStore';
+import { isPreviewableAttachment } from 'src/utilities/imageHelper';
 
+// Non-image/PDF attachments (e.g. a failed spectral-conversion .zip sibling) have no preview:
+// wiring them into ImageModal anyway would let a click fire GET image/:id, which only knows
+// how to serve images and PDFs and raises for anything else. Show a static file-type icon.
 export const attachmentThumbnail = (attachment) => (
   <div className="attachment-row-image">
-    <ImageModal
-      attachment={attachment}
-      popObject={{
-        title: attachment?.filename,
-      }}
-    />
+    {isPreviewableAttachment(attachment) ? (
+      <ImageModal
+        attachment={attachment}
+        popObject={{
+          title: attachment?.filename,
+        }}
+      />
+    ) : (
+      <div
+        className="preview-table d-flex align-items-center justify-content-center text-body-tertiary"
+        title={attachment?.filename}
+      >
+        <i className={`fa ${fileIconClass(attachment?.filename)} fa-2x`} aria-hidden="true" />
+      </div>
+    )}
   </div>
 );
 

--- a/app/javascript/src/components/common/ImageModal.js
+++ b/app/javascript/src/components/common/ImageModal.js
@@ -18,7 +18,7 @@ const DEFAULT_UNAVAILABLE = '/images/wild_card/not_available.svg';
 const isValidImageSrc = (src) => typeof src === 'string' && src.length > 0;
 
 // Font-awesome icon for an attachment that has no rendered thumbnail, by extension.
-const fileIconClass = (filename) => {
+export const fileIconClass = (filename) => {
   const ext = (filename || '').split('.').pop().toLowerCase();
   if (ext === 'pdf') return 'fa-file-pdf-o';
   if (['doc', 'docx', 'odt'].includes(ext)) return 'fa-file-word-o';

--- a/app/javascript/src/utilities/imageHelper.js
+++ b/app/javascript/src/utilities/imageHelper.js
@@ -132,4 +132,5 @@ export {
   fetchImageSrcByAttachmentId,
   getAttachmentFromContainer,
   getContainerImageData,
+  isPreviewableAttachment,
 };


### PR DESCRIPTION
## Summary
- `attachmentThumbnail()` wrapped every attachment row - including non-image/non-PDF ones (e.g. a failed spectral-conversion `.zip` sibling created alongside an uploaded file) - in a clickable `ImageModal` whose click handler unconditionally calls `GET /api/v1/attachments/image/:id`.
- That endpoint (`Usecases::Attachments::LoadImage.execute!`) only knows how to serve images and PDFs and raises a `RuntimeError` for anything else. The exception is unrescued server-side (logged/reported as an unhandled 500) while the frontend silently swallows the failed fetch, so the user sees a generic "not available" placeholder with no indication anything went wrong - easy to trigger by hovering/clicking the wrong row in a file list.
- Reuses the existing `isPreviewableAttachment` check (already used to filter the analysis carousel's candidates) to render a static file-type icon for non-previewable attachments instead of a clickable modal that's guaranteed to fail.
- Since `attachmentThumbnail` is shared, this covers all 6 call sites: wellplate, research plan, SBMM, generic element, and dataset-modal attachment tabs.

## Test plan
- [x] `yarn eslint` clean on the three touched files (pre-existing warnings elsewhere in `AttachmentList.js` are untouched)
- [x] webpack dev server recompiles the bundle successfully with the change
- [ ] Manually verify in the browser: a non-image/PDF attachment (e.g. a `.zip`) now shows a static archive icon instead of a clickable preview; images and PDFs still preview normally