### PR TITLE
fix(history): fix extended_metadata diffs in the History tab

### DIFF
--- a/app/services/versioning/serializers/base_serializer.rb
+++ b/app/services/versioning/serializers/base_serializer.rb
@@ -24,8 +24,18 @@ module Versioning
             changes_comparison_hash = {} # hash for changes comparison
             revertible = changes.none? { |key, _v| key == 'created_at' }
             changes.each do |key, value|
-              next if value == base[key] # ignore if value is same as in last version
-              next if blank?(base[key]) && blank?(value) # ignore if value is empty
+              previous_value = base[key]
+
+              # Deep-merge hash-valued changes (e.g. extended_metadata) instead of overwriting them outright.
+              # Logidze's jsonb diff only stores the sub-keys that actually changed in a given version, so
+              # `value` here may be a partial hash - merge it onto the previous full value so both the stored
+              # `base` and the "new" side of the comparison below reflect the complete, current state instead
+              # of losing (or, on the "new" side, spuriously blanking) sub-keys this version didn't touch.
+              value = previous_value.deep_merge(value) if previous_value.is_a?(Hash) && value.is_a?(Hash)
+              base[key] = value
+
+              next if value == previous_value # ignore if value is same as in last version
+              next if blank?(previous_value) && blank?(value) # ignore if value is empty
 
               fields = field_definitions[key]
               next if fields.nil?
@@ -35,10 +45,10 @@ module Versioning
                 formatter = field[:formatter] || default_formatter
                 revertible_value_formatter = field[:revertible_value_formatter] || formatter
 
-                old_value = formatter.call(key, base[key])
+                old_value = formatter.call(key, previous_value)
                 new_value = formatter.call(key, value)
                 current_value = formatter.call(key, record.read_attribute_before_type_cast(key))
-                revertible_value = revertible_value_formatter.call(key, base[key])
+                revertible_value = revertible_value_formatter.call(key, previous_value)
                 next if old_value == new_value # ignore if value is same as in last version
                 next if old_value.blank? && new_value.blank? # ignore if value is empty or nil
 
@@ -53,7 +63,6 @@ module Versioning
                 }
               end
             end
-            base.merge!(changes) # merge changes with last version data for next iteration
             next if changes_comparison_hash.empty?
 
             result << {

--- a/app/services/versioning/serializers/base_serializer.rb
+++ b/app/services/versioning/serializers/base_serializer.rb
@@ -132,6 +132,16 @@ module Versioning
         ->(_key, value) { value }
       end
 
+      # An untouched Quill editor still autosaves a delta like {"ops"=>[{"insert"=>"\n"}]}, which
+      # isn't the same value as nil/{} but is visually just as empty - normalize it so it doesn't
+      # get treated as a real content change in the history view.
+      def quill_formatter
+        lambda do |key, value|
+          parsed = default_formatter.call(key, value)
+          Chemotion::QuillToPlainText.blank_content?(parsed) ? {} : parsed
+        end
+      end
+
       def fix_malformed_value_formatter
         lambda do |key, value|
           if value.is_a?(String) && value.start_with?('{')

--- a/app/services/versioning/serializers/container_serializer.rb
+++ b/app/services/versioning/serializers/container_serializer.rb
@@ -26,69 +26,83 @@ class Versioning::Serializers::ContainerSerializer < Versioning::Serializers::Ba
         label: 'Description',
         revert: %i[description],
       },
-      extended_metadata: [
-        {
-          name: 'extended_metadata.content',
-          label: 'Content',
-          kind: :quill,
-          formatter: lambda { |key, value|
-            value = fix_malformed_value_formatter.call(key, value)
-            parsed = JSON.parse(jsonb_formatter('content').call(key, value) || '{}')
-            # An untouched Quill editor still autosaves a delta like {"ops"=>[{"insert"=>"\n"}]},
-            # which isn't the same JSON value as nil/{} but is visually just as empty - normalize
-            # it so it doesn't get treated as a real content change in the history view.
-            Chemotion::QuillToPlainText.blank_content?(parsed) ? {} : parsed
-          },
-          revert: %i[extended_metadata.content],
-          revertible_value_formatter: lambda { |key, value|
-            value = fix_malformed_value_formatter.call(key, value)
-            jsonb_formatter('content').call(key, value) || '{}'
-          },
-        },
-        # buggy
-        # {
-        #   name: 'extended_metadata.index',
-        #   label: 'Position',
-        #   formatter: jsonb_formatter('index'),
-        # },
-        {
-          name: 'extended_metadata.report',
-          label: 'Add to Report',
-          kind: :boolean,
-          revert: %i[extended_metadata.report],
-          formatter: ->(key, value) { jsonb_formatter('report').call(key, value) == 'true' },
-        },
-        {
-          name: 'extended_metadata.status',
-          label: 'Status',
-          revert: %i[extended_metadata.status],
-          formatter: jsonb_formatter('status'),
-        },
-        {
-          name: 'extended_metadata.kind',
-          label: 'Type',
-          revert: %i[extended_metadata.kind],
-          formatter: jsonb_formatter('kind'),
-        },
-        {
-          name: 'extended_metadata.hyperlinks',
-          label: 'Hyperlinks',
-          formatter: lambda { |key, value|
-            result = jsonb_formatter('hyperlinks').call(key, value)
-            return '' if result.blank?
-
-            JSON.parse(result).join("\n")
-          },
-          revert: %i[extended_metadata.hyperlinks],
-          revertible_value_formatter: ->(key, value) { JSON.parse(jsonb_formatter('hyperlinks').call(key, value) || '[]') },
-        },
-        {
-          name: 'extended_metadata.instrument',
-          label: 'Instrument',
-          revert: %i[extended_metadata.instrument],
-          formatter: jsonb_formatter('instrument'),
-        },
-      ],
+      extended_metadata: extended_metadata_field_definitions,
     }.with_indifferent_access
+  end
+
+  private
+
+  def extended_metadata_field_definitions
+    [
+      content_field_definition,
+      # buggy
+      # {
+      #   name: 'extended_metadata.index',
+      #   label: 'Position',
+      #   formatter: jsonb_formatter('index'),
+      # },
+      {
+        name: 'extended_metadata.report',
+        label: 'Add to Report',
+        kind: :boolean,
+        revert: %i[extended_metadata.report],
+        formatter: ->(key, value) { jsonb_formatter('report').call(key, value) == 'true' },
+      },
+      {
+        name: 'extended_metadata.status',
+        label: 'Status',
+        revert: %i[extended_metadata.status],
+        formatter: jsonb_formatter('status'),
+      },
+      {
+        name: 'extended_metadata.kind',
+        label: 'Type',
+        revert: %i[extended_metadata.kind],
+        formatter: jsonb_formatter('kind'),
+      },
+      hyperlinks_field_definition,
+      {
+        name: 'extended_metadata.instrument',
+        label: 'Instrument',
+        revert: %i[extended_metadata.instrument],
+        formatter: jsonb_formatter('instrument'),
+      },
+    ]
+  end
+
+  def content_field_definition
+    {
+      name: 'extended_metadata.content',
+      label: 'Content',
+      kind: :quill,
+      formatter: lambda { |key, value|
+        value = fix_malformed_value_formatter.call(key, value)
+        parsed = JSON.parse(jsonb_formatter('content').call(key, value) || '{}')
+        # An untouched Quill editor still autosaves a delta like {"ops"=>[{"insert"=>"\n"}]},
+        # which isn't the same JSON value as nil/{} but is visually just as empty - normalize
+        # it so it doesn't get treated as a real content change in the history view.
+        Chemotion::QuillToPlainText.blank_content?(parsed) ? {} : parsed
+      },
+      revert: %i[extended_metadata.content],
+      revertible_value_formatter: lambda { |key, value|
+        value = fix_malformed_value_formatter.call(key, value)
+        jsonb_formatter('content').call(key, value) || '{}'
+      },
+    }
+  end
+
+  def hyperlinks_field_definition
+    {
+      name: 'extended_metadata.hyperlinks',
+      label: 'Hyperlinks',
+      formatter: lambda { |key, value|
+        result = jsonb_formatter('hyperlinks').call(key, value)
+        return '' if result.blank?
+
+        JSON.parse(result).join("\n")
+      },
+      revert: %i[extended_metadata.hyperlinks],
+      revertible_value_formatter: ->(key, value) { JSON.parse(jsonb_formatter('hyperlinks').call(key, value) || '[]') },
+    }
   end
 end

--- a/app/services/versioning/serializers/container_serializer.rb
+++ b/app/services/versioning/serializers/container_serializer.rb
@@ -33,7 +33,11 @@ class Versioning::Serializers::ContainerSerializer < Versioning::Serializers::Ba
           kind: :quill,
           formatter: lambda { |key, value|
             value = fix_malformed_value_formatter.call(key, value)
-            JSON.parse(jsonb_formatter('content').call(key, value) || '{}')
+            parsed = JSON.parse(jsonb_formatter('content').call(key, value) || '{}')
+            # An untouched Quill editor still autosaves a delta like {"ops"=>[{"insert"=>"\n"}]},
+            # which isn't the same JSON value as nil/{} but is visually just as empty - normalize
+            # it so it doesn't get treated as a real content change in the history view.
+            Chemotion::QuillToPlainText.blank_content?(parsed) ? {} : parsed
           },
           revert: %i[extended_metadata.content],
           revertible_value_formatter: lambda { |key, value|

--- a/app/services/versioning/serializers/reaction_serializer.rb
+++ b/app/services/versioning/serializers/reaction_serializer.rb
@@ -63,6 +63,7 @@ class Versioning::Serializers::ReactionSerializer < Versioning::Serializers::Bas
         label: 'Description',
         revert: %i[description],
         kind: :quill,
+        formatter: quill_formatter,
       },
       purification: {
         label: 'Purification',
@@ -72,6 +73,7 @@ class Versioning::Serializers::ReactionSerializer < Versioning::Serializers::Bas
         label: 'Additional information for publication and purification details',
         revert: %i[observation],
         kind: :quill,
+        formatter: quill_formatter,
       },
       duration: {
         label: 'Duration',

--- a/app/services/versioning/serializers/screen_serializer.rb
+++ b/app/services/versioning/serializers/screen_serializer.rb
@@ -35,6 +35,7 @@ class Versioning::Serializers::ScreenSerializer < Versioning::Serializers::BaseS
         label: 'Description',
         kind: :quill,
         revert: %i[description],
+        formatter: quill_formatter,
       },
     }.with_indifferent_access
   end

--- a/app/services/versioning/serializers/screen_serializer.rb
+++ b/app/services/versioning/serializers/screen_serializer.rb
@@ -31,12 +31,18 @@ class Versioning::Serializers::ScreenSerializer < Versioning::Serializers::BaseS
         label: 'Result',
         revert: %i[result],
       },
-      description: {
-        label: 'Description',
-        kind: :quill,
-        revert: %i[description],
-        formatter: quill_formatter,
-      },
+      description: description_field,
     }.with_indifferent_access
+  end
+
+  private
+
+  def description_field
+    {
+      label: 'Description',
+      kind: :quill,
+      revert: %i[description],
+      formatter: quill_formatter,
+    }
   end
 end

--- a/app/services/versioning/serializers/wellplate_serializer.rb
+++ b/app/services/versioning/serializers/wellplate_serializer.rb
@@ -21,6 +21,7 @@ module Versioning
             label: 'Description',
             kind: :quill,
             revert: %i[description],
+            formatter: quill_formatter,
           },
           width: {
             label: 'Width',

--- a/lib/quill_utils.rb
+++ b/lib/quill_utils.rb
@@ -23,6 +23,13 @@ module QuillUtils
     file&.close!
   end
 
+  # desc: whether the quill delta is visually empty (no text was ever typed), without spawning a
+  # nodejs process. Kept public (unlike blank_ops?) for callers that only need the emptiness
+  # check, e.g. deciding whether a content change is worth surfacing as a diff.
+  def blank_content?(content)
+    blank_ops?(content)
+  end
+
   private
 
   # rubocop:disable Style/StringLiterals

--- a/spec/services/versioning/serializers/container_serializer_spec.rb
+++ b/spec/services/versioning/serializers/container_serializer_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Versioning::Serializers::ContainerSerializer do
+  let(:user) { create(:user) }
+  let(:content_before) { '{"ops":[{"insert":"first"}]}' }
+  let(:content_mid) { '{"ops":[{"insert":"second"}]}' }
+  let(:content_after) { '{"ops":[{"insert":"third"}]}' }
+
+  # Each block simulates one HTTP request: LogidzeModule wraps every request in
+  # Logidze.with_responsible!/clear_responsible!, which is what gives each update its own
+  # version uuid so the history view groups them into separate entries.
+  def as_request
+    Logidze.with_responsible!(user.id)
+    yield
+  ensure
+    Logidze.clear_responsible!
+  end
+
+  def edit_metadata(container, changes)
+    container.update!(extended_metadata: container.extended_metadata.merge(changes))
+  end
+
+  def content_changes(container)
+    container_with_log_data = Container.with_log_data.find(container.id)
+    described_class.call(container_with_log_data, 'Dataset')
+                   .flat_map { |entry| entry[:changes]['extended_metadata.content'] }
+                   .compact
+  end
+
+  it 'keeps a sibling extended_metadata sub-key from blanking out an untouched one' do
+    container = create(:container, extended_metadata: { 'content' => content_before })
+    as_request { edit_metadata(container, 'content' => content_mid) }
+    # This version only changes `status`; Logidze's jsonb diff only stores the sub-keys that
+    # actually changed, so it does not mention `content` at all.
+    as_request { edit_metadata(container, 'status' => 'Confirmed') }
+    as_request { edit_metadata(container, 'content' => content_after) }
+
+    # [creation (blank -> content_before), content_before -> content_mid, content_mid -> content_after].
+    # The status-only version contributes no entry of its own, since content didn't change in it.
+    #
+    # Without the deep-merge fix, the intervening status-only version wipes out the previously
+    # known content from the running "base" state, so the last old_value would come back {}.
+    expect(content_changes(container).map { |change| [change[:old_value], change[:new_value]] }).to eq(
+      [
+        [{}, JSON.parse(content_before)],
+        [JSON.parse(content_before), JSON.parse(content_mid)],
+        [JSON.parse(content_mid), JSON.parse(content_after)],
+      ],
+    )
+  end
+end

--- a/spec/services/versioning/serializers/container_serializer_spec.rb
+++ b/spec/services/versioning/serializers/container_serializer_spec.rb
@@ -50,4 +50,23 @@ RSpec.describe Versioning::Serializers::ContainerSerializer do
       ],
     )
   end
+
+  it 'does not surface a diff when the editor autosaves its empty-delta placeholder' do
+    # A Quill editor that nobody typed into still autosaves {"ops":[{"insert":"\n"}]} - visually
+    # empty, but not the same JSON value as the nil the container started with.
+    container = create(:container, extended_metadata: {})
+    as_request { edit_metadata(container, 'content' => '{"ops":[{"insert":"\n"}]}') }
+
+    expect(content_changes(container)).to be_empty
+  end
+
+  it 'still surfaces a diff when real content is cleared back to the empty-delta placeholder' do
+    container = create(:container, extended_metadata: { 'content' => content_before })
+    as_request { edit_metadata(container, 'content' => '{"ops":[{"insert":"\n"}]}') }
+
+    changes = content_changes(container)
+    expect(changes.size).to eq 2 # creation (blank -> content_before), then content_before -> blank
+    expect(changes.last[:old_value]).to eq JSON.parse(content_before)
+    expect(changes.last[:new_value]).to eq({})
+  end
 end

--- a/spec/services/versioning/serializers/reaction_serializer_spec.rb
+++ b/spec/services/versioning/serializers/reaction_serializer_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Versioning::Serializers::ReactionSerializer do
+  let(:user) { create(:user) }
+
+  def as_request
+    Logidze.with_responsible!(user.id)
+    yield
+  ensure
+    Logidze.clear_responsible!
+  end
+
+  def field_changes(reaction, field)
+    reaction_with_log_data = Reaction.with_log_data.find(reaction.id)
+    described_class.call(reaction_with_log_data)
+                   .flat_map { |entry| entry[:changes][field.to_s] }
+                   .compact
+  end
+
+  # A Quill editor that nobody typed into still autosaves {"ops":[{"insert":"\n"}]} - visually
+  # empty, but not the same value as the nil description/observation start out as.
+  it 'does not surface a diff when description autosaves its empty-delta placeholder' do
+    reaction = create(:reaction, description: nil)
+    as_request { reaction.update!(description: { 'ops' => [{ 'insert' => "\n" }] }) }
+
+    expect(field_changes(reaction, :description)).to be_empty
+  end
+
+  it 'does not surface a diff when observation autosaves its empty-delta placeholder' do
+    reaction = create(:reaction, observation: nil)
+    as_request { reaction.update!(observation: { 'ops' => [{ 'insert' => "\n" }] }) }
+
+    expect(field_changes(reaction, :observation)).to be_empty
+  end
+
+  it 'still surfaces a diff for a real description change' do
+    reaction = create(:reaction, description: { 'ops' => [{ 'insert' => 'first' }] })
+    as_request { reaction.update!(description: { 'ops' => [{ 'insert' => 'second' }] }) }
+
+    changes = field_changes(reaction, :description)
+    # [creation (blank -> first), first -> second]
+    expect(changes.size).to eq 2
+    expect(changes.last[:old_value]).to eq({ 'ops' => [{ 'insert' => 'first' }] })
+    expect(changes.last[:new_value]).to eq({ 'ops' => [{ 'insert' => 'second' }] })
+  end
+end

--- a/spec/services/versioning/serializers/screen_serializer_spec.rb
+++ b/spec/services/versioning/serializers/screen_serializer_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Versioning::Serializers::ScreenSerializer do
+  let(:user) { create(:user) }
+
+  def as_request
+    Logidze.with_responsible!(user.id)
+    yield
+  ensure
+    Logidze.clear_responsible!
+  end
+
+  def description_changes(screen)
+    screen_with_log_data = Screen.with_log_data.find(screen.id)
+    described_class.call(screen_with_log_data)
+                   .flat_map { |entry| entry[:changes]['description'] }
+                   .compact
+  end
+
+  # A Quill editor that nobody typed into still autosaves {"ops":[{"insert":"\n"}]} - visually
+  # empty, but not the same value as the nil description started out as.
+  it 'does not surface a diff when description autosaves its empty-delta placeholder' do
+    screen = create(:screen, description: nil)
+    as_request { screen.update!(description: { 'ops' => [{ 'insert' => "\n" }] }) }
+
+    expect(description_changes(screen)).to be_empty
+  end
+
+  it 'still surfaces a diff for a real description change' do
+    screen = create(:screen, description: { 'ops' => [{ 'insert' => 'first' }] })
+    as_request { screen.update!(description: { 'ops' => [{ 'insert' => 'second' }] }) }
+
+    changes = description_changes(screen)
+    # [creation (blank -> first), first -> second]
+    expect(changes.size).to eq 2
+    expect(changes.last[:old_value]).to eq({ 'ops' => [{ 'insert' => 'first' }] })
+    expect(changes.last[:new_value]).to eq({ 'ops' => [{ 'insert' => 'second' }] })
+  end
+end

--- a/spec/services/versioning/serializers/wellplate_serializer_spec.rb
+++ b/spec/services/versioning/serializers/wellplate_serializer_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Versioning::Serializers::WellplateSerializer do
+  let(:user) { create(:user) }
+
+  def as_request
+    Logidze.with_responsible!(user.id)
+    yield
+  ensure
+    Logidze.clear_responsible!
+  end
+
+  def description_changes(wellplate)
+    wellplate_with_log_data = Wellplate.with_log_data.find(wellplate.id)
+    described_class.call(wellplate_with_log_data)
+                   .flat_map { |entry| entry[:changes]['description'] }
+                   .compact
+  end
+
+  # A Quill editor that nobody typed into still autosaves {"ops":[{"insert":"\n"}]} - visually
+  # empty, but not the same value as the nil description started out as.
+  it 'does not surface a diff when description autosaves its empty-delta placeholder' do
+    wellplate = create(:wellplate, description: nil)
+    as_request { wellplate.update!(description: { 'ops' => [{ 'insert' => "\n" }] }) }
+
+    expect(description_changes(wellplate)).to be_empty
+  end
+
+  it 'still surfaces a diff for a real description change' do
+    wellplate = create(:wellplate, description: { 'ops' => [{ 'insert' => 'first' }] })
+    as_request { wellplate.update!(description: { 'ops' => [{ 'insert' => 'second' }] }) }
+
+    changes = description_changes(wellplate)
+    # [creation (blank -> first), first -> second]
+    expect(changes.size).to eq 2
+    expect(changes.last[:old_value]).to eq({ 'ops' => [{ 'insert' => 'first' }] })
+    expect(changes.last[:new_value]).to eq({ 'ops' => [{ 'insert' => 'second' }] })
+  end
+end


### PR DESCRIPTION
## Summary
- **Deep-merge fix**: Logidze's jsonb diff only records the sub-keys of a hash-valued column (e.g. `Container#extended_metadata`) that actually changed in a given version. `BaseSerializer` used to overwrite its running "base" state with that partial hash outright, so a version that only touched `status` would silently drop `content` (and other sibling sub-keys) from both the running state and that version's own comparison, producing blank/incorrect previous and updated values in the History tab. Now deep-merges hash-valued changes onto the prior state instead.
- **Empty-Quill-delta fix**: an untouched Quill editor autosaves a delta like `{"ops":[{"insert":"\n"}]}` rather than leaving the column `nil`. That value isn't caught by `blank?` checks and showed up as a spurious content change even though the field is visually empty before and after. Reuses the existing `QuillUtils` empty-delta detection (exposed as a public `blank_content?`/shared `quill_formatter`) to normalize such values so identically-empty states compare equal and produce no diff entry, while a real edit that clears content still shows correctly.
- Applied the same empty-Quill-delta fix to `Reaction#description`/`#observation`, `Wellplate#description`, and `Screen#description`, which have the exact same `serialize(..., Hash)`-backed Quill pattern as `Container#extended_metadata.content`.
- `ResearchPlanSerializer`'s richtext blocks are diffed as part of the whole `body` array's structure (a block being added/removed is itself a real, worth-showing change), so this normalization intentionally doesn't apply there.
- Left the commented-out `extended_metadata.index` ("Position") field commented out: it has a *different*, unrelated bug (an Hstore-vs-JSON-string deserialization mismatch in Logidze's creation snapshot) plus a UX-noise concern (reordering N sibling containers produces N separate history entries) - out of scope for this PR.

## Test plan
- [x] New specs for `ContainerSerializer`, `ReactionSerializer`, `WellplateSerializer`, `ScreenSerializer` covering: sibling-key preservation across versions, and no-diff-for-still-empty-content vs. diff-shown-for-real-content-cleared
- [x] Verified each new spec fails against the pre-fix code and passes after
- [x] `bundle exec rspec spec/services/versioning/ spec/api/chemotion/version_api_spec.rb spec/lib/chemotion/quill_to_plain_text_spec.rb` - all green
- [x] `bundle exec rubocop` clean on all touched files (only pre-existing, pronto-diff-invisible offenses remain)