### PR TITLE
fix(reactions): highlight Amount (not Mass) as the recalculated field when Eq is edited

### DIFF
--- a/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
+++ b/app/javascript/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.js
@@ -1853,9 +1853,19 @@ export default class ReactionDetailsScheme extends React.Component {
       // For mixture samples with a valid reference component, calculate mass from mol amount
       const newAmountG = newAmountMol * sample.reference_component.relative_molecular_weight;
       sample.setAmount({ value: newAmountG, unit: 'g' });
-    } else {
-      // For regular samples or mixtures without reference MW, fall back to standard method
+    } else if (sample.isGas() || sample.isMixture()) {
+      // Gas amounts are derived from the reaction vessel, and mixtures without a usable
+      // reference MW track their amount as total mass; keep the gram-normalized behavior
+      // for these so their existing calculations are unchanged.
       sample.setAmountAndNormalizeToGram({
+        value: newAmountMol,
+        unit: 'mol',
+      });
+    } else {
+      // For regular samples, set the mol amount directly. Equivalents are derived from the
+      // molar amount, so keep 'mol' as amount_unit here (rather than normalizing to grams)
+      // so the Amount field is highlighted as the recalculated field instead of Mass.
+      sample.setAmount({
         value: newAmountMol,
         unit: 'mol',
       });
@@ -1875,10 +1885,16 @@ export default class ReactionDetailsScheme extends React.Component {
           const newAmountMol = Number(updatedSample.equivalent) * referenceAmountMol;
           this.handleEquivalentBasedAmountUpdate(sample, newAmountMol);
         } else if (sample.amount_value && updatedSample.gas_type !== 'feedstock') {
-          sample.setAmountAndNormalizeToGram({
-            value: updatedSample.equivalent * sample.amount_mol,
-            unit: 'mol'
-          });
+          const newAmountMol = updatedSample.equivalent * sample.amount_mol;
+          if (sample.isGas() || sample.isMixture()) {
+            // Preserve the gram-normalized behavior for gas/mixture samples (see
+            // handleEquivalentBasedAmountUpdate) so their calculations are unchanged.
+            sample.setAmountAndNormalizeToGram({ value: newAmountMol, unit: 'mol' });
+          } else {
+            // Keep 'mol' as amount_unit so the Amount field (not Mass) is highlighted as the
+            // recalculated field, since equivalents are derived from the molar amount.
+            sample.setAmount({ value: newAmountMol, unit: 'mol' });
+          }
         }
         // Validate resulting mass against available mixture mass and warn if exceeded
         this.warnIfMixtureMassExceeded(sample, sample.amount_g);

--- a/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.spec.js
+++ b/spec/javascripts/packs/src/apps/mydb/elements/details/reactions/schemeTab/ReactionDetailsScheme.spec.js
@@ -301,6 +301,71 @@ describe('ReactionDetailsScheme#updatedSamplesForAmountChange — solvent volume
   });
 });
 
+// Regression tests for the Eq-edit highlight bug:
+// When the Eq of a starting material/reactant is edited, the recalculation is molar-amount
+// based, so the sample's amount_unit must stay 'mol' (which highlights the Amount field),
+// NOT be normalized to 'g' (which would highlight the Mass field). Gas and reference-less
+// mixture samples keep the old gram-normalized behavior so their calculations are unchanged.
+describe('ReactionDetailsScheme#updatedSamplesForEquivalentChange — recalculated field is Amount', () => {
+  const buildCtx = () => ({
+    props: { reaction: { referenceMaterial: { amount_mol: 0.1, coefficient: 1 } } },
+    handleEquivalentBasedAmountUpdate:
+      ReactionDetailsScheme.prototype.handleEquivalentBasedAmountUpdate,
+    warnIfMixtureMassExceeded: sinon.spy(),
+  });
+
+  const makeMaterial = (overrides = {}) => ({
+    id: 'mat-1',
+    reference: false,
+    gas_type: 'off',
+    equivalent: 1,
+    amount_mol: 0.05,
+    amount_g: 5,
+    coefficient: 1,
+    isMixture: () => false,
+    hasComponents: () => false,
+    isGas: () => false,
+    setAmount: sinon.spy(),
+    setAmountAndNormalizeToGram: sinon.spy(),
+    ...overrides,
+  });
+
+  it('sets a regular material amount in mol (unit=mol) so the Amount field is highlighted', () => {
+    const ctx = buildCtx();
+    const material = makeMaterial();
+
+    ReactionDetailsScheme.prototype.updatedSamplesForEquivalentChange.call(
+      ctx,
+      [material],
+      { id: 'mat-1', equivalent: 3, gas_type: 'off' },
+      'reactants'
+    );
+
+    // equivalent (3) * reference amount_mol (0.1) = 0.3 mol
+    expect(material.setAmountAndNormalizeToGram.called).toBe(false);
+    expect(material.setAmount.calledOnce).toBe(true);
+    const arg = material.setAmount.firstCall.args[0];
+    expect(arg.unit).toBe('mol');
+    expect(Math.abs(arg.value - 0.3) < 1e-9).toBe(true);
+  });
+
+  it('keeps the gram-normalized path for a gas material so its vessel-driven amount is unchanged', () => {
+    const ctx = buildCtx();
+    const gas = makeMaterial({ isGas: () => true });
+
+    ReactionDetailsScheme.prototype.updatedSamplesForEquivalentChange.call(
+      ctx,
+      [gas],
+      { id: 'mat-1', equivalent: 3, gas_type: 'gas' },
+      'reactants'
+    );
+
+    expect(gas.setAmount.called).toBe(false);
+    expect(gas.setAmountAndNormalizeToGram.calledOnce).toBe(true);
+    expect(gas.setAmountAndNormalizeToGram.firstCall.args[0].unit).toBe('mol');
+  });
+});
+
 // Regression tests for the second polymer code path:
 // calculateEquivalentForProduct must route polymer products through checkMassPolymer
 // instead of the MW-based equivalent formula (which gives 0 when amount_g is null).


### PR DESCRIPTION
## Problem

When the **Eq** value of a starting material or reactant is edited in a reaction,
the **Mass** field is highlighted as the recalculated field. But the calculation is
molar-amount based (equivalents are derived from the molar amount), so the **Amount**
field should be highlighted instead. The current behavior makes it look as if the user
defined the amount by mass.

Reported on ELN 3.1.2.

## Root cause

The highlighted ("active") field in the reaction table is driven entirely by the
sample's `amount_unit`:

- Mass is highlighted when `amount_unit === 'g'` (`Material.js:1164`)
- Amount is highlighted when `amount_unit === 'mol'` (`Material.js:740`)

The Eq-change handler computed a new molar amount but stored it via
`setAmountAndNormalizeToGram(...)`, which forces `amount_unit = 'g'` (`Sample.js:1124-1127`).
So the amount was correctly computed from moles, but the unit flag was flipped to grams,
lighting up **Mass**.

## Fix

In the two equivalent-change paths in `ReactionDetailsScheme.js`
(`handleEquivalentBasedAmountUpdate` and `updatedSamplesForEquivalentChange`), regular
materials now use `setAmount({ value: newAmountMol, unit: 'mol' })` so `amount_unit`
stays `'mol'` and the **Amount** field is highlighted.

This mirrors the pattern the team already adopted for direct amount edits
(`ReactionDetailsScheme.js:746-750`), where `setAmountAndNormalizeToGram` was replaced
with `setAmount(amount)` specifically to preserve the edited unit for highlighting.

No displayed numbers change: `amount_g` and `amount_mol` are derived getters, and for a
material with a valid molecular weight the two storage forms round-trip to identical
values. Only which field is highlighted changes.

## Scope / safety

- **Gas** samples (amount derived from the reaction vessel) and **mixtures without a
  usable reference MW** (amount tracked as total mass) keep the original gram-normalized
  path, so their calculations are unchanged.
- SBMM samples were already correct (separate mol-driven path).
- `amount_unit === 'mol'` is already a supported, persisted state (it is what a direct
  mol-field edit produces), so serialization and the backend are unaffected.

## Testing

- Added regression tests: a regular material recalculates via `setAmount({ unit: 'mol' })`
  (Amount highlighted); a gas material still uses the gram-normalized path.
- All 36 tests in `ReactionDetailsScheme.spec.js` pass.

## Steps to verify

1. Open a reaction.
2. Add a reference starting material and another starting material/reactant.
3. Enter quantities for the reference material.
4. Edit the **Eq** value of the other material.
5. The **Amount** field is highlighted (previously **Mass** was).

Closes https://github.com/ComPlat/chemotion_ELN/issues/3538