### PR TITLE
test: fill in missing API specs, fix five authorization/exposure bugs found along the way

### DIFF
--- a/app/api/chemotion/attachable_api.rb
+++ b/app/api/chemotion/attachable_api.rb
@@ -4,6 +4,17 @@
 
 module Chemotion
   class AttachableAPI < Grape::API
+    # Every attachable_type the frontend actually sends to update_attachments_attachable
+    # (AttachmentFetcher.js#updateAttachables). Anything else is rejected below rather than
+    # silently skipping authorization, as previously happened for every type but ResearchPlan.
+    ATTACHABLE_CLASSES = {
+      'ResearchPlan' => ResearchPlan,
+      'Wellplate' => Wellplate,
+      'DeviceDescription' => DeviceDescription,
+      'SequenceBasedMacromoleculeSample' => SequenceBasedMacromoleculeSample,
+      'SequenceBasedMacromolecule' => SequenceBasedMacromolecule,
+    }.freeze
+
     resource :attachable do
       params do
         optional :files, type: [File], desc: 'files', default: []
@@ -13,13 +24,9 @@ module Chemotion
         optional :del_files, type: [Integer], desc: 'del file id', default: []
       end
       after_validation do
-        case params[:attachable_type]
-        when 'ResearchPlan'
-          error!('401 Unauthorized', 401) unless ElementPolicy.new(
-            current_user,
-            ResearchPlan.find_by(id: params[:attachable_id]),
-          ).update?
-        end
+        klass = ATTACHABLE_CLASSES[params[:attachable_type]]
+        record = klass&.find_by(id: params[:attachable_id])
+        error!('401 Unauthorized', 401) unless ElementPolicy.new(current_user, record).update?
       end
 
       desc 'Update attachable records'

--- a/app/api/chemotion/attachment_api.rb
+++ b/app/api/chemotion/attachment_api.rb
@@ -250,6 +250,8 @@ module Chemotion
         params do
           require :updated_svg_string, type: String
         end
+        error!('401 Unauthorized', 401) unless writable?(@attachment)
+
         updater = Usecases::Attachments::Annotation::AnnotationUpdater.new
         updater.update_annotation(
           params['updated_svg_string'],
@@ -599,6 +601,8 @@ module Chemotion
         optional :lcms_integrals_str, type: String
       end
       post 'save_spectrum' do
+        error!('401 Unauthorized', 401) unless writable?(@attachment)
+
         lcms_data = params[:lcms_mz_page_data]
         if lcms_data.respond_to?(:read)
           params[:lcms_mz_page_data] = lcms_data.read
@@ -677,6 +681,8 @@ module Chemotion
         optional :layout, type: String
       end
       post 'infer' do
+        error!('401 Unauthorized', 401) unless writable?(@attachment)
+
         predict = @attachment.infer_spectrum(params)
         params[:predict] = predict.to_json
         jcamp_att = @attachment.generate_spectrum(

--- a/app/api/chemotion/user_api.rb
+++ b/app/api/chemotion/user_api.rb
@@ -69,7 +69,9 @@ module Chemotion
       namespace :omniauth_providers do
         desc 'get omniauth providers'
         get do
-          { providers: Devise.omniauth_configs.keys, current_user: current_user }
+          # Only the linked-provider ids are used by the frontend (OmniauthCredential.js); serializing
+          # the full current_user leaked encrypted_otp_secret/otp_secret/otp_backup_codes.
+          { providers: Devise.omniauth_configs.keys, current_user: { providers: current_user.providers } }
         end
       end
 

--- a/app/api/chemotion/user_label_api.rb
+++ b/app/api/chemotion/user_label_api.rb
@@ -32,7 +32,8 @@ module Chemotion
           }
           label = nil
           if params[:id].present?
-            label = UserLabel.find(params[:id])
+            label = UserLabel.find_by(id: params[:id], user_id: current_user.id)
+            error!('404 Not Found', 404) if label.nil?
             label.update!(attr)
           else
             label = UserLabel.create!(attr)

--- a/app/jobs/download_analyses_job.rb
+++ b/app/jobs/download_analyses_job.rb
@@ -82,7 +82,7 @@ class DownloadAnalysesJob < ApplicationJob
         end
       end
 
-      if rt == false
+      if @rt == false
         zip_file.rewind
         File.write(@file_path, zip_file.read)
       end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -200,6 +200,7 @@ class Attachment < ApplicationRecord
     super
 
     set_key
+    self
   end
 
   def set_key; end

--- a/spec/api/chemotion/attachable_api_spec.rb
+++ b/spec/api/chemotion/attachable_api_spec.rb
@@ -3,8 +3,125 @@
 require 'rails_helper'
 
 describe Chemotion::AttachableAPI do
+  include_context 'api request authorization context'
+
+  let(:other_user) { create(:person) }
+  let(:collection) { create(:collection, user: user) }
+  let(:other_collection) { create(:collection, user: other_user) }
+
+  let(:params) do
+    {
+      files: [fixture_file_upload(Rails.root.join('spec/fixtures/upload.txt'), 'text/plain')],
+      attfilesIdentifier: ['upload.txt'],
+      attachable_type: attachable_type,
+      attachable_id: attachable_id,
+    }
+  end
+
   describe 'POST /api/v1/attachable/update_attachments_attachable' do
-    # TODO: Add a spec for this endpoint
-    pending 'not yet implemented'
+    context 'when attachable_type is not a recognized element type' do
+      let(:attachable_type) { 'Container' }
+      let(:attachable_id) { 0 }
+
+      before { post '/api/v1/attachable/update_attachments_attachable', params: params }
+
+      it 'is rejected as unauthorized and creates no attachment' do
+        expect(response).to have_http_status(:unauthorized)
+        expect(Attachment.count).to eq(0)
+      end
+    end
+
+    context 'when attachable_type is ResearchPlan and it is in the current user\'s own collection' do
+      let(:attachable_type) { 'ResearchPlan' }
+      let(:attachable_id) { research_plan.id }
+      let(:research_plan) { create(:research_plan, collections: [collection]) }
+
+      before { post '/api/v1/attachable/update_attachments_attachable', params: params }
+
+      it 'attaches the file to the research plan' do
+        expect(response).to have_http_status(:created)
+        expect(Attachment.count).to eq(1)
+        expect(Attachment.last).to have_attributes(
+          attachable_type: 'ResearchPlan', attachable_id: research_plan.id, filename: 'upload.txt',
+        )
+      end
+    end
+
+    context 'when attachable_type is ResearchPlan and it belongs to another user' do
+      let(:attachable_type) { 'ResearchPlan' }
+      let(:attachable_id) { research_plan.id }
+      let(:research_plan) { create(:research_plan, collections: [other_collection]) }
+
+      before { post '/api/v1/attachable/update_attachments_attachable', params: params }
+
+      it 'is rejected as unauthorized and creates no attachment' do
+        expect(response).to have_http_status(:unauthorized)
+        expect(Attachment.count).to eq(0)
+      end
+    end
+
+    # Regression: authorization used to only run for attachable_type == 'ResearchPlan'; every
+    # other type (Wellplate, DeviceDescription, sbmm samples/macromolecules) let any authenticated
+    # user attach files to, or detach attachments from, elements they had no access to.
+    context 'when attachable_type is Wellplate and it is in the current user\'s own collection' do
+      let(:attachable_type) { 'Wellplate' }
+      let(:attachable_id) { wellplate.id }
+      let(:wellplate) { create(:wellplate, collections: [collection]) }
+
+      before { post '/api/v1/attachable/update_attachments_attachable', params: params }
+
+      it 'attaches the file to the wellplate' do
+        expect(response).to have_http_status(:created)
+        expect(Attachment.count).to eq(1)
+        expect(Attachment.last).to have_attributes(attachable_type: 'Wellplate', attachable_id: wellplate.id)
+      end
+    end
+
+    context 'when attachable_type is Wellplate and it belongs to another user' do
+      let(:attachable_type) { 'Wellplate' }
+      let(:attachable_id) { wellplate.id }
+      let(:wellplate) { create(:wellplate, collections: [other_collection]) }
+
+      before { post '/api/v1/attachable/update_attachments_attachable', params: params }
+
+      it 'is rejected as unauthorized and creates no attachment' do
+        expect(response).to have_http_status(:unauthorized)
+        expect(Attachment.count).to eq(0)
+      end
+    end
+
+    context 'when deleting an attachment from a wellplate in the current user\'s own collection' do
+      let(:attachable_type) { 'Wellplate' }
+      let(:attachable_id) { wellplate.id }
+      let(:wellplate) { create(:wellplate, collections: [collection]) }
+      let!(:attachment) { create(:attachment, attachable: wellplate) }
+      let(:params) do
+        { attachable_type: attachable_type, attachable_id: attachable_id, del_files: [attachment.id] }
+      end
+
+      before { post '/api/v1/attachable/update_attachments_attachable', params: params }
+
+      it 'unlinks the attachment' do
+        expect(response).to have_http_status(:created)
+        expect(attachment.reload.attachable_id).to be_nil
+      end
+    end
+
+    context 'when deleting an attachment from a wellplate belonging to another user' do
+      let(:attachable_type) { 'Wellplate' }
+      let(:attachable_id) { wellplate.id }
+      let(:wellplate) { create(:wellplate, collections: [other_collection]) }
+      let!(:attachment) { create(:attachment, attachable: wellplate) }
+      let(:params) do
+        { attachable_type: attachable_type, attachable_id: attachable_id, del_files: [attachment.id] }
+      end
+
+      before { post '/api/v1/attachable/update_attachments_attachable', params: params }
+
+      it 'is rejected as unauthorized and leaves the attachment linked' do
+        expect(response).to have_http_status(:unauthorized)
+        expect(attachment.reload.attachable_id).to eq(wellplate.id)
+      end
+    end
   end
 end

--- a/spec/api/chemotion/attachment_api_spec.rb
+++ b/spec/api/chemotion/attachment_api_spec.rb
@@ -901,7 +901,13 @@ describe Chemotion::AttachmentAPI do
     end
 
     context 'when the attachment belongs to the current user' do
-      before { post "/api/v1/attachments/#{attachment.id}/annotation", params: annotation_params }
+      before do
+        # Thumbnail regeneration depends on real image-processing tooling and whether a thumbnail
+        # derivative already exists; irrelevant to the authorization check under test here.
+        allow_any_instance_of(Usecases::Attachments::Annotation::AnnotationUpdater).to receive(:update_thumbnail)
+
+        post "/api/v1/attachments/#{attachment.id}/annotation", params: annotation_params
+      end
 
       it 'returns statuscode 201' do
         expect(response).to have_http_status(:created)

--- a/spec/api/chemotion/attachment_api_spec.rb
+++ b/spec/api/chemotion/attachment_api_spec.rb
@@ -895,9 +895,10 @@ describe Chemotion::AttachmentAPI do
     let(:attachment) { create(:attachment, :with_image, created_for: user.id, attachable_type: '') }
     let(:annotation_params) do
       image_tag = "<image id=\"original_image\" href=\"/api/v1/attachments/image/#{attachment.id}\"/>"
-      {
-        updated_svg_string: "<svg xmlns=\"http://www.w3.org/2000/svg\">#{image_tag}</svg>",
-      }
+      # width/height are required: rsvg-convert (used by create_annotated_flat_image) errors
+      # with "The SVG has no dimensions" otherwise.
+      svg_tag = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"100\">#{image_tag}</svg>"
+      { updated_svg_string: svg_tag }
     end
 
     context 'when the attachment belongs to the current user' do

--- a/spec/api/chemotion/attachment_api_spec.rb
+++ b/spec/api/chemotion/attachment_api_spec.rb
@@ -506,7 +506,30 @@ describe Chemotion::AttachmentAPI do
   end
 
   describe 'GET /api/v1/attachments/sample_analyses/{sample_id}' do
-    pending 'not yet implemented'
+    let(:sample) { create(:sample_with_image_in_analysis, collections: [collection]) }
+    let(:execute) { get "/api/v1/attachments/sample_analyses/#{sample.id}" }
+
+    context 'when the sample is in the current user\'s own collection' do
+      let(:collection) { create(:collection, user: user) }
+
+      before { execute }
+
+      it 'returns the zip file of analytical attachments' do
+        expect(response).to have_http_status(:ok)
+        expect(response.header['Content-Type']).to include('application/zip')
+      end
+    end
+
+    context 'when the sample belongs to another user' do
+      let(:other_user) { create(:person) }
+      let(:collection) { create(:collection, user: other_user) }
+
+      before { execute }
+
+      it 'is rejected as unauthorized' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
   end
 
   describe 'GET /api/v1/attachments/image/{attachment_id}' do
@@ -553,15 +576,84 @@ describe Chemotion::AttachmentAPI do
   end
 
   describe 'GET /api/v1/attachments/thumbnail/{attachment_id}' do
-    pending 'not yet implemented'
+    let(:sample) { create(:sample_with_image_in_analysis, collections: [collection]) }
+    let(:attachment) { sample.container.children[0].children[0].attachments.first }
+
+    before { get "/api/v1/attachments/thumbnail/#{attachment.id}" }
+
+    context 'when the sample is in the current user\'s own collection' do
+      let(:collection) { create(:collection, user: user) }
+
+      it 'returns the thumbnail' do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq(attachment.thumbnail_base64.to_json)
+      end
+    end
+
+    context 'when the sample belongs to another user' do
+      let(:other_user) { create(:person) }
+      let(:collection) { create(:collection, user: other_user) }
+
+      it 'is rejected as unauthorized' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
   end
 
   describe 'POST /api/v1/attachments/thumbnails' do
-    pending
+    let(:collection) { create(:collection, user: user) }
+    let(:own_sample) { create(:sample_with_image_in_analysis, collections: [collection]) }
+    let(:own_attachment) { own_sample.container.children[0].children[0].attachments.first }
+
+    let(:other_user) { create(:person) }
+    let(:other_collection) { create(:collection, user: other_user) }
+    let(:foreign_sample) { create(:sample_with_image_in_analysis, collections: [other_collection]) }
+    let(:foreign_attachment) { foreign_sample.container.children[0].children[0].attachments.first }
+
+    before do
+      post '/api/v1/attachments/thumbnails', params: { ids: [own_attachment.id, foreign_attachment.id] }
+    end
+
+    it 'returns the thumbnail for the accessible attachment and nil for the inaccessible one' do
+      thumbnails = parsed_json_response['thumbnails']
+      expect(thumbnails.length).to eq(2)
+      expect(thumbnails[0]['id']).to eq(own_attachment.id)
+      expect(thumbnails[1]).to be_nil
+    end
   end
 
   describe 'POST /api/v1/attachments/files' do
-    pending 'not yet implemented'
+    let(:collection) { create(:collection, user: user) }
+    let(:own_sample) { create(:sample_with_image_in_analysis, collections: [collection]) }
+    let(:own_attachment) { own_sample.container.children[0].children[0].attachments.first }
+
+    let(:other_user) { create(:person) }
+    let(:other_collection) { create(:collection, user: other_user) }
+    let(:foreign_sample) { create(:sample_with_image_in_analysis, collections: [other_collection]) }
+    let(:foreign_attachment) { foreign_sample.container.children[0].children[0].attachments.first }
+
+    context 'when at least one attachment is accessible' do
+      before do
+        post '/api/v1/attachments/files', params: { ids: [own_attachment.id, foreign_attachment.id] }
+      end
+
+      it 'returns the file for the accessible attachment and nil for the inaccessible one' do
+        files = parsed_json_response['files']
+        expect(files.length).to eq(2)
+        expect(files[0]['id']).to eq(own_attachment.id)
+        expect(files[1]).to be_nil
+      end
+    end
+
+    context 'when no attachment is accessible' do
+      before do
+        post '/api/v1/attachments/files', params: { ids: [foreign_attachment.id] }
+      end
+
+      it 'is rejected as unauthorized' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
   end
 
   describe 'POST /api/v1/attachments/regenerate_spectrum' do
@@ -602,7 +694,10 @@ describe Chemotion::AttachmentAPI do
   end
 
   describe 'POST /api/v1/attachments/save_spectrum' do
-    let(:attachment) { create(:attachment, :with_spectra_file) }
+    let(:collection) { create(:collection, user: user) }
+    let(:sample) { create(:sample, collections: [collection]) }
+    let(:container) { create(:container, containable: sample) }
+    let(:attachment) { create(:attachment, :with_spectra_file, attachable: container) }
 
     context 'when parameters are correct' do
       let(:spectrum_params) { JSON.parse(File.read('spec/fixtures/spectrum_param_chloroform_d.json')) }
@@ -632,6 +727,19 @@ describe Chemotion::AttachmentAPI do
 
       it 'new attachment was created' do
         expect(Attachment.find(generated_attachment_id)).not_to be_nil
+      end
+    end
+
+    # Regression: this endpoint used to run with no authorization check at all, letting any
+    # authenticated user regenerate/overwrite spectrum data for an attachment they don't own.
+    context 'when the attachment belongs to another user' do
+      let(:attachment) { create(:attachment, :with_spectra_file) }
+      let(:spectrum_params) { { attachment_id: attachment.id } }
+
+      before { post '/api/v1/attachments/save_spectrum', params: spectrum_params }
+
+      it 'is rejected as unauthorized' do
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end
@@ -687,12 +795,55 @@ describe Chemotion::AttachmentAPI do
     end
 
     context 'when attachment is no image' do
-      pending 'not yet implemented'
+      let(:attachment) { create(:attachment, created_for: user.id, attachable_type: '') }
+      let(:attachment_id) { attachment.id }
+
+      it('returning status 200') do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it('ignores the annotated param and returns the original file') do
+        expect(response.header['Content-Length'].to_i).to eq(attachment.attachment_attacher.file.size)
+      end
     end
   end
 
   describe 'POST /api/v1/attachments/infer' do
-    pending 'not yet implemented'
+    let(:attachment) { create(:attachment, :with_spectra_file, created_for: user.id, attachable_type: '') }
+    let(:infer_params) { { attachment_id: attachment.id, layout: 'IR' } }
+
+    context 'when parameters are correct' do
+      let(:generated_attachment) { create(:attachment, :with_spectra_file) }
+
+      before do
+        allow_any_instance_of(Attachment).to receive(:infer_spectrum).and_return('shift' => [])
+        allow_any_instance_of(Attachment).to receive(:generate_spectrum).and_return(generated_attachment)
+
+        post '/api/v1/attachments/infer', params: infer_params
+      end
+
+      it 'returns statuscode 201' do
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'returns the inferred prediction and generated attachment' do
+        expect(parsed_json_response['predict']).to eq('shift' => [])
+        expect(parsed_json_response['files'].first['id']).to eq(generated_attachment.id)
+      end
+    end
+
+    # Regression: this endpoint used to run with no authorization check at all, letting any
+    # authenticated user run spectrum inference against - and read the raw file content of -
+    # an attachment they don't own.
+    context 'when the attachment belongs to another user' do
+      let(:attachment) { create(:attachment, :with_spectra_file) }
+
+      before { post '/api/v1/attachments/infer', params: infer_params }
+
+      it 'is rejected as unauthorized' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
   end
 
   describe 'POST /api/v1/attachments/lcms_page' do
@@ -735,8 +886,39 @@ describe Chemotion::AttachmentAPI do
     end
   end
 
-  describe 'GET /api/v1/attachments/svgs' do
-    pending 'not yet implemented'
+  # GET /api/v1/attachments/svgs (QR code SVG) has no frontend caller left, and the shared
+  # `before` block above only grants can_dwnld for zip/*_analyses/plain-attachment URLs - any
+  # request to /svgs falls through with can_dwnld staying false, so it unconditionally 401s.
+  # Dead and already unreachable; not worth a spec pretending it works.
+
+  describe 'POST /api/v1/attachments/:attachment_id/annotation' do
+    let(:attachment) { create(:attachment, :with_image, created_for: user.id, attachable_type: '') }
+    let(:annotation_params) do
+      image_tag = "<image id=\"original_image\" href=\"/api/v1/attachments/image/#{attachment.id}\"/>"
+      {
+        updated_svg_string: "<svg xmlns=\"http://www.w3.org/2000/svg\">#{image_tag}</svg>",
+      }
+    end
+
+    context 'when the attachment belongs to the current user' do
+      before { post "/api/v1/attachments/#{attachment.id}/annotation", params: annotation_params }
+
+      it 'returns statuscode 201' do
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    # Regression: this endpoint used to run with no authorization check at all, letting any
+    # authenticated user overwrite the annotation SVG of an attachment they don't own.
+    context 'when the attachment belongs to another user' do
+      let(:attachment) { create(:attachment, :with_image) }
+
+      before { post "/api/v1/attachments/#{attachment.id}/annotation", params: annotation_params }
+
+      it 'is rejected as unauthorized' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
   end
 
   # TODO: Check these specs and remove everything that is already covered by the specs above

--- a/spec/api/chemotion/search_api_spec.rb
+++ b/spec/api/chemotion/search_api_spec.rb
@@ -125,9 +125,9 @@ describe Chemotion::SearchAPI do
     CollectionsDeviceDescription.create!(device_description: device_description, collection: collection)
   end
 
-  describe 'POST /api/v1/search/elements' do
-    pending 'TODO: Add missing spec'
-  end
+  # POST /api/v1/search/elements was renamed to /search/all in 0be3cd9844 ("feat: extend search");
+  # the pending spec here tested a route that no longer exists. Its replacement is covered below by
+  # 'POST /api/v1/search/all'.
 
   describe 'POST /api/v1/search/cell_lines' do
     let(:url) { '/api/v1/search/cell_lines' }
@@ -747,15 +747,104 @@ describe Chemotion::SearchAPI do
   end
 
   describe 'POST /api/v1/search/reactions' do
-    pending 'TODO: Add missing spec'
+    let(:url) { '/api/v1/search/reactions' }
+
+    before do
+      do_request
+    end
+
+    context 'when searching a reaction in correct collection' do
+      let(:search_term) { 'Other Reaction' }
+      let(:params) do
+        {
+          selection: {
+            elementType: :reactions,
+            name: search_term,
+            search_by_method: :substring,
+          },
+          collection_id: other_collection.id,
+        }
+      end
+
+      it 'returns the reaction' do
+        expect(parsed_json_response.dig('reactions', 'totalElements')).to eq 1
+        expect(parsed_json_response.dig('reactions', 'ids')).to eq [other_reaction.id]
+      end
+    end
   end
 
   describe 'POST /api/v1/search/wellplates' do
-    pending 'TODO: Add missing spec'
+    let(:url) { '/api/v1/search/wellplates' }
+
+    before do
+      do_request
+    end
+
+    context 'when searching a wellplate in correct collection' do
+      let(:search_term) { 'Other Wellplate' }
+      let(:params) do
+        {
+          selection: {
+            elementType: :wellplates,
+            name: search_term,
+            search_by_method: :substring,
+          },
+          collection_id: other_collection.id,
+        }
+      end
+
+      it 'returns the wellplate' do
+        expect(parsed_json_response.dig('wellplates', 'totalElements')).to eq 1
+        expect(parsed_json_response.dig('wellplates', 'ids')).to eq [other_wellplate.id]
+      end
+
+      it 'returns the referenced screen of the wellplate' do
+        expect(parsed_json_response.dig('screens', 'totalElements')).to eq 1
+        expect(parsed_json_response.dig('screens', 'ids')).to eq [other_screen.id]
+      end
+
+      it 'returns the referenced sample of the wellplate' do
+        expect(parsed_json_response.dig('samples', 'totalElements')).to eq 1
+        expect(parsed_json_response.dig('samples', 'ids')).to eq [sample_b.id]
+      end
+    end
   end
 
   describe 'POST /api/v1/search/screens' do
-    pending 'TODO: Add missing spec'
+    let(:url) { '/api/v1/search/screens' }
+
+    before do
+      do_request
+    end
+
+    context 'when searching a screen in correct collection' do
+      let(:search_term) { 'Other Screen' }
+      let(:params) do
+        {
+          selection: {
+            elementType: :screens,
+            name: search_term,
+            search_by_method: :substring,
+          },
+          collection_id: other_collection.id,
+        }
+      end
+
+      it 'returns the screen' do
+        expect(parsed_json_response.dig('screens', 'totalElements')).to eq 1
+        expect(parsed_json_response.dig('screens', 'ids')).to eq [other_screen.id]
+      end
+
+      it 'returns the referenced wellplate of the screen' do
+        expect(parsed_json_response.dig('wellplates', 'totalElements')).to eq 1
+        expect(parsed_json_response.dig('wellplates', 'ids')).to eq [other_wellplate.id]
+      end
+
+      it 'returns the referenced sample of the screen' do
+        expect(parsed_json_response.dig('samples', 'totalElements')).to eq 1
+        expect(parsed_json_response.dig('samples', 'ids')).to eq [sample_b.id]
+      end
+    end
   end
 end
 # rubocop:enable RSpec/IndexedLet, Naming/VariableNumber

--- a/spec/api/chemotion/user_api_spec.rb
+++ b/spec/api/chemotion/user_api_spec.rb
@@ -88,23 +88,84 @@ describe Chemotion::UserAPI do
   end
 
   describe 'GET /api/v1/users/list_editors' do
-    pending 'TODO: Add missing spec'
+    before do
+      create(:matrice, name: 'ketcherEditor', enabled: true)
+      create(:matrice, name: 'marvinjsEditor', enabled: false)
+      user.reload
+      get '/api/v1/users/list_editors'
+    end
+
+    it 'returns only the editors enabled for the current user' do
+      expect(parsed_json_response['matrices'].pluck('name')).to eq(['ketcherEditor'])
+    end
   end
 
   describe 'GET /api/v1/users/omniauth_providers' do
-    pending 'TODO: Add missing spec'
+    before do
+      get '/api/v1/users/omniauth_providers'
+    end
+
+    it 'returns the omniauth providers configured for the app' do
+      expect(parsed_json_response['providers']).to eq(Devise.omniauth_configs.keys.map(&:to_s))
+    end
+
+    # Regression: this used to serialize the whole current_user object, leaking
+    # encrypted_otp_secret/otp_secret/otp_backup_codes to any authenticated user.
+    it "returns only the current user's linked providers" do
+      expect(parsed_json_response['current_user']).to eq('providers' => nil)
+    end
+
+    context 'when the user has linked providers' do
+      let(:user) { create(:person, providers: { 'github' => { 'uid' => '123' } }) }
+
+      it "returns the user's linked providers" do
+        expect(parsed_json_response['current_user']['providers']).to eq('github' => { 'uid' => '123' })
+      end
+    end
   end
 
   describe 'PUT /api/v1/users/update_counter' do
-    pending 'TODO: Add missing spec'
+    before do
+      put '/api/v1/users/update_counter', params: { type: 'samples', counter: 5 }, as: :json
+    end
+
+    it 'updates the given counter and preserves the others' do
+      expect(parsed_json_response['counters']).to eq('samples' => '5', 'reactions' => '0', 'wellplates' => '0')
+    end
   end
 
   describe 'GET /api/v1/users/scifinder' do
-    pending 'TODO: Add missing spec'
+    context 'when no credential exists for the current user' do
+      before { get '/api/v1/users/scifinder' }
+
+      it 'returns an empty credential' do
+        expect(parsed_json_response).to eq(
+          'id' => nil, 'access_token' => nil, 'refresh_token' => nil, 'expires_at' => nil, 'updated_at' => nil,
+        )
+      end
+    end
+
+    context 'when a credential exists for the current user' do
+      let!(:credential) do
+        ScifinderNCredential.create!(
+          created_by: user.id, access_token: 'tok', refresh_token: 'ref', expires_at: 1.day.from_now,
+        )
+      end
+
+      before { get '/api/v1/users/scifinder' }
+
+      it "returns the current user's credential" do
+        expect(parsed_json_response['id']).to eq(credential.id)
+        expect(parsed_json_response['access_token']).to eq('tok')
+      end
+    end
   end
 
   describe 'DELETE /api/v1/users/sign_out' do
-    pending 'TODO: Add missing spec'
+    it 'returns 204' do
+      delete '/api/v1/users/sign_out'
+      expect(response).to have_http_status(:no_content)
+    end
   end
 
   describe 'GET /api/v1/users/devices' do
@@ -165,10 +226,49 @@ describe Chemotion::UserAPI do
   end
 
   describe 'GET /api/v1/devices/novnc' do
-    pending 'TODO: Add missing spec'
+    let(:novnc_device) { create(:device, :novnc_settings) }
+    let(:unrelated_novnc_device) { create(:device, :novnc_settings) }
+    let(:device_without_target) { create(:device) }
+
+    before do
+      novnc_device.people << user
+      device_without_target.people << user
+      unrelated_novnc_device
+      get '/api/v1/devices/novnc'
+    end
+
+    it 'returns only accessible devices that have a novnc target' do
+      ids = parsed_json_response['devices'].pluck('id')
+      expect(ids).to contain_exactly(novnc_device.id)
+    end
   end
 
   describe 'GET /api/v1/devices/current_connection' do
-    pending 'TODO: Add missing spec'
+    let(:device) { create(:device) }
+    let(:path) { NOVNC_DEVICES_DIR.join(device.id.to_s) }
+
+    after { FileUtils.rm_f(path) }
+
+    context 'when the device belongs to the current user' do
+      before do
+        device.people << user
+        get '/api/v1/devices/current_connection', params: { id: device.id, status: 'true' }
+      end
+
+      it 'returns 200 and appends the connection status to the device log' do
+        expect(response).to have_http_status(:ok)
+        expect(File.read(path)).to include("#{user.id},1")
+      end
+    end
+
+    context 'when the current user has no relation to the device' do
+      before do
+        get '/api/v1/devices/current_connection', params: { id: device.id, status: 'true' }
+      end
+
+      it 'returns 404' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 end

--- a/spec/api/chemotion/user_label_api_spec.rb
+++ b/spec/api/chemotion/user_label_api_spec.rb
@@ -43,7 +43,76 @@ describe Chemotion::UserLabelAPI do
   end
 
   describe 'PUT /api/v1/user_labels/save_label' do
-    pending 'TODO: Add missing spec'
+    context 'when creating a new label' do
+      let(:params) { { title: 'New label', description: 'A description', color: '#123456', access_level: 1 } }
+
+      it 'creates a label owned by the current user' do
+        expect do
+          put '/api/v1/user_labels/save_label', params: params, as: :json
+        end.to change(UserLabel, :count).by(1)
+
+        expect(response).to have_http_status(:success)
+        expect(UserLabel.last).to have_attributes(
+          user_id: user.id,
+          title: 'New label',
+          description: 'A description',
+          color: '#123456',
+          access_level: 1,
+        )
+      end
+
+      it 'defaults access_level to 0 when not supplied' do
+        put '/api/v1/user_labels/save_label', params: params.except(:access_level), as: :json
+
+        expect(UserLabel.last.access_level).to eq(0)
+      end
+
+      it 'returns the created label' do
+        put '/api/v1/user_labels/save_label', params: params, as: :json
+
+        expect(parsed_json_response['title']).to eq('New label')
+        expect(parsed_json_response['color']).to eq('#123456')
+      end
+    end
+
+    context 'when updating an existing label' do
+      it 'updates the label attributes' do
+        params = { id: label_a.id, title: 'Renamed', description: 'Updated', color: '#fff000', access_level: 1 }
+
+        put '/api/v1/user_labels/save_label', params: params, as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(label_a.reload).to have_attributes(
+          title: 'Renamed',
+          description: 'Updated',
+          color: '#fff000',
+          access_level: 1,
+        )
+      end
+
+      it 'does not create an additional label' do
+        params = { id: label_a.id, title: 'Renamed', color: '#fff000' }
+
+        expect do
+          put '/api/v1/user_labels/save_label', params: params, as: :json
+        end.not_to change(UserLabel, :count)
+      end
+    end
+
+    context 'when the id belongs to another user' do
+      let(:foreign_label) do
+        UserLabel.create!(user_id: other_user.id, access_level: 0, title: 'Foreign', color: '#fff')
+      end
+
+      it 'returns 404 and leaves the label untouched' do
+        params = { id: foreign_label.id, title: 'Hijacked', color: '#000000' }
+
+        put '/api/v1/user_labels/save_label', params: params, as: :json
+
+        expect(response).to have_http_status(:not_found)
+        expect(foreign_label.reload).to have_attributes(title: 'Foreign', color: '#fff', user_id: other_user.id)
+      end
+    end
   end
 
   def ui_state_for(sample_ids)
@@ -70,7 +139,8 @@ describe Chemotion::UserLabelAPI do
     end
 
     it 'removes labels from the selected samples while preserving others' do
-      sample_1.tag.update!(taggable_data: (sample_1.tag.taggable_data || {}).merge('user_labels' => [label_a.id, label_b.id]))
+      sample_1.tag.update!(taggable_data: (sample_1.tag.taggable_data || {}).merge('user_labels' => [label_a.id,
+                                                                                                     label_b.id]))
 
       params = { ui_state: ui_state_for([sample_1.id]), remove_label_ids: [label_a.id] }
 
@@ -119,7 +189,8 @@ describe Chemotion::UserLabelAPI do
 
       ui_state = {
         currentCollection: { id: foreign_collection.id },
-        sample: { checkedAll: false, checkedIds: [foreign_sample.id], uncheckedIds: [], collection_id: foreign_collection.id },
+        sample: { checkedAll: false, checkedIds: [foreign_sample.id], uncheckedIds: [],
+                  collection_id: foreign_collection.id },
       }
       params = { ui_state: ui_state, add_label_ids: [label_a.id] }
 

--- a/spec/api/chemotion/wellplate_api_spec.rb
+++ b/spec/api/chemotion/wellplate_api_spec.rb
@@ -440,7 +440,70 @@ describe Chemotion::WellplateAPI do
   end
 
   describe 'POST /api/v1/wellplates/subwellplates' do
-    pending 'TODO: Add missing spec'
+    let(:sample) { create(:sample) }
+    let!(:well) { create(:well, wellplate: wellplate, sample: sample, position_x: 1, position_y: 1) }
+
+    let(:params) do
+      {
+        ui_state: {
+          wellplate: { all: true, included_ids: [], excluded_ids: [] },
+          currentCollectionId: collection.id,
+        },
+      }
+    end
+
+    before do
+      post '/api/v1/wellplates/subwellplates', params: params, as: :json
+    end
+
+    it 'splits the wellplate into a subwellplate in the target collection' do
+      expect(response).to have_http_status :created
+
+      subwellplate = Wellplate.find_by(name: "#{wellplate.name}-Split")
+      expect(subwellplate).not_to be_nil
+      expect(subwellplate.collections).to include(collection)
+    end
+
+    it 'creates exactly one subwell' do
+      subwellplate = Wellplate.find_by(name: "#{wellplate.name}-Split")
+      expect(subwellplate.wells.count).to eq(1)
+    end
+
+    it 'carries over the position and readouts' do
+      subwell = Wellplate.find_by(name: "#{wellplate.name}-Split").wells.first
+      expect(subwell).to have_attributes(
+        position_x: well.position_x, position_y: well.position_y, readouts: well.readouts,
+      )
+    end
+
+    it "splits the well's sample and links it as the subwell's sample" do
+      subwell = Wellplate.find_by(name: "#{wellplate.name}-Split").wells.first
+      expect(subwell.sample).to have_attributes(parent: sample)
+      expect(subwell.sample.id).not_to eq(sample.id)
+    end
+
+    context 'when the collection is a read-only share' do
+      let(:read_only_collection) do
+        create(:collection, user: other_user).tap do |shared_collection|
+          create(:collection_share, collection: shared_collection, shared_with: user,
+                                    permission_level: CollectionShare.permission_level(:read_elements))
+        end
+      end
+      let(:wellplate) { create(:wellplate, collections: [read_only_collection]) }
+      let(:params) do
+        {
+          ui_state: {
+            wellplate: { all: true, included_ids: [], excluded_ids: [] },
+            currentCollectionId: read_only_collection.id,
+          },
+        }
+      end
+
+      it 'is rejected as unauthorized and creates no subwellplate' do
+        expect(response).to have_http_status :unauthorized
+        expect(Wellplate.find_by(name: "#{wellplate.name}-Split")).to be_nil
+      end
+    end
   end
 
   describe 'PUT /api/v1/wellplates/import_spreadsheet/:id' do
@@ -487,13 +550,9 @@ describe Chemotion::WellplateAPI do
     end
   end
 
-  describe 'POST /api/v1/wellplates/well_label' do
-    pending 'TODO: Add missing spec'
-  end
-
-  describe 'POST /api/v1/wellplates/well_color_code' do
-    pending 'TODO: Add missing spec'
-  end
+  # POST /api/v1/wellplates/well_label and /well_color_code were removed in #1930
+  # (label/color_code are now set through PUT /wellplates/:id instead); their pending
+  # specs tested routes that no longer exist and were removed along with them.
 
   describe 'GET /api/v1/wellplates/template' do
     context 'when wellplate does not exit' do


### PR DESCRIPTION
## Summary

Works through the old `pending 'TODO: Add missing spec'` / `'not yet implemented'` placeholders across six API spec files. For each, checked whether the endpoint under test is still live before writing coverage; several placeholders tested endpoints that had actually been removed or renamed years ago, so those were dropped in favor of a short note instead of faked coverage.

Writing real request specs against the actual behavior surfaced five pre-existing authorization/exposure bugs, fixed here alongside their regression specs, plus two small unrelated correctness bugs found and fixed along the way:

### Authorization / exposure fixes

- **`user_label_api.rb`** — `PUT /api/v1/user_labels/save_label` looked up the target label with `UserLabel.find(params[:id])`, with no check that it belonged to `current_user`. Any authenticated user could rename/recolor another user's label by id, and the update would even reassign it to themselves (`attr` always set `user_id: current_user.id`). Now scoped to `UserLabel.find_by(id:, user_id: current_user.id)`, returning 404 on mismatch.
- **`user_api.rb`** — `GET /api/v1/users/omniauth_providers` serialized the raw `current_user` AR object instead of going through `Entities::UserEntity` like every other user-facing endpoint. This leaked `encrypted_otp_secret`, the *decrypted* `otp_secret` (devise-two-factor's `attr_encrypted` virtual attribute), and `otp_backup_codes` to any authenticated user. The frontend (`OmniauthCredential.js`) only ever reads `current_user.providers`, so the response is now scoped to that.
- **`attachable_api.rb`** — `POST /api/v1/attachable/update_attachments_attachable` only authorized `attachable_type == 'ResearchPlan'`. Every other type the frontend actually sends (`Wellplate`, `DeviceDescription`, `SequenceBasedMacromoleculeSample`, `SequenceBasedMacromolecule`) had **no authorization check at all** — any authenticated user could attach a file to, or detach an existing attachment from, any other user's element by id. Replaced the single-branch check with a lookup table covering every real `attachable_type`, resolved uniformly through `ElementPolicy#update?`; an unrecognized type now fails closed.
- **`attachment_api.rb`** — three POST endpoints ran with no authorization at all, since the shared `before` block only covers GET/DELETE:
  - `POST /attachments/infer` — any authenticated user could run spectrum inference against any attachment by id, and the response leaks the base64-encoded file content (a read bypass, not just write).
  - `POST /attachments/save_spectrum` — same gap, letting any user regenerate/overwrite spectrum data on an attachment they don't own.
  - `POST /attachments/:attachment_id/annotation` — any authenticated user could overwrite the annotation SVG of any attachment by id.
  All three now use `writable?(@attachment)` (`AttachmentPolicy`), the same check already used by `regenerate_spectrum`/`regenerate_edited_spectrum` in this file.

None of these were previously reported in the `ComPlat/chemotion_ELN` or `ComPlat/chemotion` issue trackers (searched both before fixing).

### Small unrelated bugs fixed along the way

- **`attachment.rb`** — `Attachment#reload` returned `set_key`'s value (`nil`) instead of `self`, breaking the standard `record.reload.attribute` chain for any `Attachment` instance. Found while writing a detach regression spec.
- **`download_analyses_job.rb`** — `DownloadAnalysesJob#perform` checked `if rt == false` instead of `if @rt == false`, so it always raised `NameError` (silently swallowed by a surrounding `rescue`) and never wrote the zip to disk for the large-file async export path. Found while writing the `sample_analyses` spec.

### Per-file breakdown

- `spec/api/chemotion/user_label_api_spec.rb` — filled `save_label` (create/update/default access_level + the IDOR regression case).
- `spec/api/chemotion/wellplate_api_spec.rb` — filled `subwellplates` (split behavior, well/sample duplication, read-only-collection 401). Dropped the `well_label`/`well_color_code` stubs — both routes were removed in #1930; label/color_code are now set via `PUT /wellplates/:id`.
- `spec/api/chemotion/search_api_spec.rb` — filled `reactions`/`wellplates`/`screens` (substring search + cross-referenced elements). Dropped the `elements` stub — the route was renamed to `/search/all` back in early 2024 and is already covered under that describe block.
- `spec/api/chemotion/user_api_spec.rb` — filled `list_editors`, `omniauth_providers` (incl. the leak regression test), `update_counter`, `scifinder`, `sign_out`, `devices/novnc`, `devices/current_connection`.
- `spec/api/chemotion/attachable_api_spec.rb` — filled `update_attachments_attachable` (create/update for ResearchPlan and Wellplate, both owned and cross-user, plus detach) — the only pending spec in this file, and the one that surfaced the broken-access-control gap above.
- `spec/api/chemotion/attachment_api_spec.rb` — filled `sample_analyses`, `thumbnail`, `thumbnails`, `files`, the no-image case of the annotated-download endpoint, and `infer`; added coverage for `save_spectrum`'s and the annotation endpoint's new authorization checks. Dropped the `svgs` stub — the endpoint has no frontend caller and is structurally unreachable (the shared before-hook never grants it `can_dwnld`, so it unconditionally 401s).

## Test plan

- [x] `bundle exec rspec spec/api/chemotion/user_label_api_spec.rb spec/api/chemotion/wellplate_api_spec.rb spec/api/chemotion/search_api_spec.rb spec/api/chemotion/user_api_spec.rb spec/api/chemotion/attachable_api_spec.rb spec/api/chemotion/attachment_api_spec.rb spec/models/attachment_spec.rb` — all green (one pre-existing, unrelated network-stub flake in `attachment_spec.rb`, confirmed present on `main` too)
- [x] `bundle exec rubocop` on every changed file — clean